### PR TITLE
Update --strategy=alpha-git-patch improvements

### DIFF
--- a/kpt/cmdupdate/cmdupdate.go
+++ b/kpt/cmdupdate/cmdupdate.go
@@ -122,9 +122,9 @@ func (r *Runner) preRunE(c *cobra.Command, args []string) error {
 
 func (r *Runner) runE(c *cobra.Command, args []string) error {
 	if len(r.Ref) > 0 {
-		fmt.Fprintf(c.OutOrStdout(), "updating package %s to %s\n", r.Command.Path, r.Ref)
+		fmt.Fprintf(c.ErrOrStderr(), "updating package %s to %s\n", r.Command.Path, r.Ref)
 	} else {
-		fmt.Fprintf(c.OutOrStdout(), "updating package %s\n", r.Command.Path)
+		fmt.Fprintf(c.ErrOrStderr(), "updating package %s\n", r.Command.Path)
 	}
 	return r.Run()
 }

--- a/lib/gitutil/gitutil.go
+++ b/lib/gitutil/gitutil.go
@@ -44,6 +44,7 @@ func NewUpstreamGitRunner(uri, dir string, refs ...string) (*GitRunner, error) {
 	if err != nil {
 		return nil, err
 	}
+	g.RepoDir = cacheDir
 	g.Dir = filepath.Join(cacheDir, dir)
 	return g, nil
 }
@@ -57,6 +58,9 @@ func NewLocalGitRunner(pkg string) *GitRunner {
 type GitRunner struct {
 	// Dir is the directory the commands are run in.
 	Dir string
+
+	// RepoDir is the directory of the git repo containing the package
+	RepoDir string
 
 	// Stderr is where the git command Stderr is written
 	Stderr *bytes.Buffer


### PR DESCRIPTION
- fix issue with updating the Kptfile
- improve `git am` success chances by fetching commits from patch origin repo
- write messages to stderr instead of stdout so --dry-run patch is clean