### PR TITLE
Don't auto-set gcloud values that are empty

### DIFF
--- a/internal/util/setters/setters.go
+++ b/internal/util/setters/setters.go
@@ -58,6 +58,10 @@ func PerformSetters(path string) error {
 			continue
 		}
 		v := strings.TrimSpace(string(b))
+		if v == "" {
+			// don't replace values that aren't set - stick with the defaults as defined in the manifest
+			continue
+		}
 		fltrs = append(fltrs, &setters.PerformSetters{Name: fmt.Sprintf("gcloud.%s", c), Value: v, SetBy: "kpt"})
 	}
 


### PR DESCRIPTION
compute.region and compute.zone often aren't set; in those cases we
should likely just stick with the default values defined in the
manifest.

This also applies to core.project, where the default value won't be
correct, but skipping still feels better than applying an empty value
or raising an error.