### PR TITLE
Set ENTRYPOINT in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,4 @@ RUN apk update && apk upgrade && \
     rm -rf /var/lib/apt/lists/* && \
     rm /var/cache/apk/*
 COPY --from=0 /usr/local/bin/kpt /usr/local/bin/kpt
-CMD ["kpt"]
+ENTRYPOINT ["kpt"]


### PR DESCRIPTION
This enables:

docker run kpt fn

Instead of:

docker run kpt kpt fn

Fixes #173