### PR TITLE
gomod: fix invalid go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/GoogleContainerTools/kpt
 
-go 1.13.5
+go 1.13
 
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.0


### PR DESCRIPTION
Fix invalid go version.
occur error:

```console
$ GO111MODULE=on go get -v -x github.com/GoogleContainerTools/kpt
.
.
go: errors parsing go.mod:
/Users/zchee/go/src/github.com/GoogleContainerTools/kpt/go.mod:3: usage: go 1.23
```