### PR TITLE
add an auto setter for gcloud.project.projectNumber

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/google/go-cmp v0.3.1 // indirect
 	github.com/mailru/easyjson v0.7.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.4
+	github.com/pkg/errors v0.8.1
 	github.com/posener/complete/v2 v2.0.1-alpha.12
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5

--- a/internal/util/setters/setters.go
+++ b/internal/util/setters/setters.go
@@ -49,6 +49,7 @@ func PerformSetters(path string) error {
 
 	// auto-fill setters from gcloud
 	gcloudConfig := []string{"compute.region", "compute.zone", "core.project"}
+	projectID := ""
 	for _, c := range gcloudConfig {
 		gcloudCmd := exec.Command("gcloud",
 			"config", "list", "--format", fmt.Sprintf("value(%s)", c))
@@ -62,7 +63,17 @@ func PerformSetters(path string) error {
 			// don't replace values that aren't set - stick with the defaults as defined in the manifest
 			continue
 		}
+		if c == "core.project" {
+			projectID = v
+		}
 		fltrs = append(fltrs, &setters.PerformSetters{Name: fmt.Sprintf("gcloud.%s", c), Value: v, SetBy: "kpt"})
+	}
+
+	if projectID != "" {
+		projectNumber, err := GetProjectNumberFromProjectID(projectID)
+		if err == nil && projectNumber != "" {
+			fltrs = append(fltrs, &setters.PerformSetters{Name: "gcloud.project.projectNumber", Value: projectNumber, SetBy: "kpt"})
+		}
 	}
 
 	if len(fltrs) == 0 {
@@ -71,4 +82,16 @@ func PerformSetters(path string) error {
 
 	return kio.Pipeline{Inputs: []kio.Reader{rw}, Filters: fltrs, Outputs: []kio.Writer{rw}}.
 		Execute()
+}
+
+func GetProjectNumberFromProjectID(projectID string) (string, error) {
+	gcloudCmd := exec.Command("gcloud",
+		"projects", "describe", projectID, "--format", "value(projectNumber)")
+	b, err := gcloudCmd.Output()
+	if err != nil {
+		fmt.Printf("err: %v\n", err)
+		return "", err
+	}
+	fmt.Println(strings.TrimSpace(string(b)))
+	return strings.TrimSpace(string(b)), nil
 }


### PR DESCRIPTION
This allows kpt to automatically set a project number if the relevant
setter appears in the config, saving users from having to go look it
up themselves. A future change should automatically set this whenever
gcloud.core.project is set.