### PR TITLE
Update docs with new flags for status

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -148,7 +148,7 @@ Reconcile configuration files with the live state.
     service/helloworld-gke created
 
     # run apply
-    $ kpt live apply --status helloworld
+    $ kpt live apply --wait-for-reconcile helloworld
     configmap/test-inventory-2911da3b created
     deployment.apps/helloworld-gke created
     service/helloworld-gke created

--- a/docs/live/apply.md
+++ b/docs/live/apply.md
@@ -29,15 +29,15 @@ Flags:
   no-prune:
     If true, previously applied objects will not be pruned.
     
-  status:
+  wait-for-reconcile:
     If true, after all resources have been applied, the cluster will
     be polled until either all resources have been fully reconciled
     or the timeout is reached.
     
-  status-period:
+  wait-polling-period:
     The frequency with which the cluster will be polled to determine 
     the status of the applied resources. The default value is every 2 seconds.
     
-  status-timeout:
+  wait-timeout:
     The threshold for how long to wait for all resources to reconcile before
     giving up. The default value is 1 minute.


### PR DESCRIPTION
We changed the flags in https://github.com/kubernetes-sigs/cli-utils/pull/54. This updates the docs.

@seans3 