### PR TITLE
Moves cli-utils version 0.1.0 -> 0.1.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	// Currently, we have to import the latest version of kubectl.
 	// Once there is a 0.18 release, we can import a semver release.
 	k8s.io/kubectl v0.0.0-20191219154910-1528d4eea6dd
-	sigs.k8s.io/cli-utils v0.1.0
+	sigs.k8s.io/cli-utils v0.1.2
 	sigs.k8s.io/kustomize/cmd/config v0.0.13
 	sigs.k8s.io/kustomize/kyaml v0.0.13
 )

--- a/go.sum
+++ b/go.sum
@@ -521,6 +521,8 @@ modernc.org/strutil v1.0.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=
 sigs.k8s.io/cli-utils v0.1.0 h1:KMP8CUNm3X50Zq2TP2ONkF13BvqsLkBkCI2Xx5Ir84Y=
 sigs.k8s.io/cli-utils v0.1.0/go.mod h1:2O9uTeLSN3rdzHwaXCus2dgqdkeygAfDPrsf+X7U1pM=
+sigs.k8s.io/cli-utils v0.1.2 h1:a4qiEtazIjkfmFi97y4077IJ+sOYp6h/EkrhPHWk7W4=
+sigs.k8s.io/cli-utils v0.1.2/go.mod h1:2O9uTeLSN3rdzHwaXCus2dgqdkeygAfDPrsf+X7U1pM=
 sigs.k8s.io/controller-runtime v0.4.0 h1:wATM6/m+3w8lj8FXNaO6Fs/rq/vqoOjO1Q116Z9NPsg=
 sigs.k8s.io/controller-runtime v0.4.0/go.mod h1:ApC79lpY3PHW9xj/w9pj+lYkLgwAAUZwfXkME1Lajns=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=


### PR DESCRIPTION
* Updates the cli-utils version from 0.1.0 to 0.1.2.
* This cli-utils version is the MVP for `kpt live` commands