### PR TITLE
Fix the deployment manifest in example to use correct image tag

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -135,7 +135,7 @@ Reconcile configuration files with the live state.
     $ kpt cfg list-setters helloworld
     NAME            DESCRIPTION         VALUE    TYPE     COUNT   SETBY
     http-port   'helloworld port'         80      integer   3
-    image-tag   'hello-world image tag'   0.1.0   string    1
+    image-tag   'hello-world image tag'   v0.3.0  string    1
     replicas    'helloworld replicas'     5       integer   1
 
     $ kpt cfg set helloworld replicas 3 --set-by pwittrock  --description 'reason'

--- a/internal/docs/generated/overview/docs.go
+++ b/internal/docs/generated/overview/docs.go
@@ -122,7 +122,7 @@ var READMEExamples = `
     $ kpt cfg list-setters helloworld
     NAME            DESCRIPTION         VALUE    TYPE     COUNT   SETBY
     http-port   'helloworld port'         80      integer   3
-    image-tag   'hello-world image tag'   0.1.0   string    1
+    image-tag   'hello-world image tag'   v0.3.0  string    1
     replicas    'helloworld replicas'     5       integer   1
 
     $ kpt cfg set helloworld replicas 3 --set-by pwittrock  --description 'reason'

--- a/package-examples/helloworld-set/Kptfile
+++ b/package-examples/helloworld-set/Kptfile
@@ -23,7 +23,7 @@ openAPI:
       x-k8s-cli:
         setter:
           name: image-tag
-          value: 0.1.0
+          value: v0.3.0
           setBy: package-default
     io.k8s.cli.substitutions.image-tag:
       x-k8s-cli:

--- a/package-examples/helloworld-set/deploy.yaml
+++ b/package-examples/helloworld-set/deploy.yaml
@@ -31,7 +31,7 @@ spec:
     spec:
       containers:
       - name: helloworld-gke
-        image: gcr.io/kpt-dev/helloworld-gke:0.1.0 # {"$ref":"#/definitions/io.k8s.cli.substitutions.image-tag"}
+        image: gcr.io/kpt-dev/helloworld-gke:v0.3.0 # {"$ref":"#/definitions/io.k8s.cli.substitutions.image-tag"}
         ports:
         - name: http
           containerPort: 80 # {"$ref":"#/definitions/io.k8s.cli.setters.http-port"}


### PR DESCRIPTION
The example on the kpt docs landing page currently doesn't work. The reason is that the image version tag is incorrect. This PR updates the manifest to use the latest available version of the `helloworld-gke` image. 
After this is merged we would also have to create a new release of `package-examples/helloworld-set` and then update the docs to point to the new version.

@pwittrock 