### PR TITLE
Better documentation on the use of kpt pkg sync set

### DIFF
--- a/docs/live/README.md
+++ b/docs/live/README.md
@@ -99,7 +99,6 @@ for the set. For CRDs, there is a set of recommendations that if followed, will 
 kpt live apply to correctly compute status.
 
 ###
-
 [tutorial-script]: ../gifs/live.sh
 [init]: init.md
 [apply]: apply.md

--- a/docs/pkg/sync-set.md
+++ b/docs/pkg/sync-set.md
@@ -19,6 +19,8 @@ While is it possible to directly edit the Kptfile, `set` can be used to add or u
 Kptfile dependencies.
 
     kpt pkg set REPO_URI[.git]/PKG_PATH[@VERSION] LOCAL_DEST_DIRECTORY [flags]
+    
+This command must be run from within the local package directory.
 
   REPO_URI:
 

--- a/docs/pkg/sync.md
+++ b/docs/pkg/sync.md
@@ -22,6 +22,12 @@ specified ref.
 This is an alternative to managing package dependencies individually using
 the `get` and `update` commands.
 
+| Command  | Description                             |
+|----------|-----------------------------------------|
+| [set]    | add a sync dependency to a Kptfile      |
+
+#### Run Sync
+
     kpt pkg sync LOCAL_PKG_DIR [flags]
 
   LOCAL_PKG_DIR:
@@ -45,6 +51,8 @@ with `kpt pkg sync set`.  e.g.
 
     kpt pkg sync set https://github.com/GoogleContainerTools/kpt.git/package-examples/helloworld-set \
         hello-world
+Note that the [set] command must be run from within the local package directory and the
+last argument specifies the local destination directory for the dependency.
 
 Or edit the Kptfile directly:
 
@@ -109,3 +117,5 @@ against the directory.
     kpt pkg sync my-package-dir/
 
 [tutorial-script]: ../gifs/pkg-sync.sh
+[sync-set]: sync-set.md
+

--- a/internal/docs/generated/livedocs/docs.go
+++ b/internal/docs/generated/livedocs/docs.go
@@ -93,7 +93,6 @@ for the set. For CRDs, there is a set of recommendations that if followed, will 
 kpt live apply to correctly compute status.
 
 ###
-
 [tutorial-script]: ../gifs/live.sh
 [init]: init.md
 [apply]: apply.md

--- a/internal/docs/generated/pkgdocs/docs.go
+++ b/internal/docs/generated/pkgdocs/docs.go
@@ -357,6 +357,8 @@ While is it possible to directly edit the Kptfile, ` + "`" + `set` + "`" + ` can
 Kptfile dependencies.
 
     kpt pkg set REPO_URI[.git]/PKG_PATH[@VERSION] LOCAL_DEST_DIRECTORY [flags]
+    
+This command must be run from within the local package directory.
 
   REPO_URI:
 
@@ -439,6 +441,12 @@ specified ref.
 This is an alternative to managing package dependencies individually using
 the ` + "`" + `get` + "`" + ` and ` + "`" + `update` + "`" + ` commands.
 
+| Command  | Description                             |
+|----------|-----------------------------------------|
+| [set]    | add a sync dependency to a Kptfile      |
+
+#### Run Sync
+
     kpt pkg sync LOCAL_PKG_DIR [flags]
 
   LOCAL_PKG_DIR:
@@ -462,6 +470,8 @@ with ` + "`" + `kpt pkg sync set` + "`" + `.  e.g.
 
     kpt pkg sync set https://github.com/GoogleContainerTools/kpt.git/package-examples/helloworld-set \
         hello-world
+Note that the [set] command must be run from within the local package directory and the
+last argument specifies the local destination directory for the dependency.
 
 Or edit the Kptfile directly:
 
@@ -524,7 +534,9 @@ var SyncExamples = `
     # sync the dependencies
     kpt pkg sync my-package-dir/
 
-[tutorial-script]: ../gifs/pkg-sync.sh`
+[tutorial-script]: ../gifs/pkg-sync.sh
+[sync-set]: sync-set.md
+`
 
 var UpdateShort = `Apply upstream package updates`
 var UpdateLong = `


### PR DESCRIPTION
The documentation of `sync` doesn't contain any links to the description of the `sync set` command. This adds this link and adds some clarification on how to use the `sync set` command.

Ref #308

@pwittrock 