### PR TITLE
Removes no-prune flag and docs

### DIFF
--- a/commands/livecmd.go
+++ b/commands/livecmd.go
@@ -60,6 +60,7 @@ func GetLiveCommand(name string) *cobra.Command {
 	}
 
 	applyCmd := apply.NewCmdApply(f, ioStreams)
+	_ = applyCmd.Flags().MarkHidden("no-prune")
 	applyCmd.Short = livedocs.ApplyShort
 	applyCmd.Long = livedocs.ApplyShort + "\n" + livedocs.ApplyLong
 

--- a/docs/live/apply.md
+++ b/docs/live/apply.md
@@ -26,9 +26,6 @@ Args:
     must contain exactly one ConfigMap with the grouping object annotation.
     
 Flags:
-  no-prune:
-    If true, previously applied objects will not be pruned.
-    
   wait-for-reconcile:
     If true, after all resources have been applied, the cluster will
     be polled until either all resources have been fully reconciled

--- a/internal/docs/generated/livedocs/docs.go
+++ b/internal/docs/generated/livedocs/docs.go
@@ -121,9 +121,6 @@ Args:
     must contain exactly one ConfigMap with the grouping object annotation.
     
 Flags:
-  no-prune:
-    If true, previously applied objects will not be pruned.
-    
   wait-for-reconcile:
     If true, after all resources have been applied, the cluster will
     be polled until either all resources have been fully reconciled


### PR DESCRIPTION
* Hides the apply command `--no-prune` flag.
* Removes the `--no-prune` documentation.
* Manually tested that flag was removed.