### PR TITLE
Fix tar file positioning

### DIFF
--- a/release/tag/cloudbuild.yaml
+++ b/release/tag/cloudbuild.yaml
@@ -46,7 +46,8 @@ steps:
   - name: 'kpt-builder'
     args: ['tar', '-cf',
     '/workspace/releases/${TAG_NAME}/windows_amd64/kpt_windows_amd64-${TAG_NAME}.tar',
-    '-C', '/workspace/releases/${TAG_NAME}/windows_amd64', '.']
+    '-C', '/workspace/releases/${TAG_NAME}/windows_amd64',
+    'kpt.exe', 'LICENSES.txt', 'lib.zip']
   - name: 'kpt-builder'
     args: ['gzip', '/workspace/releases/${TAG_NAME}/windows_amd64/kpt_windows_amd64-${TAG_NAME}.tar']
   # Cleanup by removing files that have been packaged into the
@@ -75,7 +76,8 @@ steps:
   - name: 'kpt-builder'
     args: ['tar', '-cf',
     '/workspace/releases/${TAG_NAME}/linux_amd64/kpt_linux_amd64-${TAG_NAME}.tar',
-    '-C', '/workspace/releases/${TAG_NAME}/linux_amd64', '.']
+    '-C', '/workspace/releases/${TAG_NAME}/linux_amd64',
+    'kpt', 'LICENSES.txt', 'lib.zip']
   - name: 'kpt-builder'
     args: ['gzip', '/workspace/releases/${TAG_NAME}/linux_amd64/kpt_linux_amd64-${TAG_NAME}.tar']
   # Cleanup by removing files that have been packaged into the
@@ -104,7 +106,8 @@ steps:
   - name: 'kpt-builder'
     args: ['tar', '-cf',
     '/workspace/releases/${TAG_NAME}/darwin_amd64/kpt_darwin_amd64-${TAG_NAME}.tar',
-    '-C', '/workspace/releases/${TAG_NAME}/darwin_amd64', '.']
+    '-C', '/workspace/releases/${TAG_NAME}/darwin_amd64',
+    'kpt', 'LICENSES.txt', 'lib.zip']
   - name: 'kpt-builder'
     args: ['gzip', '/workspace/releases/${TAG_NAME}/darwin_amd64/kpt_darwin_amd64-${TAG_NAME}.tar']
   # Cleanup by removing files that have been packaged into the


### PR DESCRIPTION
* Changes the created tar files to remove the preceding slash (/) from each file. Currently, when the files are added to the tarfile, they have a preceding slash. Example:

```
tar tvf /tmp/workspace/releases/v0.12.0/linux_amd64/kpt_linux_amd64-v0.12.0.tar.gz 
drwxr-xr-x root/root         0 2020-03-17 18:01 ./
-rwxr-xr-x root/root  47855068 2020-03-17 18:01 ./kpt
-rw-r--r-- root/root     13334 2020-03-17 18:01 ./lib.zip
-rw-r--r-- root/root    553248 2020-03-17 18:01 ./LICENSES.txt
```

This does not work with the gcloud distribution. The preceding slashes are removed in this PR by explicitly stating the file to be included.