### PR TITLE
Update the reference site content with mdtogo html comments

### DIFF
--- a/site/content/en/reference/_index.md
+++ b/site/content/en/reference/_index.md
@@ -9,15 +9,20 @@ menu:
 description: >
     Overview of kpt commands
 ---
+<!--mdtogo:Short
+    Overview of kpt commands
+-->
 
 {{< asciinema key="kpt" rows="10" preload="1" >}}
 
+<!--mdtogo:Long-->
 kpt functionality is subdivided into command groups, each of which operates on
 a particular set of entities, with a consistent command syntax and pattern of
 inputs and outputs.
+<!--mdtogo-->
 
 ### Examples
-
+<!--mdtogo:Examples-->
 ```sh
 # get a package
 $ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/helloworld-set@v0.5.0 helloworld
@@ -43,6 +48,7 @@ $ kpt live apply --wait-for-reconcile helloworld
 ...
 all resources has reached the Current status
 ```
+<!--mdtogo-->
 
 | Command Group | Description                                                                     |  Reads From     | Writes To       |
 |---------------|---------------------------------------------------------------------------------|-----------------|-----------------|

--- a/site/content/en/reference/cfg/_index.md
+++ b/site/content/en/reference/cfg/_index.md
@@ -6,9 +6,13 @@ weight: 2
 description: >
     Display and modify JSON or YAML configuration
 ---
+<!--mdtogo:Short
+    Display and modify JSON or YAML configuration
+-->
 
 {{< asciinema key="cfg" rows="10" preload="1" >}}
 
+<!--mdtogo:Long-->
 | Reads From              | Writes To                |
 |-------------------------|--------------------------|
 | local files or stdin    | local files or stdout    |
@@ -20,11 +24,12 @@ directly.
 
 Many cfg subcommands may also read from STDIN, allowing them to be paired
 with other tools such as `kubectl get`.
+<!--mdtogo-->
 
     kpt cfg [SUBCOMMAND]
 
 ### Examples
-
+<!--mdtogo:Examples-->
 ```sh
 # print the package using tree based structure
 $ kpt cfg tree helloworld --name --image --replicas
@@ -48,3 +53,4 @@ $ kpt cfg list-setters helloworld replicas
 $ kpt cfg set helloworld replicas 3
 set 1 fields
 ```
+<!--mdtogo-->

--- a/site/content/en/reference/cfg/annotate/_index.md
+++ b/site/content/en/reference/cfg/annotate/_index.md
@@ -6,6 +6,9 @@ type: docs
 description: >
    Set an annotation on one or more resources
 ---
+<!--mdtogo:Short
+    Set an annotation on one or more resources
+-->
 
 {{< asciinema key="cfg-annotate" rows="10" preload="1" >}}
 
@@ -15,7 +18,7 @@ Annotate can be useful when combined with other tools or commands that
 read annotations to configure their behavior.
 
 ### Examples
-
+<!--mdtogo:Examples-->
 ```sh
 # set an annotation on all Resources: 'key: value'
 kpt cfg annotate DIR --kv key=value
@@ -35,9 +38,10 @@ kpt cfg annotate DIR --kv key=value --kind Service --name foo
 # set multiple annotations
 kpt cfg annotate DIR --kv key1=value1 --kv key2=value2
 ```
+<!--mdtogo-->
 
 ### Synopsis
-
+<!--mdtogo:Long-->
     kpt cfg annotate DIR --kv KEY=VALUE...
 
 #### Args
@@ -62,3 +66,4 @@ kpt cfg annotate DIR --kv key1=value1 --kv key2=value2
 
     --namespace
       Only set annotations on resources with this name.
+<!--mdtogo-->

--- a/site/content/en/reference/cfg/cat/_index.md
+++ b/site/content/en/reference/cfg/cat/_index.md
@@ -6,6 +6,9 @@ type: docs
 description: >
    Print the resources in a package
 ---
+<!--mdtogo:Short
+    Print the resources in a package
+-->
 
 {{< asciinema key="cfg-count" rows="10" preload="1" >}}
 
@@ -15,15 +18,17 @@ Cat is useful for printing only the resources in a package which might
 contain other non-resource files.
 
 ### Examples
-
+<!--mdtogo:Examples-->
 ```sh
 # print Resource config from a directory
 kpt cfg cat my-dir/
 ```
+<!--mdtogo-->
 
 ### Synopsis
-
+<!--mdtogo:Long-->
     kpt cfg cat DIR
 
     DIR:
       Path to a package directory
+<!--mdtogo-->

--- a/site/content/en/reference/cfg/count/_index.md
+++ b/site/content/en/reference/cfg/count/_index.md
@@ -6,13 +6,16 @@ type: docs
 description: >
    Print resource counts for a package
 ---
+<!--mdtogo:Short
+    Print resource counts for a package
+-->
 
 {{< asciinema key="cfg-count" rows="10" preload="1" >}}
 
 Count quickly summarizes the number of resources in a package.
 
 ### Examples
-
+<!--mdtogo:Examples-->
 ```sh
 # print Resource counts from a directory
 kpt cfg count my-dir/
@@ -22,10 +25,12 @@ kpt cfg count my-dir/
 # print Resource counts from a cluster
 kubectl get all -o yaml | kpt cfg count
 ```
+<!--mdtogo-->
 
 ### Synopsis
-
+<!--mdtogo:Long-->
     kpt cfg count [DIR]
 
     DIR:
       Path to a package directory.  Defaults to stdin if unspecified.
+<!--mdtogo-->

--- a/site/content/en/reference/cfg/create-setter/_index.md
+++ b/site/content/en/reference/cfg/create-setter/_index.md
@@ -6,6 +6,9 @@ type: docs
 description: >
    Create a setter for one or more field
 ---
+<!--mdtogo:Short
+    Create a setter for one or more field
+-->
 
 {{< asciinema key="cfg-create-setter" rows="10" preload="1" >}}
 
@@ -17,7 +20,7 @@ structured data -- e.g. using `sed` to replace values.
 See the [creating setters] guide for more info on creating setters.
 
 ### Examples
-
+<!--mdtogo:Examples-->
 ```sh
 # create a setter called replicas for fields matching "3"
 kpt cfg create-setter DIR/ replicas 3
@@ -46,9 +49,10 @@ kpt cfg create-setter DIR/ replicas 3 --set-by "package-default" \
 # only the final part of the the field path is specified
 kpt cfg create-setter DIR/ app nginx --field "annotations.app" --type string
 ```
+<!--mdtogo-->
 
 ### Synopsis
-
+<!--mdtogo:Long-->
     kpt cfg create-setter DIR NAME VALUE
 
     DIR:
@@ -62,5 +66,6 @@ kpt cfg create-setter DIR/ app nginx --field "annotations.app" --type string
     VALUE
       The new value of the setter.
       e.g. 3
+<!--mdtogo-->
 
 [creating setters]: ../../../guides/producer/setters

--- a/site/content/en/reference/cfg/create-subst/_index.md
+++ b/site/content/en/reference/cfg/create-subst/_index.md
@@ -6,6 +6,9 @@ type: docs
 description: >
    Create a substitution for one or more fields
 ---
+<!--mdtogo:Short
+    Create a substitution for one or more fields
+-->
 
 {{< asciinema key="cfg-create-subst" rows="10" preload="1" >}}
 
@@ -17,7 +20,7 @@ See the [creating substitutions] guide for more info on creating
 substitutions.
 
 ### Examples
-
+<!--mdtogo:Examples-->
 ```sh
 
 # Automatically create setters when creating the substitution, inferring
@@ -57,9 +60,10 @@ kpt cfg create-subst DIR/ image-tag nginx:v1.7.9 \
 # 4. update the substitution value by setting one of the setters
 kpt cfg set tag v1.8.0
 ```
+<!--mdtogo-->
 
 ### Synopsis
-
+<!--mdtogo:Long-->
     kpt cfg create-subst DIR NAME VALUE --pattern PATTERN --value MARKER=SETTER
 
     DIR
@@ -80,6 +84,7 @@ kpt cfg set tag v1.8.0
       different MARKERS, the same MARKER multiple times, and non-MARKER
       substrings.
       e.g. IMAGE_SETTER:TAG_SETTER
+<!--mdtogo-->
 
 [setters]: ../create-setter
 [creating substitutions]: ../../../guides/producer/substitutions

--- a/site/content/en/reference/cfg/fmt/_index.md
+++ b/site/content/en/reference/cfg/fmt/_index.md
@@ -6,6 +6,9 @@ type: docs
 description: >
    Format configuration files
 ---
+<!--mdtogo:Short
+    Format configuration files
+-->
 
 {{< asciinema key="cfg-fmt" rows="10" preload="1" >}}
 
@@ -34,7 +37,7 @@ field paths.
 - .webhooks.rules.operations (by element value)
 
 ### Examples
-
+<!--mdtogo:Examples-->
 ```sh
 # format file1.yaml and file2.yml
 kpt cfg fmt file1.yaml file2.yml
@@ -54,10 +57,12 @@ kubectl get -o yaml deployments | kpt cfg fmt
 # format kustomize output
 kustomize build | kpt cfg fmt
 ```
+<!--mdtogo-->
 
 ### Synopsis
-
+<!--mdtogo:Long-->
     kpt cfg fmt [DIR]
 
     DIR:
       Path to a package directory.  Reads from STDIN if not provided.
+<!--mdtogo-->

--- a/site/content/en/reference/cfg/grep/_index.md
+++ b/site/content/en/reference/cfg/grep/_index.md
@@ -6,6 +6,9 @@ type: docs
 description: >
    Filter resources by their field values
 ---
+<!--mdtogo:Short
+    Filter resources by their field values
+-->
 
 {{< asciinema key="cfg-grep" rows="10" preload="1" >}}
 
@@ -16,7 +19,7 @@ Grep may have sources such as `kubectl get -o yaml` piped to it, or may
 be piped to other commands such as `kpt cfg tree` for display.
 
 ### Examples
-
+<!--mdtogo:Examples-->
 ```sh
 # find Deployment Resources
 kpt cfg grep "kind=Deployment" my-dir/
@@ -37,9 +40,10 @@ kpt cfg grep "metadata.name=nginx" my-dir/ | kpt cfg tree
 kpt cfg grep "spec.template.spec.containers[name=nginx].image=nginx:1\.7\.9" \
     my-dir/ | kpt cfg tree
 ```
+<!--mdtogo-->
 
 ### Synopsis
-
+<!--mdtogo:Long-->
     kpt cfg grep QUERY DIR
 
 #### Args
@@ -58,3 +62,4 @@ kpt cfg grep "spec.template.spec.containers[name=nginx].image=nginx:1\.7\.9" \
 
     --invert-match, -v
       keep resources NOT matching the specified pattern
+<!--mdtogo-->

--- a/site/content/en/reference/cfg/list-setters/_index.md
+++ b/site/content/en/reference/cfg/list-setters/_index.md
@@ -6,6 +6,9 @@ type: docs
 description: >
    List setters for a package
 ---
+<!--mdtogo:Short
+    List setters for a package
+-->
 
 {{< asciinema key="cfg-set" rows="10" preload="1" >}}
 
@@ -21,7 +24,7 @@ See [create-setter] and [create-subst] for how setters and substitutions
 are defined in a Kptfile.
 
 ### Examples
-
+<!--mdtogo:Examples-->
 ```sh
 # list the setters in the hello-world package
 kpt cfg list-setters hello-world/
@@ -29,9 +32,10 @@ kpt cfg list-setters hello-world/
   NAME     VALUE    SET BY    DESCRIPTION   COUNT  
 replicas   4       isabella   good value    1   
 ```
+<!--mdtogo-->
 
 ### Synopsis
-
+<!--mdtogo:Long-->
     kpt cfg list-setters DIR [NAME]
 
     DIR
@@ -39,6 +43,7 @@ replicas   4       isabella   good value    1
 
     NAME
       Optional.  The name of the setter to display.
+<!--mdtogo-->
 
 [create-setter]: ../create-setter
 [create-subst]: ../create-subst

--- a/site/content/en/reference/cfg/set/_index.md
+++ b/site/content/en/reference/cfg/set/_index.md
@@ -6,6 +6,9 @@ type: docs
 description: >
    Set one or more field values
 ---
+<!--mdtogo:Short
+    Set one or more field values
+-->
 
 {{< asciinema key="cfg-set" rows="10" preload="1" >}}
 
@@ -56,7 +59,7 @@ When set is called, it may also update substitutions which are derived from
 the setter.
 
 ### Examples
-
+<!--mdtogo:Examples-->
 ```sh
 # set replicas to 3 using the 'replicas' setter
 kpt cfg set hello-world/ replicas 3
@@ -77,9 +80,10 @@ kpt cfg set hello-world/ replicas 5 --set-by "mia"
 # the tag setter is referenced as a value by a substitution in the Kptfile
 kpt cfg set hello-world/ tag 1.8.1
 ```
+<!--mdtogo-->
 
 ### Synopsis
-
+<!--mdtogo:Long-->
     kpt cfg set DIR NAME VALUE
 
 #### Args
@@ -101,6 +105,7 @@ kpt cfg set hello-world/ tag 1.8.1
     --set-by
       Optional record of who set the value.  Clears the last set-by
       value if unset.
+<!--mdtogo-->
 
 [create-setter]: ../create-setter
 [create-subst]: ../create-subst

--- a/site/content/en/reference/cfg/tree/_index.md
+++ b/site/content/en/reference/cfg/tree/_index.md
@@ -6,6 +6,9 @@ type: docs
 description: >
    Render resources using a tree structure
 ---
+<!--mdtogo:Short
+    Render resources using a tree structure
+-->
 
 {{< asciinema key="cfg-tree" rows="10" preload="1" >}}
 
@@ -21,7 +24,7 @@ remote cluster resources rather than local package resources.
 Otherwise, directory graph structure is used.
 
 ### Examples
-
+<!--mdtogo:Examples-->
 ```sh
 # print Resources using directory structure
 kpt cfg tree my-dir/
@@ -62,9 +65,10 @@ kubectl get all -o yaml | kpt cfg tree \
   --field="status.conditions[type=Ready].status" \
   --field="status.conditions[type=ContainersReady].status"
 ```
+<!--mdtogo-->
 
 ### Synopsis
-
+<!--mdtogo:Long-->
     kpt cfg tree [DIR] [flags]
 
 #### Args
@@ -100,3 +104,4 @@ kubectl get all -o yaml | kpt cfg tree \
 
     --resources:
       if true, print the resource reservations
+<!--mdtogo-->

--- a/site/content/en/reference/fn/_index.md
+++ b/site/content/en/reference/fn/_index.md
@@ -6,7 +6,11 @@ weight: 4
 description: >
    Generate, transform, and validate configuration files.
 ---
+<!--mdtogo:Short
+    Generate, transform, and validate configuration files.
+-->
 
+<!--mdtogo:Long-->
 | Configuration Read From | Configuration Written To |
 |-------------------------|--------------------------|
 | local files or stdin    | local files or stdout    |
@@ -14,6 +18,7 @@ description: >
 Functions are executables ([that you can write](#developing-functions))
 packaged in container images which accept a collection of Resource
 configuration as input, and emit a collection of Resource configuration as output.
+<!--mdtogo-->
 
 Functions may be used to:
 
@@ -35,7 +40,7 @@ the organizational needs:
 * as pre-rollout checks
 
 ### Examples
-
+<!--mdtogo:Examples-->
 ```sh
 # run the function defined by gcr.io/example.com/my-fn as a local container
 # against the configuration in DIR
@@ -51,6 +56,7 @@ kpt fn run DIR/ --fn-path FUNCTIONS_DIR/
 # run the functions declared in files under DIR/
 kpt fn run DIR/
 ```
+<!--mdtogo-->
 
 #### Functions Catalog
 

--- a/site/content/en/reference/fn/run/_index.md
+++ b/site/content/en/reference/fn/run/_index.md
@@ -5,6 +5,9 @@ type: docs
 description: >
    Locally execute one or more functions in containers
 ---
+<!--mdtogo:Short
+    Locally execute one or more functions in containers
+-->
 
 Generate, transform, or validate configuration files using locally run
 containerized functions.
@@ -13,7 +16,7 @@ Functions are packaged as container images which are run locally against
 the contents of a package.
 
 ### Examples
-
+<!--mdtogo:Examples-->
 ```sh
 # read the Resources from DIR, provide them to a container my-fun as input,
 # write my-fn output back to DIR
@@ -35,6 +38,7 @@ kpt fn run DIR/ --fn-path FUNCTIONS_DIR/
 # functions may be scoped to a subset of Resources -- see `kpt help fn run`
 kpt fn run DIR/
 ```
+<!--mdtogo-->
 
 #### Imperatively run an single function
 
@@ -183,7 +187,7 @@ spec:
 ```
 
 ### Synopsis
-
+<!--mdtogo:Long-->
     kpt fn run DIR [flags]
 
 If the container exits with non-zero status code, run will fail and print the
@@ -191,3 +195,4 @@ container `STDERR`.
 
     DIR:
       Path to a package directory.  Defaults to stdin if unspecified.
+<!--mdtogo-->

--- a/site/content/en/reference/fn/sink/_index.md
+++ b/site/content/en/reference/fn/sink/_index.md
@@ -5,6 +5,9 @@ type: docs
 description: >
    Explicitly specify an output sink for a function
 ---
+<!--mdtogo:Short
+    Explicitly specify an output sink for a function
+-->
 
 Implements a sink by reading stdin and writing output to a local directory.
 
@@ -12,16 +15,17 @@ Sink will not prune / delete files for delete resources because it only knows
 about files for which it sees input resources.
 
 ### Examples
-
+<!--mdtogo:Examples-->
 ```sh
 # run a function using explicit sources and sinks
 kpt fn source DIR/ | kpt run --image gcr.io/example.com/my-fn | kpt fn sink DIR/
 ```
+<!--mdtogo-->
 
 ### Synopsis
-
+<!--mdtogo:Long-->
     kpt fn sink [DIR]
 
     DIR:
       Path to a package directory.  Defaults to stdout if unspecified.
-
+<!--mdtogo-->

--- a/site/content/en/reference/fn/source/_index.md
+++ b/site/content/en/reference/fn/source/_index.md
@@ -5,11 +5,14 @@ type: docs
 description: >
    Explicitly specify an output source for a function
 ---
+<!--mdtogo:Short
+    Explicitly specify an output source for a function
+-->
 
 Implements a Source by reading configuration and writing to command stdout.
 
 ### Examples
-
+<!--mdtogo:Examples-->
 ```sh
 # print to stdout configuration formatted as an input source
 kpt fn source DIR/
@@ -19,11 +22,12 @@ kpt fn source DIR/
 # run a function using explicit sources and sinks
 kpt fn source DIR/ | kpt run --image gcr.io/example.com/my-fn | kpt fn sink DIR/
 ```
+<!--mdtogo-->
 
 ### Synopsis
-
+<!--mdtogo:Long-->
     kpt fn source [DIR...]
 
     DIR:
       Path to a package directory.  Defaults to stdin if unspecified.
-
+<!--mdtogo-->

--- a/site/content/en/reference/live/_index.md
+++ b/site/content/en/reference/live/_index.md
@@ -6,7 +6,11 @@ type: docs
 description: >
    Reconcile configuration files with the live state
 ---
+<!--mdtogo:Short
+    Reconcile configuration files with the live state
+-->
 
+<!--mdtogo:Long-->
 | Reads From              | Writes To                |
 |-------------------------|--------------------------|
 | local files             | cluster                  |
@@ -14,3 +18,4 @@ description: >
 
 Live contains the next-generation versions of apply related commands for
 deploying local configuration packages to a cluster.
+<!--mdtogo-->

--- a/site/content/en/reference/live/apply/_index.md
+++ b/site/content/en/reference/live/apply/_index.md
@@ -5,6 +5,9 @@ type: docs
 description: >
    Apply a package to the cluster (create, update, delete)
 ---
+<!--mdtogo:Short
+    Apply a package to the cluster (create, update, delete)
+-->
 
 Apply creates, updates and deletes resources in the cluster to make the remote
 cluster resources match the local package configuration.
@@ -103,7 +106,7 @@ for the set. For CRDs, there is a set of recommendations that if followed, will 
 kpt live apply to correctly compute status.
 
 ### Synopsis
-
+<!--mdtogo:Long-->
     kpt live apply DIR [flags]
 
 #### Args
@@ -126,3 +129,4 @@ kpt live apply to correctly compute status.
     --wait-timeout:
       The threshold for how long to wait for all resources to reconcile before
       giving up. The default value is 1 minute.
+<!--mdtogo-->

--- a/site/content/en/reference/live/destroy/_index.md
+++ b/site/content/en/reference/live/destroy/_index.md
@@ -5,11 +5,14 @@ type: docs
 description: >
    Remove all previously applied resources in a package from the cluster
 ---
+<!--mdtogo:Short
+    Remove all previously applied resources in a package from the cluster
+-->
 
 The destroy command removes all files belonging to a package from the cluster.
 
 ### Synopsis
-
+<!--mdtogo:Long-->
     kpt live destroy DIR
 
 #### Args
@@ -17,3 +20,4 @@ The destroy command removes all files belonging to a package from the cluster.
     DIR:
       Path to a package directory.  The directory must contain exactly
       one ConfigMap with the grouping object annotation.
+<!--mdtogo-->

--- a/site/content/en/reference/live/init/_index.md
+++ b/site/content/en/reference/live/init/_index.md
@@ -5,6 +5,9 @@ type: docs
 description: >
    Initialize a package with a object to track previously applied resources
 ---
+<!--mdtogo:Short
+    Initialize a package with a object to track previously applied resources
+-->
 
 The init command initializes a package with a template resource which will
 be used to track previously applied resources so that they can be pruned
@@ -14,7 +17,7 @@ The template resource is required by other live commands
 such as apply, preview and destroy.
 
 ### Synopsis
-
+<!--mdtogo:Long-->
     kpt live init DIRECTORY [flags]
 
 #### Args
@@ -29,3 +32,4 @@ such as apply, preview and destroy.
       String name to group applied resources. Must be composed of valid
       label value characters. If not specified, the default group name
       is generated from the package directory name.
+<!--mdtogo-->

--- a/site/content/en/reference/live/preview/_index.md
+++ b/site/content/en/reference/live/preview/_index.md
@@ -5,13 +5,16 @@ type: docs
 description: >
    Preview prints the changes apply would make to the cluster
 ---
+<!--mdtogo:Short
+    Preview prints the changes apply would make to the cluster
+-->
 
 The preview command will run through the same steps as apply, but 
 it will only print what would happen when running apply against the current
 live cluster state. 
 
 ### Synopsis
-
+<!--mdtogo:Long-->
     kpt live preview DIRECTORY [flags]
 
 #### Args
@@ -24,3 +27,4 @@ live cluster state.
 
     --destroy:
       If true, dry-run deletion of all resources.
+<!--mdtogo-->

--- a/site/content/en/reference/pkg/_index.md
+++ b/site/content/en/reference/pkg/_index.md
@@ -6,22 +6,28 @@ type: docs
 description: >
    Fetch, update, and sync configuration files using git
 ---
-
-|              Reads From | Writes To                |
-|-------------------------|--------------------------|
-| git repository          | local directory          |
+<!--mdtogo:Short
+    Fetch, update, and sync configuration files using git
+-->
 
 {{< asciinema key="pkg" rows="10" preload="1" >}}
 
-    kpt pkg [SUBCOMMAND]
+<!--mdtogo:Long-->
+|              Reads From | Writes To                |
+|-------------------------|--------------------------|
+| git repository          | local directory          |
 
 The `pkg` command group contains subcommands which read remote upstream
 git repositories, and write local directories.  They are focused on
 providing porcelain on top of workflows which would otherwise require
 wrapping git to pull clone subdirectories and perform updates by merging
 resources rather than files.
-### Examples
+<!--mdtogo-->
 
+    kpt pkg [SUBCOMMAND]
+
+### Examples
+<!--mdtogo:Examples-->
 ```sh
 # create your workspace
 $ mkdir hello-world-workspace
@@ -39,6 +45,7 @@ $ git commit -am "Add hello world to my workspace."
 # pull in upstream updates by merging Resources
 $ kpt pkg update helloworld@v0.5.0 --strategy=resource-merge
 ```
+<!--mdtogo-->
 
 ### Synopsis
 

--- a/site/content/en/reference/pkg/desc/_index.md
+++ b/site/content/en/reference/pkg/desc/_index.md
@@ -5,20 +5,24 @@ type: docs
 description: >
    Display upstream package metadata
 ---
+<!--mdtogo:Short
+    Display upstream package metadata
+-->
 
 Desc displays information about the upstream package in tabular format.
 
 ### Examples
-
+<!--mdtogo:Examples-->
 ```sh
 # display description for the local hello-world package
 kpt pkg desc hello-world/
 ```
+<!--mdtogo-->
 
 ### Synopsis
-
+<!--mdtogo:Long-->
     kpt pkg desc DIR
 
     DIR:
       Path to a package directory
-
+<!--mdtogo-->

--- a/site/content/en/reference/pkg/diff/_index.md
+++ b/site/content/en/reference/pkg/diff/_index.md
@@ -5,6 +5,9 @@ type: docs
 description: >
    Diff a local package against upstream
 ---
+<!--mdtogo:Short
+    Diff a local package against upstream
+-->
 
 Diff displays differences between upstream and local packages.
 
@@ -17,7 +20,7 @@ The diff tool can be specified.  By default, the local 'diff' command is used to
 display differences.
 
 ### Examples
-
+<!--mdtogo:Examples-->
 ```sh
 # Show changes in current package relative to upstream source package
 kpt pkg diff
@@ -45,9 +48,10 @@ kpt pkg diff @v4.0.0 --diff-type combined
 # version and upstream package at target version using meld
 kpt pkg diff @v4.0.0 --diff-type 3way --diff-tool meld --diff-tool-opts "-a"
 ```
+<!--mdtogo-->
 
 ### Synopsis
-
+<!--mdtogo:Long-->
     kpt pkg diff [DIR@VERSION]
 
 #### Args
@@ -100,4 +104,4 @@ kpt pkg diff @v4.0.0 --diff-type 3way --diff-tool meld --diff-tool-opts "-a"
        Commandline options to use for the diffing tool. For ex.
        # Using "-a" diff option
        KPT_EXTERNAL_DIFF_OPTS="-a" kpt pkg diff --diff-tool meld
-
+<!--mdtogo-->

--- a/site/content/en/reference/pkg/get/_index.md
+++ b/site/content/en/reference/pkg/get/_index.md
@@ -5,6 +5,9 @@ type: docs
 description: >
    Fetch a package from a git repo.
 ---
+<!--mdtogo:Short
+    Fetch a package from a git repo.
+-->
 
 {{< asciinema key="pkg-get" rows="10" preload="1" >}}
 
@@ -13,7 +16,7 @@ local directory.  The local directory name does not need to match the upstream
 directory name.
 
 ### Examples
-
+<!--mdtogo:Examples-->
 ```sh
 # fetch package cockroachdb from github.com/kubernetes/examples/staging/cockroachdb
 # creates directory ./cockroachdb/ containing the package contents
@@ -32,9 +35,10 @@ kpt pkg get https://github.com/kubernetes/examples.git/staging/cockroachdb@maste
 # creates directory ./examples fetched from the provided commit
 kpt pkg get https://github.com/kubernetes/examples.git/@8186bef8e5c0621bf80fa8106bd595aae8b62884 ./
 ```
+<!--mdtogo-->
 
 ### Synopsis
-
+<!--mdtogo:Long-->
     kpt pkg get REPO_URI[.git]/PKG_PATH[@VERSION] LOCAL_DEST_DIRECTORY [flags]
 
     REPO_URI:
@@ -68,3 +72,4 @@ kpt pkg get https://github.com/kubernetes/examples.git/@8186bef8e5c0621bf80fa810
           specified one, defaulting the name to the Base of REPO/PKG_PATH
         * If the directory DOES exist and already contains a directory with
           the same name of the one that would be created: fail
+<!--mdtogo-->

--- a/site/content/en/reference/pkg/init/_index.md
+++ b/site/content/en/reference/pkg/init/_index.md
@@ -5,6 +5,9 @@ type: docs
 description: >
    Initialize an empty package
 ---
+<!--mdtogo:Short
+    Initialize an empty package
+-->
 
 {{< asciinema key="pkg-init" rows="10" preload="1" >}}
 
@@ -27,16 +30,17 @@ Init will:
 * Create a README.md for package documentation if it doesn't exist.
 
 ### Examples
-
+<!--mdtogo:Examples-->
 ```sh
 # writes Kptfile package meta if not found
 mkdir my-pkg
 kpt pkg init my-pkg --tag kpt.dev/app=cockroachdb \
     --description "my cockroachdb implementation"
 ```
+<!--mdtogo-->
 
 ### Synopsis
-
+<!--mdtogo:Long-->
     kpt pkg init DIR [flags]
 
 #### Args
@@ -57,5 +61,4 @@ kpt pkg init my-pkg --tag kpt.dev/app=cockroachdb \
 
     --url
       link to page with information about the package.
-
-
+<!--mdtogo-->

--- a/site/content/en/reference/pkg/update/_index.md
+++ b/site/content/en/reference/pkg/update/_index.md
@@ -5,6 +5,9 @@ type: docs
 description: >
    Apply upstream package updates
 ---
+<!--mdtogo:Short
+    Apply upstream package updates
+-->
 
 {{< asciinema key="pkg-update" rows="10" preload="1" >}}
 
@@ -16,7 +19,7 @@ All changes must be committed to git before running update
 {{% /pageinfo %}}
 
 ### Examples
-
+<!--mdtogo:Examples-->
 ```sh
 # update my-package-dir/
 git add . && git commit -m 'some message'
@@ -34,9 +37,10 @@ kpt pkg update my-package-dir/@v1.3
 git add . && git commit -m "package updates"
 kpt pkg  update my-package-dir/@master --strategy alpha-git-patch
 ```
+<!--mdtogo-->
 
 ### Synopsis
-
+<!--mdtogo:Long-->
     kpt pkg update LOCAL_PKG_DIR[@VERSION] [flags]
 
 #### Args
@@ -84,4 +88,4 @@ kpt pkg  update my-package-dir/@master --strategy alpha-git-patch
       Controls where to cache remote packages when fetching them to update
       local packages.
       Defaults to ~/.kpt/repos/
-
+<!--mdtogo-->


### PR DESCRIPTION
This adds the html comments to the md pages. There is a separate PR (https://github.com/kubernetes-sigs/kustomize/pull/2285) that updates the mdtogo tool to use these comments for identifying content rather than specially named headers. Once both of these have merged, I will do another PR that actually updates the generated content.

@pwittrock 