### PR TITLE
Generate docs for Sync command from Hugo content

### DIFF
--- a/internal/cmdsync/cmdsync.go
+++ b/internal/cmdsync/cmdsync.go
@@ -16,6 +16,7 @@
 package cmdsync
 
 import (
+	docs "github.com/GoogleContainerTools/kpt/internal/docs/generated/pkgdocs"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/sync"
 	"github.com/spf13/cobra"
@@ -26,9 +27,9 @@ func NewRunner(parent string) *Runner {
 	r := &Runner{}
 	c := &cobra.Command{
 		Use:     "sync LOCAL_PKG_DIR",
-		Short:   SyncShort,
-		Long:    SyncLong,
-		Example: SyncExamples,
+		Short:   docs.SyncShort,
+		Long:    docs.SyncLong,
+		Example: docs.SyncExamples,
 		RunE:    r.runE,
 		Args:    cobra.ExactArgs(1),
 		PreRunE: r.preRunE,
@@ -64,114 +65,3 @@ func (r *Runner) preRunE(c *cobra.Command, args []string) error {
 func (r *Runner) runE(c *cobra.Command, args []string) error {
 	return r.Sync.Run()
 }
-
-// This content is no longer available on the Hugo site, so we just put
-// it here for now.
-
-var SyncShort = `Fetch and update packages declaratively`
-var SyncLong = `
-Sync uses a manifest to manage a collection of dependencies.
-
-The manifest declares *all* direct dependencies of a package in a Kptfile.
-When ` + "`" + `sync` + "`" + ` is run, it will ensure each dependency has been fetched at the
-specified ref.
-
-This is an alternative to managing package dependencies individually using
-the ` + "`" + `get` + "`" + ` and ` + "`" + `update` + "`" + ` commands.
-
-| Command  | Description                             |
-|----------|-----------------------------------------|
-| [set]    | add a sync dependency to a Kptfile      |
-
-#### Run Sync
-
-    kpt pkg sync LOCAL_PKG_DIR [flags]
-
-  LOCAL_PKG_DIR:
-
-    Local package with dependencies to sync.  Directory must exist and contain a Kptfile.
-
-#### Env Vars
-
-  KPT_CACHE_DIR:
-
-    Controls where to cache remote packages during updates.
-    Defaults to ~/.kpt/repos/
-
-#### Dependencies
-
-For each dependency in the Kptfile, ` + "`" + `sync` + "`" + ` will ensure that it exists locally with the
-matching repo and ref.
-
-Dependencies are specified in the ` + "`" + `Kptfile` + "`" + ` ` + "`" + `dependencies` + "`" + ` field and can be added or updated
-with ` + "`" + `kpt pkg sync set` + "`" + `.  e.g.
-
-    kpt pkg sync set https://github.com/GoogleContainerTools/kpt.git/package-examples/helloworld-set \
-        hello-world
-Note that the [set] command must be run from within the local package directory and the
-last argument specifies the local destination directory for the dependency.
-
-Or edit the Kptfile directly:
-
-    apiVersion: kpt.dev/v1alpha1
-    kind: Kptfile
-    dependencies:
-    - name: hello-world
-      git:
-        repo: "https://github.com/GoogleContainerTools/kpt.git"
-        directory: "/package-examples/helloworld-set"
-        ref: "master"
-
-Dependencies have following schema:
-
-    name: <local path (relative to the Kptfile) to fetch the dependency to>
-    git:
-      repo: <git repository>
-      directory: <sub-directory under the git repository>
-      ref: <git reference -- e.g. tag, branch, commit, etc>
-    updateStrategy: <strategy to use when updating the dependency -- see kpt help update for more details>
-    ensureNotExists: <remove the dependency, mutually exclusive with git>
-
-Dependencies maybe be updated by updating their ` + "`" + `git.ref` + "`" + ` field and running ` + "`" + `kpt pkg sync` + "`" + `
-against the directory.
-`
-var SyncExamples = `
-  Example Kptfile to sync:
-
-    # file: my-package-dir/Kptfile
-
-    apiVersion: kpt.dev/v1alpha1
-    kind: Kptfile
-    # list of dependencies to sync
-    dependencies:
-    - name: local/destination/dir
-      git:
-        # repo is the git repository
-        repo: "https://github.com/pwittrock/examples"
-        # directory is the git subdirectory
-        directory: "staging/cockroachdb"
-        # ref is the ref to fetch
-        ref: "v1.0.0"
-    - name: local/destination/dir1
-      git:
-        repo: "https://github.com/pwittrock/examples"
-        directory: "staging/javaee"
-        ref: "v1.0.0"
-      # set the strategy for applying package updates
-      updateStrategy: "resource-merge"
-    - name: app2
-      path: local/destination/dir2
-      # declaratively delete this dependency
-      ensureNotExists: true
-
-  Example invocation:
-
-    # print the dependencies that would be modified
-    kpt pkg sync my-package-dir/ --dry-run
-
-    # sync the dependencies
-    kpt pkg sync my-package-dir/
-
-[tutorial-script]: ../gifs/pkg-sync.sh
-[sync-set]: sync-set.md
-`

--- a/internal/cmdsync/cmdsyncset.go
+++ b/internal/cmdsync/cmdsyncset.go
@@ -16,6 +16,7 @@
 package cmdsync
 
 import (
+	docs "github.com/GoogleContainerTools/kpt/internal/docs/generated/pkgdocs"
 	"github.com/GoogleContainerTools/kpt/internal/kptfile"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/parse"
@@ -29,9 +30,9 @@ func NewSetRunner(parent string) *SetRunner {
 	c := &cobra.Command{
 		Use:     "set REPO_URI[.git]/PKG_PATH[@VERSION] LOCAL_DEST_DIRECTORY",
 		RunE:    r.runE,
-		Long:    SyncSetLong,
-		Short:   SyncSetShort,
-		Example: SyncSetExamples,
+		Long:    docs.SetLong,
+		Short:   docs.SetShort,
+		Example: docs.SetExamples,
 		Args:    cobra.ExactArgs(2),
 		PreRunE: r.preRunE,
 	}
@@ -67,88 +68,3 @@ func (r *SetRunner) preRunE(_ *cobra.Command, args []string) error {
 func (r *SetRunner) runE(_ *cobra.Command, args []string) error {
 	return sync.SetDependency(r.Dependency)
 }
-
-// This content is no longer available on the Hugo site, so we just put
-// it here for now.
-
-var SyncSetShort = `Add a sync dependency to a Kptfile`
-
-var SyncSetLong = `
-Add a sync dependency to a Kptfile.
-
-While is it possible to directly edit the Kptfile, ` + "`" + `set` + "`" + ` can be used to add or update
-Kptfile dependencies.
-
-    kpt pkg set REPO_URI[.git]/PKG_PATH[@VERSION] LOCAL_DEST_DIRECTORY [flags]
-    
-This command must be run from within the local package directory.
-
-  REPO_URI:
-
-    URI of a git repository containing 1 or more packages as subdirectories.
-    In most cases the .git suffix should be specified to delimit the REPO_URI from the PKG_PATH,
-    but this is not required for widely recognized repo prefixes.  If get cannot parse the repo
-    for the directory and version, then it will print an error asking for '.git' to be specified
-    as part of the argument.
-    e.g. https://github.com/kubernetes/examples.git
-    Specify - to read Resources from stdin and write to a LOCAL_DEST_DIRECTORY.
-
-  PKG_PATH:
-
-    Path to remote subdirectory containing Kubernetes Resource configuration files or directories.
-    Defaults to the root directory.
-    Uses '/' as the path separator (regardless of OS).
-    e.g. staging/cockroachdb
-
-  VERSION:
-
-    A git tag, branch, ref or commit for the remote version of the package to fetch.
-    Defaults to the repository master branch.
-    e.g. @master
-
-  LOCAL_DEST_DIRECTORY:
-
-    The local directory to write the package to.
-    e.g. ./my-cockroachdb-copy
-
-    * If the directory does NOT exist: create the specified directory and write
-      the package contents to it
-    * If the directory DOES exist: create a NEW directory under the specified one,
-      defaulting the name to the Base of REPO/PKG_PATH
-    * If the directory DOES exist and already contains a directory with the same name
-      of the one that would be created: fail
-
-  --strategy:
-
-    Controls how changes to the local package are handled.  Defaults to fast-forward.
-
-    * resource-merge: perform a structural comparison of the original / updated Resources, and merge
-	  the changes into the local package.  See ` + "`" + `kpt help apis merge3` + "`" + ` for details on merge.
-    * fast-forward: fail without updating if the local package was modified since it was fetched.
-    * alpha-git-patch: use 'git format-patch' and 'git am' to apply a patch of the
-      changes between the source version and destination version.
-      **REQUIRES THE LOCAL PACKAGE TO HAVE BEEN COMMITTED TO A LOCAL GIT REPO.**
-    * force-delete-replace: THIS WILL WIPE ALL LOCAL CHANGES TO
-      THE PACKAGE.  DELETE the local package at local_pkg_dir/ and replace it
-      with the remote version.
-`
-var SyncSetExamples = `
-  Create a new package and add a dependency to it
-
-    # init a package so it can be synced
-    kpt pkg init
-
-    # add a dependency to the package
-    kpt pkg sync set https://github.com/GoogleContainerTools/kpt.git/package-examples/helloworld-set \
-        hello-world
-
-    # sync the dependencies
-    kpt pkg sync .
-
-  Update an existing package dependency
-
-    # add a dependency to an existing package
-    kpt pkg sync set https://github.com/GoogleContainerTools/kpt.git/package-examples/helloworld-set@v0.2.0 \
-        hello-world --strategy=resource-merge
-
-[tutorial-script]: ../gifs/pkg-sync.sh`

--- a/internal/docs/generated/pkgdocs/docs.go
+++ b/internal/docs/generated/pkgdocs/docs.go
@@ -213,6 +213,103 @@ var InitExamples = `
       --description "my cockroachdb implementation"
 `
 
+var SyncShort = `Fetch and update packages declaratively`
+var SyncLong = `
+    kpt pkg sync LOCAL_PKG_DIR [flags]
+
+    LOCAL_PKG_DIR:
+      Local package with dependencies to sync.  Directory must exist and
+      contain a Kptfile.
+
+#### Env Vars
+
+  KPT_CACHE_DIR:
+
+    Controls where to cache remote packages during updates.
+    Defaults to ~/.kpt/repos/
+`
+var SyncExamples = `
+  # print the dependencies that would be modified
+  kpt pkg sync . --dry-run
+
+  # sync the dependencies
+  kpt pkg sync .
+`
+
+var SetShort = `Add a sync dependency to a Kptfile`
+var SetLong = `
+    kpt pkg set REPO_URI[.git]/PKG_PATH[@VERSION] LOCAL_DEST_DIRECTORY [flags]
+
+    REPO_URI:
+      URI of a git repository containing 1 or more packages as subdirectories.
+      In most cases the .git suffix should be specified to delimit the REPO_URI
+      from the PKG_PATH, but this is not required for widely recognized repo
+      prefixes.  If get cannot parse the repo for the directory and version, 
+      then it will print an error asking for '.git' to be specified as part of
+      the argument.
+      e.g. https://github.com/kubernetes/examples.git
+      Specify - to read Resources from stdin and write to a LOCAL_DEST_DIRECTORY
+
+    PKG_PATH:
+      Path to remote subdirectory containing Kubernetes Resource configuration
+      files or directories.  Defaults to the root directory.
+      Uses '/' as the path separator (regardless of OS).
+      e.g. staging/cockroachdb
+
+    VERSION:
+      A git tag, branch, ref or commit for the remote version of the package to
+      fetch.  Defaults to the repository master branch.
+      e.g. @master
+
+    LOCAL_DEST_DIRECTORY:
+      The local directory to write the package to. e.g. ./my-cockroachdb-copy
+
+        * If the directory does NOT exist: create the specified directory and write
+          the package contents to it
+        * If the directory DOES exist: create a NEW directory under the specified one,
+          defaulting the name to the Base of REPO/PKG_PATH
+        * If the directory DOES exist and already contains a directory with the same name
+          of the one that would be created: fail
+
+#### Flags
+
+    --strategy:
+      Controls how changes to the local package are handled.
+      Defaults to fast-forward.
+
+        * resource-merge: perform a structural comparison of the original /
+          updated Resources, and merge the changes into the local package.
+          See ` + "`" + `kpt help apis merge3` + "`" + ` for details on merge.
+        * fast-forward: fail without updating if the local package was modified
+          since it was fetched.
+        * alpha-git-patch: use 'git format-patch' and 'git am' to apply a
+          patch of the changes between the source version and destination
+          version.
+          REQUIRES THE LOCAL PACKAGE TO HAVE BEEN COMMITTED TO A LOCAL GIT REPO.
+        * force-delete-replace: THIS WILL WIPE ALL LOCAL CHANGES TO
+          THE PACKAGE.  DELETE the local package at local_pkg_dir/ and replace
+          it with the remote version.
+`
+var SetExamples = `
+#### Create a new package and add a dependency to it
+
+  # init a package so it can be synced
+  kpt pkg init
+  
+  # add a dependency to the package
+  kpt pkg sync set https://github.com/GoogleContainerTools/kpt.git/package-examples/helloworld-set \
+      hello-world
+  
+  # sync the dependencies
+  kpt pkg sync .
+
+#### Update an existing package dependency
+
+  # add a dependency to an existing package
+  kpt pkg sync set https://github.com/GoogleContainerTools/kpt.git/package-examples/helloworld-set@v0.2.0 \
+      hello-world --strategy=resource-merge
+`
+
 var UpdateShort = `Apply upstream package updates`
 var UpdateLong = `
     kpt pkg update LOCAL_PKG_DIR[@VERSION] [flags]

--- a/site/content/en/reference/pkg/sync/_index.md
+++ b/site/content/en/reference/pkg/sync/_index.md
@@ -2,9 +2,13 @@
 title: "Sync"
 linkTitle: "sync"
 type: docs
+draft: true
 description: >
    Fetch and update packages declaratively
 ---
+<!--mdtogo:Short
+    Fetch and update packages declaratively
+-->
 
 {{< asciinema key="pkg-sync" rows="10" preload="1" >}}
 
@@ -21,7 +25,7 @@ the `get` and `update` commands.
 ### Examples
 
 #### Example sync commands
-
+<!--mdtogo:Examples-->
 ```sh
 # print the dependencies that would be modified
 kpt pkg sync . --dry-run
@@ -31,6 +35,7 @@ kpt pkg sync . --dry-run
 # sync the dependencies
 kpt pkg sync .
 ```
+<!--mdtogo-->
 
 #### Example Kptfile with dependencies
 
@@ -62,7 +67,7 @@ dependencies:
 ```
 
 ### Synopsis
-
+<!--mdtogo:Long-->
     kpt pkg sync LOCAL_PKG_DIR [flags]
 
     LOCAL_PKG_DIR:
@@ -75,6 +80,7 @@ dependencies:
 
     Controls where to cache remote packages during updates.
     Defaults to ~/.kpt/repos/
+<!--mdtogo-->
 
 #### Dependencies
 

--- a/site/content/en/reference/pkg/sync/set/_index.md
+++ b/site/content/en/reference/pkg/sync/set/_index.md
@@ -2,9 +2,13 @@
 title: "Set"
 linkTitle: "set"
 type: docs
+draft: true
 description: >
    Add a sync dependency to a Kptfile
 ---
+<!--mdtogo:Short
+    Add a sync dependency to a Kptfile
+-->
 
 `kpt pkg sync set` can be used to add or update Kptfile dependencies
 programmatically.
@@ -15,6 +19,7 @@ to be updated.
 {{% /pageinfo %}}
 
 ### Examples
+<!--mdtogo:Examples-->
 
 #### Create a new package and add a dependency to it
 
@@ -37,10 +42,11 @@ kpt pkg sync .
 kpt pkg sync set https://github.com/GoogleContainerTools/kpt.git/package-examples/helloworld-set@v0.2.0 \
     hello-world --strategy=resource-merge
 ```
+<!--mdtogo-->
 
+### Synopsis
+<!--mdtogo:Long-->
     kpt pkg set REPO_URI[.git]/PKG_PATH[@VERSION] LOCAL_DEST_DIRECTORY [flags]
-
-#### Args
 
     REPO_URI:
       URI of a git repository containing 1 or more packages as subdirectories.
@@ -91,3 +97,4 @@ kpt pkg sync set https://github.com/GoogleContainerTools/kpt.git/package-example
         * force-delete-replace: THIS WILL WIPE ALL LOCAL CHANGES TO
           THE PACKAGE.  DELETE the local package at local_pkg_dir/ and replace
           it with the remote version.
+<!--mdtogo-->


### PR DESCRIPTION
This moves the content for `Sync` and `Sync Set` from the saved folder to the appropriate location under the reference folder. This allows us to capture the docs for these commands in the same way as the others with `mdtogo`. Both documents has been tagged with the `draft: true` in the front matter for the pages which will exclude them during rendering.

@pwittrock 