### PR TITLE
Fix indentation in generated Long message

### DIFF
--- a/docs/reference/cfg/annotate/index.html
+++ b/docs/reference/cfg/annotate/index.html
@@ -892,12 +892,10 @@ kpt cfg annotate DIR --kv <span style="color:#000">key1</span><span style="color
 <h3 id="synopsis">Synopsis</h3>
 <!--mdtogo:Long-->
 <pre><code>kpt cfg annotate DIR --kv KEY=VALUE...
-</code></pre>
-<h4 id="args">Args</h4>
+</code></pre><h4 id="args">Args</h4>
 <pre><code>DIR:
   Path to a package directory
-</code></pre>
-<h4 id="flags">Flags</h4>
+</code></pre><h4 id="flags">Flags</h4>
 <pre><code>--apiVersion
   Only set annotations on resources with this apiVersion.
 
@@ -913,8 +911,7 @@ kpt cfg annotate DIR --kv <span style="color:#000">key1</span><span style="color
 
 --namespace
   Only set annotations on resources with this name.
-</code></pre>
-<!--mdtogo-->
+</code></pre><!--mdtogo-->
 
         <div class="section-index">
     
@@ -982,7 +979,7 @@ kpt cfg annotate DIR --kv <span style="color:#000">key1</span><span style="color
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 19, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/b5797b1a0ef0f8d4967962e5168222753d2efbd1">Update the reference site content with mdtogo html comments (b5797b1a)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified March 22, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4397847ac7f8c642d62df6ef5123189ff5bb89e2">Fix indentation in generated Long message (4397847a)</a>
 </div>
 </div>
 

--- a/docs/reference/cfg/cat/index.html
+++ b/docs/reference/cfg/cat/index.html
@@ -889,8 +889,7 @@ kpt cfg cat my-dir/
 
 DIR:
   Path to a package directory
-</code></pre>
-<!--mdtogo-->
+</code></pre><!--mdtogo-->
         <div class="section-index">
     
     
@@ -957,7 +956,7 @@ DIR:
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 19, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/b5797b1a0ef0f8d4967962e5168222753d2efbd1">Update the reference site content with mdtogo html comments (b5797b1a)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified March 22, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4397847ac7f8c642d62df6ef5123189ff5bb89e2">Fix indentation in generated Long message (4397847a)</a>
 </div>
 </div>
 

--- a/docs/reference/cfg/count/index.html
+++ b/docs/reference/cfg/count/index.html
@@ -889,8 +889,7 @@ kubectl get all -o yaml <span style="color:#000;font-weight:bold">|</span> kpt c
 
 DIR:
   Path to a package directory.  Defaults to stdin if unspecified.
-</code></pre>
-<!--mdtogo-->
+</code></pre><!--mdtogo-->
         <div class="section-index">
     
     
@@ -957,7 +956,7 @@ DIR:
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 19, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/b5797b1a0ef0f8d4967962e5168222753d2efbd1">Update the reference site content with mdtogo html comments (b5797b1a)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified March 22, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4397847ac7f8c642d62df6ef5123189ff5bb89e2">Fix indentation in generated Long message (4397847a)</a>
 </div>
 </div>
 

--- a/docs/reference/cfg/create-setter/index.html
+++ b/docs/reference/cfg/create-setter/index.html
@@ -912,8 +912,7 @@ NAME:
 VALUE
   The new value of the setter.
   e.g. 3
-</code></pre>
-<!--mdtogo-->
+</code></pre><!--mdtogo-->
 
         <div class="section-index">
     
@@ -981,7 +980,7 @@ VALUE
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 19, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/b5797b1a0ef0f8d4967962e5168222753d2efbd1">Update the reference site content with mdtogo html comments (b5797b1a)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified March 22, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4397847ac7f8c642d62df6ef5123189ff5bb89e2">Fix indentation in generated Long message (4397847a)</a>
 </div>
 </div>
 

--- a/docs/reference/cfg/create-subst/index.html
+++ b/docs/reference/cfg/create-subst/index.html
@@ -942,8 +942,7 @@ PATTERN
   different MARKERS, the same MARKER multiple times, and non-MARKER
   substrings.
   e.g. IMAGE_SETTER:TAG_SETTER
-</code></pre>
-<!--mdtogo-->
+</code></pre><!--mdtogo-->
 
         <div class="section-index">
     
@@ -1011,7 +1010,7 @@ PATTERN
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 19, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/b5797b1a0ef0f8d4967962e5168222753d2efbd1">Update the reference site content with mdtogo html comments (b5797b1a)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified March 22, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4397847ac7f8c642d62df6ef5123189ff5bb89e2">Fix indentation in generated Long message (4397847a)</a>
 </div>
 </div>
 

--- a/docs/reference/cfg/fmt/index.html
+++ b/docs/reference/cfg/fmt/index.html
@@ -913,8 +913,7 @@ kustomize build <span style="color:#000;font-weight:bold">|</span> kpt cfg fmt
 
 DIR:
   Path to a package directory.  Reads from STDIN if not provided.
-</code></pre>
-<!--mdtogo-->
+</code></pre><!--mdtogo-->
 
         <div class="section-index">
     
@@ -982,7 +981,7 @@ DIR:
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 19, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/b5797b1a0ef0f8d4967962e5168222753d2efbd1">Update the reference site content with mdtogo html comments (b5797b1a)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified March 22, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4397847ac7f8c642d62df6ef5123189ff5bb89e2">Fix indentation in generated Long message (4397847a)</a>
 </div>
 </div>
 

--- a/docs/reference/cfg/grep/index.html
+++ b/docs/reference/cfg/grep/index.html
@@ -894,23 +894,20 @@ kpt cfg grep <span style="color:#4e9a06">&#34;spec.template.spec.containers[name
 <h3 id="synopsis">Synopsis</h3>
 <!--mdtogo:Long-->
 <pre><code>kpt cfg grep QUERY DIR
-</code></pre>
-<h4 id="args">Args</h4>
-<pre><code>QUERY:
-  Query to match expressed as 'path.to.field=value'.
-  Maps and fields are matched as '.field-name' or '.map-key'
-  List elements are matched as '[list-elem-field=field-value]'
-  The value to match is expressed as '=value'
-  '.' as part of a key or value can be escaped as '\.'
+</code></pre><h4 id="args">Args</h4>
+<pre><code>    QUERY:
+      Query to match expressed as 'path.to.field=value'.
+      Maps and fields are matched as '.field-name' or '.map-key'
+      List elements are matched as '[list-elem-field=field-value]'
+      The value to match is expressed as '=value'
+      '.' as part of a key or value can be escaped as '\.'
 
-DIR:
-  Path to a package directory
-</code></pre>
-<h4 id="flags">Flags</h4>
-<pre><code>--invert-match, -v
-  keep resources NOT matching the specified pattern
-</code></pre>
-<!--mdtogo-->
+    DIR:
+      Path to a package directory
+</code></pre><h4 id="flags">Flags</h4>
+<pre><code>    --invert-match, -v
+      keep resources NOT matching the specified pattern
+</code></pre><!--mdtogo-->
 
         <div class="section-index">
     
@@ -978,7 +975,7 @@ DIR:
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 19, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/b5797b1a0ef0f8d4967962e5168222753d2efbd1">Update the reference site content with mdtogo html comments (b5797b1a)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified March 22, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4397847ac7f8c642d62df6ef5123189ff5bb89e2">Fix indentation in generated Long message (4397847a)</a>
 </div>
 </div>
 

--- a/docs/reference/cfg/index.xml
+++ b/docs/reference/cfg/index.xml
@@ -74,12 +74,10 @@ kpt cfg annotate DIR --kv &lt;span style=&#34;color:#000&#34;&gt;key1&lt;/span&g
 &lt;h3 id=&#34;synopsis&#34;&gt;Synopsis&lt;/h3&gt;
 &lt;!--mdtogo:Long--&gt;
 &lt;pre&gt;&lt;code&gt;kpt cfg annotate DIR --kv KEY=VALUE...
-&lt;/code&gt;&lt;/pre&gt;
-&lt;h4 id=&#34;args&#34;&gt;Args&lt;/h4&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;h4 id=&#34;args&#34;&gt;Args&lt;/h4&gt;
 &lt;pre&gt;&lt;code&gt;DIR:
   Path to a package directory
-&lt;/code&gt;&lt;/pre&gt;
-&lt;h4 id=&#34;flags&#34;&gt;Flags&lt;/h4&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;h4 id=&#34;flags&#34;&gt;Flags&lt;/h4&gt;
 &lt;pre&gt;&lt;code&gt;--apiVersion
   Only set annotations on resources with this apiVersion.
 
@@ -95,8 +93,7 @@ kpt cfg annotate DIR --kv &lt;span style=&#34;color:#000&#34;&gt;key1&lt;/span&g
 
 --namespace
   Only set annotations on resources with this name.
-&lt;/code&gt;&lt;/pre&gt;
-&lt;!--mdtogo--&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;!--mdtogo--&gt;
 
       </description>
     </item>
@@ -159,8 +156,7 @@ kpt cfg cat my-dir/
 
 DIR:
   Path to a package directory
-&lt;/code&gt;&lt;/pre&gt;
-&lt;!--mdtogo--&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;!--mdtogo--&gt;
       </description>
     </item>
     
@@ -222,8 +218,7 @@ kubectl get all -o yaml &lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;
 
 DIR:
   Path to a package directory.  Defaults to stdin if unspecified.
-&lt;/code&gt;&lt;/pre&gt;
-&lt;!--mdtogo--&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;!--mdtogo--&gt;
       </description>
     </item>
     
@@ -308,8 +303,7 @@ NAME:
 VALUE
   The new value of the setter.
   e.g. 3
-&lt;/code&gt;&lt;/pre&gt;
-&lt;!--mdtogo--&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;!--mdtogo--&gt;
 
       </description>
     </item>
@@ -425,8 +419,7 @@ PATTERN
   different MARKERS, the same MARKER multiple times, and non-MARKER
   substrings.
   e.g. IMAGE_SETTER:TAG_SETTER
-&lt;/code&gt;&lt;/pre&gt;
-&lt;!--mdtogo--&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;!--mdtogo--&gt;
 
       </description>
     </item>
@@ -513,8 +506,7 @@ kustomize build &lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;|&lt;/sp
 
 DIR:
   Path to a package directory.  Reads from STDIN if not provided.
-&lt;/code&gt;&lt;/pre&gt;
-&lt;!--mdtogo--&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;!--mdtogo--&gt;
 
       </description>
     </item>
@@ -582,23 +574,20 @@ kpt cfg grep &lt;span style=&#34;color:#4e9a06&#34;&gt;&amp;#34;spec.template.sp
 &lt;h3 id=&#34;synopsis&#34;&gt;Synopsis&lt;/h3&gt;
 &lt;!--mdtogo:Long--&gt;
 &lt;pre&gt;&lt;code&gt;kpt cfg grep QUERY DIR
-&lt;/code&gt;&lt;/pre&gt;
-&lt;h4 id=&#34;args&#34;&gt;Args&lt;/h4&gt;
-&lt;pre&gt;&lt;code&gt;QUERY:
-  Query to match expressed as &#39;path.to.field=value&#39;.
-  Maps and fields are matched as &#39;.field-name&#39; or &#39;.map-key&#39;
-  List elements are matched as &#39;[list-elem-field=field-value]&#39;
-  The value to match is expressed as &#39;=value&#39;
-  &#39;.&#39; as part of a key or value can be escaped as &#39;\.&#39;
+&lt;/code&gt;&lt;/pre&gt;&lt;h4 id=&#34;args&#34;&gt;Args&lt;/h4&gt;
+&lt;pre&gt;&lt;code&gt;    QUERY:
+      Query to match expressed as &#39;path.to.field=value&#39;.
+      Maps and fields are matched as &#39;.field-name&#39; or &#39;.map-key&#39;
+      List elements are matched as &#39;[list-elem-field=field-value]&#39;
+      The value to match is expressed as &#39;=value&#39;
+      &#39;.&#39; as part of a key or value can be escaped as &#39;\.&#39;
 
-DIR:
-  Path to a package directory
-&lt;/code&gt;&lt;/pre&gt;
-&lt;h4 id=&#34;flags&#34;&gt;Flags&lt;/h4&gt;
-&lt;pre&gt;&lt;code&gt;--invert-match, -v
-  keep resources NOT matching the specified pattern
-&lt;/code&gt;&lt;/pre&gt;
-&lt;!--mdtogo--&gt;
+    DIR:
+      Path to a package directory
+&lt;/code&gt;&lt;/pre&gt;&lt;h4 id=&#34;flags&#34;&gt;Flags&lt;/h4&gt;
+&lt;pre&gt;&lt;code&gt;    --invert-match, -v
+      keep resources NOT matching the specified pattern
+&lt;/code&gt;&lt;/pre&gt;&lt;!--mdtogo--&gt;
 
       </description>
     </item>
@@ -674,8 +663,7 @@ DIR
 
 NAME
   Optional.  The name of the setter to display.
-&lt;/code&gt;&lt;/pre&gt;
-&lt;!--mdtogo--&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;!--mdtogo--&gt;
 
       </description>
     </item>
@@ -772,8 +760,7 @@ kpt cfg &lt;span style=&#34;color:#204a87&#34;&gt;set&lt;/span&gt; hello-world/ 
 &lt;h3 id=&#34;synopsis&#34;&gt;Synopsis&lt;/h3&gt;
 &lt;!--mdtogo:Long--&gt;
 &lt;pre&gt;&lt;code&gt;kpt cfg set DIR NAME VALUE
-&lt;/code&gt;&lt;/pre&gt;
-&lt;h4 id=&#34;args&#34;&gt;Args&lt;/h4&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;h4 id=&#34;args&#34;&gt;Args&lt;/h4&gt;
 &lt;pre&gt;&lt;code&gt;DIR
   Path to a package directory. e.g. hello-world/
 
@@ -782,16 +769,14 @@ NAME
 
 VALUE
   The new value to set on fields. e.g. 3
-&lt;/code&gt;&lt;/pre&gt;
-&lt;h4 id=&#34;flags&#34;&gt;Flags&lt;/h4&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;h4 id=&#34;flags&#34;&gt;Flags&lt;/h4&gt;
 &lt;pre&gt;&lt;code&gt;--description
   Optional description about the value.
 
 --set-by
   Optional record of who set the value.  Clears the last set-by
   value if unset.
-&lt;/code&gt;&lt;/pre&gt;
-&lt;!--mdtogo--&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;!--mdtogo--&gt;
 
       </description>
     </item>
@@ -874,12 +859,10 @@ kubectl get all -o yaml &lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;
 &lt;h3 id=&#34;synopsis&#34;&gt;Synopsis&lt;/h3&gt;
 &lt;!--mdtogo:Long--&gt;
 &lt;pre&gt;&lt;code&gt;kpt cfg tree [DIR] [flags]
-&lt;/code&gt;&lt;/pre&gt;
-&lt;h4 id=&#34;args&#34;&gt;Args&lt;/h4&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;h4 id=&#34;args&#34;&gt;Args&lt;/h4&gt;
 &lt;pre&gt;&lt;code&gt;DIR:
   Path to a package directory.  Defaults to STDIN if not specified.
-&lt;/code&gt;&lt;/pre&gt;
-&lt;h4 id=&#34;flags&#34;&gt;Flags&lt;/h4&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;h4 id=&#34;flags&#34;&gt;Flags&lt;/h4&gt;
 &lt;pre&gt;&lt;code&gt;--args:
   if true, print the container args field
 
@@ -906,8 +889,7 @@ kubectl get all -o yaml &lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;
 
 --resources:
   if true, print the resource reservations
-&lt;/code&gt;&lt;/pre&gt;
-&lt;!--mdtogo--&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;!--mdtogo--&gt;
 
       </description>
     </item>

--- a/docs/reference/cfg/list-setters/index.html
+++ b/docs/reference/cfg/list-setters/index.html
@@ -902,8 +902,7 @@ DIR
 
 NAME
   Optional.  The name of the setter to display.
-</code></pre>
-<!--mdtogo-->
+</code></pre><!--mdtogo-->
 
         <div class="section-index">
     
@@ -971,7 +970,7 @@ NAME
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 19, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/b5797b1a0ef0f8d4967962e5168222753d2efbd1">Update the reference site content with mdtogo html comments (b5797b1a)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified March 22, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4397847ac7f8c642d62df6ef5123189ff5bb89e2">Fix indentation in generated Long message (4397847a)</a>
 </div>
 </div>
 

--- a/docs/reference/cfg/set/index.html
+++ b/docs/reference/cfg/set/index.html
@@ -935,8 +935,7 @@ kpt cfg <span style="color:#204a87">set</span> hello-world/ tag 1.8.1
 <h3 id="synopsis">Synopsis</h3>
 <!--mdtogo:Long-->
 <pre><code>kpt cfg set DIR NAME VALUE
-</code></pre>
-<h4 id="args">Args</h4>
+</code></pre><h4 id="args">Args</h4>
 <pre><code>DIR
   Path to a package directory. e.g. hello-world/
 
@@ -945,16 +944,14 @@ NAME
 
 VALUE
   The new value to set on fields. e.g. 3
-</code></pre>
-<h4 id="flags">Flags</h4>
+</code></pre><h4 id="flags">Flags</h4>
 <pre><code>--description
   Optional description about the value.
 
 --set-by
   Optional record of who set the value.  Clears the last set-by
   value if unset.
-</code></pre>
-<!--mdtogo-->
+</code></pre><!--mdtogo-->
 
         <div class="section-index">
     
@@ -1022,7 +1019,7 @@ VALUE
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 19, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/b5797b1a0ef0f8d4967962e5168222753d2efbd1">Update the reference site content with mdtogo html comments (b5797b1a)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified March 22, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4397847ac7f8c642d62df6ef5123189ff5bb89e2">Fix indentation in generated Long message (4397847a)</a>
 </div>
 </div>
 

--- a/docs/reference/cfg/tree/index.html
+++ b/docs/reference/cfg/tree/index.html
@@ -909,12 +909,10 @@ kubectl get all -o yaml <span style="color:#000;font-weight:bold">|</span> kpt c
 <h3 id="synopsis">Synopsis</h3>
 <!--mdtogo:Long-->
 <pre><code>kpt cfg tree [DIR] [flags]
-</code></pre>
-<h4 id="args">Args</h4>
+</code></pre><h4 id="args">Args</h4>
 <pre><code>DIR:
   Path to a package directory.  Defaults to STDIN if not specified.
-</code></pre>
-<h4 id="flags">Flags</h4>
+</code></pre><h4 id="flags">Flags</h4>
 <pre><code>--args:
   if true, print the container args field
 
@@ -941,8 +939,7 @@ kubectl get all -o yaml <span style="color:#000;font-weight:bold">|</span> kpt c
 
 --resources:
   if true, print the resource reservations
-</code></pre>
-<!--mdtogo-->
+</code></pre><!--mdtogo-->
 
         <div class="section-index">
     
@@ -1010,7 +1007,7 @@ kubectl get all -o yaml <span style="color:#000;font-weight:bold">|</span> kpt c
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 19, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/b5797b1a0ef0f8d4967962e5168222753d2efbd1">Update the reference site content with mdtogo html comments (b5797b1a)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified March 22, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4397847ac7f8c642d62df6ef5123189ff5bb89e2">Fix indentation in generated Long message (4397847a)</a>
 </div>
 </div>
 

--- a/docs/reference/fn/index.xml
+++ b/docs/reference/fn/index.xml
@@ -139,13 +139,11 @@ of CRDs:&lt;/p&gt;
 &lt;/span&gt;&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;h3 id=&#34;synopsis&#34;&gt;Synopsis&lt;/h3&gt;
 &lt;!--mdtogo:Long--&gt;
 &lt;pre&gt;&lt;code&gt;kpt fn run DIR [flags]
-&lt;/code&gt;&lt;/pre&gt;
-&lt;p&gt;If the container exits with non-zero status code, run will fail and print the
+&lt;/code&gt;&lt;/pre&gt;&lt;p&gt;If the container exits with non-zero status code, run will fail and print the
 container &lt;code&gt;STDERR&lt;/code&gt;.&lt;/p&gt;
 &lt;pre&gt;&lt;code&gt;DIR:
   Path to a package directory.  Defaults to stdin if unspecified.
-&lt;/code&gt;&lt;/pre&gt;
-&lt;!--mdtogo--&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;!--mdtogo--&gt;
 
       </description>
     </item>
@@ -176,8 +174,7 @@ kpt fn &lt;span style=&#34;color:#204a87&#34;&gt;source&lt;/span&gt; DIR/ &lt;sp
 
 DIR:
   Path to a package directory.  Defaults to stdout if unspecified.
-&lt;/code&gt;&lt;/pre&gt;
-&lt;!--mdtogo--&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;!--mdtogo--&gt;
 
       </description>
     </item>
@@ -208,8 +205,7 @@ kpt fn &lt;span style=&#34;color:#204a87&#34;&gt;source&lt;/span&gt; DIR/ &lt;sp
 
 DIR:
   Path to a package directory.  Defaults to stdin if unspecified.
-&lt;/code&gt;&lt;/pre&gt;
-&lt;!--mdtogo--&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;!--mdtogo--&gt;
 
       </description>
     </item>

--- a/docs/reference/fn/run/index.html
+++ b/docs/reference/fn/run/index.html
@@ -957,13 +957,11 @@ of CRDs:</p>
 </span></code></pre></div><h3 id="synopsis">Synopsis</h3>
 <!--mdtogo:Long-->
 <pre><code>kpt fn run DIR [flags]
-</code></pre>
-<p>If the container exits with non-zero status code, run will fail and print the
+</code></pre><p>If the container exits with non-zero status code, run will fail and print the
 container <code>STDERR</code>.</p>
 <pre><code>DIR:
   Path to a package directory.  Defaults to stdin if unspecified.
-</code></pre>
-<!--mdtogo-->
+</code></pre><!--mdtogo-->
 
         <div class="section-index">
     
@@ -1031,7 +1029,7 @@ container <code>STDERR</code>.</p>
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 19, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/b5797b1a0ef0f8d4967962e5168222753d2efbd1">Update the reference site content with mdtogo html comments (b5797b1a)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified March 22, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4397847ac7f8c642d62df6ef5123189ff5bb89e2">Fix indentation in generated Long message (4397847a)</a>
 </div>
 </div>
 

--- a/docs/reference/fn/sink/index.html
+++ b/docs/reference/fn/sink/index.html
@@ -857,8 +857,7 @@ kpt fn <span style="color:#204a87">source</span> DIR/ <span style="color:#000;fo
 
 DIR:
   Path to a package directory.  Defaults to stdout if unspecified.
-</code></pre>
-<!--mdtogo-->
+</code></pre><!--mdtogo-->
 
         <div class="section-index">
     
@@ -926,7 +925,7 @@ DIR:
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 19, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/b5797b1a0ef0f8d4967962e5168222753d2efbd1">Update the reference site content with mdtogo html comments (b5797b1a)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified March 22, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4397847ac7f8c642d62df6ef5123189ff5bb89e2">Fix indentation in generated Long message (4397847a)</a>
 </div>
 </div>
 

--- a/docs/reference/fn/source/index.html
+++ b/docs/reference/fn/source/index.html
@@ -857,8 +857,7 @@ kpt fn <span style="color:#204a87">source</span> DIR/ <span style="color:#000;fo
 
 DIR:
   Path to a package directory.  Defaults to stdin if unspecified.
-</code></pre>
-<!--mdtogo-->
+</code></pre><!--mdtogo-->
 
         <div class="section-index">
     
@@ -926,7 +925,7 @@ DIR:
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 19, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/b5797b1a0ef0f8d4967962e5168222753d2efbd1">Update the reference site content with mdtogo html comments (b5797b1a)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified March 22, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4397847ac7f8c642d62df6ef5123189ff5bb89e2">Fix indentation in generated Long message (4397847a)</a>
 </div>
 </div>
 

--- a/docs/reference/live/apply/index.html
+++ b/docs/reference/live/apply/index.html
@@ -979,13 +979,11 @@ kpt live apply to correctly compute status.</p>
 <h3 id="synopsis">Synopsis</h3>
 <!--mdtogo:Long-->
 <pre><code>kpt live apply DIR [flags]
-</code></pre>
-<h4 id="args">Args</h4>
+</code></pre><h4 id="args">Args</h4>
 <pre><code>DIR:
   Path to a package directory.  The directory must contain exactly
   one ConfigMap with the grouping object annotation.
-</code></pre>
-<h4 id="flags">Flags:</h4>
+</code></pre><h4 id="flags">Flags:</h4>
 <pre><code>--wait-for-reconcile:
   If true, after all resources have been applied, the cluster will
   be polled until either all resources have been fully reconciled
@@ -998,8 +996,7 @@ kpt live apply to correctly compute status.</p>
 --wait-timeout:
   The threshold for how long to wait for all resources to reconcile before
   giving up. The default value is 1 minute.
-</code></pre>
-<!--mdtogo-->
+</code></pre><!--mdtogo-->
 
         <div class="section-index">
     
@@ -1067,7 +1064,7 @@ kpt live apply to correctly compute status.</p>
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 20, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/fec483d839a5bc76a59844427cecb3786ff73702">Scripts and recordings for live commands (fec483d8)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified March 22, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4397847ac7f8c642d62df6ef5123189ff5bb89e2">Fix indentation in generated Long message (4397847a)</a>
 </div>
 </div>
 

--- a/docs/reference/live/destroy/index.html
+++ b/docs/reference/live/destroy/index.html
@@ -879,13 +879,11 @@
 <h3 id="synopsis">Synopsis</h3>
 <!--mdtogo:Long-->
 <pre><code>kpt live destroy DIR
-</code></pre>
-<h4 id="args">Args</h4>
+</code></pre><h4 id="args">Args</h4>
 <pre><code>DIR:
   Path to a package directory.  The directory must contain exactly
   one ConfigMap with the grouping object annotation.
-</code></pre>
-<!--mdtogo-->
+</code></pre><!--mdtogo-->
 
         <div class="section-index">
     
@@ -953,7 +951,7 @@
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 20, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/fec483d839a5bc76a59844427cecb3786ff73702">Scripts and recordings for live commands (fec483d8)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified March 22, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4397847ac7f8c642d62df6ef5123189ff5bb89e2">Fix indentation in generated Long message (4397847a)</a>
 </div>
 </div>
 

--- a/docs/reference/live/index.xml
+++ b/docs/reference/live/index.xml
@@ -148,13 +148,11 @@ kpt live apply to correctly compute status.&lt;/p&gt;
 &lt;h3 id=&#34;synopsis&#34;&gt;Synopsis&lt;/h3&gt;
 &lt;!--mdtogo:Long--&gt;
 &lt;pre&gt;&lt;code&gt;kpt live apply DIR [flags]
-&lt;/code&gt;&lt;/pre&gt;
-&lt;h4 id=&#34;args&#34;&gt;Args&lt;/h4&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;h4 id=&#34;args&#34;&gt;Args&lt;/h4&gt;
 &lt;pre&gt;&lt;code&gt;DIR:
   Path to a package directory.  The directory must contain exactly
   one ConfigMap with the grouping object annotation.
-&lt;/code&gt;&lt;/pre&gt;
-&lt;h4 id=&#34;flags&#34;&gt;Flags:&lt;/h4&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;h4 id=&#34;flags&#34;&gt;Flags:&lt;/h4&gt;
 &lt;pre&gt;&lt;code&gt;--wait-for-reconcile:
   If true, after all resources have been applied, the cluster will
   be polled until either all resources have been fully reconciled
@@ -167,8 +165,7 @@ kpt live apply to correctly compute status.&lt;/p&gt;
 --wait-timeout:
   The threshold for how long to wait for all resources to reconcile before
   giving up. The default value is 1 minute.
-&lt;/code&gt;&lt;/pre&gt;
-&lt;!--mdtogo--&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;!--mdtogo--&gt;
 
       </description>
     </item>
@@ -221,13 +218,11 @@ kpt live apply to correctly compute status.&lt;/p&gt;
 &lt;h3 id=&#34;synopsis&#34;&gt;Synopsis&lt;/h3&gt;
 &lt;!--mdtogo:Long--&gt;
 &lt;pre&gt;&lt;code&gt;kpt live destroy DIR
-&lt;/code&gt;&lt;/pre&gt;
-&lt;h4 id=&#34;args&#34;&gt;Args&lt;/h4&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;h4 id=&#34;args&#34;&gt;Args&lt;/h4&gt;
 &lt;pre&gt;&lt;code&gt;DIR:
   Path to a package directory.  The directory must contain exactly
   one ConfigMap with the grouping object annotation.
-&lt;/code&gt;&lt;/pre&gt;
-&lt;!--mdtogo--&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;!--mdtogo--&gt;
 
       </description>
     </item>
@@ -284,19 +279,16 @@ such as apply, preview and destroy.&lt;/p&gt;
 &lt;h3 id=&#34;synopsis&#34;&gt;Synopsis&lt;/h3&gt;
 &lt;!--mdtogo:Long--&gt;
 &lt;pre&gt;&lt;code&gt;kpt live init DIRECTORY [flags]
-&lt;/code&gt;&lt;/pre&gt;
-&lt;h4 id=&#34;args&#34;&gt;Args&lt;/h4&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;h4 id=&#34;args&#34;&gt;Args&lt;/h4&gt;
 &lt;pre&gt;&lt;code&gt;DIR:
   Path to a package directory.  The directory must contain exactly
   one ConfigMap with the grouping object annotation.
-&lt;/code&gt;&lt;/pre&gt;
-&lt;h4 id=&#34;flags&#34;&gt;Flags&lt;/h4&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;h4 id=&#34;flags&#34;&gt;Flags&lt;/h4&gt;
 &lt;pre&gt;&lt;code&gt;--group-name:
   String name to group applied resources. Must be composed of valid
   label value characters. If not specified, the default group name
   is generated from the package directory name.
-&lt;/code&gt;&lt;/pre&gt;
-&lt;!--mdtogo--&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;!--mdtogo--&gt;
 
       </description>
     </item>
@@ -351,17 +343,14 @@ live cluster state.&lt;/p&gt;
 &lt;h3 id=&#34;synopsis&#34;&gt;Synopsis&lt;/h3&gt;
 &lt;!--mdtogo:Long--&gt;
 &lt;pre&gt;&lt;code&gt;kpt live preview DIRECTORY [flags]
-&lt;/code&gt;&lt;/pre&gt;
-&lt;h4 id=&#34;args&#34;&gt;Args&lt;/h4&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;h4 id=&#34;args&#34;&gt;Args&lt;/h4&gt;
 &lt;pre&gt;&lt;code&gt;DIRECTORY:
   One directory that contain k8s manifests. The directory
   must contain exactly one ConfigMap with the grouping object annotation.
-&lt;/code&gt;&lt;/pre&gt;
-&lt;h4 id=&#34;flags&#34;&gt;Flags&lt;/h4&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;h4 id=&#34;flags&#34;&gt;Flags&lt;/h4&gt;
 &lt;pre&gt;&lt;code&gt;--destroy:
   If true, dry-run deletion of all resources.
-&lt;/code&gt;&lt;/pre&gt;
-&lt;!--mdtogo--&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;!--mdtogo--&gt;
 
       </description>
     </item>

--- a/docs/reference/live/init/index.html
+++ b/docs/reference/live/init/index.html
@@ -883,19 +883,16 @@ such as apply, preview and destroy.</p>
 <h3 id="synopsis">Synopsis</h3>
 <!--mdtogo:Long-->
 <pre><code>kpt live init DIRECTORY [flags]
-</code></pre>
-<h4 id="args">Args</h4>
+</code></pre><h4 id="args">Args</h4>
 <pre><code>DIR:
   Path to a package directory.  The directory must contain exactly
   one ConfigMap with the grouping object annotation.
-</code></pre>
-<h4 id="flags">Flags</h4>
+</code></pre><h4 id="flags">Flags</h4>
 <pre><code>--group-name:
   String name to group applied resources. Must be composed of valid
   label value characters. If not specified, the default group name
   is generated from the package directory name.
-</code></pre>
-<!--mdtogo-->
+</code></pre><!--mdtogo-->
 
         <div class="section-index">
     
@@ -963,7 +960,7 @@ such as apply, preview and destroy.</p>
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 20, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/fec483d839a5bc76a59844427cecb3786ff73702">Scripts and recordings for live commands (fec483d8)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified March 22, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4397847ac7f8c642d62df6ef5123189ff5bb89e2">Fix indentation in generated Long message (4397847a)</a>
 </div>
 </div>
 

--- a/docs/reference/live/preview/index.html
+++ b/docs/reference/live/preview/index.html
@@ -881,17 +881,14 @@ live cluster state.</p>
 <h3 id="synopsis">Synopsis</h3>
 <!--mdtogo:Long-->
 <pre><code>kpt live preview DIRECTORY [flags]
-</code></pre>
-<h4 id="args">Args</h4>
+</code></pre><h4 id="args">Args</h4>
 <pre><code>DIRECTORY:
   One directory that contain k8s manifests. The directory
   must contain exactly one ConfigMap with the grouping object annotation.
-</code></pre>
-<h4 id="flags">Flags</h4>
+</code></pre><h4 id="flags">Flags</h4>
 <pre><code>--destroy:
   If true, dry-run deletion of all resources.
-</code></pre>
-<!--mdtogo-->
+</code></pre><!--mdtogo-->
 
         <div class="section-index">
     
@@ -959,7 +956,7 @@ live cluster state.</p>
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 20, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/fec483d839a5bc76a59844427cecb3786ff73702">Scripts and recordings for live commands (fec483d8)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified March 22, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4397847ac7f8c642d62df6ef5123189ff5bb89e2">Fix indentation in generated Long message (4397847a)</a>
 </div>
 </div>
 

--- a/docs/reference/pkg/desc/index.html
+++ b/docs/reference/pkg/desc/index.html
@@ -855,8 +855,7 @@ kpt pkg desc hello-world/
 
 DIR:
   Path to a package directory
-</code></pre>
-<!--mdtogo-->
+</code></pre><!--mdtogo-->
 
         <div class="section-index">
     
@@ -924,7 +923,7 @@ DIR:
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 19, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/b5797b1a0ef0f8d4967962e5168222753d2efbd1">Update the reference site content with mdtogo html comments (b5797b1a)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified March 22, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4397847ac7f8c642d62df6ef5123189ff5bb89e2">Fix indentation in generated Long message (4397847a)</a>
 </div>
 </div>
 

--- a/docs/reference/pkg/diff/index.html
+++ b/docs/reference/pkg/diff/index.html
@@ -870,8 +870,7 @@ kpt pkg diff @v4.0.0 --diff-type 3way --diff-tool meld --diff-tool-opts <span st
 <h3 id="synopsis">Synopsis</h3>
 <!--mdtogo:Long-->
 <pre><code>kpt pkg diff [DIR@VERSION]
-</code></pre>
-<h4 id="args">Args</h4>
+</code></pre><h4 id="args">Args</h4>
 <pre><code>DIR:
   Local package to compare. Command will fail if the directory doesn't exist, or does not
   contain a Kptfile.  Defaults to the current working directory.
@@ -879,8 +878,7 @@ kpt pkg diff @v4.0.0 --diff-type 3way --diff-tool meld --diff-tool-opts <span st
 VERSION:
   A git tag, branch, ref or commit. Specified after the local_package with @ -- pkg_dir@version.
   Defaults to the local package version that was last fetched.
-</code></pre>
-<h4 id="flags">Flags</h4>
+</code></pre><h4 id="flags">Flags</h4>
 <pre><code>--diff-type:
   The type of changes to view (local by default). Following types are
   supported:
@@ -906,8 +904,7 @@ VERSION:
   Note that it overrides the KPT_EXTERNAL_DIFF_OPTS environment variable.
   # Show changes using &quot;diff&quot; with recurive options
   kpt pkg diff @master --diff-tool meld --diff-opts &quot;-r&quot;
-</code></pre>
-<h4 id="environment-variables">Environment Variables</h4>
+</code></pre><h4 id="environment-variables">Environment Variables</h4>
 <pre><code>KPT_EXTERNAL_DIFF:
    Commandline diffing tool (diff by default) that will be used to show
    changes.
@@ -918,8 +915,7 @@ KPT_EXTERNAL_DIFF_OPTS:
    Commandline options to use for the diffing tool. For ex.
    # Using &quot;-a&quot; diff option
    KPT_EXTERNAL_DIFF_OPTS=&quot;-a&quot; kpt pkg diff --diff-tool meld
-</code></pre>
-<!--mdtogo-->
+</code></pre><!--mdtogo-->
 
         <div class="section-index">
     
@@ -987,7 +983,7 @@ KPT_EXTERNAL_DIFF_OPTS:
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 19, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/b5797b1a0ef0f8d4967962e5168222753d2efbd1">Update the reference site content with mdtogo html comments (b5797b1a)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified March 22, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4397847ac7f8c642d62df6ef5123189ff5bb89e2">Fix indentation in generated Long message (4397847a)</a>
 </div>
 </div>
 

--- a/docs/reference/pkg/get/index.html
+++ b/docs/reference/pkg/get/index.html
@@ -926,8 +926,7 @@ LOCAL_DEST_DIRECTORY:
       specified one, defaulting the name to the Base of REPO/PKG_PATH
     * If the directory DOES exist and already contains a directory with
       the same name of the one that would be created: fail
-</code></pre>
-<!--mdtogo-->
+</code></pre><!--mdtogo-->
 
         <div class="section-index">
     
@@ -995,7 +994,7 @@ LOCAL_DEST_DIRECTORY:
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 19, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/b5797b1a0ef0f8d4967962e5168222753d2efbd1">Update the reference site content with mdtogo html comments (b5797b1a)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified March 22, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4397847ac7f8c642d62df6ef5123189ff5bb89e2">Fix indentation in generated Long message (4397847a)</a>
 </div>
 </div>
 

--- a/docs/reference/pkg/index.xml
+++ b/docs/reference/pkg/index.xml
@@ -37,8 +37,7 @@ kpt pkg desc hello-world/
 
 DIR:
   Path to a package directory
-&lt;/code&gt;&lt;/pre&gt;
-&lt;!--mdtogo--&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;!--mdtogo--&gt;
 
       </description>
     </item>
@@ -82,8 +81,7 @@ kpt pkg diff @v4.0.0 --diff-type 3way --diff-tool meld --diff-tool-opts &lt;span
 &lt;h3 id=&#34;synopsis&#34;&gt;Synopsis&lt;/h3&gt;
 &lt;!--mdtogo:Long--&gt;
 &lt;pre&gt;&lt;code&gt;kpt pkg diff [DIR@VERSION]
-&lt;/code&gt;&lt;/pre&gt;
-&lt;h4 id=&#34;args&#34;&gt;Args&lt;/h4&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;h4 id=&#34;args&#34;&gt;Args&lt;/h4&gt;
 &lt;pre&gt;&lt;code&gt;DIR:
   Local package to compare. Command will fail if the directory doesn&#39;t exist, or does not
   contain a Kptfile.  Defaults to the current working directory.
@@ -91,8 +89,7 @@ kpt pkg diff @v4.0.0 --diff-type 3way --diff-tool meld --diff-tool-opts &lt;span
 VERSION:
   A git tag, branch, ref or commit. Specified after the local_package with @ -- pkg_dir@version.
   Defaults to the local package version that was last fetched.
-&lt;/code&gt;&lt;/pre&gt;
-&lt;h4 id=&#34;flags&#34;&gt;Flags&lt;/h4&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;h4 id=&#34;flags&#34;&gt;Flags&lt;/h4&gt;
 &lt;pre&gt;&lt;code&gt;--diff-type:
   The type of changes to view (local by default). Following types are
   supported:
@@ -118,8 +115,7 @@ VERSION:
   Note that it overrides the KPT_EXTERNAL_DIFF_OPTS environment variable.
   # Show changes using &amp;quot;diff&amp;quot; with recurive options
   kpt pkg diff @master --diff-tool meld --diff-opts &amp;quot;-r&amp;quot;
-&lt;/code&gt;&lt;/pre&gt;
-&lt;h4 id=&#34;environment-variables&#34;&gt;Environment Variables&lt;/h4&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;h4 id=&#34;environment-variables&#34;&gt;Environment Variables&lt;/h4&gt;
 &lt;pre&gt;&lt;code&gt;KPT_EXTERNAL_DIFF:
    Commandline diffing tool (diff by default) that will be used to show
    changes.
@@ -130,8 +126,7 @@ KPT_EXTERNAL_DIFF_OPTS:
    Commandline options to use for the diffing tool. For ex.
    # Using &amp;quot;-a&amp;quot; diff option
    KPT_EXTERNAL_DIFF_OPTS=&amp;quot;-a&amp;quot; kpt pkg diff --diff-tool meld
-&lt;/code&gt;&lt;/pre&gt;
-&lt;!--mdtogo--&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;!--mdtogo--&gt;
 
       </description>
     </item>
@@ -231,8 +226,7 @@ LOCAL_DEST_DIRECTORY:
       specified one, defaulting the name to the Base of REPO/PKG_PATH
     * If the directory DOES exist and already contains a directory with
       the same name of the one that would be created: fail
-&lt;/code&gt;&lt;/pre&gt;
-&lt;!--mdtogo--&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;!--mdtogo--&gt;
 
       </description>
     </item>
@@ -307,12 +301,10 @@ kpt pkg init my-pkg --tag kpt.dev/app&lt;span style=&#34;color:#ce5c00;font-weig
 &lt;h3 id=&#34;synopsis&#34;&gt;Synopsis&lt;/h3&gt;
 &lt;!--mdtogo:Long--&gt;
 &lt;pre&gt;&lt;code&gt;kpt pkg init DIR [flags]
-&lt;/code&gt;&lt;/pre&gt;
-&lt;h4 id=&#34;args&#34;&gt;Args&lt;/h4&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;h4 id=&#34;args&#34;&gt;Args&lt;/h4&gt;
 &lt;pre&gt;&lt;code&gt;DIR:
   Init fails if DIR does not already exist
-&lt;/code&gt;&lt;/pre&gt;
-&lt;h4 id=&#34;flags&#34;&gt;Flags&lt;/h4&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;h4 id=&#34;flags&#34;&gt;Flags&lt;/h4&gt;
 &lt;pre&gt;&lt;code&gt;--description
   short description of the package. (default &amp;quot;sample description&amp;quot;)
 
@@ -324,8 +316,7 @@ kpt pkg init my-pkg --tag kpt.dev/app&lt;span style=&#34;color:#ce5c00;font-weig
 
 --url
   link to page with information about the package.
-&lt;/code&gt;&lt;/pre&gt;
-&lt;!--mdtogo--&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;!--mdtogo--&gt;
 
       </description>
     </item>
@@ -398,8 +389,7 @@ kpt pkg  update my-package-dir/@master --strategy alpha-git-patch
 &lt;h3 id=&#34;synopsis&#34;&gt;Synopsis&lt;/h3&gt;
 &lt;!--mdtogo:Long--&gt;
 &lt;pre&gt;&lt;code&gt;kpt pkg update LOCAL_PKG_DIR[@VERSION] [flags]
-&lt;/code&gt;&lt;/pre&gt;
-&lt;h4 id=&#34;args&#34;&gt;Args&lt;/h4&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;h4 id=&#34;args&#34;&gt;Args&lt;/h4&gt;
 &lt;pre&gt;&lt;code&gt;LOCAL_PKG_DIR:
   Local package to update.  Directory must exist and contain a Kptfile
   to be updated.
@@ -413,8 +403,7 @@ VERSION:
     * branch: update the local contents to the tip of the remote branch
     * tag: update the local contents to the remote tag
     * commit: update the local contents to the remote commit
-&lt;/code&gt;&lt;/pre&gt;
-&lt;h4 id=&#34;flags&#34;&gt;Flags&lt;/h4&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;h4 id=&#34;flags&#34;&gt;Flags&lt;/h4&gt;
 &lt;pre&gt;&lt;code&gt;--strategy:
   Controls how changes to the local package are handled.  Defaults to fast-forward.
 
@@ -435,14 +424,12 @@ VERSION:
 
 --dry-run
   Print the &#39;alpha-git-patch&#39; strategy patch rather than merging it.
-&lt;/code&gt;&lt;/pre&gt;
-&lt;h4 id=&#34;env-vars&#34;&gt;Env Vars&lt;/h4&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;h4 id=&#34;env-vars&#34;&gt;Env Vars&lt;/h4&gt;
 &lt;pre&gt;&lt;code&gt;KPT_CACHE_DIR:
   Controls where to cache remote packages when fetching them to update
   local packages.
   Defaults to ~/.kpt/repos/
-&lt;/code&gt;&lt;/pre&gt;
-&lt;!--mdtogo--&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;!--mdtogo--&gt;
 
       </description>
     </item>

--- a/docs/reference/pkg/init/index.html
+++ b/docs/reference/pkg/init/index.html
@@ -901,12 +901,10 @@ kpt pkg init my-pkg --tag kpt.dev/app<span style="color:#ce5c00;font-weight:bold
 <h3 id="synopsis">Synopsis</h3>
 <!--mdtogo:Long-->
 <pre><code>kpt pkg init DIR [flags]
-</code></pre>
-<h4 id="args">Args</h4>
+</code></pre><h4 id="args">Args</h4>
 <pre><code>DIR:
   Init fails if DIR does not already exist
-</code></pre>
-<h4 id="flags">Flags</h4>
+</code></pre><h4 id="flags">Flags</h4>
 <pre><code>--description
   short description of the package. (default &quot;sample description&quot;)
 
@@ -918,8 +916,7 @@ kpt pkg init my-pkg --tag kpt.dev/app<span style="color:#ce5c00;font-weight:bold
 
 --url
   link to page with information about the package.
-</code></pre>
-<!--mdtogo-->
+</code></pre><!--mdtogo-->
 
         <div class="section-index">
     
@@ -987,7 +984,7 @@ kpt pkg init my-pkg --tag kpt.dev/app<span style="color:#ce5c00;font-weight:bold
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 19, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/b5797b1a0ef0f8d4967962e5168222753d2efbd1">Update the reference site content with mdtogo html comments (b5797b1a)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified March 22, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4397847ac7f8c642d62df6ef5123189ff5bb89e2">Fix indentation in generated Long message (4397847a)</a>
 </div>
 </div>
 

--- a/docs/reference/pkg/update/index.html
+++ b/docs/reference/pkg/update/index.html
@@ -899,8 +899,7 @@ kpt pkg  update my-package-dir/@master --strategy alpha-git-patch
 <h3 id="synopsis">Synopsis</h3>
 <!--mdtogo:Long-->
 <pre><code>kpt pkg update LOCAL_PKG_DIR[@VERSION] [flags]
-</code></pre>
-<h4 id="args">Args</h4>
+</code></pre><h4 id="args">Args</h4>
 <pre><code>LOCAL_PKG_DIR:
   Local package to update.  Directory must exist and contain a Kptfile
   to be updated.
@@ -914,8 +913,7 @@ VERSION:
     * branch: update the local contents to the tip of the remote branch
     * tag: update the local contents to the remote tag
     * commit: update the local contents to the remote commit
-</code></pre>
-<h4 id="flags">Flags</h4>
+</code></pre><h4 id="flags">Flags</h4>
 <pre><code>--strategy:
   Controls how changes to the local package are handled.  Defaults to fast-forward.
 
@@ -936,14 +934,12 @@ VERSION:
 
 --dry-run
   Print the 'alpha-git-patch' strategy patch rather than merging it.
-</code></pre>
-<h4 id="env-vars">Env Vars</h4>
+</code></pre><h4 id="env-vars">Env Vars</h4>
 <pre><code>KPT_CACHE_DIR:
   Controls where to cache remote packages when fetching them to update
   local packages.
   Defaults to ~/.kpt/repos/
-</code></pre>
-<!--mdtogo-->
+</code></pre><!--mdtogo-->
 
         <div class="section-index">
     
@@ -1011,7 +1007,7 @@ VERSION:
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 19, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/b5797b1a0ef0f8d4967962e5168222753d2efbd1">Update the reference site content with mdtogo html comments (b5797b1a)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified March 22, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4397847ac7f8c642d62df6ef5123189ff5bb89e2">Fix indentation in generated Long message (4397847a)</a>
 </div>
 </div>
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -94,12 +94,12 @@
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/cfg/annotate/</loc>
-    <lastmod>2020-03-19T21:01:23-07:00</lastmod>
+    <lastmod>2020-03-22T23:09:14-07:00</lastmod>
   </url>
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/cfg/cat/</loc>
-    <lastmod>2020-03-19T21:01:23-07:00</lastmod>
+    <lastmod>2020-03-22T23:09:14-07:00</lastmod>
   </url>
   
   <url>
@@ -109,17 +109,17 @@
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/cfg/count/</loc>
-    <lastmod>2020-03-19T21:01:23-07:00</lastmod>
+    <lastmod>2020-03-22T23:09:14-07:00</lastmod>
   </url>
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/cfg/create-setter/</loc>
-    <lastmod>2020-03-19T21:01:23-07:00</lastmod>
+    <lastmod>2020-03-22T23:09:14-07:00</lastmod>
   </url>
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/cfg/create-subst/</loc>
-    <lastmod>2020-03-19T21:01:23-07:00</lastmod>
+    <lastmod>2020-03-22T23:09:14-07:00</lastmod>
   </url>
   
   <url>
@@ -129,7 +129,7 @@
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/cfg/fmt/</loc>
-    <lastmod>2020-03-19T21:01:23-07:00</lastmod>
+    <lastmod>2020-03-22T23:09:14-07:00</lastmod>
   </url>
   
   <url>
@@ -139,12 +139,12 @@
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/cfg/grep/</loc>
-    <lastmod>2020-03-19T21:01:23-07:00</lastmod>
+    <lastmod>2020-03-22T23:09:14-07:00</lastmod>
   </url>
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/cfg/list-setters/</loc>
-    <lastmod>2020-03-19T21:01:23-07:00</lastmod>
+    <lastmod>2020-03-22T23:09:14-07:00</lastmod>
   </url>
   
   <url>
@@ -154,7 +154,7 @@
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/cfg/set/</loc>
-    <lastmod>2020-03-19T21:01:23-07:00</lastmod>
+    <lastmod>2020-03-22T23:09:14-07:00</lastmod>
   </url>
   
   <url>
@@ -169,7 +169,7 @@
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/cfg/tree/</loc>
-    <lastmod>2020-03-19T21:01:23-07:00</lastmod>
+    <lastmod>2020-03-22T23:09:14-07:00</lastmod>
   </url>
   
   <url>
@@ -229,37 +229,37 @@
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/live/apply/</loc>
-    <lastmod>2020-03-20T15:16:12-07:00</lastmod>
+    <lastmod>2020-03-22T23:09:14-07:00</lastmod>
   </url>
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/pkg/desc/</loc>
-    <lastmod>2020-03-19T21:01:23-07:00</lastmod>
+    <lastmod>2020-03-22T23:09:14-07:00</lastmod>
   </url>
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/live/destroy/</loc>
-    <lastmod>2020-03-20T15:16:12-07:00</lastmod>
+    <lastmod>2020-03-22T23:09:14-07:00</lastmod>
   </url>
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/pkg/diff/</loc>
-    <lastmod>2020-03-19T21:01:23-07:00</lastmod>
+    <lastmod>2020-03-22T23:09:14-07:00</lastmod>
   </url>
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/pkg/get/</loc>
-    <lastmod>2020-03-19T21:01:23-07:00</lastmod>
+    <lastmod>2020-03-22T23:09:14-07:00</lastmod>
   </url>
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/live/init/</loc>
-    <lastmod>2020-03-20T15:16:12-07:00</lastmod>
+    <lastmod>2020-03-22T23:09:14-07:00</lastmod>
   </url>
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/pkg/init/</loc>
-    <lastmod>2020-03-19T21:01:23-07:00</lastmod>
+    <lastmod>2020-03-22T23:09:14-07:00</lastmod>
   </url>
   
   <url>
@@ -269,12 +269,12 @@
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/live/preview/</loc>
-    <lastmod>2020-03-20T15:16:12-07:00</lastmod>
+    <lastmod>2020-03-22T23:09:14-07:00</lastmod>
   </url>
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/fn/run/</loc>
-    <lastmod>2020-03-19T21:01:23-07:00</lastmod>
+    <lastmod>2020-03-22T23:09:14-07:00</lastmod>
   </url>
   
   <url>
@@ -284,17 +284,17 @@
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/fn/sink/</loc>
-    <lastmod>2020-03-19T21:01:23-07:00</lastmod>
+    <lastmod>2020-03-22T23:09:14-07:00</lastmod>
   </url>
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/fn/source/</loc>
-    <lastmod>2020-03-19T21:01:23-07:00</lastmod>
+    <lastmod>2020-03-22T23:09:14-07:00</lastmod>
   </url>
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/pkg/update/</loc>
-    <lastmod>2020-03-19T21:01:23-07:00</lastmod>
+    <lastmod>2020-03-22T23:09:14-07:00</lastmod>
   </url>
   
 </urlset>

--- a/internal/docs/generated/cfgdocs/docs.go
+++ b/internal/docs/generated/cfgdocs/docs.go
@@ -53,30 +53,28 @@ var CfgExamples = `
 
 var AnnotateShort = `Set an annotation on one or more resources`
 var AnnotateLong = `
-    kpt cfg annotate DIR --kv KEY=VALUE...
+  kpt cfg annotate DIR --kv KEY=VALUE...
 
-#### Args
+Args:
+  DIR:
+    Path to a package directory
 
-    DIR:
-      Path to a package directory
-
-#### Flags
-
-    --apiVersion
-      Only set annotations on resources with this apiVersion.
-
-    --kind
-      Only set annotations on resources of this kind.
-
-    --kv
-      The annotation key and value to set.  May be specified multiple times
-      to set multiple annotations at once.
-
-    --namespace
-      Only set annotations on resources in this namespace.
-
-    --namespace
-      Only set annotations on resources with this name.
+Flags:
+  --apiVersion
+    Only set annotations on resources with this apiVersion.
+  
+  --kind
+    Only set annotations on resources of this kind.
+  
+  --kv
+    The annotation key and value to set.  May be specified multiple times
+    to set multiple annotations at once.
+  
+  --namespace
+    Only set annotations on resources in this namespace.
+  
+  --namespace
+    Only set annotations on resources with this name.
 `
 var AnnotateExamples = `
   # set an annotation on all Resources: 'key: value'
@@ -94,10 +92,10 @@ var AnnotateExamples = `
 
 var CatShort = `Print the resources in a package`
 var CatLong = `
-    kpt cfg cat DIR
-
-    DIR:
-      Path to a package directory
+  kpt cfg cat DIR
+  
+  DIR:
+    Path to a package directory
 `
 var CatExamples = `
   # print Resource config from a directory
@@ -106,10 +104,10 @@ var CatExamples = `
 
 var CountShort = `Print resource counts for a package`
 var CountLong = `
-    kpt cfg count [DIR]
-
-    DIR:
-      Path to a package directory.  Defaults to stdin if unspecified.
+  kpt cfg count [DIR]
+  
+  DIR:
+    Path to a package directory.  Defaults to stdin if unspecified.
 `
 var CountExamples = `
   # print Resource counts from a directory
@@ -121,19 +119,19 @@ var CountExamples = `
 
 var CreateSetterShort = `Create a setter for one or more field`
 var CreateSetterLong = `
-    kpt cfg create-setter DIR NAME VALUE
-
-    DIR:
-      Path to a package directory
-
-    NAME:
-      The name of the substitution to create.  This is both the name that will
-      be given to the *set* command, and that will be referenced by fields.
-      e.g. replicas
-
-    VALUE
-      The new value of the setter.
-      e.g. 3
+  kpt cfg create-setter DIR NAME VALUE
+  
+  DIR:
+    Path to a package directory
+  
+  NAME:
+    The name of the substitution to create.  This is both the name that will
+    be given to the *set* command, and that will be referenced by fields.
+    e.g. replicas
+  
+  VALUE
+    The new value of the setter.
+    e.g. 3
 `
 var CreateSetterExamples = `
   # create a setter called replicas for fields matching "3"
@@ -158,26 +156,26 @@ var CreateSetterExamples = `
 
 var CreateSubstShort = `Create a substitution for one or more fields`
 var CreateSubstLong = `
-    kpt cfg create-subst DIR NAME VALUE --pattern PATTERN --value MARKER=SETTER
-
-    DIR
-      Path to a package directory
-
-    NAME
-      The name of the substitution to create.  This is simply the unique key
-      which is referenced by fields which have the substitution applied.
-      e.g. image-substitution
-
-    VALUE
-      The current value of the field that will have PATTERN substituted.
-      e.g. nginx:1.7.9
-
-    PATTERN
-      A string containing one or more MARKER substrings which will be
-      substituted for setter values.  The pattern may contain multiple
-      different MARKERS, the same MARKER multiple times, and non-MARKER
-      substrings.
-      e.g. IMAGE_SETTER:TAG_SETTER
+  kpt cfg create-subst DIR NAME VALUE --pattern PATTERN --value MARKER=SETTER
+  
+  DIR
+    Path to a package directory
+  
+  NAME
+    The name of the substitution to create.  This is simply the unique key
+    which is referenced by fields which have the substitution applied.
+    e.g. image-substitution
+  
+  VALUE
+    The current value of the field that will have PATTERN substituted.
+    e.g. nginx:1.7.9
+  
+  PATTERN
+    A string containing one or more MARKER substrings which will be
+    substituted for setter values.  The pattern may contain multiple
+    different MARKERS, the same MARKER multiple times, and non-MARKER
+    substrings.
+    e.g. IMAGE_SETTER:TAG_SETTER
 `
 var CreateSubstExamples = `
   
@@ -221,10 +219,10 @@ var CreateSubstExamples = `
 
 var FmtShort = `Format configuration files`
 var FmtLong = `
-    kpt cfg fmt [DIR]
-
-    DIR:
-      Path to a package directory.  Reads from STDIN if not provided.
+  kpt cfg fmt [DIR]
+  
+  DIR:
+    Path to a package directory.  Reads from STDIN if not provided.
 `
 var FmtExamples = `
   # format file1.yaml and file2.yml
@@ -242,24 +240,22 @@ var FmtExamples = `
 
 var GrepShort = `Filter resources by their field values`
 var GrepLong = `
-    kpt cfg grep QUERY DIR
+  kpt cfg grep QUERY DIR
 
-#### Args
+Args:
+      QUERY:
+        Query to match expressed as 'path.to.field=value'.
+        Maps and fields are matched as '.field-name' or '.map-key'
+        List elements are matched as '[list-elem-field=field-value]'
+        The value to match is expressed as '=value'
+        '.' as part of a key or value can be escaped as '\.'
+  
+      DIR:
+        Path to a package directory
 
-    QUERY:
-      Query to match expressed as 'path.to.field=value'.
-      Maps and fields are matched as '.field-name' or '.map-key'
-      List elements are matched as '[list-elem-field=field-value]'
-      The value to match is expressed as '=value'
-      '.' as part of a key or value can be escaped as '\.'
-
-    DIR:
-      Path to a package directory
-
-#### Flags
-
-    --invert-match, -v
-      keep resources NOT matching the specified pattern
+Flags:
+      --invert-match, -v
+        keep resources NOT matching the specified pattern
 `
 var GrepExamples = `
   # find Deployment Resources
@@ -278,13 +274,13 @@ var GrepExamples = `
 
 var ListSettersShort = `List setters for a package`
 var ListSettersLong = `
-    kpt cfg list-setters DIR [NAME]
-
-    DIR
-      Path to a package directory
-
-    NAME
-      Optional.  The name of the setter to display.
+  kpt cfg list-setters DIR [NAME]
+  
+  DIR
+    Path to a package directory
+  
+  NAME
+    Optional.  The name of the setter to display.
 `
 var ListSettersExamples = `
   # list the setters in the hello-world package
@@ -296,27 +292,25 @@ var ListSettersExamples = `
 
 var SetShort = `Set one or more field values`
 var SetLong = `
-    kpt cfg set DIR NAME VALUE
+  kpt cfg set DIR NAME VALUE
 
-#### Args
+Args:
+  DIR
+    Path to a package directory. e.g. hello-world/
+  
+  NAME
+    The name of the setter. e.g. replicas
+  
+  VALUE
+    The new value to set on fields. e.g. 3
 
-    DIR
-      Path to a package directory. e.g. hello-world/
-
-    NAME
-      The name of the setter. e.g. replicas
-
-    VALUE
-      The new value to set on fields. e.g. 3
-
-#### Flags
-
-    --description
-      Optional description about the value.
-
-    --set-by
-      Optional record of who set the value.  Clears the last set-by
-      value if unset.
+Flags:
+  --description
+    Optional description about the value.
+  
+  --set-by
+    Optional record of who set the value.  Clears the last set-by
+    value if unset.
 `
 var SetExamples = `
   # set replicas to 3 using the 'replicas' setter
@@ -335,41 +329,39 @@ var SetExamples = `
 
 var TreeShort = `Render resources using a tree structure`
 var TreeLong = `
-    kpt cfg tree [DIR] [flags]
+  kpt cfg tree [DIR] [flags]
 
-#### Args
+Args:
+  DIR:
+    Path to a package directory.  Defaults to STDIN if not specified.
 
-    DIR:
-      Path to a package directory.  Defaults to STDIN if not specified.
-
-#### Flags
-
-    --args:
-      if true, print the container args field
-
-    --command:
-      if true, print the container command field
-
-    --env:
-      if true, print the container env field
-
-    --field:
-      dot-separated path to a field to print
-
-    --image:
-      if true, print the container image fields
-
-    --name:
-      if true, print the container name fields
-
-    --ports:
-      if true, print the container port fields
-
-    --replicas:
-      if true, print the replica field
-
-    --resources:
-      if true, print the resource reservations
+Flags:
+  --args:
+    if true, print the container args field
+  
+  --command:
+    if true, print the container command field
+  
+  --env:
+    if true, print the container env field
+  
+  --field:
+    dot-separated path to a field to print
+  
+  --image:
+    if true, print the container image fields
+  
+  --name:
+    if true, print the container name fields
+  
+  --ports:
+    if true, print the container port fields
+  
+  --replicas:
+    if true, print the replica field
+  
+  --resources:
+    if true, print the resource reservations
 `
 var TreeExamples = `
   # print Resources using directory structure

--- a/internal/docs/generated/fndocs/docs.go
+++ b/internal/docs/generated/fndocs/docs.go
@@ -39,13 +39,13 @@ var FnExamples = `
 
 var RunShort = `Locally execute one or more functions in containers`
 var RunLong = `
-    kpt fn run DIR [flags]
+  kpt fn run DIR [flags]
 
 If the container exits with non-zero status code, run will fail and print the
 container ` + "`" + `STDERR` + "`" + `.
 
-    DIR:
-      Path to a package directory.  Defaults to stdin if unspecified.
+  DIR:
+    Path to a package directory.  Defaults to stdin if unspecified.
 `
 var RunExamples = `
   # read the Resources from DIR, provide them to a container my-fun as input,
@@ -65,10 +65,10 @@ var RunExamples = `
 
 var SinkShort = `Explicitly specify an output sink for a function`
 var SinkLong = `
-    kpt fn sink [DIR]
-
-    DIR:
-      Path to a package directory.  Defaults to stdout if unspecified.
+  kpt fn sink [DIR]
+  
+  DIR:
+    Path to a package directory.  Defaults to stdout if unspecified.
 `
 var SinkExamples = `
   # run a function using explicit sources and sinks
@@ -77,10 +77,10 @@ var SinkExamples = `
 
 var SourceShort = `Explicitly specify an output source for a function`
 var SourceLong = `
-    kpt fn source [DIR...]
-
-    DIR:
-      Path to a package directory.  Defaults to stdin if unspecified.
+  kpt fn source [DIR...]
+  
+  DIR:
+    Path to a package directory.  Defaults to stdin if unspecified.
 `
 var SourceExamples = `
   # print to stdout configuration formatted as an input source

--- a/internal/docs/generated/livedocs/docs.go
+++ b/internal/docs/generated/livedocs/docs.go
@@ -28,71 +28,64 @@ deploying local configuration packages to a cluster.
 
 var ApplyShort = `Apply a package to the cluster (create, update, delete)`
 var ApplyLong = `
-    kpt live apply DIR [flags]
+  kpt live apply DIR [flags]
 
-#### Args
+Args:
+  DIR:
+    Path to a package directory.  The directory must contain exactly
+    one ConfigMap with the grouping object annotation.
 
-    DIR:
-      Path to a package directory.  The directory must contain exactly
-      one ConfigMap with the grouping object annotation.
-
-#### Flags:
-
-    --wait-for-reconcile:
-      If true, after all resources have been applied, the cluster will
-      be polled until either all resources have been fully reconciled
-      or the timeout is reached.
-
-    --wait-polling-period:
-      The frequency with which the cluster will be polled to determine 
-      the status of the applied resources. The default value is every 2 seconds.
-
-    --wait-timeout:
-      The threshold for how long to wait for all resources to reconcile before
-      giving up. The default value is 1 minute.
+Flags::
+  --wait-for-reconcile:
+    If true, after all resources have been applied, the cluster will
+    be polled until either all resources have been fully reconciled
+    or the timeout is reached.
+  
+  --wait-polling-period:
+    The frequency with which the cluster will be polled to determine 
+    the status of the applied resources. The default value is every 2 seconds.
+  
+  --wait-timeout:
+    The threshold for how long to wait for all resources to reconcile before
+    giving up. The default value is 1 minute.
 `
 
 var DestroyShort = `Remove all previously applied resources in a package from the cluster`
 var DestroyLong = `
-    kpt live destroy DIR
+  kpt live destroy DIR
 
-#### Args
-
-    DIR:
-      Path to a package directory.  The directory must contain exactly
-      one ConfigMap with the grouping object annotation.
+Args:
+  DIR:
+    Path to a package directory.  The directory must contain exactly
+    one ConfigMap with the grouping object annotation.
 `
 
 var InitShort = `Initialize a package with a object to track previously applied resources`
 var InitLong = `
-    kpt live init DIRECTORY [flags]
+  kpt live init DIRECTORY [flags]
 
-#### Args
+Args:
+  DIR:
+    Path to a package directory.  The directory must contain exactly
+    one ConfigMap with the grouping object annotation.
 
-    DIR:
-      Path to a package directory.  The directory must contain exactly
-      one ConfigMap with the grouping object annotation.
-
-#### Flags
-
-    --group-name:
-      String name to group applied resources. Must be composed of valid
-      label value characters. If not specified, the default group name
-      is generated from the package directory name.
+Flags:
+  --group-name:
+    String name to group applied resources. Must be composed of valid
+    label value characters. If not specified, the default group name
+    is generated from the package directory name.
 `
 
 var PreviewShort = `Preview prints the changes apply would make to the cluster`
 var PreviewLong = `
-    kpt live preview DIRECTORY [flags]
+  kpt live preview DIRECTORY [flags]
 
-#### Args
+Args:
+  DIRECTORY:
+    One directory that contain k8s manifests. The directory
+    must contain exactly one ConfigMap with the grouping object annotation.
 
-    DIRECTORY:
-      One directory that contain k8s manifests. The directory
-      must contain exactly one ConfigMap with the grouping object annotation.
-
-#### Flags
-
-    --destroy:
-      If true, dry-run deletion of all resources.
+Flags:
+  --destroy:
+    If true, dry-run deletion of all resources.
 `

--- a/internal/docs/generated/pkgdocs/docs.go
+++ b/internal/docs/generated/pkgdocs/docs.go
@@ -47,10 +47,10 @@ var PkgExamples = `
 
 var DescShort = `Display upstream package metadata`
 var DescLong = `
-    kpt pkg desc DIR
-
-    DIR:
-      Path to a package directory
+  kpt pkg desc DIR
+  
+  DIR:
+    Path to a package directory
 `
 var DescExamples = `
   # display description for the local hello-world package
@@ -59,58 +59,55 @@ var DescExamples = `
 
 var DiffShort = `Diff a local package against upstream`
 var DiffLong = `
-    kpt pkg diff [DIR@VERSION]
+  kpt pkg diff [DIR@VERSION]
 
-#### Args
+Args:
+  DIR:
+    Local package to compare. Command will fail if the directory doesn't exist, or does not
+    contain a Kptfile.  Defaults to the current working directory.
+  
+  VERSION:
+    A git tag, branch, ref or commit. Specified after the local_package with @ -- pkg_dir@version.
+    Defaults to the local package version that was last fetched.
 
-    DIR:
-      Local package to compare. Command will fail if the directory doesn't exist, or does not
-      contain a Kptfile.  Defaults to the current working directory.
+Flags:
+  --diff-type:
+    The type of changes to view (local by default). Following types are
+    supported:
+  
+    local: shows changes in local package relative to upstream source package 
+           at original version
+    remote: shows changes in upstream source package at target version
+            relative to original version
+    combined: shows changes in local package relative to upstream source
+              package at target version
+    3way: shows changes in local package and source package at target version
+          relative to original version side by side
+  
+  --diff-tool:
+    Commandline tool (diff by default) for showing the changes.
+    Note that it overrides the KPT_EXTERNAL_DIFF environment variable.
+    
+    # Show changes using 'meld' commandline tool
+    kpt pkg diff @master --diff-tool meld
+  
+  --diff-opts:
+    Commandline options to use with the diffing tool.
+    Note that it overrides the KPT_EXTERNAL_DIFF_OPTS environment variable.
+    # Show changes using "diff" with recurive options
+    kpt pkg diff @master --diff-tool meld --diff-opts "-r"
 
-    VERSION:
-      A git tag, branch, ref or commit. Specified after the local_package with @ -- pkg_dir@version.
-      Defaults to the local package version that was last fetched.
-
-#### Flags
-
-    --diff-type:
-      The type of changes to view (local by default). Following types are
-      supported:
-
-	  local: shows changes in local package relative to upstream source package 
-	         at original version
-	  remote: shows changes in upstream source package at target version
-	          relative to original version
-	  combined: shows changes in local package relative to upstream source
-	            package at target version
-	  3way: shows changes in local package and source package at target version
-	        relative to original version side by side
-
-    --diff-tool:
-      Commandline tool (diff by default) for showing the changes.
-      Note that it overrides the KPT_EXTERNAL_DIFF environment variable.
-	  
-	  # Show changes using 'meld' commandline tool
-	  kpt pkg diff @master --diff-tool meld
-
-    --diff-opts:
-      Commandline options to use with the diffing tool.
-      Note that it overrides the KPT_EXTERNAL_DIFF_OPTS environment variable.
-	  # Show changes using "diff" with recurive options
-	  kpt pkg diff @master --diff-tool meld --diff-opts "-r"
-
-#### Environment Variables
-
-    KPT_EXTERNAL_DIFF:
-       Commandline diffing tool (diff by default) that will be used to show
-       changes.
-       # Use meld to show changes
-       KPT_EXTERNAL_DIFF=meld kpt pkg diff
-
-    KPT_EXTERNAL_DIFF_OPTS:
-       Commandline options to use for the diffing tool. For ex.
-       # Using "-a" diff option
-       KPT_EXTERNAL_DIFF_OPTS="-a" kpt pkg diff --diff-tool meld
+Environment Variables:
+  KPT_EXTERNAL_DIFF:
+     Commandline diffing tool (diff by default) that will be used to show
+     changes.
+     # Use meld to show changes
+     KPT_EXTERNAL_DIFF=meld kpt pkg diff
+  
+  KPT_EXTERNAL_DIFF_OPTS:
+     Commandline options to use for the diffing tool. For ex.
+     # Using "-a" diff option
+     KPT_EXTERNAL_DIFF_OPTS="-a" kpt pkg diff --diff-tool meld
 `
 var DiffExamples = `
   # Show changes in current package relative to upstream source package
@@ -134,39 +131,39 @@ var DiffExamples = `
 
 var GetShort = `Fetch a package from a git repo.`
 var GetLong = `
-    kpt pkg get REPO_URI[.git]/PKG_PATH[@VERSION] LOCAL_DEST_DIRECTORY [flags]
-
-    REPO_URI:
-      URI of a git repository containing 1 or more packages as subdirectories.
-      In most cases the .git suffix should be specified to delimit the REPO_URI
-      from the PKG_PATH, but this is not required for widely recognized repo
-      prefixes.  If get cannot parse the repo for the directory and version,
-      then it will print an error asking for '.git' to be specified as part of
-      the argument.
-      e.g. https://github.com/kubernetes/examples.git
-      Specify - to read Resources from stdin and write to a LOCAL_DEST_DIRECTORY
-
-    PKG_PATH:
-      Path to remote subdirectory containing Kubernetes resource configuration
-      files or directories. Defaults to the root directory.
-      Uses '/' as the path separator (regardless of OS).
-      e.g. staging/cockroachdb
-
-    VERSION:
-      A git tag, branch, ref or commit for the remote version of the package
-      to fetch.  Defaults to the repository master branch.
-      e.g. @master
-
-    LOCAL_DEST_DIRECTORY:
-      The local directory to write the package to.
-      e.g. ./my-cockroachdb-copy
-
-        * If the directory does NOT exist: create the specified directory
-          and write the package contents to it
-        * If the directory DOES exist: create a NEW directory under the
-          specified one, defaulting the name to the Base of REPO/PKG_PATH
-        * If the directory DOES exist and already contains a directory with
-          the same name of the one that would be created: fail
+  kpt pkg get REPO_URI[.git]/PKG_PATH[@VERSION] LOCAL_DEST_DIRECTORY [flags]
+  
+  REPO_URI:
+    URI of a git repository containing 1 or more packages as subdirectories.
+    In most cases the .git suffix should be specified to delimit the REPO_URI
+    from the PKG_PATH, but this is not required for widely recognized repo
+    prefixes.  If get cannot parse the repo for the directory and version,
+    then it will print an error asking for '.git' to be specified as part of
+    the argument.
+    e.g. https://github.com/kubernetes/examples.git
+    Specify - to read Resources from stdin and write to a LOCAL_DEST_DIRECTORY
+  
+  PKG_PATH:
+    Path to remote subdirectory containing Kubernetes resource configuration
+    files or directories. Defaults to the root directory.
+    Uses '/' as the path separator (regardless of OS).
+    e.g. staging/cockroachdb
+  
+  VERSION:
+    A git tag, branch, ref or commit for the remote version of the package
+    to fetch.  Defaults to the repository master branch.
+    e.g. @master
+  
+  LOCAL_DEST_DIRECTORY:
+    The local directory to write the package to.
+    e.g. ./my-cockroachdb-copy
+  
+      * If the directory does NOT exist: create the specified directory
+        and write the package contents to it
+      * If the directory DOES exist: create a NEW directory under the
+        specified one, defaulting the name to the Base of REPO/PKG_PATH
+      * If the directory DOES exist and already contains a directory with
+        the same name of the one that would be created: fail
 `
 var GetExamples = `
   # fetch package cockroachdb from github.com/kubernetes/examples/staging/cockroachdb
@@ -185,26 +182,24 @@ var GetExamples = `
 
 var InitShort = `Initialize an empty package`
 var InitLong = `
-    kpt pkg init DIR [flags]
+  kpt pkg init DIR [flags]
 
-#### Args
+Args:
+  DIR:
+    Init fails if DIR does not already exist
 
-    DIR:
-      Init fails if DIR does not already exist
-
-#### Flags
-
-    --description
-      short description of the package. (default "sample description")
-
-    --name
-      package name.  defaults to the directory base name.
-
-    --tag
-      list of tags for the package.
-
-    --url
-      link to page with information about the package.
+Flags:
+  --description
+    short description of the package. (default "sample description")
+  
+  --name
+    package name.  defaults to the directory base name.
+  
+  --tag
+    list of tags for the package.
+  
+  --url
+    link to page with information about the package.
 `
 var InitExamples = `
   # writes Kptfile package meta if not found
@@ -215,16 +210,14 @@ var InitExamples = `
 
 var SyncShort = `Fetch and update packages declaratively`
 var SyncLong = `
-    kpt pkg sync LOCAL_PKG_DIR [flags]
+  kpt pkg sync LOCAL_PKG_DIR [flags]
+  
+  LOCAL_PKG_DIR:
+    Local package with dependencies to sync.  Directory must exist and
+    contain a Kptfile.
 
-    LOCAL_PKG_DIR:
-      Local package with dependencies to sync.  Directory must exist and
-      contain a Kptfile.
-
-#### Env Vars
-
+Env Vars:
   KPT_CACHE_DIR:
-
     Controls where to cache remote packages during updates.
     Defaults to ~/.kpt/repos/
 `
@@ -238,60 +231,59 @@ var SyncExamples = `
 
 var SetShort = `Add a sync dependency to a Kptfile`
 var SetLong = `
-    kpt pkg set REPO_URI[.git]/PKG_PATH[@VERSION] LOCAL_DEST_DIRECTORY [flags]
+  kpt pkg set REPO_URI[.git]/PKG_PATH[@VERSION] LOCAL_DEST_DIRECTORY [flags]
+  
+  REPO_URI:
+    URI of a git repository containing 1 or more packages as subdirectories.
+    In most cases the .git suffix should be specified to delimit the REPO_URI
+    from the PKG_PATH, but this is not required for widely recognized repo
+    prefixes.  If get cannot parse the repo for the directory and version, 
+    then it will print an error asking for '.git' to be specified as part of
+    the argument.
+    e.g. https://github.com/kubernetes/examples.git
+    Specify - to read Resources from stdin and write to a LOCAL_DEST_DIRECTORY
+  
+  PKG_PATH:
+    Path to remote subdirectory containing Kubernetes Resource configuration
+    files or directories.  Defaults to the root directory.
+    Uses '/' as the path separator (regardless of OS).
+    e.g. staging/cockroachdb
+  
+  VERSION:
+    A git tag, branch, ref or commit for the remote version of the package to
+    fetch.  Defaults to the repository master branch.
+    e.g. @master
+  
+  LOCAL_DEST_DIRECTORY:
+    The local directory to write the package to. e.g. ./my-cockroachdb-copy
+  
+      * If the directory does NOT exist: create the specified directory and write
+        the package contents to it
+      * If the directory DOES exist: create a NEW directory under the specified one,
+        defaulting the name to the Base of REPO/PKG_PATH
+      * If the directory DOES exist and already contains a directory with the same name
+        of the one that would be created: fail
 
-    REPO_URI:
-      URI of a git repository containing 1 or more packages as subdirectories.
-      In most cases the .git suffix should be specified to delimit the REPO_URI
-      from the PKG_PATH, but this is not required for widely recognized repo
-      prefixes.  If get cannot parse the repo for the directory and version, 
-      then it will print an error asking for '.git' to be specified as part of
-      the argument.
-      e.g. https://github.com/kubernetes/examples.git
-      Specify - to read Resources from stdin and write to a LOCAL_DEST_DIRECTORY
-
-    PKG_PATH:
-      Path to remote subdirectory containing Kubernetes Resource configuration
-      files or directories.  Defaults to the root directory.
-      Uses '/' as the path separator (regardless of OS).
-      e.g. staging/cockroachdb
-
-    VERSION:
-      A git tag, branch, ref or commit for the remote version of the package to
-      fetch.  Defaults to the repository master branch.
-      e.g. @master
-
-    LOCAL_DEST_DIRECTORY:
-      The local directory to write the package to. e.g. ./my-cockroachdb-copy
-
-        * If the directory does NOT exist: create the specified directory and write
-          the package contents to it
-        * If the directory DOES exist: create a NEW directory under the specified one,
-          defaulting the name to the Base of REPO/PKG_PATH
-        * If the directory DOES exist and already contains a directory with the same name
-          of the one that would be created: fail
-
-#### Flags
-
-    --strategy:
-      Controls how changes to the local package are handled.
-      Defaults to fast-forward.
-
-        * resource-merge: perform a structural comparison of the original /
-          updated Resources, and merge the changes into the local package.
-          See ` + "`" + `kpt help apis merge3` + "`" + ` for details on merge.
-        * fast-forward: fail without updating if the local package was modified
-          since it was fetched.
-        * alpha-git-patch: use 'git format-patch' and 'git am' to apply a
-          patch of the changes between the source version and destination
-          version.
-          REQUIRES THE LOCAL PACKAGE TO HAVE BEEN COMMITTED TO A LOCAL GIT REPO.
-        * force-delete-replace: THIS WILL WIPE ALL LOCAL CHANGES TO
-          THE PACKAGE.  DELETE the local package at local_pkg_dir/ and replace
-          it with the remote version.
+Flags:
+  --strategy:
+    Controls how changes to the local package are handled.
+    Defaults to fast-forward.
+  
+      * resource-merge: perform a structural comparison of the original /
+        updated Resources, and merge the changes into the local package.
+        See ` + "`" + `kpt help apis merge3` + "`" + ` for details on merge.
+      * fast-forward: fail without updating if the local package was modified
+        since it was fetched.
+      * alpha-git-patch: use 'git format-patch' and 'git am' to apply a
+        patch of the changes between the source version and destination
+        version.
+        REQUIRES THE LOCAL PACKAGE TO HAVE BEEN COMMITTED TO A LOCAL GIT REPO.
+      * force-delete-replace: THIS WILL WIPE ALL LOCAL CHANGES TO
+        THE PACKAGE.  DELETE the local package at local_pkg_dir/ and replace
+        it with the remote version.
 `
 var SetExamples = `
-#### Create a new package and add a dependency to it
+Create a new package and add a dependency to it:
 
   # init a package so it can be synced
   kpt pkg init
@@ -303,7 +295,7 @@ var SetExamples = `
   # sync the dependencies
   kpt pkg sync .
 
-#### Update an existing package dependency
+Update an existing package dependency:
 
   # add a dependency to an existing package
   kpt pkg sync set https://github.com/GoogleContainerTools/kpt.git/package-examples/helloworld-set@v0.2.0 \
@@ -312,53 +304,50 @@ var SetExamples = `
 
 var UpdateShort = `Apply upstream package updates`
 var UpdateLong = `
-    kpt pkg update LOCAL_PKG_DIR[@VERSION] [flags]
+  kpt pkg update LOCAL_PKG_DIR[@VERSION] [flags]
 
-#### Args
+Args:
+  LOCAL_PKG_DIR:
+    Local package to update.  Directory must exist and contain a Kptfile
+    to be updated.
+  
+  VERSION:
+    A git tag, branch, ref or commit.  Specified after the local_package
+    with @ -- pkg@version.
+    Defaults the local package version that was last fetched.
+  
+    Version types:
+      * branch: update the local contents to the tip of the remote branch
+      * tag: update the local contents to the remote tag
+      * commit: update the local contents to the remote commit
 
-    LOCAL_PKG_DIR:
-      Local package to update.  Directory must exist and contain a Kptfile
-      to be updated.
+Flags:
+  --strategy:
+    Controls how changes to the local package are handled.  Defaults to fast-forward.
+  
+      * resource-merge: perform a structural comparison of the original /
+        updated Resources, and merge the changes into the local package.
+      * fast-forward: fail without updating if the local package was modified
+        since it was fetched.
+      * alpha-git-patch: use 'git format-patch' and 'git am' to apply a
+        patch of the changes between the source version and destination
+        version.
+      * force-delete-replace: WIPE ALL LOCAL CHANGES TO THE PACKAGE.
+        DELETE the local package at local_pkg_dir/ and replace it
+        with the remote version.
+  
+  -r, --repo:
+    Git repo url for updating contents.  Defaults to the repo the package
+    was fetched from.
+  
+  --dry-run
+    Print the 'alpha-git-patch' strategy patch rather than merging it.
 
-    VERSION:
-  	  A git tag, branch, ref or commit.  Specified after the local_package
-  	  with @ -- pkg@version.
-      Defaults the local package version that was last fetched.
-
-	  Version types:
-        * branch: update the local contents to the tip of the remote branch
-        * tag: update the local contents to the remote tag
-        * commit: update the local contents to the remote commit
-
-#### Flags
-
-    --strategy:
-      Controls how changes to the local package are handled.  Defaults to fast-forward.
-
-        * resource-merge: perform a structural comparison of the original /
-          updated Resources, and merge the changes into the local package.
-        * fast-forward: fail without updating if the local package was modified
-          since it was fetched.
-        * alpha-git-patch: use 'git format-patch' and 'git am' to apply a
-          patch of the changes between the source version and destination
-          version.
-        * force-delete-replace: WIPE ALL LOCAL CHANGES TO THE PACKAGE.
-          DELETE the local package at local_pkg_dir/ and replace it
-          with the remote version.
-
-    -r, --repo:
-      Git repo url for updating contents.  Defaults to the repo the package
-      was fetched from.
-
-    --dry-run
-      Print the 'alpha-git-patch' strategy patch rather than merging it.
-
-#### Env Vars
-
-    KPT_CACHE_DIR:
-      Controls where to cache remote packages when fetching them to update
-      local packages.
-      Defaults to ~/.kpt/repos/
+Env Vars:
+  KPT_CACHE_DIR:
+    Controls where to cache remote packages when fetching them to update
+    local packages.
+    Defaults to ~/.kpt/repos/
 `
 var UpdateExamples = `
   # update my-package-dir/

--- a/mdtogo/main.go
+++ b/mdtogo/main.go
@@ -204,6 +204,11 @@ func cleanUpContent(text string) string {
 
 		line = strings.ReplaceAll(line, "`", "` + \"`\" + `")
 
+		if strings.HasPrefix(line, "####") {
+			line = strings.TrimPrefix(line, "####")
+			line = fmt.Sprintf("%s:", strings.TrimSpace(line))
+		}
+
 		lines = append(lines, line)
 	}
 

--- a/site/content/en/reference/cfg/annotate/_index.md
+++ b/site/content/en/reference/cfg/annotate/_index.md
@@ -42,28 +42,32 @@ kpt cfg annotate DIR --kv key1=value1 --kv key2=value2
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt cfg annotate DIR --kv KEY=VALUE...
+```
+kpt cfg annotate DIR --kv KEY=VALUE...
+```
 
 #### Args
-
-    DIR:
-      Path to a package directory
+```
+DIR:
+  Path to a package directory
+```
 
 #### Flags
+```
+--apiVersion
+  Only set annotations on resources with this apiVersion.
 
-    --apiVersion
-      Only set annotations on resources with this apiVersion.
+--kind
+  Only set annotations on resources of this kind.
 
-    --kind
-      Only set annotations on resources of this kind.
+--kv
+  The annotation key and value to set.  May be specified multiple times
+  to set multiple annotations at once.
 
-    --kv
-      The annotation key and value to set.  May be specified multiple times
-      to set multiple annotations at once.
+--namespace
+  Only set annotations on resources in this namespace.
 
-    --namespace
-      Only set annotations on resources in this namespace.
-
-    --namespace
-      Only set annotations on resources with this name.
+--namespace
+  Only set annotations on resources with this name.
+```
 <!--mdtogo-->

--- a/site/content/en/reference/cfg/cat/_index.md
+++ b/site/content/en/reference/cfg/cat/_index.md
@@ -27,8 +27,10 @@ kpt cfg cat my-dir/
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt cfg cat DIR
+```
+kpt cfg cat DIR
 
-    DIR:
-      Path to a package directory
+DIR:
+  Path to a package directory
+```
 <!--mdtogo-->

--- a/site/content/en/reference/cfg/count/_index.md
+++ b/site/content/en/reference/cfg/count/_index.md
@@ -29,8 +29,10 @@ kubectl get all -o yaml | kpt cfg count
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt cfg count [DIR]
+```
+kpt cfg count [DIR]
 
-    DIR:
-      Path to a package directory.  Defaults to stdin if unspecified.
+DIR:
+  Path to a package directory.  Defaults to stdin if unspecified.
+```
 <!--mdtogo-->

--- a/site/content/en/reference/cfg/create-setter/_index.md
+++ b/site/content/en/reference/cfg/create-setter/_index.md
@@ -53,19 +53,21 @@ kpt cfg create-setter DIR/ app nginx --field "annotations.app" --type string
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt cfg create-setter DIR NAME VALUE
+```
+kpt cfg create-setter DIR NAME VALUE
 
-    DIR:
-      Path to a package directory
+DIR:
+  Path to a package directory
 
-    NAME:
-      The name of the substitution to create.  This is both the name that will
-      be given to the *set* command, and that will be referenced by fields.
-      e.g. replicas
+NAME:
+  The name of the substitution to create.  This is both the name that will
+  be given to the *set* command, and that will be referenced by fields.
+  e.g. replicas
 
-    VALUE
-      The new value of the setter.
-      e.g. 3
+VALUE
+  The new value of the setter.
+  e.g. 3
+```
 <!--mdtogo-->
 
 [creating setters]: ../../../guides/producer/setters

--- a/site/content/en/reference/cfg/create-subst/_index.md
+++ b/site/content/en/reference/cfg/create-subst/_index.md
@@ -64,26 +64,28 @@ kpt cfg set tag v1.8.0
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt cfg create-subst DIR NAME VALUE --pattern PATTERN --value MARKER=SETTER
+```
+kpt cfg create-subst DIR NAME VALUE --pattern PATTERN --value MARKER=SETTER
 
-    DIR
-      Path to a package directory
+DIR
+  Path to a package directory
 
-    NAME
-      The name of the substitution to create.  This is simply the unique key
-      which is referenced by fields which have the substitution applied.
-      e.g. image-substitution
+NAME
+  The name of the substitution to create.  This is simply the unique key
+  which is referenced by fields which have the substitution applied.
+  e.g. image-substitution
 
-    VALUE
-      The current value of the field that will have PATTERN substituted.
-      e.g. nginx:1.7.9
+VALUE
+  The current value of the field that will have PATTERN substituted.
+  e.g. nginx:1.7.9
 
-    PATTERN
-      A string containing one or more MARKER substrings which will be
-      substituted for setter values.  The pattern may contain multiple
-      different MARKERS, the same MARKER multiple times, and non-MARKER
-      substrings.
-      e.g. IMAGE_SETTER:TAG_SETTER
+PATTERN
+  A string containing one or more MARKER substrings which will be
+  substituted for setter values.  The pattern may contain multiple
+  different MARKERS, the same MARKER multiple times, and non-MARKER
+  substrings.
+  e.g. IMAGE_SETTER:TAG_SETTER
+```
 <!--mdtogo-->
 
 [setters]: ../create-setter

--- a/site/content/en/reference/cfg/fmt/_index.md
+++ b/site/content/en/reference/cfg/fmt/_index.md
@@ -61,8 +61,10 @@ kustomize build | kpt cfg fmt
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt cfg fmt [DIR]
+```
+kpt cfg fmt [DIR]
 
-    DIR:
-      Path to a package directory.  Reads from STDIN if not provided.
+DIR:
+  Path to a package directory.  Reads from STDIN if not provided.
+```
 <!--mdtogo-->

--- a/site/content/en/reference/cfg/grep/_index.md
+++ b/site/content/en/reference/cfg/grep/_index.md
@@ -44,10 +44,12 @@ kpt cfg grep "spec.template.spec.containers[name=nginx].image=nginx:1\.7\.9" \
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt cfg grep QUERY DIR
+```
+kpt cfg grep QUERY DIR
+```
 
 #### Args
-
+```
     QUERY:
       Query to match expressed as 'path.to.field=value'.
       Maps and fields are matched as '.field-name' or '.map-key'
@@ -57,9 +59,11 @@ kpt cfg grep "spec.template.spec.containers[name=nginx].image=nginx:1\.7\.9" \
 
     DIR:
       Path to a package directory
+```
 
 #### Flags
-
+```
     --invert-match, -v
       keep resources NOT matching the specified pattern
+```
 <!--mdtogo-->

--- a/site/content/en/reference/cfg/list-setters/_index.md
+++ b/site/content/en/reference/cfg/list-setters/_index.md
@@ -36,13 +36,15 @@ replicas   4       isabella   good value    1
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt cfg list-setters DIR [NAME]
+```
+kpt cfg list-setters DIR [NAME]
 
-    DIR
-      Path to a package directory
+DIR
+  Path to a package directory
 
-    NAME
-      Optional.  The name of the setter to display.
+NAME
+  Optional.  The name of the setter to display.
+```
 <!--mdtogo-->
 
 [create-setter]: ../create-setter

--- a/site/content/en/reference/cfg/set/_index.md
+++ b/site/content/en/reference/cfg/set/_index.md
@@ -84,27 +84,31 @@ kpt cfg set hello-world/ tag 1.8.1
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt cfg set DIR NAME VALUE
+```
+kpt cfg set DIR NAME VALUE
+```
 
 #### Args
+```
+DIR
+  Path to a package directory. e.g. hello-world/
 
-    DIR
-      Path to a package directory. e.g. hello-world/
+NAME
+  The name of the setter. e.g. replicas
 
-    NAME
-      The name of the setter. e.g. replicas
-
-    VALUE
-      The new value to set on fields. e.g. 3
+VALUE
+  The new value to set on fields. e.g. 3
+```
 
 #### Flags
+```
+--description
+  Optional description about the value.
 
-    --description
-      Optional description about the value.
-
-    --set-by
-      Optional record of who set the value.  Clears the last set-by
-      value if unset.
+--set-by
+  Optional record of who set the value.  Clears the last set-by
+  value if unset.
+```
 <!--mdtogo-->
 
 [create-setter]: ../create-setter

--- a/site/content/en/reference/cfg/tree/_index.md
+++ b/site/content/en/reference/cfg/tree/_index.md
@@ -69,39 +69,43 @@ kubectl get all -o yaml | kpt cfg tree \
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt cfg tree [DIR] [flags]
+```
+kpt cfg tree [DIR] [flags]
+```
 
 #### Args
-
-    DIR:
-      Path to a package directory.  Defaults to STDIN if not specified.
+```
+DIR:
+  Path to a package directory.  Defaults to STDIN if not specified.
+```
 
 #### Flags
+```
+--args:
+  if true, print the container args field
 
-    --args:
-      if true, print the container args field
+--command:
+  if true, print the container command field
 
-    --command:
-      if true, print the container command field
+--env:
+  if true, print the container env field
 
-    --env:
-      if true, print the container env field
+--field:
+  dot-separated path to a field to print
 
-    --field:
-      dot-separated path to a field to print
+--image:
+  if true, print the container image fields
 
-    --image:
-      if true, print the container image fields
+--name:
+  if true, print the container name fields
 
-    --name:
-      if true, print the container name fields
+--ports:
+  if true, print the container port fields
 
-    --ports:
-      if true, print the container port fields
+--replicas:
+  if true, print the replica field
 
-    --replicas:
-      if true, print the replica field
-
-    --resources:
-      if true, print the resource reservations
+--resources:
+  if true, print the resource reservations
+```
 <!--mdtogo-->

--- a/site/content/en/reference/fn/run/_index.md
+++ b/site/content/en/reference/fn/run/_index.md
@@ -188,11 +188,15 @@ spec:
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt fn run DIR [flags]
+```
+kpt fn run DIR [flags]
+```
 
 If the container exits with non-zero status code, run will fail and print the
 container `STDERR`.
 
-    DIR:
-      Path to a package directory.  Defaults to stdin if unspecified.
+```
+DIR:
+  Path to a package directory.  Defaults to stdin if unspecified.
+```
 <!--mdtogo-->

--- a/site/content/en/reference/fn/sink/_index.md
+++ b/site/content/en/reference/fn/sink/_index.md
@@ -24,8 +24,10 @@ kpt fn source DIR/ | kpt run --image gcr.io/example.com/my-fn | kpt fn sink DIR/
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt fn sink [DIR]
+```
+kpt fn sink [DIR]
 
-    DIR:
-      Path to a package directory.  Defaults to stdout if unspecified.
+DIR:
+  Path to a package directory.  Defaults to stdout if unspecified.
+```
 <!--mdtogo-->

--- a/site/content/en/reference/fn/source/_index.md
+++ b/site/content/en/reference/fn/source/_index.md
@@ -26,8 +26,10 @@ kpt fn source DIR/ | kpt run --image gcr.io/example.com/my-fn | kpt fn sink DIR/
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt fn source [DIR...]
+```
+kpt fn source [DIR...]
 
-    DIR:
-      Path to a package directory.  Defaults to stdin if unspecified.
+DIR:
+  Path to a package directory.  Defaults to stdin if unspecified.
+```
 <!--mdtogo-->

--- a/site/content/en/reference/live/apply/_index.md
+++ b/site/content/en/reference/live/apply/_index.md
@@ -109,26 +109,30 @@ kpt live apply to correctly compute status.
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt live apply DIR [flags]
+```
+kpt live apply DIR [flags]
+```
 
 #### Args
-
-    DIR:
-      Path to a package directory.  The directory must contain exactly
-      one ConfigMap with the grouping object annotation.
+```
+DIR:
+  Path to a package directory.  The directory must contain exactly
+  one ConfigMap with the grouping object annotation.
+```
 
 #### Flags:
+```
+--wait-for-reconcile:
+  If true, after all resources have been applied, the cluster will
+  be polled until either all resources have been fully reconciled
+  or the timeout is reached.
 
-    --wait-for-reconcile:
-      If true, after all resources have been applied, the cluster will
-      be polled until either all resources have been fully reconciled
-      or the timeout is reached.
+--wait-polling-period:
+  The frequency with which the cluster will be polled to determine 
+  the status of the applied resources. The default value is every 2 seconds.
 
-    --wait-polling-period:
-      The frequency with which the cluster will be polled to determine 
-      the status of the applied resources. The default value is every 2 seconds.
-
-    --wait-timeout:
-      The threshold for how long to wait for all resources to reconcile before
-      giving up. The default value is 1 minute.
+--wait-timeout:
+  The threshold for how long to wait for all resources to reconcile before
+  giving up. The default value is 1 minute.
+```
 <!--mdtogo-->

--- a/site/content/en/reference/live/destroy/_index.md
+++ b/site/content/en/reference/live/destroy/_index.md
@@ -15,11 +15,14 @@ The destroy command removes all files belonging to a package from the cluster.
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt live destroy DIR
+```
+kpt live destroy DIR
+```
 
 #### Args
-
-    DIR:
-      Path to a package directory.  The directory must contain exactly
-      one ConfigMap with the grouping object annotation.
+```
+DIR:
+  Path to a package directory.  The directory must contain exactly
+  one ConfigMap with the grouping object annotation.
+```
 <!--mdtogo-->

--- a/site/content/en/reference/live/init/_index.md
+++ b/site/content/en/reference/live/init/_index.md
@@ -20,18 +20,22 @@ such as apply, preview and destroy.
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt live init DIRECTORY [flags]
+```
+kpt live init DIRECTORY [flags]
+```
 
 #### Args
-
-    DIR:
-      Path to a package directory.  The directory must contain exactly
-      one ConfigMap with the grouping object annotation.
+```
+DIR:
+  Path to a package directory.  The directory must contain exactly
+  one ConfigMap with the grouping object annotation.
+```
 
 #### Flags
-
-    --group-name:
-      String name to group applied resources. Must be composed of valid
-      label value characters. If not specified, the default group name
-      is generated from the package directory name.
+```
+--group-name:
+  String name to group applied resources. Must be composed of valid
+  label value characters. If not specified, the default group name
+  is generated from the package directory name.
+```
 <!--mdtogo-->

--- a/site/content/en/reference/live/preview/_index.md
+++ b/site/content/en/reference/live/preview/_index.md
@@ -17,16 +17,20 @@ live cluster state.
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt live preview DIRECTORY [flags]
+```
+kpt live preview DIRECTORY [flags]
+```
 
 #### Args
-
-    DIRECTORY:
-      One directory that contain k8s manifests. The directory
-      must contain exactly one ConfigMap with the grouping object annotation.
+```
+DIRECTORY:
+  One directory that contain k8s manifests. The directory
+  must contain exactly one ConfigMap with the grouping object annotation.
+```
 
 #### Flags
-
-    --destroy:
-      If true, dry-run deletion of all resources.
+```
+--destroy:
+  If true, dry-run deletion of all resources.
+```
 <!--mdtogo-->

--- a/site/content/en/reference/pkg/desc/_index.md
+++ b/site/content/en/reference/pkg/desc/_index.md
@@ -21,8 +21,10 @@ kpt pkg desc hello-world/
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt pkg desc DIR
+```
+kpt pkg desc DIR
 
-    DIR:
-      Path to a package directory
+DIR:
+  Path to a package directory
+```
 <!--mdtogo-->

--- a/site/content/en/reference/pkg/diff/_index.md
+++ b/site/content/en/reference/pkg/diff/_index.md
@@ -52,56 +52,61 @@ kpt pkg diff @v4.0.0 --diff-type 3way --diff-tool meld --diff-tool-opts "-a"
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt pkg diff [DIR@VERSION]
+```
+kpt pkg diff [DIR@VERSION]
+```
 
 #### Args
+```
+DIR:
+  Local package to compare. Command will fail if the directory doesn't exist, or does not
+  contain a Kptfile.  Defaults to the current working directory.
 
-    DIR:
-      Local package to compare. Command will fail if the directory doesn't exist, or does not
-      contain a Kptfile.  Defaults to the current working directory.
-
-    VERSION:
-      A git tag, branch, ref or commit. Specified after the local_package with @ -- pkg_dir@version.
-      Defaults to the local package version that was last fetched.
+VERSION:
+  A git tag, branch, ref or commit. Specified after the local_package with @ -- pkg_dir@version.
+  Defaults to the local package version that was last fetched.
+```
 
 #### Flags
+```
+--diff-type:
+  The type of changes to view (local by default). Following types are
+  supported:
 
-    --diff-type:
-      The type of changes to view (local by default). Following types are
-      supported:
+  local: shows changes in local package relative to upstream source package 
+         at original version
+  remote: shows changes in upstream source package at target version
+          relative to original version
+  combined: shows changes in local package relative to upstream source
+            package at target version
+  3way: shows changes in local package and source package at target version
+        relative to original version side by side
 
-	  local: shows changes in local package relative to upstream source package 
-	         at original version
-	  remote: shows changes in upstream source package at target version
-	          relative to original version
-	  combined: shows changes in local package relative to upstream source
-	            package at target version
-	  3way: shows changes in local package and source package at target version
-	        relative to original version side by side
+--diff-tool:
+  Commandline tool (diff by default) for showing the changes.
+  Note that it overrides the KPT_EXTERNAL_DIFF environment variable.
+  
+  # Show changes using 'meld' commandline tool
+  kpt pkg diff @master --diff-tool meld
 
-    --diff-tool:
-      Commandline tool (diff by default) for showing the changes.
-      Note that it overrides the KPT_EXTERNAL_DIFF environment variable.
-	  
-	  # Show changes using 'meld' commandline tool
-	  kpt pkg diff @master --diff-tool meld
-
-    --diff-opts:
-      Commandline options to use with the diffing tool.
-      Note that it overrides the KPT_EXTERNAL_DIFF_OPTS environment variable.
-	  # Show changes using "diff" with recurive options
-	  kpt pkg diff @master --diff-tool meld --diff-opts "-r"
+--diff-opts:
+  Commandline options to use with the diffing tool.
+  Note that it overrides the KPT_EXTERNAL_DIFF_OPTS environment variable.
+  # Show changes using "diff" with recurive options
+  kpt pkg diff @master --diff-tool meld --diff-opts "-r"
+```
 
 #### Environment Variables
+```
+KPT_EXTERNAL_DIFF:
+   Commandline diffing tool (diff by default) that will be used to show
+   changes.
+   # Use meld to show changes
+   KPT_EXTERNAL_DIFF=meld kpt pkg diff
 
-    KPT_EXTERNAL_DIFF:
-       Commandline diffing tool (diff by default) that will be used to show
-       changes.
-       # Use meld to show changes
-       KPT_EXTERNAL_DIFF=meld kpt pkg diff
-
-    KPT_EXTERNAL_DIFF_OPTS:
-       Commandline options to use for the diffing tool. For ex.
-       # Using "-a" diff option
-       KPT_EXTERNAL_DIFF_OPTS="-a" kpt pkg diff --diff-tool meld
+KPT_EXTERNAL_DIFF_OPTS:
+   Commandline options to use for the diffing tool. For ex.
+   # Using "-a" diff option
+   KPT_EXTERNAL_DIFF_OPTS="-a" kpt pkg diff --diff-tool meld
+```
 <!--mdtogo-->

--- a/site/content/en/reference/pkg/get/_index.md
+++ b/site/content/en/reference/pkg/get/_index.md
@@ -39,37 +39,39 @@ kpt pkg get https://github.com/kubernetes/examples.git/@8186bef8e5c0621bf80fa810
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt pkg get REPO_URI[.git]/PKG_PATH[@VERSION] LOCAL_DEST_DIRECTORY [flags]
+```
+kpt pkg get REPO_URI[.git]/PKG_PATH[@VERSION] LOCAL_DEST_DIRECTORY [flags]
 
-    REPO_URI:
-      URI of a git repository containing 1 or more packages as subdirectories.
-      In most cases the .git suffix should be specified to delimit the REPO_URI
-      from the PKG_PATH, but this is not required for widely recognized repo
-      prefixes.  If get cannot parse the repo for the directory and version,
-      then it will print an error asking for '.git' to be specified as part of
-      the argument.
-      e.g. https://github.com/kubernetes/examples.git
-      Specify - to read Resources from stdin and write to a LOCAL_DEST_DIRECTORY
+REPO_URI:
+  URI of a git repository containing 1 or more packages as subdirectories.
+  In most cases the .git suffix should be specified to delimit the REPO_URI
+  from the PKG_PATH, but this is not required for widely recognized repo
+  prefixes.  If get cannot parse the repo for the directory and version,
+  then it will print an error asking for '.git' to be specified as part of
+  the argument.
+  e.g. https://github.com/kubernetes/examples.git
+  Specify - to read Resources from stdin and write to a LOCAL_DEST_DIRECTORY
 
-    PKG_PATH:
-      Path to remote subdirectory containing Kubernetes resource configuration
-      files or directories. Defaults to the root directory.
-      Uses '/' as the path separator (regardless of OS).
-      e.g. staging/cockroachdb
+PKG_PATH:
+  Path to remote subdirectory containing Kubernetes resource configuration
+  files or directories. Defaults to the root directory.
+  Uses '/' as the path separator (regardless of OS).
+  e.g. staging/cockroachdb
 
-    VERSION:
-      A git tag, branch, ref or commit for the remote version of the package
-      to fetch.  Defaults to the repository master branch.
-      e.g. @master
+VERSION:
+  A git tag, branch, ref or commit for the remote version of the package
+  to fetch.  Defaults to the repository master branch.
+  e.g. @master
 
-    LOCAL_DEST_DIRECTORY:
-      The local directory to write the package to.
-      e.g. ./my-cockroachdb-copy
+LOCAL_DEST_DIRECTORY:
+  The local directory to write the package to.
+  e.g. ./my-cockroachdb-copy
 
-        * If the directory does NOT exist: create the specified directory
-          and write the package contents to it
-        * If the directory DOES exist: create a NEW directory under the
-          specified one, defaulting the name to the Base of REPO/PKG_PATH
-        * If the directory DOES exist and already contains a directory with
-          the same name of the one that would be created: fail
+    * If the directory does NOT exist: create the specified directory
+      and write the package contents to it
+    * If the directory DOES exist: create a NEW directory under the
+      specified one, defaulting the name to the Base of REPO/PKG_PATH
+    * If the directory DOES exist and already contains a directory with
+      the same name of the one that would be created: fail
+```
 <!--mdtogo-->

--- a/site/content/en/reference/pkg/init/_index.md
+++ b/site/content/en/reference/pkg/init/_index.md
@@ -41,24 +41,28 @@ kpt pkg init my-pkg --tag kpt.dev/app=cockroachdb \
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt pkg init DIR [flags]
+```
+kpt pkg init DIR [flags]
+```
 
 #### Args
-
-    DIR:
-      Init fails if DIR does not already exist
+```
+DIR:
+  Init fails if DIR does not already exist
+```
 
 #### Flags
+```
+--description
+  short description of the package. (default "sample description")
 
-    --description
-      short description of the package. (default "sample description")
+--name
+  package name.  defaults to the directory base name.
 
-    --name
-      package name.  defaults to the directory base name.
+--tag
+  list of tags for the package.
 
-    --tag
-      list of tags for the package.
-
-    --url
-      link to page with information about the package.
+--url
+  link to page with information about the package.
+```
 <!--mdtogo-->

--- a/site/content/en/reference/pkg/sync/_index.md
+++ b/site/content/en/reference/pkg/sync/_index.md
@@ -68,18 +68,20 @@ dependencies:
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt pkg sync LOCAL_PKG_DIR [flags]
+```
+kpt pkg sync LOCAL_PKG_DIR [flags]
 
-    LOCAL_PKG_DIR:
-      Local package with dependencies to sync.  Directory must exist and
-      contain a Kptfile.
+LOCAL_PKG_DIR:
+  Local package with dependencies to sync.  Directory must exist and
+  contain a Kptfile.
+```
 
 #### Env Vars
-
-  KPT_CACHE_DIR:
-
-    Controls where to cache remote packages during updates.
-    Defaults to ~/.kpt/repos/
+```
+KPT_CACHE_DIR:
+  Controls where to cache remote packages during updates.
+  Defaults to ~/.kpt/repos/
+```
 <!--mdtogo-->
 
 #### Dependencies

--- a/site/content/en/reference/pkg/sync/set/_index.md
+++ b/site/content/en/reference/pkg/sync/set/_index.md
@@ -46,55 +46,58 @@ kpt pkg sync set https://github.com/GoogleContainerTools/kpt.git/package-example
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt pkg set REPO_URI[.git]/PKG_PATH[@VERSION] LOCAL_DEST_DIRECTORY [flags]
+```
+kpt pkg set REPO_URI[.git]/PKG_PATH[@VERSION] LOCAL_DEST_DIRECTORY [flags]
 
-    REPO_URI:
-      URI of a git repository containing 1 or more packages as subdirectories.
-      In most cases the .git suffix should be specified to delimit the REPO_URI
-      from the PKG_PATH, but this is not required for widely recognized repo
-      prefixes.  If get cannot parse the repo for the directory and version, 
-      then it will print an error asking for '.git' to be specified as part of
-      the argument.
-      e.g. https://github.com/kubernetes/examples.git
-      Specify - to read Resources from stdin and write to a LOCAL_DEST_DIRECTORY
+REPO_URI:
+  URI of a git repository containing 1 or more packages as subdirectories.
+  In most cases the .git suffix should be specified to delimit the REPO_URI
+  from the PKG_PATH, but this is not required for widely recognized repo
+  prefixes.  If get cannot parse the repo for the directory and version, 
+  then it will print an error asking for '.git' to be specified as part of
+  the argument.
+  e.g. https://github.com/kubernetes/examples.git
+  Specify - to read Resources from stdin and write to a LOCAL_DEST_DIRECTORY
 
-    PKG_PATH:
-      Path to remote subdirectory containing Kubernetes Resource configuration
-      files or directories.  Defaults to the root directory.
-      Uses '/' as the path separator (regardless of OS).
-      e.g. staging/cockroachdb
+PKG_PATH:
+  Path to remote subdirectory containing Kubernetes Resource configuration
+  files or directories.  Defaults to the root directory.
+  Uses '/' as the path separator (regardless of OS).
+  e.g. staging/cockroachdb
 
-    VERSION:
-      A git tag, branch, ref or commit for the remote version of the package to
-      fetch.  Defaults to the repository master branch.
-      e.g. @master
+VERSION:
+  A git tag, branch, ref or commit for the remote version of the package to
+  fetch.  Defaults to the repository master branch.
+  e.g. @master
 
-    LOCAL_DEST_DIRECTORY:
-      The local directory to write the package to. e.g. ./my-cockroachdb-copy
+LOCAL_DEST_DIRECTORY:
+  The local directory to write the package to. e.g. ./my-cockroachdb-copy
 
-        * If the directory does NOT exist: create the specified directory and write
-          the package contents to it
-        * If the directory DOES exist: create a NEW directory under the specified one,
-          defaulting the name to the Base of REPO/PKG_PATH
-        * If the directory DOES exist and already contains a directory with the same name
-          of the one that would be created: fail
+    * If the directory does NOT exist: create the specified directory and write
+      the package contents to it
+    * If the directory DOES exist: create a NEW directory under the specified one,
+      defaulting the name to the Base of REPO/PKG_PATH
+    * If the directory DOES exist and already contains a directory with the same name
+      of the one that would be created: fail
+```
 
 #### Flags
+```
+--strategy:
+  Controls how changes to the local package are handled.
+  Defaults to fast-forward.
 
-    --strategy:
-      Controls how changes to the local package are handled.
-      Defaults to fast-forward.
-
-        * resource-merge: perform a structural comparison of the original /
-          updated Resources, and merge the changes into the local package.
-          See `kpt help apis merge3` for details on merge.
-        * fast-forward: fail without updating if the local package was modified
-          since it was fetched.
-        * alpha-git-patch: use 'git format-patch' and 'git am' to apply a
-          patch of the changes between the source version and destination
-          version.
-          REQUIRES THE LOCAL PACKAGE TO HAVE BEEN COMMITTED TO A LOCAL GIT REPO.
-        * force-delete-replace: THIS WILL WIPE ALL LOCAL CHANGES TO
-          THE PACKAGE.  DELETE the local package at local_pkg_dir/ and replace
-          it with the remote version.
+    * resource-merge: perform a structural comparison of the original /
+      updated Resources, and merge the changes into the local package.
+      See `kpt help apis merge3` for details on merge.
+    * fast-forward: fail without updating if the local package was modified
+      since it was fetched.
+    * alpha-git-patch: use 'git format-patch' and 'git am' to apply a
+      patch of the changes between the source version and destination
+      version.
+      REQUIRES THE LOCAL PACKAGE TO HAVE BEEN COMMITTED TO A LOCAL GIT REPO.
+    * force-delete-replace: THIS WILL WIPE ALL LOCAL CHANGES TO
+      THE PACKAGE.  DELETE the local package at local_pkg_dir/ and replace
+      it with the remote version.
+```
 <!--mdtogo-->

--- a/site/content/en/reference/pkg/update/_index.md
+++ b/site/content/en/reference/pkg/update/_index.md
@@ -41,51 +41,56 @@ kpt pkg  update my-package-dir/@master --strategy alpha-git-patch
 
 ### Synopsis
 <!--mdtogo:Long-->
-    kpt pkg update LOCAL_PKG_DIR[@VERSION] [flags]
+```
+kpt pkg update LOCAL_PKG_DIR[@VERSION] [flags]
+```
 
 #### Args
+```
+LOCAL_PKG_DIR:
+  Local package to update.  Directory must exist and contain a Kptfile
+  to be updated.
 
-    LOCAL_PKG_DIR:
-      Local package to update.  Directory must exist and contain a Kptfile
-      to be updated.
+VERSION:
+  A git tag, branch, ref or commit.  Specified after the local_package
+  with @ -- pkg@version.
+  Defaults the local package version that was last fetched.
 
-    VERSION:
-  	  A git tag, branch, ref or commit.  Specified after the local_package
-  	  with @ -- pkg@version.
-      Defaults the local package version that was last fetched.
-
-	  Version types:
-        * branch: update the local contents to the tip of the remote branch
-        * tag: update the local contents to the remote tag
-        * commit: update the local contents to the remote commit
+  Version types:
+    * branch: update the local contents to the tip of the remote branch
+    * tag: update the local contents to the remote tag
+    * commit: update the local contents to the remote commit
+```
 
 #### Flags
+```
+--strategy:
+  Controls how changes to the local package are handled.  Defaults to fast-forward.
 
-    --strategy:
-      Controls how changes to the local package are handled.  Defaults to fast-forward.
+    * resource-merge: perform a structural comparison of the original /
+      updated Resources, and merge the changes into the local package.
+    * fast-forward: fail without updating if the local package was modified
+      since it was fetched.
+    * alpha-git-patch: use 'git format-patch' and 'git am' to apply a
+      patch of the changes between the source version and destination
+      version.
+    * force-delete-replace: WIPE ALL LOCAL CHANGES TO THE PACKAGE.
+      DELETE the local package at local_pkg_dir/ and replace it
+      with the remote version.
 
-        * resource-merge: perform a structural comparison of the original /
-          updated Resources, and merge the changes into the local package.
-        * fast-forward: fail without updating if the local package was modified
-          since it was fetched.
-        * alpha-git-patch: use 'git format-patch' and 'git am' to apply a
-          patch of the changes between the source version and destination
-          version.
-        * force-delete-replace: WIPE ALL LOCAL CHANGES TO THE PACKAGE.
-          DELETE the local package at local_pkg_dir/ and replace it
-          with the remote version.
+-r, --repo:
+  Git repo url for updating contents.  Defaults to the repo the package
+  was fetched from.
 
-    -r, --repo:
-      Git repo url for updating contents.  Defaults to the repo the package
-      was fetched from.
-
-    --dry-run
-      Print the 'alpha-git-patch' strategy patch rather than merging it.
+--dry-run
+  Print the 'alpha-git-patch' strategy patch rather than merging it.
+```
 
 #### Env Vars
-
-    KPT_CACHE_DIR:
-      Controls where to cache remote packages when fetching them to update
-      local packages.
-      Defaults to ~/.kpt/repos/
+```
+KPT_CACHE_DIR:
+  Controls where to cache remote packages when fetching them to update
+  local packages.
+  Defaults to ~/.kpt/repos/
+```
 <!--mdtogo-->


### PR DESCRIPTION
This changes the formatting used in the Hugo markdown from defining blocks with indentation to using "```". This approach works better with mdtogo since the content of the generated Long message gets the same indentation as the rest of the Cobra output. We should also go through all the commands and use a consistent way to describe usage, args, flags and env vars. I will do that separately from this.

Will do a follow-up PR to regenerate the Hugo content.

@pwittrock 