### PR TITLE
Support auto-running functions after set,get,update

### DIFF
--- a/commands/configcmd.go
+++ b/commands/configcmd.go
@@ -16,6 +16,7 @@ package commands
 
 import (
 	"github.com/GoogleContainerTools/kpt/internal/docs/generated/cfgdocs"
+	"github.com/GoogleContainerTools/kpt/internal/util/functions"
 	"github.com/GoogleContainerTools/kpt/internal/util/setters"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/cmd/config/configcobra"
@@ -103,8 +104,12 @@ func SetCommand(parent string) *cobra.Command {
 	setCmd.RunE = func(c *cobra.Command, args []string) error {
 		kustomizeCmd.SetArgs(args)
 		if err := kustomizeCmd.Execute(); err != nil {
-			return nil
+			return err
 		}
+		if err := functions.ReconcileFunctions(args[0]); err != nil {
+			return err
+		}
+
 		if len(args) != 3 || args[1] != "gcloud.core.project" {
 			return nil
 		}

--- a/commands/guidecmd.go
+++ b/commands/guidecmd.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package commands
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,6 @@ require (
 	// Once there is a 0.18 release, we can import a semver release.
 	k8s.io/kubectl v0.0.0-20191219154910-1528d4eea6dd
 	sigs.k8s.io/cli-utils v0.5.0
-	sigs.k8s.io/kustomize/cmd/config v0.1.2
-	sigs.k8s.io/kustomize/kyaml v0.1.2
+	sigs.k8s.io/kustomize/cmd/config v0.1.3
+	sigs.k8s.io/kustomize/kyaml v0.1.3
 )

--- a/go.sum
+++ b/go.sum
@@ -654,12 +654,12 @@ sigs.k8s.io/controller-runtime v0.4.0 h1:wATM6/m+3w8lj8FXNaO6Fs/rq/vqoOjO1Q116Z9
 sigs.k8s.io/controller-runtime v0.4.0/go.mod h1:ApC79lpY3PHW9xj/w9pj+lYkLgwAAUZwfXkME1Lajns=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
-sigs.k8s.io/kustomize/cmd/config v0.1.2 h1:Sc6erGxlFgzmU028x3PeyVFXEFdY50z59PE6FDNvBJw=
-sigs.k8s.io/kustomize/cmd/config v0.1.2/go.mod h1:BfpkycBGhDm7yKu0WDYhCOHonugx9huknQVK4wsW9No=
+sigs.k8s.io/kustomize/cmd/config v0.1.3 h1:TsHxt4U8x5zV/iKniVMPlTOvGdi0+h+/aWE7woGRw0Y=
+sigs.k8s.io/kustomize/cmd/config v0.1.3/go.mod h1:rpxYLWzRSXlgGSicr6C9wxf1c2t4MCYr8d93Dx5WhJM=
 sigs.k8s.io/kustomize/kyaml v0.1.0 h1:bpdlb136YAqxeL6+ziESe34SXRSBBpiUvoTu2dQG5Ss=
 sigs.k8s.io/kustomize/kyaml v0.1.0/go.mod h1:/NdPPfrperSCGjm55cwEro1loBVtbtVIXSb7FguK6uk=
-sigs.k8s.io/kustomize/kyaml v0.1.2 h1:l12+QGl+ETUHhP8/bZAi6TknU7H194fXL/9b2gUxZFY=
-sigs.k8s.io/kustomize/kyaml v0.1.2/go.mod h1:461i94nj0h0ylJ6w83jLkR4SqqVhn1iY6fjD0JSTQeE=
+sigs.k8s.io/kustomize/kyaml v0.1.3 h1:zbeHVTMCQPtWgjIH/YYJZC45mm7coTdw2TblyJ79BrY=
+sigs.k8s.io/kustomize/kyaml v0.1.3/go.mod h1:461i94nj0h0ylJ6w83jLkR4SqqVhn1iY6fjD0JSTQeE=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca h1:6dsH6AYQWbyZmtttJNe8Gq1cXOeS1BdV3eW37zHilAQ=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=

--- a/internal/cmdget/cmdget.go
+++ b/internal/cmdget/cmdget.go
@@ -20,6 +20,7 @@ import (
 
 	docs "github.com/GoogleContainerTools/kpt/internal/docs/generated/pkgdocs"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
+	"github.com/GoogleContainerTools/kpt/internal/util/functions"
 	"github.com/GoogleContainerTools/kpt/internal/util/get"
 	"github.com/GoogleContainerTools/kpt/internal/util/get/getioreader"
 	"github.com/GoogleContainerTools/kpt/internal/util/parse"
@@ -88,6 +89,10 @@ func (r *Runner) runE(c *cobra.Command, args []string) error {
 
 	if r.AutoSet {
 		if err := setters.PerformSetters(r.Get.Destination); err != nil {
+			return err
+		}
+	} else { // Setters will also reconcile functions, so only do it in else
+		if err := functions.ReconcileFunctions(r.Get.Destination); err != nil {
 			return err
 		}
 	}

--- a/internal/cmdupdate/cmdupdate.go
+++ b/internal/cmdupdate/cmdupdate.go
@@ -21,6 +21,7 @@ import (
 
 	docs "github.com/GoogleContainerTools/kpt/internal/docs/generated/pkgdocs"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
+	"github.com/GoogleContainerTools/kpt/internal/util/functions"
 	"github.com/GoogleContainerTools/kpt/internal/util/update"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/kyaml/errors"
@@ -88,5 +89,14 @@ func (r *Runner) runE(c *cobra.Command, args []string) error {
 		fmt.Fprintf(c.ErrOrStderr(), "updating package %s\n",
 			r.Update.Path)
 	}
-	return r.Update.Run()
+	if err := r.Update.Run(); err != nil {
+		return err
+	}
+
+	// re-run functions
+	if err := functions.ReconcileFunctions(r.Update.Path); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/internal/kptfile/pkgfile.go
+++ b/internal/kptfile/pkgfile.go
@@ -45,6 +45,24 @@ type KptFile struct {
 	// See https://github.com/go-yaml/yaml/issues/518 and
 	// https://github.com/go-yaml/yaml/issues/575
 	OpenAPI interface{} `yaml:"openAPI,omitempty"`
+
+	// Functions contains configuration for running functions
+	Functions Functions `yaml:"functions,omitempty"`
+}
+
+type Functions struct {
+	// AutoRunStarlark will cause starlark functions to automatically be run.
+	AutoRunStarlark bool `yaml:"autoRunStarlark,omitempty"`
+
+	// StarlarkFunctions is a list of starlark functions to run
+	StarlarkFunctions []StarlarkFunction `yaml:"starlarkFunctions,omitempty"`
+}
+
+type StarlarkFunction struct {
+	// Name is the name that will be given to the program
+	Name string `yaml:"name,omitempty"`
+	// Path is the path to the *.star script to run
+	Path string `yaml:"path,omitempty"`
 }
 
 // MergeOpenAPI adds the OpenAPI definitions from file to k.

--- a/internal/util/functions/functions_test.go
+++ b/internal/util/functions/functions_test.go
@@ -1,0 +1,227 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package functions_test
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/GoogleContainerTools/kpt/internal/util/functions"
+	"github.com/stretchr/testify/assert"
+)
+
+var tests = []testCase{
+	// Test 1
+	{
+		name: "starlarkFunctions",
+		inputs: func(s string) map[string]string {
+			return map[string]string{
+				"Kptfile": fmt.Sprintf(`
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: my-pkg
+functions:
+  starlarkFunctions:
+  - name: func
+    path: %s
+`, filepath.Join(s, "reconcile.star")),
+
+				"deploy.yaml": `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        # head comment
+        image: nginx:1.8.1 # {"$ref": "#/definitions/io.k8s.cli.substitutions.image"}
+`,
+
+				"reconcile.star": `
+# set the foo annotation on each resource
+def run(r):
+  for resource in r:
+    resource["metadata"]["annotations"]["foo"] = "bar"
+
+run(resourceList["items"])
+`,
+			}
+		},
+		outputs: func(s string) map[string]string {
+			return map[string]string{
+				"deploy.yaml": `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  annotations:
+    foo: bar
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        # head comment
+        image: nginx:1.8.1 # {"$ref": "#/definitions/io.k8s.cli.substitutions.image"}
+`,
+			}
+		},
+	},
+
+	// Test 2
+	{
+		name: "autoRunStarlark",
+		inputs: func(s string) map[string]string {
+			return map[string]string{
+				"Kptfile": `
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: my-pkg
+functions:
+  autoRunStarlark: true`,
+
+				"deploy1.yaml": fmt.Sprintf(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment-1
+  annotations:
+    config.kubernetes.io/function: |
+      starlark:
+        path: %s
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        # head comment
+        image: nginx:1.8.1 # {"$ref": "#/definitions/io.k8s.cli.substitutions.image"}
+`, filepath.Join(s, "reconcile.star")),
+
+				"deploy2.yaml": `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment-2
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        # head comment
+        image: nginx:1.8.1 # {"$ref": "#/definitions/io.k8s.cli.substitutions.image"}
+`,
+
+				"reconcile.star": `
+# set the foo annotation on each resource
+def run(r):
+  for resource in r:
+    resource["metadata"]["annotations"]["foo"] = "bar"
+
+run(resourceList["items"])
+`,
+			}
+		},
+		outputs: func(s string) map[string]string {
+			return map[string]string{
+				"deploy1.yaml": fmt.Sprintf(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment-1
+  annotations:
+    config.kubernetes.io/function: |
+      starlark:
+        path: %s
+    foo: bar
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        # head comment
+        image: nginx:1.8.1 # {"$ref": "#/definitions/io.k8s.cli.substitutions.image"}
+`, filepath.Join(s, "reconcile.star")),
+
+				"deploy2.yaml": `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment-2
+  annotations:
+    foo: bar
+spec:
+  template:
+    spec:
+      containers:
+      - name: nginx
+        # head comment
+        image: nginx:1.8.1 # {"$ref": "#/definitions/io.k8s.cli.substitutions.image"}
+`,
+			}
+		},
+	},
+}
+
+type testCase struct {
+	name    string
+	inputs  func(string) map[string]string
+	outputs func(string) map[string]string
+}
+
+func TestReconcileFunctions(t *testing.T) {
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			d, err := ioutil.TempDir("", "kpt")
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			defer os.RemoveAll(d)
+
+			for filename, value := range test.inputs(d) {
+				err = ioutil.WriteFile(
+					filepath.Join(d, filename), []byte(value), 0600)
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+			}
+
+			err = functions.ReconcileFunctions(d)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			for filename, expected := range test.outputs(d) {
+				actual, err := ioutil.ReadFile(filepath.Join(d, filename))
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+
+				if !assert.Equal(t,
+					strings.TrimSpace(expected),
+					strings.TrimSpace(string(actual)),
+				) {
+					t.FailNow()
+				}
+			}
+		})
+	}
+}

--- a/mdtogo/cmddocs/cmddocs.go
+++ b/mdtogo/cmddocs/cmddocs.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cmddocs
 
 import (

--- a/mdtogo/common/common.go
+++ b/mdtogo/common/common.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common
 
 import (

--- a/mdtogo/guides/guides.go
+++ b/mdtogo/guides/guides.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package guides
 
 import (


### PR DESCRIPTION
This allows a package to declare that some or all functions should be run after programmatically modifying the package through get,set,update.