### PR TITLE
FAQ typos / github_subdir in hugo config

### DIFF
--- a/docs/api-reference/index.html
+++ b/docs/api-reference/index.html
@@ -207,7 +207,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/api-reference/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/api-reference/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=API%20Reference" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/api-reference/kptfile/index.html
+++ b/docs/api-reference/kptfile/index.html
@@ -208,7 +208,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/api-reference/kptfile/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/api-reference/kptfile/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Kptfile" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/concepts/index.html
+++ b/docs/concepts/index.html
@@ -207,7 +207,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/concepts/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/concepts/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Concepts" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/concepts/packaging/index.html
+++ b/docs/concepts/packaging/index.html
@@ -207,7 +207,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/concepts/packaging/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/concepts/packaging/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Packaging" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/faq/index.html
+++ b/docs/faq/index.html
@@ -184,7 +184,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/faq/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/faq/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=FAQ" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 
@@ -239,10 +239,10 @@
 of naming tools to start with <code>k</code>, and also be short enough that you don&rsquo;t have to alias it.
 It is pronounced &ldquo;kept&rdquo;.</p>
 <h4 id="q-what-does-kpt-provide-that-git-clone-doesnt"><strong>Q: What does kpt provide that git clone doesn&rsquo;t</strong></h4>
-<p>A: <code>kpt</code> enables out-of-the-box workflows that <code>git clone</code> does not such such:
+<p>A: <code>kpt</code> enables out-of-the-box workflows that <code>git clone</code> does not such as:
 cloning and versioning git subdirectories, updating from upstream by
 performing structured merges on resources, programmatically editing
-configuration (rather than with and editor), etc</p>
+configuration (rather than with an editor), etc</p>
 <h4 id="q-how-is-kpt-different-from-other-solutions"><strong>Q: How is <code>kpt</code> different from other solutions?</strong></h4>
 <p>A: Rather than expressing configuration as code, <code>kpt</code> represents configuration packages as data,
 in particular as YAML or JSON objects adhering to the
@@ -326,7 +326,7 @@ channels with <a href="/reference/fn/run">functions</a>, or 2) <a href="/referen
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 18, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/b6557dc5d43f4d95becaa24385a5202417005da5">Fix docsy hugo theme (b6557dc5)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified March 27, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/9b9fa5af5e820aec434b92c5ae9c9c2b5e9fe95e">Fixing a couple typos (9b9fa5af)</a>
 </div>
 </div>
 

--- a/docs/guides/consumer/apply/index.html
+++ b/docs/guides/consumer/apply/index.html
@@ -598,7 +598,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/guides/consumer/apply/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/guides/consumer/apply/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Apply%20a%20local%20package" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/guides/consumer/display/index.html
+++ b/docs/guides/consumer/display/index.html
@@ -598,7 +598,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/guides/consumer/display/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/guides/consumer/display/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Display%20local%20package%20contents" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/guides/consumer/function/index.html
+++ b/docs/guides/consumer/function/index.html
@@ -598,7 +598,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/guides/consumer/function/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/guides/consumer/function/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Running%20functions" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/guides/consumer/get/index.html
+++ b/docs/guides/consumer/get/index.html
@@ -598,7 +598,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/guides/consumer/get/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/guides/consumer/get/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Get%20a%20remote%20package" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/guides/consumer/index.html
+++ b/docs/guides/consumer/index.html
@@ -598,7 +598,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/guides/consumer/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/guides/consumer/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Package%20Consumers" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/guides/consumer/set/index.html
+++ b/docs/guides/consumer/set/index.html
@@ -598,7 +598,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/guides/consumer/set/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/guides/consumer/set/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Set%20field%20values" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/guides/consumer/substitute/index.html
+++ b/docs/guides/consumer/substitute/index.html
@@ -598,7 +598,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/guides/consumer/substitute/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/guides/consumer/substitute/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Substitute%20a%20values%20into%20fields" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/guides/consumer/update/index.html
+++ b/docs/guides/consumer/update/index.html
@@ -598,7 +598,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/guides/consumer/update/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/guides/consumer/update/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Update%20a%20local%20package" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/guides/ecosystem/helm/index.html
+++ b/docs/guides/ecosystem/helm/index.html
@@ -598,7 +598,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/guides/ecosystem/helm/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/guides/ecosystem/helm/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Helm" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/guides/ecosystem/index.html
+++ b/docs/guides/ecosystem/index.html
@@ -598,7 +598,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/guides/ecosystem/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/guides/ecosystem/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Ecosystem" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/guides/ecosystem/kustomize/index.html
+++ b/docs/guides/ecosystem/kustomize/index.html
@@ -598,7 +598,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/guides/ecosystem/kustomize/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/guides/ecosystem/kustomize/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Kustomize" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -595,7 +595,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/guides/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/guides/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Guides" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/guides/producer/blueprint/index.html
+++ b/docs/guides/producer/blueprint/index.html
@@ -598,7 +598,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/guides/producer/blueprint/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/guides/producer/blueprint/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Publishing%20a%20blueprint" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/guides/producer/bootstrap/index.html
+++ b/docs/guides/producer/bootstrap/index.html
@@ -598,7 +598,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/guides/producer/bootstrap/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/guides/producer/bootstrap/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Bootstrapping" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/guides/producer/index.html
+++ b/docs/guides/producer/index.html
@@ -598,7 +598,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/guides/producer/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/guides/producer/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Package%20Publishers" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/guides/producer/init/index.html
+++ b/docs/guides/producer/init/index.html
@@ -598,7 +598,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/guides/producer/init/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/guides/producer/init/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Init" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/guides/producer/setters/index.html
+++ b/docs/guides/producer/setters/index.html
@@ -598,7 +598,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/guides/producer/setters/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/guides/producer/setters/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Create%20Setters" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/guides/producer/substitutions/index.html
+++ b/docs/guides/producer/substitutions/index.html
@@ -598,7 +598,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/guides/producer/substitutions/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/guides/producer/substitutions/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Create%20Substitutions" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/guides/producer/variant/index.html
+++ b/docs/guides/producer/variant/index.html
@@ -598,7 +598,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/guides/producer/variant/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/guides/producer/variant/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Publishing%20a%20variants" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/installation/binaries/index.html
+++ b/docs/installation/binaries/index.html
@@ -276,7 +276,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/installation/binaries/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/installation/binaries/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=binaries" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/installation/gcloud/index.html
+++ b/docs/installation/gcloud/index.html
@@ -276,7 +276,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/installation/gcloud/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/installation/gcloud/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=gcloud" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/installation/homebrew/index.html
+++ b/docs/installation/homebrew/index.html
@@ -276,7 +276,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/installation/homebrew/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/installation/homebrew/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=homebrew" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/installation/index.html
+++ b/docs/installation/index.html
@@ -273,7 +273,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/installation/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/installation/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Installation" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/installation/source/index.html
+++ b/docs/installation/source/index.html
@@ -276,7 +276,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/installation/source/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/installation/source/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=source%20code" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/cfg/annotate/index.html
+++ b/docs/reference/cfg/annotate/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/cfg/annotate/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/cfg/annotate/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Annotate" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/cfg/cat/index.html
+++ b/docs/reference/cfg/cat/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/cfg/cat/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/cfg/cat/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Cat" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/cfg/count/index.html
+++ b/docs/reference/cfg/count/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/cfg/count/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/cfg/count/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Count" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/cfg/create-setter/index.html
+++ b/docs/reference/cfg/create-setter/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/cfg/create-setter/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/cfg/create-setter/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Create-setter" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/cfg/create-subst/index.html
+++ b/docs/reference/cfg/create-subst/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/cfg/create-subst/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/cfg/create-subst/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Create-subst" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/cfg/fmt/index.html
+++ b/docs/reference/cfg/fmt/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/cfg/fmt/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/cfg/fmt/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Fmt" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/cfg/grep/index.html
+++ b/docs/reference/cfg/grep/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/cfg/grep/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/cfg/grep/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Grep" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/cfg/index.html
+++ b/docs/reference/cfg/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/cfg/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/cfg/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Cfg" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/cfg/list-setters/index.html
+++ b/docs/reference/cfg/list-setters/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/cfg/list-setters/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/cfg/list-setters/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=List%20Setters" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/cfg/set/index.html
+++ b/docs/reference/cfg/set/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/cfg/set/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/cfg/set/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Set" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/cfg/tree/index.html
+++ b/docs/reference/cfg/tree/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/cfg/tree/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/cfg/tree/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Tree" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/fn/index.html
+++ b/docs/reference/fn/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/fn/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/fn/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Fn" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/fn/run/index.html
+++ b/docs/reference/fn/run/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/fn/run/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/fn/run/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Run" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/fn/sink/index.html
+++ b/docs/reference/fn/sink/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/fn/sink/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/fn/sink/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Sink" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/fn/source/index.html
+++ b/docs/reference/fn/source/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/fn/source/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/fn/source/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Sink" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Command%20Reference" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/live/apply/index.html
+++ b/docs/reference/live/apply/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/live/apply/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/live/apply/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Apply" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/live/destroy/index.html
+++ b/docs/reference/live/destroy/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/live/destroy/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/live/destroy/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Destroy" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/live/index.html
+++ b/docs/reference/live/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/live/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/live/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Live" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/live/init/index.html
+++ b/docs/reference/live/init/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/live/init/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/live/init/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Init" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/live/preview/index.html
+++ b/docs/reference/live/preview/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/live/preview/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/live/preview/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Preview" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/pkg/desc/index.html
+++ b/docs/reference/pkg/desc/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/pkg/desc/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/pkg/desc/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Desc" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/pkg/diff/index.html
+++ b/docs/reference/pkg/diff/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/pkg/diff/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/pkg/diff/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Diff" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/pkg/get/index.html
+++ b/docs/reference/pkg/get/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/pkg/get/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/pkg/get/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Get" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/pkg/index.html
+++ b/docs/reference/pkg/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/pkg/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/pkg/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Pkg" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/pkg/init/index.html
+++ b/docs/reference/pkg/init/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/pkg/init/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/pkg/init/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Init" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/reference/pkg/update/index.html
+++ b/docs/reference/pkg/update/index.html
@@ -782,7 +782,7 @@
 
 
 
-<a href="https://github.com/GoogleContainerTools/kpt/edit/master/content/en/reference/pkg/update/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
+<a href="https://github.com/GoogleContainerTools/kpt/edit/master/site/content/en/reference/pkg/update/_index.md" target="_blank"><i class="fa fa-edit fa-fw"></i> Edit this page</a>
 <a href="https://github.com/GoogleContainerTools/kpt/issues/new?title=Update" target="_blank"><i class="fab fa-github fa-fw"></i> Create documentation issue</a>
 
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -219,7 +219,7 @@
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/faq/</loc>
-    <lastmod>2020-03-18T14:46:20-07:00</lastmod>
+    <lastmod>2020-03-27T16:41:43-07:00</lastmod>
   </url>
   
   <url>

--- a/site/config.toml
+++ b/site/config.toml
@@ -99,7 +99,7 @@ github_repo = "https://github.com/GoogleContainerTools/kpt"
 github_project_repo = "https://github.com/GoogleContainerTools/kpt"
 
 # Specify a value here if your content directory is not in your repo's root directory
-# github_subdir = ""
+github_subdir = "site"
 
 # Google Custom Search Engine ID. Remove or comment out to disable search.
 # gcs_engine_id = "011737558837375720776:fsdu1nryfng"

--- a/site/content/en/faq/_index.md
+++ b/site/content/en/faq/_index.md
@@ -18,10 +18,10 @@ A: `kpt` was inspired by `apt`, but with a Kubernetes focus.  We wanted to uphol
 
 #### **Q: What does kpt provide that git clone doesn't**
 
-A: `kpt` enables out-of-the-box workflows that `git clone` does not such such:
+A: `kpt` enables out-of-the-box workflows that `git clone` does not such as:
     cloning and versioning git subdirectories, updating from upstream by
     performing structured merges on resources, programmatically editing
-    configuration (rather than with and editor), etc
+    configuration (rather than with an editor), etc
 
 #### **Q: How is `kpt` different from other solutions?**
 


### PR DESCRIPTION
A couple docs changes here:
1. Fixing a couple minor typos in the FAQ
2. Setting the `github_subdir` in the Hugo config to unbreak the "Edit this page" links