### PR TITLE
Fix publishing latest binary in cloudbuild

### DIFF
--- a/release/tag/cloudbuild.yaml
+++ b/release/tag/cloudbuild.yaml
@@ -50,6 +50,13 @@ steps:
     'kpt.exe', 'LICENSES.txt', 'lib.zip']
   - name: 'kpt-builder'
     args: ['gzip', '/workspace/releases/${TAG_NAME}/windows_amd64/kpt_windows_amd64-${TAG_NAME}.tar']
+
+  # copy latest
+  - name: 'kpt-builder'
+    args: ['cp', '-r', '/workspace/releases/${TAG_NAME}/windows_amd64/kpt.exe', '/workspace/latest']
+  - name: 'kpt-builder'
+    args: ['cp', '/workspace/releases/${TAG_NAME}/windows_amd64/kpt_windows_amd64-${TAG_NAME}.tar.gz', '/workspace/latest/kpt_windows_amd64.tar.gz']
+
   # Cleanup by removing files that have been packaged into the
   # tarball.
   - name: 'kpt-builder'
@@ -57,8 +64,6 @@ steps:
     '/workspace/releases/${TAG_NAME}/windows_amd64/kpt.exe',
     '/workspace/releases/${TAG_NAME}/windows_amd64/LICENSES.txt',
     '/workspace/releases/${TAG_NAME}/windows_amd64/lib.zip']
-  - name: 'kpt-builder'
-    args: ['cp', '-r', '/workspace/releases/${TAG_NAME}/windows_amd64', '/workspace/latest']
 
   # build linux
   - name: 'kpt-builder'
@@ -80,6 +85,13 @@ steps:
     'kpt', 'LICENSES.txt', 'lib.zip']
   - name: 'kpt-builder'
     args: ['gzip', '/workspace/releases/${TAG_NAME}/linux_amd64/kpt_linux_amd64-${TAG_NAME}.tar']
+
+    # copy latest
+  - name: 'kpt-builder'
+    args: ['cp', '-r', '/workspace/releases/${TAG_NAME}/linux_amd64/kpt', '/workspace/latest']
+  - name: 'kpt-builder'
+    args: ['cp', '/workspace/releases/${TAG_NAME}/linux_amd64/kpt_linux_amd64-${TAG_NAME}.tar.gz', '/workspace/latest/kpt_linux_amd64.tar.gz']
+
   # Cleanup by removing files that have been packaged into the
   # tarball.
   - name: 'kpt-builder'
@@ -87,8 +99,6 @@ steps:
     '/workspace/releases/${TAG_NAME}/linux_amd64/kpt',
     '/workspace/releases/${TAG_NAME}/linux_amd64/LICENSES.txt',
     '/workspace/releases/${TAG_NAME}/linux_amd64/lib.zip']
-  - name: 'kpt-builder'
-    args: ['cp', '-r', '/workspace/releases/${TAG_NAME}/linux_amd64', '/workspace/latest']
 
   # build darwin
   - name: 'kpt-builder'
@@ -110,6 +120,13 @@ steps:
     'kpt', 'LICENSES.txt', 'lib.zip']
   - name: 'kpt-builder'
     args: ['gzip', '/workspace/releases/${TAG_NAME}/darwin_amd64/kpt_darwin_amd64-${TAG_NAME}.tar']
+
+  # copy latest
+  - name: 'kpt-builder'
+    args: ['cp', '-r', '/workspace/releases/${TAG_NAME}/darwin_amd64/kpt', '/workspace/latest']
+  - name: 'kpt-builder'
+    args: ['cp', '/workspace/releases/${TAG_NAME}/darwin_amd64/kpt_darwin_amd64-${TAG_NAME}.tar.gz', '/workspace/latest/kpt_darwin_amd64.tar.gz']
+
   # Cleanup by removing files that have been packaged into the
   # tarball.
   - name: 'kpt-builder'
@@ -117,8 +134,6 @@ steps:
     '/workspace/releases/${TAG_NAME}/darwin_amd64/kpt',
     '/workspace/releases/${TAG_NAME}/darwin_amd64/LICENSES.txt',
     '/workspace/releases/${TAG_NAME}/darwin_amd64/lib.zip']
-  - name: 'kpt-builder'
-    args: ['cp', '-r', '/workspace/releases/${TAG_NAME}/darwin_amd64', '/workspace/latest']
 
   # build docker image
   - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
The latest link in the docs points to a binary that wasn't being updated

The current cloud build scripts copy the tar.gz with the version tag, but should copy a binary and tar.gz without the version.