### PR TITLE
Fix --name flag documentation for kpt cfg annotate

### DIFF
--- a/site/content/en/reference/cfg/annotate/_index.md
+++ b/site/content/en/reference/cfg/annotate/_index.md
@@ -67,7 +67,7 @@ DIR:
 --namespace
   Only set annotations on resources in this namespace.
 
---namespace
+--name
   Only set annotations on resources with this name.
 ```
 <!--mdtogo-->


### PR DESCRIPTION
Flags were mentioning --namespace twice when the second one was supposed to be --name