### PR TITLE
Fix asciinema cast for kpt cfg cat

### DIFF
--- a/site/content/en/reference/cfg/cat/_index.md
+++ b/site/content/en/reference/cfg/cat/_index.md
@@ -10,7 +10,7 @@ description: >
     Print the resources in a package
 -->
 
-{{< asciinema key="cfg-count" rows="10" preload="1" >}}
+{{< asciinema key="cfg-cat" rows="10" preload="1" >}}
 
 Cat prints the resources in a package as yaml to stdout.
 


### PR DESCRIPTION
It was pointing to kpt cfg count instead