### PR TITLE
Set useragent for kpt requests

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/cmdupdate"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
 	"github.com/spf13/cobra"
+	"k8s.io/kubectl/pkg/cmd/util"
 )
 
 func GetAnthosCommands(name string) []*cobra.Command {
@@ -67,13 +68,13 @@ func NormalizeCommand(c ...*cobra.Command) {
 }
 
 // GetKptCommands returns the set of kpt commands to be registered
-func GetKptCommands(name string) []*cobra.Command {
+func GetKptCommands(name string, f util.Factory) []*cobra.Command {
 	var c []*cobra.Command
 	cfgCmd := GetConfigCommand(name)
 	fnCmd := GetFnCommand(name)
 	pkgCmd := GetPkgCommand(name)
 	ttlCmd := GetTTLCommand(name)
-	liveCmd := GetLiveCommand(name)
+	liveCmd := GetLiveCommand(name, f)
 	guideCmd := GetGuideCommand(name)
 
 	c = append(c, cfgCmd, pkgCmd, fnCmd, ttlCmd, liveCmd, guideCmd)

--- a/commands/livecmd.go
+++ b/commands/livecmd.go
@@ -15,7 +15,6 @@
 package commands
 
 import (
-	"flag"
 	"os"
 
 	"github.com/GoogleContainerTools/kpt/internal/docs/generated/livedocs"
@@ -29,7 +28,7 @@ import (
 	"sigs.k8s.io/cli-utils/cmd/preview"
 )
 
-func GetLiveCommand(name string) *cobra.Command {
+func GetLiveCommand(name string, f util.Factory) *cobra.Command {
 	liveCmd := &cobra.Command{
 		Use:   "live",
 		Short: livedocs.LiveShort,
@@ -46,15 +45,6 @@ func GetLiveCommand(name string) *cobra.Command {
 		},
 	}
 
-	// Create the factory and IOStreams for the "live" commands. The factory
-	// is created using the config flags.
-	flags := liveCmd.PersistentFlags()
-	kubeConfigFlags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
-	kubeConfigFlags.AddFlags(flags)
-	matchVersionKubeConfigFlags := util.NewMatchVersionFlags(kubeConfigFlags)
-	matchVersionKubeConfigFlags.AddFlags(liveCmd.PersistentFlags())
-	liveCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
-	f := util.NewFactory(matchVersionKubeConfigFlags)
 	ioStreams := genericclioptions.IOStreams{
 		In:     os.Stdin,
 		Out:    os.Stdout,

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71
 	gotest.tools v2.2.0+incompatible
+	k8s.io/apimachinery v0.17.3
 	k8s.io/cli-runtime v0.17.3
 	k8s.io/client-go v0.17.3
 	// Currently, we have to import the latest version of kubectl.

--- a/internal/util/cfgflags/useragent.go
+++ b/internal/util/cfgflags/useragent.go
@@ -1,0 +1,37 @@
+package cfgflags
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type UserAgentKubeConfigFlags struct {
+	Delegate  genericclioptions.RESTClientGetter
+	UserAgent string
+}
+
+func (u *UserAgentKubeConfigFlags) ToRESTConfig() (*rest.Config, error) {
+	clientConfig, err := u.Delegate.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+	if u.UserAgent != "" {
+		clientConfig.UserAgent = u.UserAgent
+	}
+	return clientConfig, nil
+}
+
+func (u *UserAgentKubeConfigFlags) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	return u.Delegate.ToDiscoveryClient()
+}
+
+func (u *UserAgentKubeConfigFlags) ToRESTMapper() (meta.RESTMapper, error) {
+	return u.Delegate.ToRESTMapper()
+}
+
+func (u *UserAgentKubeConfigFlags) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	return u.Delegate.ToRawKubeConfigLoader()
+}

--- a/internal/util/cfgflags/useragent_test.go
+++ b/internal/util/cfgflags/useragent_test.go
@@ -1,0 +1,72 @@
+package cfgflags
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func TestUserAgentConfigFlags(t *testing.T) {
+	testCases := []struct {
+		name              string
+		existingUserAgent string
+		newUserAgent      string
+		expectedUserAgent string
+	}{
+		{
+			name:              "new useragent",
+			existingUserAgent: "kubectl",
+			newUserAgent:      "kpt",
+			expectedUserAgent: "kpt",
+		},
+		{
+			name:              "no new useragent",
+			existingUserAgent: "kubectl",
+			newUserAgent:      "",
+			expectedUserAgent: "kubectl",
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			baseConfig := &rest.Config{
+				UserAgent: tc.existingUserAgent,
+			}
+
+			cf := &UserAgentKubeConfigFlags{
+				Delegate: &fakeRESTClientGetter{
+					config: baseConfig,
+				},
+				UserAgent: tc.newUserAgent,
+			}
+			config, err := cf.ToRESTConfig()
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedUserAgent, config.UserAgent)
+		})
+	}
+}
+
+type fakeRESTClientGetter struct {
+	config *rest.Config
+}
+
+func (f *fakeRESTClientGetter) ToRESTConfig() (*rest.Config, error) {
+	return f.config, nil
+}
+
+func (f *fakeRESTClientGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	return nil, nil
+}
+
+func (f *fakeRESTClientGetter) ToRESTMapper() (meta.RESTMapper, error) {
+	return nil, nil
+}
+
+func (f *fakeRESTClientGetter) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	return nil
+}


### PR DESCRIPTION
This updates the `util.Factory` to return a `rest.Config` with the useragent set to something like `kpt/v0.23.0`. This works as expected for the normal clients.
The issue is that the `RESTClientGetter` interface also provides functions for getting a DiscoveryClient and a RESTMapper, so these will not use the updated `rest.Config` and therefore not pick up the right useragent. I haven't found a way to address this that doesn't require a change in the upstream code.

Another option we could use is to set the variables in `k8s.io/client-go/pkg/version/base.go` during build and then just rely on the regular way the useragent is set for kubernetes. But it does feel a bit strange and it would be different from the way we currently set the version in `run.go` during build.

@pwittrock @seans3 