### PR TITLE
live: Persist kubeconfig flags to subcommands.

### DIFF
--- a/commands/livecmd.go
+++ b/commands/livecmd.go
@@ -48,7 +48,7 @@ func GetLiveCommand(name string) *cobra.Command {
 
 	// Create the factory and IOStreams for the "live" commands. The factory
 	// is created using the config flags.
-	flags := liveCmd.Flags()
+	flags := liveCmd.PersistentFlags()
 	kubeConfigFlags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
 	kubeConfigFlags.AddFlags(flags)
 	matchVersionKubeConfigFlags := util.NewMatchVersionFlags(kubeConfigFlags)


### PR DESCRIPTION
Fixes #455

Follow up to https://github.com/GoogleContainerTools/kpt/pull/511 which I couldn't reopen because I deleted my branch for that PR.