### PR TITLE
Support fetching openAPI schema from cluster or read from disk

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -25,6 +25,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/cmdupdate"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
 	"github.com/spf13/cobra"
+	"k8s.io/kubectl/pkg/cmd/util"
 )
 
 func GetAnthosCommands(name string) []*cobra.Command {
@@ -67,13 +68,13 @@ func NormalizeCommand(c ...*cobra.Command) {
 }
 
 // GetKptCommands returns the set of kpt commands to be registered
-func GetKptCommands(name string) []*cobra.Command {
+func GetKptCommands(name string, f util.Factory) []*cobra.Command {
 	var c []*cobra.Command
 	cfgCmd := GetConfigCommand(name)
 	fnCmd := GetFnCommand(name)
 	pkgCmd := GetPkgCommand(name)
 	ttlCmd := GetTTLCommand(name)
-	liveCmd := GetLiveCommand(name)
+	liveCmd := GetLiveCommand(name, f)
 	guideCmd := GetGuideCommand(name)
 
 	c = append(c, cfgCmd, pkgCmd, fnCmd, ttlCmd, liveCmd, guideCmd)

--- a/commands/livecmd.go
+++ b/commands/livecmd.go
@@ -17,6 +17,7 @@ package commands
 import (
 	"os"
 
+	"github.com/GoogleContainerTools/kpt/internal/cmdfetchk8sschema"
 	"github.com/GoogleContainerTools/kpt/internal/docs/generated/livedocs"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -77,7 +78,10 @@ func GetLiveCommand(name string, f util.Factory) *cobra.Command {
 	destroyCmd.Long = livedocs.DestroyShort + "\n" + livedocs.DestroyLong
 	destroyCmd.Example = livedocs.DestroyExamples
 
-	liveCmd.AddCommand(initCmd, applyCmd, previewCmd, diffCmd, destroyCmd)
+	fetchOpenAPICmd := cmdfetchk8sschema.NewCommand(name, f, ioStreams)
+
+	liveCmd.AddCommand(initCmd, applyCmd, previewCmd, diffCmd, destroyCmd,
+		fetchOpenAPICmd)
 
 	return liveCmd
 }

--- a/commands/livecmd.go
+++ b/commands/livecmd.go
@@ -15,7 +15,6 @@
 package commands
 
 import (
-	"flag"
 	"os"
 
 	"github.com/GoogleContainerTools/kpt/internal/docs/generated/livedocs"
@@ -29,7 +28,7 @@ import (
 	"sigs.k8s.io/cli-utils/cmd/preview"
 )
 
-func GetLiveCommand(name string) *cobra.Command {
+func GetLiveCommand(name string, f util.Factory) *cobra.Command {
 	liveCmd := &cobra.Command{
 		Use:   "live",
 		Short: livedocs.LiveShort,
@@ -46,15 +45,6 @@ func GetLiveCommand(name string) *cobra.Command {
 		},
 	}
 
-	// Create the factory and IOStreams for the "live" commands. The factory
-	// is created using the config flags.
-	flags := liveCmd.PersistentFlags()
-	kubeConfigFlags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
-	kubeConfigFlags.AddFlags(flags)
-	matchVersionKubeConfigFlags := util.NewMatchVersionFlags(kubeConfigFlags)
-	matchVersionKubeConfigFlags.AddFlags(liveCmd.PersistentFlags())
-	liveCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
-	f := util.NewFactory(matchVersionKubeConfigFlags)
 	ioStreams := genericclioptions.IOStreams{
 		In:     os.Stdin,
 		Out:    os.Stdout,

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200121175148-a6ecf24a6d71
 	gotest.tools v2.2.0+incompatible
+	k8s.io/apimachinery v0.17.3
 	k8s.io/cli-runtime v0.17.3
 	k8s.io/client-go v0.17.3
 	// Currently, we have to import the latest version of kubectl.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.0
 	github.com/go-errors/errors v1.0.1
+	github.com/go-openapi/spec v0.19.5
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/google/addlicense v0.0.0-20200422172452-68a83edd47bc // indirect
 	github.com/olekukonko/tablewriter v0.0.4

--- a/internal/cmdfetchk8sschema/cmdfetchk8sschema.go
+++ b/internal/cmdfetchk8sschema/cmdfetchk8sschema.go
@@ -1,0 +1,98 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdfetchk8sschema
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
+	"github.com/GoogleContainerTools/kpt/internal/util/openapi"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/kubectl/pkg/cmd/util"
+)
+
+func NewRunner(parent string, f util.Factory,
+	ioStreams genericclioptions.IOStreams) *Runner {
+	r := &Runner{
+		IOStreams: ioStreams,
+		Factory:   f,
+	}
+	// TODO: Update description with info from the site.
+	c := &cobra.Command{
+		Use:   "fetch-k8s-schema",
+		Short: "Fetch kubernetes schema from cluster and print to stdout",
+		Long: `
+Fetch kubernetes schema from cluster and print to stdout
+
+  kpt live fetch-k8s-schema [flags]
+
+Flags:
+  --pretty-print:
+    Format the schema before printing it
+`,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// Don't run the PreRun functions that read k8s-schema since
+			// we are doing that in the command itself.
+			return nil
+		},
+		RunE: r.runE,
+	}
+	cmdutil.FixDocs("kpt", parent, c)
+	r.Command = c
+
+	c.Flags().BoolVar(&r.PrettyPrint, "pretty-print", false,
+		`Format the schema before printing`)
+
+	return r
+}
+
+func NewCommand(parent string, f util.Factory,
+	ioStreams genericclioptions.IOStreams) *cobra.Command {
+	return NewRunner(parent, f, ioStreams).Command
+}
+
+// Runner contains the run function
+type Runner struct {
+	Command   *cobra.Command
+	IOStreams genericclioptions.IOStreams
+	Factory   util.Factory
+
+	PrettyPrint bool
+}
+
+func (r *Runner) runE(c *cobra.Command, args []string) error {
+	schema, err := openapi.FetchOpenAPISchemaFromCluster(r.Factory)
+	if err != nil {
+		return err
+	}
+
+	if r.PrettyPrint {
+		var data map[string]interface{}
+		err = json.Unmarshal(schema, &data)
+		if err != nil {
+			return err
+		}
+
+		schema, err = json.MarshalIndent(data, "", "  ")
+		if err != nil {
+			return err
+		}
+	}
+
+	fmt.Fprintf(r.IOStreams.Out, "%s\n", string(schema))
+	return nil
+}

--- a/internal/util/cfgflags/useragent.go
+++ b/internal/util/cfgflags/useragent.go
@@ -1,0 +1,37 @@
+package cfgflags
+
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+type UserAgentKubeConfigFlags struct {
+	Delegate  genericclioptions.RESTClientGetter
+	UserAgent string
+}
+
+func (u *UserAgentKubeConfigFlags) ToRESTConfig() (*rest.Config, error) {
+	clientConfig, err := u.Delegate.ToRESTConfig()
+	if err != nil {
+		return nil, err
+	}
+	if u.UserAgent != "" {
+		clientConfig.UserAgent = u.UserAgent
+	}
+	return clientConfig, nil
+}
+
+func (u *UserAgentKubeConfigFlags) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	return u.Delegate.ToDiscoveryClient()
+}
+
+func (u *UserAgentKubeConfigFlags) ToRESTMapper() (meta.RESTMapper, error) {
+	return u.Delegate.ToRESTMapper()
+}
+
+func (u *UserAgentKubeConfigFlags) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	return u.Delegate.ToRawKubeConfigLoader()
+}

--- a/internal/util/cfgflags/useragent_test.go
+++ b/internal/util/cfgflags/useragent_test.go
@@ -1,0 +1,72 @@
+package cfgflags
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func TestUserAgentConfigFlags(t *testing.T) {
+	testCases := []struct {
+		name              string
+		existingUserAgent string
+		newUserAgent      string
+		expectedUserAgent string
+	}{
+		{
+			name:              "new useragent",
+			existingUserAgent: "kubectl",
+			newUserAgent:      "kpt",
+			expectedUserAgent: "kpt",
+		},
+		{
+			name:              "no new useragent",
+			existingUserAgent: "kubectl",
+			newUserAgent:      "",
+			expectedUserAgent: "kubectl",
+		},
+	}
+
+	for i := range testCases {
+		tc := testCases[i]
+		t.Run(tc.name, func(t *testing.T) {
+			baseConfig := &rest.Config{
+				UserAgent: tc.existingUserAgent,
+			}
+
+			cf := &UserAgentKubeConfigFlags{
+				Delegate: &fakeRESTClientGetter{
+					config: baseConfig,
+				},
+				UserAgent: tc.newUserAgent,
+			}
+			config, err := cf.ToRESTConfig()
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedUserAgent, config.UserAgent)
+		})
+	}
+}
+
+type fakeRESTClientGetter struct {
+	config *rest.Config
+}
+
+func (f *fakeRESTClientGetter) ToRESTConfig() (*rest.Config, error) {
+	return f.config, nil
+}
+
+func (f *fakeRESTClientGetter) ToDiscoveryClient() (discovery.CachedDiscoveryInterface, error) {
+	return nil, nil
+}
+
+func (f *fakeRESTClientGetter) ToRESTMapper() (meta.RESTMapper, error) {
+	return nil, nil
+}
+
+func (f *fakeRESTClientGetter) ToRawKubeConfigLoader() clientcmd.ClientConfig {
+	return nil
+}

--- a/internal/util/cmdutil/cmdutil.go
+++ b/internal/util/cmdutil/cmdutil.go
@@ -78,3 +78,11 @@ var ExitOnError bool
 
 // StackOnError if true, will print a stack trace on failure.
 var StackOnError bool
+
+// K8sSchemaSource defines where we should look for the kubernetes openAPI
+// schema
+var K8sSchemaSource string
+
+// K8sSchemaPath defines the path to the openAPI schema if we are reading from
+// a file
+var K8sSchemaPath string

--- a/internal/util/openapi/openapi.go
+++ b/internal/util/openapi/openapi.go
@@ -1,0 +1,91 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openapi
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/kustomize/kyaml/openapi"
+	"sigs.k8s.io/kustomize/kyaml/openapi/kustomizationapi"
+)
+
+// ConfigureOpenAPI sets the openAPI schema in kyaml. It can either
+// fetch the schema from a cluster, read it from file, or just the
+// schema built into kyaml.
+func ConfigureOpenAPI(factory util.Factory, k8sSchemaSource, k8sSchemaPath string) error {
+	switch k8sSchemaSource {
+	case "":
+		openAPISchema, err := FetchOpenAPISchemaFromCluster(factory)
+		if err != nil {
+			// The default behavior is to try to fetch the schema from the
+			// cluster, but fall back on using the builtin one if that doesn't
+			// work
+			return nil
+		}
+		return ConfigureOpenAPISchema(openAPISchema)
+	case "cluster":
+		openAPISchema, err := FetchOpenAPISchemaFromCluster(factory)
+		if err != nil {
+			return fmt.Errorf("error fetching schema from cluster: %v", err)
+		}
+		return ConfigureOpenAPISchema(openAPISchema)
+	case "file":
+		openAPISchema, err := ReadOpenAPISchemaFromDisk(k8sSchemaPath)
+		if err != nil {
+			return fmt.Errorf("error reading file at path %s: %v",
+				k8sSchemaPath, err)
+		}
+		return ConfigureOpenAPISchema(openAPISchema)
+	case "builtin":
+		return nil
+	default:
+		return fmt.Errorf("unknown schema source %s. Must be one of file, cluster, builtin",
+			k8sSchemaSource)
+	}
+}
+
+func FetchOpenAPISchemaFromCluster(f util.Factory) ([]byte, error) {
+	restClient, err := f.RESTClient()
+	if err != nil {
+		return nil, err
+	}
+	data, err := restClient.Get().AbsPath("/openapi/v2").
+		SetHeader("Accept", "application/json").Do().Raw()
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func ReadOpenAPISchemaFromDisk(path string) ([]byte, error) {
+	return ioutil.ReadFile(path)
+}
+
+func ConfigureOpenAPISchema(openAPISchema []byte) error {
+	openapi.SuppressBuiltInSchemaUse()
+
+	_, err := openapi.AddSchema(openAPISchema)
+	if err != nil {
+		return err
+	}
+	// Also add make sure the Kustomize openAPI is always added regardless
+	// of where we got the Kubernetes openAPI schema.
+	// TODO: Refactor the openapi package in kyaml so we don't need to
+	// know the name of the kustomize asset here.
+	_, err = openapi.AddSchema(kustomizationapi.MustAsset("openapi/kustomizationapi/swagger.json"))
+	return err
+}

--- a/internal/util/openapi/openapi_test.go
+++ b/internal/util/openapi/openapi_test.go
@@ -1,0 +1,164 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package openapi
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/go-openapi/spec"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/rest/fake"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+	"sigs.k8s.io/kustomize/kyaml/openapi"
+)
+
+func TestSomething(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		schemaSource         string
+		schemaPath           string
+		response             *http.Response
+		includesRefString    string
+		notIncludesRefString string
+		expectError          bool
+	}{
+		{
+			name:         "no schemaSource provided with fallback to builtin",
+			schemaSource: "",
+			response: &http.Response{StatusCode: http.StatusNotFound,
+				Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")},
+			includesRefString: "#/definitions/io.k8s.api.core.v1.PodSpec",
+			expectError:       false,
+		},
+		{
+			name:         "no schemaSource provided with cluster available",
+			schemaSource: "",
+			response: &http.Response{StatusCode: http.StatusOK,
+				Header: cmdtesting.DefaultHeader(), Body: getSchema(t, "clusterschema.json")},
+			includesRefString: "#/definitions/io.k8s.clusterSchema",
+			expectError:       false,
+		},
+		{
+			name:         "schemaSource cluster with successful fetch",
+			schemaSource: "cluster",
+			response: &http.Response{StatusCode: http.StatusOK,
+				Header: cmdtesting.DefaultHeader(), Body: getSchema(t, "clusterschema.json")},
+			includesRefString:    "#/definitions/io.k8s.clusterSchema",
+			notIncludesRefString: "#/definitions/io.k8s.api.core.v1.PodSpec",
+			expectError:          false,
+		},
+		{
+			name:         "schemaSource cluster with failed fetch",
+			schemaSource: "cluster",
+			response: &http.Response{StatusCode: http.StatusNotFound,
+				Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")},
+			expectError: true,
+		},
+		{
+			name:                 "schemaSource file with valid path",
+			schemaSource:         "file",
+			schemaPath:           "testdata/fileschema.json",
+			includesRefString:    "#/definitions/io.k8s.fileSchema",
+			notIncludesRefString: "#/definitions/io.k8s.api.core.v1.PodSpec",
+			expectError:          false,
+		},
+		{
+			name:         "schemaSource file with invalid path",
+			schemaSource: "file",
+			schemaPath:   "testdata/notfound.json",
+			expectError:  true,
+		},
+		{
+			name:              "schemaSource builtin",
+			schemaSource:      "builtin",
+			includesRefString: "#/definitions/io.k8s.api.core.v1.PodSpec",
+			expectError:       false,
+		},
+		{
+			name:         "unknown schemasource",
+			schemaSource: "unknown",
+			expectError:  true,
+		},
+	}
+
+	for i := range testCases {
+		test := testCases[i]
+		t.Run(test.name, func(t *testing.T) {
+			tf := cmdtesting.NewTestFactory().WithNamespace("test-namespace")
+			defer tf.Cleanup()
+
+			tf.ClientConfigVal.GroupVersion = &schema.GroupVersion{
+				Group:   "",
+				Version: "v1",
+			}
+			tf.ClientConfigVal.NegotiatedSerializer = resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer
+
+			tf.Client = &fake.RESTClient{
+				NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+					if req.Method == http.MethodGet && req.URL.Path == "/openapi/v2" {
+						return test.response, nil
+					}
+					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+					return nil, nil
+				}),
+			}
+
+			openapi.ResetOpenAPI()
+
+			err := ConfigureOpenAPI(tf, test.schemaSource, test.schemaPath)
+			if test.expectError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			ref, err := spec.NewRef(test.includesRefString)
+			assert.NoError(t, err)
+			res, err := openapi.Resolve(&ref)
+			assert.NoError(t, err)
+			assert.NotNil(t, res)
+
+			// If the notIncludesRefString is specified, make sure
+			// the schema does not include the reference.
+			if test.notIncludesRefString != "" {
+				ref2, err := spec.NewRef(test.notIncludesRefString)
+				assert.NoError(t, err)
+				res2, _ := openapi.Resolve(&ref2)
+				assert.Nil(t, res2)
+			}
+
+			// Verify that we have the Kustomize openAPI included.
+			kustomizeRef, _ := spec.NewRef("#/definitions/io.k8s.api.apps.v1.Kustomization")
+			kustomizeRes, err := openapi.Resolve(&kustomizeRef)
+			assert.NoError(t, err)
+			assert.NotNil(t, kustomizeRes)
+		})
+	}
+}
+
+func getSchema(t *testing.T, filename string) io.ReadCloser {
+	b, err := ioutil.ReadFile("testdata/" + filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ioutil.NopCloser(bytes.NewBuffer(b))
+}

--- a/internal/util/openapi/testdata/clusterschema.json
+++ b/internal/util/openapi/testdata/clusterschema.json
@@ -1,0 +1,8 @@
+{
+  "definitions": {
+    "io.k8s.clusterSchema": {
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}

--- a/internal/util/openapi/testdata/fileschema.json
+++ b/internal/util/openapi/testdata/fileschema.json
@@ -1,0 +1,8 @@
+{
+  "definitions": {
+    "io.k8s.fileSchema": {
+      "additionalProperties": false,
+      "type": "object"
+    }
+  }
+}


### PR DESCRIPTION
This PR allows users to use one of three different sources for the openAPI schema. It can fetch the schema from the cluster using the current context, it can read it from a local file, or it can use the schema compiled into kpt.
The default is to fetch it from the cluster, but automatically fall back to using the complied-in schema if that doesn't work. 
It also adds a new command under live, `fetch-openapi`, which just downloads the openAPI schema from the cluster given in the current context and outputs it to stdout.

Still need tests, but wanted to get feedback on whether we think this is the right approach.

@pwittrock @phanimarupaka @monopole 