### PR TITLE
Updated kpt release README

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -1,7 +1,16 @@
 # Releasing
 
+## Steps
+
 To cut a new kpt release perform the following:
 
+- Ensure kpt is importing the latest dependent releases
+  - [cli-utils](https://github.com/kubernetes-sigs/cli-utils/tree/master/release)
+  - Within kustomize: [kyaml](https://github.com/kubernetes-sigs/kustomize/blob/master/releasing)
+  - Within kustomize: [cmd/config](https://github.com/kubernetes-sigs/kustomize/blob/master/releasing)
+  - Update `go.mod` file with correct versions of `cli-utils`, `kyaml`, and `cmd/config`
+  - Run `make all` (which should update `go.sum` and run `go mod tidy`)
+  - Create a `kpt` PR with previous `go.mod` and `go.sum` changes, and submit. [Example PR](https://github.com/GoogleContainerTools/kpt/pull/594)
 - Fetch the latest master changes to a clean branch
   - `git checkout -b release`
   - `git fetch upstream`
@@ -15,7 +24,13 @@ To cut a new kpt release perform the following:
   - create a PR for this change and merge it
   - [example PR](https://github.com/GoogleContainerTools/kpt/pull/331/commits/baf33d8ed214f2c5e106ec6e963ad736e5ff4d98#diff-d69e3adb302ee3e84814136422cbf872)
 
+## Artifacts
+
 Release artifacts such as binaries and images will be built automatically by Cloud Build in the
 `kpt-dev` GCP project.  The binaries linked from the README.md docs will be automatically updated
 because they point to the `latest` binaries which are updated for tagged releases.  Images are
 also updated with the `latest` tag for tagged releases.
+
+- `kpt-dev` release buckets
+  - `gs://kpt-dev/latest`
+  - `gs://kpt-dev/releases`


### PR DESCRIPTION
* Updates `kpt` release README.md to describe steps for incorporating dependent release versions.
* Updates `kpt` release README.md to show where the `kpt-dev` gcs buckets are.