### PR TITLE
Minor suggestions to arch page doc

### DIFF
--- a/site/content/en/concepts/architecture/_index.md
+++ b/site/content/en/concepts/architecture/_index.md
@@ -36,14 +36,14 @@ enable **composing loosely coupled solutions** through reading and writing to a 
 
 ## Design Principles
 
-### Configuration as Data vs Configuration as Code
+### Configuration-as-Data vs Configuration-as-Code
 
 kpt packages configuration as data (APIs) rather than as code (templates /  DSLs). In this model,
 the configuration is static data, which many tools may read & write.
 
 This model has its roots in the Unix Philosophy:
 
-    Expect the output of every program to become the input to another, as yet unknown, program
+> Expect the output of every program to become the input to another, as yet unknown, program
 
 As well as in the Kubernetes control-plane where resources are read and written by loosely coupled
 controllers.
@@ -54,7 +54,7 @@ By enabling resource-controller style systems to be built on configuration files
 applying them to the cluster, kpt shifts the control-plane left -- enabling more issues to be
 caught before they are pushed into a cluster.
 
-- Cluster changes may be reviewed, approved, validated, audited and rolled back using git.
+- Cluster changes may be reviewed, approved, validated, audited and rolled back using git
 - Git automation may be applied to changes to cluster state
 
 ### Shift-Right vs Shift-Left
@@ -68,33 +68,33 @@ caught before they are pushed into a cluster.
 Design solutions to work together, expecting the output of each command to be read as input
 by another.
 
-- Operations read configuration and write it back.
+- Commands read configuration and write configuration.
 - The inputs and outputs should be symmetric.
-- It should be possible to pipe kpt operations together, and it should be possible to write
-  the output of a kpt operation back to its source (updating it in-place).
+- It should be possible to pipe kpt commands together, and it should be possible to write
+  the output of a kpt command back to its source (updating it in-place).
 
 Tools which read / write data may be developed in different languages and composed together.
 Tools which write configuration back to the same source it was read from should retain comments
 set on the input, as the comments may be used by kpt and other tools as metadata.
 
-Programs may be developed independently of one another, with operations built directly into
+Programs may be developed independently of one another, with commands built directly into
 the CLI -- e.g. `kpt cfg set`.
 
 Additionally, kpt offers *functions* as an extension mechanism to simplify publishing logic,
 and to provide deeper integration with kpt -- e.g. invoking functions automatically
-after kpt operations.
+after kpt commands.
 
 #### kpt vs kubernetes:
 
 - kpt: resource configuration is read, modified and written back to its source (or another destination)
   - resources may be updated using 3-way merge (kpt pkg update)
-- kubernetes: resources are read, modified and written back to the apiserver
+- kubernetes: resources are read, modified, and written back to the apiserver
   - resources may be updated using 3-way merge (kubectl apply)
 
 ### Resource oriented
 
 Desired system state is expressed using Kubernetes resources -- declarative, static data structures.
-This is changed through modification of resources -- these may be done:
+The desired state is changed through modification of resources -- these may be done:
 
 - programmatically by manually invoked tools -- e.g. `kpt cfg set`
 - through direct text edits -- e.g. `vi`
@@ -103,8 +103,8 @@ This is changed through modification of resources -- these may be done:
 High-level logic should be built into programs which understand configuration and are capable of
 generating and transforming it given some context.
 
-Since all tools read / write configuration data, multiple tools may be composed through
-invoking them against shared configuration data / pipelining their operations.
+Since all tools read and write configuration data, multiple tools may be composed by
+invoking them against the same configuration data and pipelining their commands.
 
 #### kpt vs kubernetes:
 
@@ -164,9 +164,9 @@ Examples:
 
 Much like Kubernetes controllers, kpt should be able to read its previous outputs and modify
 them, rather than generating them from scratch -- e.g. read a directory of
-configuration and write back to the same directory.
+configuration and write it back to the same directory.
 
-**Note:** This requires symmetric inputs and outputs.
+**Note:** This principle requires symmetric inputs and outputs.
 
 Dynamic logic may be written using templates or DSLs -- which would not support the read-write
 workflow -- by merging the newly generated template / DSL output resources with the input
@@ -175,9 +175,9 @@ resources.
 ### Targets
 
 Unlike the Kubernetes control-plane, which reads and writes from the apiserver, kpt
-reads and writes from arbitrary, sources so long as they provide resource configuration.
+reads and writes from arbitrary sources, so long as they provide resource configuration.
 
 - Local files
 - Files stored in git
-- Command stdin + stdout
+- Command stdin & stdout
 - Apiserver endpoints


### PR DESCRIPTION
Changed "operations" to kpt "commands".
Hyphenated config-as-data vs config-as-code. This will make it more easily searchable. Config, data, and code are all very common terms. Most other terms in this doc (e.g. Shift-Left) already contain hyphens.
Switched unix quote from markdown "code block" that doesn't wrap, to markdown "quote" which text wraps nicely.
A few other minor updates.