### PR TITLE
Updating examples to use the new syntax and args

### DIFF
--- a/site/content/en/guides/producer/substitutions/_index.md
+++ b/site/content/en/guides/producer/substitutions/_index.md
@@ -89,27 +89,27 @@ spec:
 
 ```sh
 # create an image substitution and a setter that populates it
-kpt cfg create-subst hello-world/ image-value nginx:1.7.9 \
-  --pattern nginx:TAG_SETTER --value TAG_SETTER=tag
+kpt cfg create-subst hello-world/ image-value --field-value nginx:1.7.9 \
+  --pattern nginx:\${TAG_SETTER}
 ```
 
 ```yaml
 # Kptfile -- updated
 openAPI:
   definitions:
-    io.k8s.cli.setters.tag:
+    io.k8s.cli.setters.TAG_SETTER:
       x-k8s-cli:
         setter:
-          name: "tag"
-          value: "1.7.9"
+          name: TAG_SETTER
+          value: 1.7.9
     io.k8s.cli.substitutions.image-value:
       x-k8s-cli:
         substitution:
           name: image-value
-          pattern: nginx:TAG_SETTER
+          pattern: nginx:${TAG_SETTER}
           values:
-          - marker: TAG_SETTER
-            ref: '#/definitions/io.k8s.cli.setters.tag'
+          - marker: ${TAG_SETTER}
+            ref: '#/definitions/io.k8s.cli.setters.TAG_SETTER'
 ```
 
 ```yaml
@@ -148,7 +148,7 @@ Substitutions are invoked by running `kpt cfg set` on a setter used by the
 substitution.
 
 ```sh
-kpt cfg set hello-world/ tag 1.8.1
+kpt cfg set hello-world/ TAG_SETTER 1.8.1
 ```
 
 ```yaml


### PR DESCRIPTION
```
$ kpt version
0.26.0
$ kpt cfg create-subst hello-world/ image-value nginx:1.7.9  \
   --pattern nginx:TAG_SETTER --value TAG_SETTER=tag

Error: unknown flag: --value
Usage: ...
```

The example on the docs no longer works. Updating the example to use the proper args and enclosing the setter names with ${}. 