### PR TITLE
updates the Kptfile merger so that it handles delete setters correctly.

### DIFF
--- a/internal/kptfile/pkgfile.go
+++ b/internal/kptfile/pkgfile.go
@@ -123,6 +123,9 @@ func (updatedKf *KptFile) MergeOpenAPI(localKf, originalKf KptFile) error {
 
 	// merge the definitions
 	err = mergeDef(updatedDef, localDef, oriDef)
+	if err != nil {
+		return err
+	}
 
 	// convert the result back to type interface{} and set it on the Kptfile
 	s, err := updated.String()

--- a/internal/kptfile/pkgfile.go
+++ b/internal/kptfile/pkgfile.go
@@ -201,12 +201,12 @@ func shouldRemoveValue (updatedDef, localDef, originalDef *yaml.MapNode, key str
 		return false
 	}
 
-	originalValStr, err := originalDef.Value.Field(key).Value.String()
+	originalValStr, err := originalVal.Value.String()
 	if err != nil {
 		return false
 	}
 
-	updatedValStr, err := updatedDef.Value.Field(key).Value.String()
+	updatedValStr, err := updatedVal.Value.String()
 	if err != nil {
 		return false
 	}

--- a/internal/kptfile/pkgfile_test.go
+++ b/internal/kptfile/pkgfile_test.go
@@ -402,6 +402,55 @@ openAPI:
                     value: nginx
 `,
 		},
+		{
+			name: "keep deleted",
+			updated: `
+openAPI:
+  definitions:
+    io.k8s.cli.setters.image:
+      x-k8s-cli:
+        setter:
+          name: "image"
+          value: "nginx"
+    io.k8s.cli.setters.tag:
+      x-k8s-cli:
+        setter:
+          name: "tag"
+          value: "1.7.9"
+`,
+			local: `
+openAPI:
+  definitions:
+    io.k8s.cli.setters.tag:
+      x-k8s-cli:
+        setter:
+          name: "tag"
+          value: "1.8.0"
+`,
+			original: `
+openAPI:
+  definitions:
+    io.k8s.cli.setters.image:
+      x-k8s-cli:
+        setter:
+          name: "image"
+          value: "nginx"
+    io.k8s.cli.setters.tag:
+      x-k8s-cli:
+        setter:
+          name: "tag"
+          value: "1.7.9"
+`,
+			expected: `
+openAPI:
+    definitions:
+        io.k8s.cli.setters.tag:
+            x-k8s-cli:
+                setter:
+                    name: tag
+                    value: 1.8.0
+`,
+		},
 	}
 
 	for i := range tests {


### PR DESCRIPTION
This PR updates the Kptfile merger so that when the setters deleted, updated Kptfile won't add it back again.

See related PRs on delete setters:
https://github.com/kubernetes-sigs/kustomize/pull/2553