### PR TITLE
Improve consumer guide

### DIFF
--- a/docs/guides/consumer/apply/index.html
+++ b/docs/guides/consumer/apply/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerupdate">
+    <li class="collapse " id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 active td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerdisplay">
+    <li class="collapse show" id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 active td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse show" id="kptguidesconsumerapply">
+    <li class="collapse " id="kptguidesconsumerupdate">
       
       
       

--- a/docs/guides/consumer/display/index.html
+++ b/docs/guides/consumer/display/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 active td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerupdate">
+    <li class="collapse show" id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 active td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse show" id="kptguidesconsumerdisplay">
+    <li class="collapse " id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerapply">
+    <li class="collapse " id="kptguidesconsumerupdate">
       
       
       
@@ -1024,7 +1024,7 @@ metadata:
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 18, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/b6557dc5d43f4d95becaa24385a5202417005da5">Fix docsy hugo theme (b6557dc5)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified June 3, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4c9e64de7e255bbed3221a3ab42b505e82e52bf8">Small improvements to the consumer guides (4c9e64de)</a>
 </div>
 </div>
 

--- a/docs/guides/consumer/function/index.html
+++ b/docs/guides/consumer/function/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerupdate">
+    <li class="collapse " id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerdisplay">
+    <li class="collapse " id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerapply">
+    <li class="collapse " id="kptguidesconsumerupdate">
       
       
       
@@ -919,7 +919,7 @@ look like this)</li>
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified April 20, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/c5e240e0e179b35dc3d1324311f63e9e60fe3ac8">Update docs with kpt functions concept docs (c5e240e0)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified June 3, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4c9e64de7e255bbed3221a3ab42b505e82e52bf8">Small improvements to the consumer guides (4c9e64de)</a>
 </div>
 </div>
 

--- a/docs/guides/consumer/get/index.html
+++ b/docs/guides/consumer/get/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerupdate">
+    <li class="collapse " id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerdisplay">
+    <li class="collapse " id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerapply">
+    <li class="collapse " id="kptguidesconsumerupdate">
       
       
       
@@ -907,6 +907,10 @@ fetched and used as a package</li>
 match the upstream directory name it is copied from</li>
 <li>including <code>.git</code> as part of the repo name is optional but good practice to
 ensure the repo + subdirectory are parsed correctly by the tool.</li>
+<li>Packages inside the same repo can be versioned individually by creating tags
+with the format <code>&lt;path to package in repo&gt;/&lt;version&gt;</code>, similar to how go
+modules are versioned. For example, a tag named <code>staging/cockroachdb/v1.2.3</code>
+would be interpreted by kpt as version <code>v1.2.3</code> of the cockroachdb package.</li>
 </ul>
 
 </div>
@@ -1078,7 +1082,7 @@ statefulset.apps/cockroachdb   3/3     54s
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified May 26, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/5cb591182d73798d699634c108a3d365e4c3302f">Remove stale reference to files that don&#39;t exist (5cb59118)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified June 3, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4c9e64de7e255bbed3221a3ab42b505e82e52bf8">Small improvements to the consumer guides (4c9e64de)</a>
 </div>
 </div>
 

--- a/docs/guides/consumer/index.html
+++ b/docs/guides/consumer/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse show" id="kptguidesconsumerupdate">
+    <li class="collapse show" id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse show" id="kptguidesconsumerdisplay">
+    <li class="collapse show" id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse show" id="kptguidesconsumerapply">
+    <li class="collapse show" id="kptguidesconsumerupdate">
       
       
       
@@ -851,7 +851,59 @@
             
         
             
+                <div class="entry">
+                    <h5>
+                        <a href="/kpt/guides/consumer/display/">Display local package contents</a>
+                    </h5>
+                    <p>Display the contents of a local package using kpt cfg for rendering.</p>
+                </div>
+            
         
+            
+        
+            
+        
+            
+        
+            
+        
+            
+        
+            
+        
+            
+                <div class="entry">
+                    <h5>
+                        <a href="/kpt/guides/consumer/set/">Set field values</a>
+                    </h5>
+                    <p>Customize a local package by setting field values.</p>
+                </div>
+            
+        
+            
+        
+            
+        
+            
+        
+            
+                <div class="entry">
+                    <h5>
+                        <a href="/kpt/guides/consumer/substitute/">Substitute a values into fields</a>
+                    </h5>
+                    <p>Customize a local package by substituting values into fields.</p>
+                </div>
+            
+        
+            
+        
+            
+                <div class="entry">
+                    <h5>
+                        <a href="/kpt/guides/consumer/apply/">Apply a local package</a>
+                    </h5>
+                    <p>Apply the contents of a local package to a remote cluster.</p>
+                </div>
             
         
             
@@ -874,62 +926,10 @@
             
                 <div class="entry">
                     <h5>
-                        <a href="/kpt/guides/consumer/set/">Set field values</a>
-                    </h5>
-                    <p>Customize a local package by setting field values.</p>
-                </div>
-            
-        
-            
-        
-            
-                <div class="entry">
-                    <h5>
-                        <a href="/kpt/guides/consumer/substitute/">Substitute a values into fields</a>
-                    </h5>
-                    <p>Customize a local package by substituting values into fields.</p>
-                </div>
-            
-        
-            
-                <div class="entry">
-                    <h5>
-                        <a href="/kpt/guides/consumer/display/">Display local package contents</a>
-                    </h5>
-                    <p>Display the contents of a local package using kpt cfg for rendering.</p>
-                </div>
-            
-        
-            
-        
-            
-        
-            
-        
-            
-                <div class="entry">
-                    <h5>
-                        <a href="/kpt/guides/consumer/apply/">Apply a local package</a>
-                    </h5>
-                    <p>Apply the contents of a local package to a remote cluster.</p>
-                </div>
-            
-        
-            
-        
-            
-        
-            
-                <div class="entry">
-                    <h5>
                         <a href="/kpt/guides/consumer/function/">Running functions</a>
                     </h5>
                     <p>Modify or validate the contents of a package by calling a function.</p>
                 </div>
-            
-        
-            
-        
             
         
             

--- a/docs/guides/consumer/index.xml
+++ b/docs/guides/consumer/index.xml
@@ -79,6 +79,10 @@ fetched and used as a package&lt;/li&gt;
 match the upstream directory name it is copied from&lt;/li&gt;
 &lt;li&gt;including &lt;code&gt;.git&lt;/code&gt; as part of the repo name is optional but good practice to
 ensure the repo + subdirectory are parsed correctly by the tool.&lt;/li&gt;
+&lt;li&gt;Packages inside the same repo can be versioned individually by creating tags
+with the format &lt;code&gt;&amp;lt;path to package in repo&amp;gt;/&amp;lt;version&amp;gt;&lt;/code&gt;, similar to how go
+modules are versioned. For example, a tag named &lt;code&gt;staging/cockroachdb/v1.2.3&lt;/code&gt;
+would be interpreted by kpt as version &lt;code&gt;v1.2.3&lt;/code&gt; of the cockroachdb package.&lt;/li&gt;
 &lt;/ul&gt;
 
 &lt;/div&gt;
@@ -190,188 +194,125 @@ statefulset.apps/cockroachdb   3/3     54s
     </item>
     
     <item>
-      <title>Guides: Update a local package</title>
-      <link>https://googlecontainertools.github.io/kpt/guides/consumer/update/</link>
+      <title>Guides: Display local package contents</title>
+      <link>https://googlecontainertools.github.io/kpt/guides/consumer/display/</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
       
-      <guid>https://googlecontainertools.github.io/kpt/guides/consumer/update/</guid>
+      <guid>https://googlecontainertools.github.io/kpt/guides/consumer/display/</guid>
       <description>
         
         
-        &lt;p&gt;&lt;em&gt;Packages can be arbitrarily customized and later merge updates from
-upstream.&lt;/em&gt;&lt;/p&gt;
+        &lt;p&gt;&lt;em&gt;Tools can parse and render configuration so it is easier for humans to read.&lt;/em&gt;&lt;/p&gt;
 &lt;h2 id=&#34;topics&#34;&gt;Topics&lt;/h2&gt;
-&lt;p&gt;&lt;a href=&#34;../../../reference/pkg/update&#34;&gt;kpt pkg update&lt;/a&gt;&lt;/p&gt;
-&lt;p&gt;Because kpt package contents are resource configuration (data) rather
-than templates or DSLs (code), it is possible to merge different versions
-of the package together using the structure of the resources to compute
-differences.&lt;/p&gt;
-&lt;p&gt;This allows package consumers to customize their copy, and merge updates
-from upstream.&lt;/p&gt;
-
-
-&lt;div class=&#34;pageinfo pageinfo-primary&#34;&gt;
-&lt;p&gt;The technique of merging fields to perform updates is also how &lt;code&gt;kubectl apply&lt;/code&gt;
-updates remote cluster resources with local file changes, without overwriting
-changes to the resources made by the cluster control-plane (e.g. an autoscaler
-can set replicas without apply overwriting them).&lt;/p&gt;
-&lt;p&gt;See [update strategies] for more choices on how to merge upstream changes.&lt;/p&gt;
-
-&lt;/div&gt;
-
-&lt;h2 id=&#34;kpt-pkg-update-explained&#34;&gt;&lt;code&gt;kpt pkg update&lt;/code&gt; explained&lt;/h2&gt;
-&lt;p&gt;Following is a short explanation of the command that will be demonstrated
-in this guide.&lt;/p&gt;
-&lt;ul&gt;
-&lt;li&gt;Copy the staging/cockroachdb subdirectory out of the [kubernetes examples] git repo&lt;/li&gt;
-&lt;li&gt;Edit the local package contents&lt;/li&gt;
-&lt;li&gt;Commit the changes&lt;/li&gt;
-&lt;li&gt;Update the local package with upstream changes from a new version&lt;/li&gt;
-&lt;/ul&gt;
-
-
-
-&lt;img src=&#34;https://googlecontainertools.github.io/kpt//images/update-command.svg&#34; /&gt;
-
+&lt;p&gt;&lt;a href=&#34;https://googlecontainertools.github.io/kpt/reference/pkg/count&#34;&gt;kpt cfg count&lt;/a&gt;, &lt;a href=&#34;https://googlecontainertools.github.io/kpt/reference/pkg/get&#34;&gt;kpt cfg tree&lt;/a&gt;,
+&lt;a href=&#34;https://googlecontainertools.github.io/kpt/reference/pkg/count&#34;&gt;kpt cfg grep&lt;/a&gt;, &lt;a href=&#34;https://googlecontainertools.github.io/kpt/reference/pkg/count&#34;&gt;kpt cfg cat&lt;/a&gt;&lt;/p&gt;
 &lt;h2 id=&#34;steps&#34;&gt;Steps&lt;/h2&gt;
 &lt;ol&gt;
 &lt;li&gt;&lt;a href=&#34;#fetch-a-remote-package&#34;&gt;Fetch a remote package&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href=&#34;#edit-the-contents&#34;&gt;Edit the contents&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href=&#34;#commit-local-changes&#34;&gt;Commit local changes&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href=&#34;#merge-upstream-changes&#34;&gt;Merge upstream changes&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href=&#34;#view-new-package-contents&#34;&gt;View new package contents&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href=&#34;#summarize-resource-counts&#34;&gt;Summarize resource counts&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href=&#34;#display-resources-as-a-tree&#34;&gt;Display resources as a tree&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href=&#34;#filter-resources&#34;&gt;Filter resources&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href=&#34;#dump-all-resources&#34;&gt;Dump all resources&lt;/a&gt;&lt;/li&gt;
 &lt;/ol&gt;
 &lt;h2 id=&#34;fetch-a-remote-package&#34;&gt;Fetch a remote package&lt;/h2&gt;
-&lt;p&gt;Packages can be fetched at specific versions defined by git tags, and have
-updated to later versions to merge in upstream changes.&lt;/p&gt;
+&lt;p&gt;Packages are fetched from remote git repository subdirectories with
+&lt;a href=&#34;https://googlecontainertools.github.io/kpt/reference/pkg/get&#34;&gt;kpt pkg get&lt;/a&gt;.  In this guide we will use the &lt;a href=&#34;https://github.com/kubernetes/examples&#34;&gt;kubernetes examples&lt;/a&gt; repository
+as a public package catalogue.&lt;/p&gt;
 &lt;h5 id=&#34;command&#34;&gt;Command&lt;/h5&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;&lt;span style=&#34;color:#204a87&#34;&gt;export&lt;/span&gt; &lt;span style=&#34;color:#000&#34;&gt;REPO&lt;/span&gt;&lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;=&lt;/span&gt;https://github.com/GoogleContainerTools/kpt.git
-kpt pkg get &lt;span style=&#34;color:#000&#34;&gt;$REPO&lt;/span&gt;/package-examples/helloworld-set@v0.3.0 helloworld
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;Fetch the &lt;code&gt;helloworld-set&lt;/code&gt; package at version &lt;code&gt;v0.3.0&lt;/code&gt;.&lt;/p&gt;
-&lt;h5 id=&#34;output&#34;&gt;Output&lt;/h5&gt;
-&lt;pre&gt;&lt;code&gt;fetching package /package-examples/helloworld-set from https://github.com/GoogleContainerTools/kpt to helloworld
-&lt;/code&gt;&lt;/pre&gt;
-
-&lt;div class=&#34;pageinfo pageinfo-info&#34;&gt;
-&lt;p&gt;Each subdirectory within a git repo may be tagged with its own version
-using the subdirectory path as a tag prefix, and kpt will automatically
-resolve the subdirectory version.&lt;/p&gt;
-&lt;p&gt;&lt;code&gt;package-examples/helloworld-set@v0.3.0&lt;/code&gt; is resolved to the tag
-&lt;code&gt;package-examples/helloworld-set/v0.3.0&lt;/code&gt; if it exists, otherwise it is
-resolved to the tag &lt;code&gt;v0.3.0&lt;/code&gt;.&lt;/p&gt;
-
-&lt;/div&gt;
-
-&lt;h2 id=&#34;edit-the-contents&#34;&gt;Edit the contents&lt;/h2&gt;
-&lt;p&gt;Edit the contents of the package by making changes to it.&lt;/p&gt;
-&lt;h5 id=&#34;old-local-configuration&#34;&gt;Old local configuration&lt;/h5&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-yaml&#34; data-lang=&#34;yaml&#34;&gt;&lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# helloworld/deploy.yaml (upstream)&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;&lt;/span&gt;...&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;        &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;image&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;gcr.io/kpt-dev/helloworld-gke&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;v0&lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;.1.0&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# {&amp;#34;$ref&amp;#34;:&amp;#34;#/definitions/io.k8s.cli.substitutions.image-tag&amp;#34;}&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;&lt;/span&gt;...&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;        &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;env&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;        &lt;/span&gt;- &lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;name&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;PORT&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;          &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;value&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#4e9a06&#34;&gt;&amp;#34;80&amp;#34;&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# {&amp;#34;$ref&amp;#34;:&amp;#34;#/definitions/io.k8s.cli.setters.http-port&amp;#34;}&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;&lt;/span&gt;...&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;The old package contents without local modifications.&lt;/p&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;vi helloworld/deploy.yaml
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;h5 id=&#34;new-local-configuration&#34;&gt;New local configuration&lt;/h5&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-yaml&#34; data-lang=&#34;yaml&#34;&gt;&lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# helloworld/deploy.yaml (locally modified)&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;&lt;/span&gt;...&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;        &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;image&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;gcr.io/kpt-dev/helloworld-gke&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;v0&lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;.1.0&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# {&amp;#34;$ref&amp;#34;:&amp;#34;#/definitions/io.k8s.cli.substitutions.image-tag&amp;#34;}&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;&lt;/span&gt;...&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;        &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;env&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;        &lt;/span&gt;- &lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;name&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;PORT&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;          &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;value&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#4e9a06&#34;&gt;&amp;#34;80&amp;#34;&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# {&amp;#34;$ref&amp;#34;:&amp;#34;#/definitions/io.k8s.cli.setters.http-port&amp;#34;}&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;        &lt;/span&gt;- &lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;name&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;NEW_ENV&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# This is a local package addition&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;          &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;value&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#4e9a06&#34;&gt;&amp;#34;local package edits&amp;#34;&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;&lt;/span&gt;...&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;The new package contents with local modifications.&lt;/p&gt;
-&lt;h2 id=&#34;commit-local-changes&#34;&gt;Commit local changes&lt;/h2&gt;
-
-
-&lt;div class=&#34;pageinfo pageinfo-warning&#34;&gt;
-&lt;p&gt;In order for updates to be easily undone, configuration must be
-committed to git prior to performing a package update.&lt;/p&gt;
-&lt;p&gt;kpt will throw an error if trying to update a package and the git repo
-has uncommitted changes.&lt;/p&gt;
-
-&lt;/div&gt;
-
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;git init
-git add .
-git commit -m &lt;span style=&#34;color:#4e9a06&#34;&gt;&amp;#34;add helloworld package at v0.3.0&amp;#34;&lt;/span&gt;
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;h2 id=&#34;merge-upstream-changes&#34;&gt;Merge upstream changes&lt;/h2&gt;
-&lt;p&gt;Package updates are performed by fetching the upstream package at the
-specified version and applying the upstream changes to the local package.&lt;/p&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;kpt pkg get https://github.com/kubernetes/examples/staging/ examples
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;Fetch the entire examples/staging directory as a kpt package under &lt;code&gt;examples&lt;/code&gt;.
+This will contain many resources.&lt;/p&gt;
 &lt;h5 id=&#34;command-1&#34;&gt;Command&lt;/h5&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;kpt pkg update helloworld@v0.5.0 --strategy&lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;=&lt;/span&gt;resource-merge
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;Update the local package to the upstream version v0.5.0 by doing a 3-way
-merge between 1) the original upstream commit, 2) the local (customized)
-package, 3) the new upstream reference.&lt;/p&gt;
-&lt;h5 id=&#34;output-1&#34;&gt;Output&lt;/h5&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;updating package helloworld to v0.5.0
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;h5 id=&#34;changes&#34;&gt;Changes&lt;/h5&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;--- a/helloworld/deploy.yaml
-+++ b/helloworld/deploy.yaml
-@@ -31,7 +31,7 @@ spec:
-     spec:
-       containers:
-       - name: helloworld-gke
--        image: gcr.io/kpt-dev/helloworld-gke:0.1.0 &lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# {&amp;#34;$ref&amp;#34;:&amp;#34;#/definitions/io.k8s.cli.substitutions.image-tag&amp;#34;}&lt;/span&gt;
-+        image: gcr.io/kpt-dev/helloworld-gke:v0.3.0 &lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# {&amp;#34;$ref&amp;#34;:&amp;#34;#/definitions/io.k8s.cli.substitutions.image-tag&amp;#34;}&lt;/span&gt;
-         ports:
-         - name: http
-           containerPort: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;80&lt;/span&gt; &lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# {&amp;#34;$ref&amp;#34;:&amp;#34;#/definitions/io.k8s.cli.setters.http-port&amp;#34;}&lt;/span&gt;
-diff --git a/helloworld/service.yaml b/helloworld/service.yaml
-index 0853ee1..c938fde &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;100644&lt;/span&gt;
---- a/helloworld/service.yaml
-+++ b/helloworld/service.yaml
-@@ -22,7 +22,7 @@ metadata:
-   labels:
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;The Deployment was updated with a new image tag.&lt;/p&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;--- a/helloworld/service.yaml
-+++ b/helloworld/service.yaml
-@@ -22,7 +22,7 @@ metadata:
-   labels:
-     app: hello
- spec:
--  type: LoadBalancer
-+  type: NodePort
-   selector:
-     app: hello
-   ports:
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;The Service was updated with a new &lt;code&gt;type&lt;/code&gt;.&lt;/p&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;--- a/helloworld/Kptfile
-+++ b/helloworld/Kptfile
-@@ -5,10 +5,10 @@ metadata:
- upstream:
-     type: git
-     git:
--        commit: 3d721bafd701deb06aeb43c5ea5afda3134cfdd6
-+        commit: 3f173ad974081896b47f6929b2c3cb595d71af94
-         repo: https://github.com/GoogleContainerTools/kpt
-         directory: /package-examples/helloworld-set
--        ref: v0.3.0
-+        ref: v0.5.0
- openAPI:
-     definitions:
-         io.k8s.cli.setters.http-port:
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;The Kptfile was updated with the new upstream metadata.&lt;/p&gt;
-&lt;h2 id=&#34;view-new-package-contents&#34;&gt;View new package contents&lt;/h2&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-yaml&#34; data-lang=&#34;yaml&#34;&gt;&lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# helloworld/deploy.yaml (updated from upstream)&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;&lt;/span&gt;...&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;        &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;image&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;gcr.io/kpt-dev/helloworld-gke&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;v0&lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;.3.0&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# {&amp;#34;$ref&amp;#34;:&amp;#34;#/definitions/io.k8s.cli.substitutions.image-tag&amp;#34;}&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;&lt;/span&gt;...&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;        &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;env&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;        &lt;/span&gt;- &lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;name&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;PORT&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;          &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;value&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#4e9a06&#34;&gt;&amp;#34;80&amp;#34;&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# {&amp;#34;$ref&amp;#34;:&amp;#34;#/definitions/io.k8s.cli.setters.http-port&amp;#34;}&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;        &lt;/span&gt;- &lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;name&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;NEW_ENV&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# This is a local package addition&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;          &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;value&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#4e9a06&#34;&gt;&amp;#34;local package edits&amp;#34;&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;&lt;/span&gt;...&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
-&lt;/span&gt;&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;The updated local package contains &lt;em&gt;both&lt;/em&gt; the upstream changes (new image tag),
-and local modifications (additional environment variable).&lt;/p&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;tree examples
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;h5 id=&#34;output&#34;&gt;Output&lt;/h5&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;examples/
+├── Kptfile
+├── cloud-controller-manager
+│   └── persistent-volume-label-initializer-config.yaml
+├── cluster-dns
+│   ├── README.md
+...
 
+&lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;79&lt;/span&gt; directories, &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;329&lt;/span&gt; files
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;The package is composed of 79 directories and, 329 files.  This is too many
+to work with using tools such as &lt;code&gt;less&lt;/code&gt;.&lt;/p&gt;
+&lt;h2 id=&#34;summarize-resource-counts&#34;&gt;Summarize resource counts&lt;/h2&gt;
+&lt;h5 id=&#34;command-2&#34;&gt;Command&lt;/h5&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;kpt cfg count examples/
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;The &lt;code&gt;kpt cfg count&lt;/code&gt; command summarizes the resource counts to show the shape of a
+package.&lt;/p&gt;
+&lt;h5 id=&#34;output-1&#34;&gt;Output&lt;/h5&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;...
+Deployment: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;10&lt;/span&gt;
+Endpoints: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;1&lt;/span&gt;
+InitializerConfiguration: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;1&lt;/span&gt;
+Namespace: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;4&lt;/span&gt;
+Pod: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;45&lt;/span&gt;
+...
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;h5 id=&#34;command-3&#34;&gt;Command&lt;/h5&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;kpt cfg count examples/cockroachdb/
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;Running &lt;code&gt;count&lt;/code&gt; on a subdirectory will summarize that directory even if
+it doesn&amp;rsquo;t have a Kptfile.&lt;/p&gt;
+&lt;h5 id=&#34;output-2&#34;&gt;Output&lt;/h5&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;PodDisruptionBudget: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;1&lt;/span&gt;
+Service: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;2&lt;/span&gt;
+StatefulSet: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;1&lt;/span&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;h5 id=&#34;command-4&#34;&gt;Command&lt;/h5&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;kpt cfg count examples/ --kind&lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;=&lt;/span&gt;&lt;span style=&#34;color:#204a87&#34;&gt;false&lt;/span&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;The total aggregate resource count can be shown with &lt;code&gt;--kind=false&lt;/code&gt;&lt;/p&gt;
+&lt;h5 id=&#34;output-3&#34;&gt;Output&lt;/h5&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;&lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;201&lt;/span&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;h2 id=&#34;display-resources-as-a-tree&#34;&gt;Display resources as a tree&lt;/h2&gt;
+&lt;h5 id=&#34;command-5&#34;&gt;Command&lt;/h5&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;kpt cfg tree examples/cockroachdb/ --image --replicas 
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;Because the raw YAML configuration may be difficult for humans to easily
+view and understand, kpt provides a command for rendering configuration
+as a tree.  Flags may be provided to print specific fields under the resources.&lt;/p&gt;
+&lt;h5 id=&#34;output-4&#34;&gt;Output&lt;/h5&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;examples/cockroachdb
+├── &lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;[&lt;/span&gt;cockroachdb-statefulset.yaml&lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;]&lt;/span&gt;  Service cockroachdb
+├── &lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;[&lt;/span&gt;cockroachdb-statefulset.yaml&lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;]&lt;/span&gt;  StatefulSet cockroachdb
+│   ├── spec.replicas: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;3&lt;/span&gt;
+│   └── spec.template.spec.containers
+│       └── &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;0&lt;/span&gt;
+│           └── image: cockroachdb/cockroach:v1.1.0
+├── &lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;[&lt;/span&gt;cockroachdb-statefulset.yaml&lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;]&lt;/span&gt;  PodDisruptionBudget cockroachdb-budget
+└── &lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;[&lt;/span&gt;cockroachdb-statefulset.yaml&lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;]&lt;/span&gt;  Service cockroachdb-public
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;In addition to the built-in printable fields, &lt;code&gt;kpt cfg tree&lt;/code&gt; will print
+arbitrary fields by providing the &lt;code&gt;--field&lt;/code&gt; flag.&lt;/p&gt;
+&lt;h2 id=&#34;filter-resources&#34;&gt;Filter resources&lt;/h2&gt;
+&lt;h5 id=&#34;command-6&#34;&gt;Command&lt;/h5&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;kpt cfg grep &lt;span style=&#34;color:#4e9a06&#34;&gt;&amp;#34;spec.replicas&amp;gt;3&amp;#34;&lt;/span&gt; examples &lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;|&lt;/span&gt; kpt cfg tree --replicas
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;Grep can be used to filter resources by field values.  The output of
+&lt;code&gt;kpt cfg grep&lt;/code&gt; is the matching full resource configuration, which
+may be piped to tree for rendering.&lt;/p&gt;
+&lt;h5 id=&#34;output-5&#34;&gt;Output&lt;/h5&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;.
+├── storage/minio
+│   └── &lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;[&lt;/span&gt;minio-distributed-statefulset.yaml&lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;]&lt;/span&gt;  StatefulSet minio
+│       └── spec.replicas: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;4&lt;/span&gt;
+├── sysdig-cloud
+│   └── &lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;[&lt;/span&gt;sysdig-rc.yaml&lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;]&lt;/span&gt;  ReplicationController sysdig-agent
+│       └── spec.replicas: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;100&lt;/span&gt;
+└── volumes/vsphere
+    └── &lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;[&lt;/span&gt;simple-statefulset.yaml&lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;]&lt;/span&gt;  StatefulSet web
+        └── spec.replicas: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;14&lt;/span&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;h2 id=&#34;dump-all-resources&#34;&gt;Dump all resources&lt;/h2&gt;
+&lt;h5 id=&#34;command-7&#34;&gt;Command&lt;/h5&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;kpt cfg cat examples/cockroachdb
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;The raw YAML configuration may be dumped using &lt;code&gt;kpt cfg cat&lt;/code&gt;.  This will
+print only the YAML for Kubernetes resources.&lt;/p&gt;
+&lt;h5 id=&#34;output-6&#34;&gt;Output&lt;/h5&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;apiVersion: v1
+kind: Service
+metadata:
+  &lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# This service is meant to be used by clients of the database. It exposes a ClusterIP that will&lt;/span&gt;
+  &lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# automatically load balance connections to the different database pods.&lt;/span&gt;
+  name: cockroachdb-public
+  labels:
+    app: cockroachdb
+...
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
       </description>
     </item>
     
@@ -612,129 +553,6 @@ package &lt;a href=&#34;../../../api-reference/kptfile&#34;&gt;Kptfile&lt;/a&gt;
     </item>
     
     <item>
-      <title>Guides: Display local package contents</title>
-      <link>https://googlecontainertools.github.io/kpt/guides/consumer/display/</link>
-      <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
-      
-      <guid>https://googlecontainertools.github.io/kpt/guides/consumer/display/</guid>
-      <description>
-        
-        
-        &lt;p&gt;&lt;em&gt;Tools can parse and render configuration so it is easier for humans to read.&lt;/em&gt;&lt;/p&gt;
-&lt;h2 id=&#34;topics&#34;&gt;Topics&lt;/h2&gt;
-&lt;p&gt;&lt;a href=&#34;https://googlecontainertools.github.io/kpt/reference/pkg/count&#34;&gt;kpt cfg count&lt;/a&gt;, &lt;a href=&#34;https://googlecontainertools.github.io/kpt/reference/pkg/get&#34;&gt;kpt cfg tree&lt;/a&gt;,
-&lt;a href=&#34;https://googlecontainertools.github.io/kpt/reference/pkg/count&#34;&gt;kpt cfg grep&lt;/a&gt;, &lt;a href=&#34;https://googlecontainertools.github.io/kpt/reference/pkg/count&#34;&gt;kpt cfg cat&lt;/a&gt;&lt;/p&gt;
-&lt;h2 id=&#34;steps&#34;&gt;Steps&lt;/h2&gt;
-&lt;ol&gt;
-&lt;li&gt;&lt;a href=&#34;#fetch-a-remote-package&#34;&gt;Fetch a remote package&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href=&#34;#summarize-resource-counts&#34;&gt;Summarize resource counts&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href=&#34;#display-resources-as-a-tree&#34;&gt;Display resources as a tree&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href=&#34;#filter-resources&#34;&gt;Filter resources&lt;/a&gt;&lt;/li&gt;
-&lt;li&gt;&lt;a href=&#34;#dump-all-resources&#34;&gt;Dump all resources&lt;/a&gt;&lt;/li&gt;
-&lt;/ol&gt;
-&lt;h2 id=&#34;fetch-a-remote-package&#34;&gt;Fetch a remote package&lt;/h2&gt;
-&lt;p&gt;Packages are fetched from remote git repository subdirectories with
-&lt;a href=&#34;https://googlecontainertools.github.io/kpt/reference/pkg/get&#34;&gt;kpt pkg get&lt;/a&gt;.  In this guide we will use the &lt;a href=&#34;https://github.com/kubernetes/examples&#34;&gt;kubernetes examples&lt;/a&gt; repository
-as a public package catalogue.&lt;/p&gt;
-&lt;h5 id=&#34;command&#34;&gt;Command&lt;/h5&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;kpt pkg get https://github.com/kubernetes/examples/staging/ examples
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;Fetch the entire examples/staging directory as a kpt package under &lt;code&gt;examples&lt;/code&gt;.
-This will contain many resources.&lt;/p&gt;
-&lt;h5 id=&#34;command-1&#34;&gt;Command&lt;/h5&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;tree examples
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;h5 id=&#34;output&#34;&gt;Output&lt;/h5&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;examples/
-├── Kptfile
-├── cloud-controller-manager
-│   └── persistent-volume-label-initializer-config.yaml
-├── cluster-dns
-│   ├── README.md
-...
-
-&lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;79&lt;/span&gt; directories, &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;329&lt;/span&gt; files
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;The package is composed of 79 directories and, 329 files.  This is too many
-to work with using tools such as &lt;code&gt;less&lt;/code&gt;.&lt;/p&gt;
-&lt;h2 id=&#34;summarize-resource-counts&#34;&gt;Summarize resource counts&lt;/h2&gt;
-&lt;h5 id=&#34;command-2&#34;&gt;Command&lt;/h5&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;kpt cfg count examples/
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;The &lt;code&gt;kpt cfg count&lt;/code&gt; command summarizes the resource counts to show the shape of a
-package.&lt;/p&gt;
-&lt;h5 id=&#34;output-1&#34;&gt;Output&lt;/h5&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;...
-Deployment: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;10&lt;/span&gt;
-Endpoints: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;1&lt;/span&gt;
-InitializerConfiguration: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;1&lt;/span&gt;
-Namespace: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;4&lt;/span&gt;
-Pod: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;45&lt;/span&gt;
-...
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;h5 id=&#34;command-3&#34;&gt;Command&lt;/h5&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;kpt cfg count examples/cockroachdb/
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;Running &lt;code&gt;count&lt;/code&gt; on a subdirectory will summarize that directory even if
-it doesn&amp;rsquo;t have a Kptfile.&lt;/p&gt;
-&lt;h5 id=&#34;output-2&#34;&gt;Output&lt;/h5&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;PodDisruptionBudget: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;1&lt;/span&gt;
-Service: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;2&lt;/span&gt;
-StatefulSet: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;1&lt;/span&gt;
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;h5 id=&#34;command-4&#34;&gt;Command&lt;/h5&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;kpt cfg count examples/ --kind&lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;=&lt;/span&gt;&lt;span style=&#34;color:#204a87&#34;&gt;false&lt;/span&gt;
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;The total aggregate resource count can be shown with &lt;code&gt;--kind=false&lt;/code&gt;&lt;/p&gt;
-&lt;h5 id=&#34;output-3&#34;&gt;Output&lt;/h5&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;&lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;201&lt;/span&gt;
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;h2 id=&#34;display-resources-as-a-tree&#34;&gt;Display resources as a tree&lt;/h2&gt;
-&lt;h5 id=&#34;command-5&#34;&gt;Command&lt;/h5&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;kpt cfg tree examples/cockroachdb/ --image --replicas 
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;Because the raw YAML configuration may be difficult for humans to easily
-view and understand, kpt provides a command for rendering configuration
-as a tree.  Flags may be provided to print specific fields under the resources.&lt;/p&gt;
-&lt;h5 id=&#34;output-4&#34;&gt;Output&lt;/h5&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;examples/cockroachdb
-├── &lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;[&lt;/span&gt;cockroachdb-statefulset.yaml&lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;]&lt;/span&gt;  Service cockroachdb
-├── &lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;[&lt;/span&gt;cockroachdb-statefulset.yaml&lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;]&lt;/span&gt;  StatefulSet cockroachdb
-│   ├── spec.replicas: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;3&lt;/span&gt;
-│   └── spec.template.spec.containers
-│       └── &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;0&lt;/span&gt;
-│           └── image: cockroachdb/cockroach:v1.1.0
-├── &lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;[&lt;/span&gt;cockroachdb-statefulset.yaml&lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;]&lt;/span&gt;  PodDisruptionBudget cockroachdb-budget
-└── &lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;[&lt;/span&gt;cockroachdb-statefulset.yaml&lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;]&lt;/span&gt;  Service cockroachdb-public
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;In addition to the built-in printable fields, &lt;code&gt;kpt cfg tree&lt;/code&gt; will print
-arbitrary fields by providing the &lt;code&gt;--field&lt;/code&gt; flag.&lt;/p&gt;
-&lt;h2 id=&#34;filter-resources&#34;&gt;Filter resources&lt;/h2&gt;
-&lt;h5 id=&#34;command-6&#34;&gt;Command&lt;/h5&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;kpt cfg grep &lt;span style=&#34;color:#4e9a06&#34;&gt;&amp;#34;spec.replicas&amp;gt;3&amp;#34;&lt;/span&gt; examples &lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;|&lt;/span&gt; kpt cfg tree --replicas
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;Grep can be used to filter resources by field values.  The output of
-&lt;code&gt;kpt cfg grep&lt;/code&gt; is the matching full resource configuration, which
-may be piped to tree for rendering.&lt;/p&gt;
-&lt;h5 id=&#34;output-5&#34;&gt;Output&lt;/h5&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;.
-├── storage/minio
-│   └── &lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;[&lt;/span&gt;minio-distributed-statefulset.yaml&lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;]&lt;/span&gt;  StatefulSet minio
-│       └── spec.replicas: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;4&lt;/span&gt;
-├── sysdig-cloud
-│   └── &lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;[&lt;/span&gt;sysdig-rc.yaml&lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;]&lt;/span&gt;  ReplicationController sysdig-agent
-│       └── spec.replicas: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;100&lt;/span&gt;
-└── volumes/vsphere
-    └── &lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;[&lt;/span&gt;simple-statefulset.yaml&lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;]&lt;/span&gt;  StatefulSet web
-        └── spec.replicas: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;14&lt;/span&gt;
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;h2 id=&#34;dump-all-resources&#34;&gt;Dump all resources&lt;/h2&gt;
-&lt;h5 id=&#34;command-7&#34;&gt;Command&lt;/h5&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;kpt cfg cat examples/cockroachdb
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;The raw YAML configuration may be dumped using &lt;code&gt;kpt cfg cat&lt;/code&gt;.  This will
-print only the YAML for Kubernetes resources.&lt;/p&gt;
-&lt;h5 id=&#34;output-6&#34;&gt;Output&lt;/h5&gt;
-&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;apiVersion: v1
-kind: Service
-metadata:
-  &lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# This service is meant to be used by clients of the database. It exposes a ClusterIP that will&lt;/span&gt;
-  &lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# automatically load balance connections to the different database pods.&lt;/span&gt;
-  name: cockroachdb-public
-  labels:
-    app: cockroachdb
-...
-&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
-      </description>
-    </item>
-    
-    <item>
       <title>Guides: Apply a local package</title>
       <link>https://googlecontainertools.github.io/kpt/guides/consumer/apply/</link>
       <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
@@ -874,6 +692,192 @@ configmap/inventory-2911da3b pruned
 &lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;kubectl get deploy
 &lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;No resources found in default namespace.
 &lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;
+      </description>
+    </item>
+    
+    <item>
+      <title>Guides: Update a local package</title>
+      <link>https://googlecontainertools.github.io/kpt/guides/consumer/update/</link>
+      <pubDate>Mon, 01 Jan 0001 00:00:00 +0000</pubDate>
+      
+      <guid>https://googlecontainertools.github.io/kpt/guides/consumer/update/</guid>
+      <description>
+        
+        
+        &lt;p&gt;&lt;em&gt;Packages can be arbitrarily customized and later merge updates from
+upstream.&lt;/em&gt;&lt;/p&gt;
+&lt;h2 id=&#34;topics&#34;&gt;Topics&lt;/h2&gt;
+&lt;p&gt;&lt;a href=&#34;../../../reference/pkg/update&#34;&gt;kpt pkg update&lt;/a&gt;&lt;/p&gt;
+&lt;p&gt;Because kpt package contents are resource configuration (data) rather
+than templates or DSLs (code), it is possible to merge different versions
+of the package together using the structure of the resources to compute
+differences.&lt;/p&gt;
+&lt;p&gt;This allows package consumers to customize their copy, and merge updates
+from upstream.&lt;/p&gt;
+
+
+&lt;div class=&#34;pageinfo pageinfo-primary&#34;&gt;
+&lt;p&gt;The technique of merging fields to perform updates is also how &lt;code&gt;kubectl apply&lt;/code&gt;
+updates remote cluster resources with local file changes, without overwriting
+changes to the resources made by the cluster control-plane (e.g. an autoscaler
+can set replicas without apply overwriting them).&lt;/p&gt;
+&lt;p&gt;See [update strategies] for more choices on how to merge upstream changes.&lt;/p&gt;
+
+&lt;/div&gt;
+
+&lt;h2 id=&#34;kpt-pkg-update-explained&#34;&gt;&lt;code&gt;kpt pkg update&lt;/code&gt; explained&lt;/h2&gt;
+&lt;p&gt;Following is a short explanation of the command that will be demonstrated
+in this guide.&lt;/p&gt;
+&lt;ul&gt;
+&lt;li&gt;Copy the staging/cockroachdb subdirectory out of the [kubernetes examples] git repo&lt;/li&gt;
+&lt;li&gt;Edit the local package contents&lt;/li&gt;
+&lt;li&gt;Commit the changes&lt;/li&gt;
+&lt;li&gt;Update the local package with upstream changes from a new version&lt;/li&gt;
+&lt;/ul&gt;
+
+
+
+&lt;img src=&#34;https://googlecontainertools.github.io/kpt//images/update-command.svg&#34; /&gt;
+
+&lt;h2 id=&#34;steps&#34;&gt;Steps&lt;/h2&gt;
+&lt;ol&gt;
+&lt;li&gt;&lt;a href=&#34;#fetch-a-remote-package&#34;&gt;Fetch a remote package&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href=&#34;#edit-the-contents&#34;&gt;Edit the contents&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href=&#34;#commit-local-changes&#34;&gt;Commit local changes&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href=&#34;#merge-upstream-changes&#34;&gt;Merge upstream changes&lt;/a&gt;&lt;/li&gt;
+&lt;li&gt;&lt;a href=&#34;#view-new-package-contents&#34;&gt;View new package contents&lt;/a&gt;&lt;/li&gt;
+&lt;/ol&gt;
+&lt;h2 id=&#34;fetch-a-remote-package&#34;&gt;Fetch a remote package&lt;/h2&gt;
+&lt;p&gt;Packages can be fetched at specific versions defined by git tags, and have
+updated to later versions to merge in upstream changes.&lt;/p&gt;
+&lt;h5 id=&#34;command&#34;&gt;Command&lt;/h5&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;&lt;span style=&#34;color:#204a87&#34;&gt;export&lt;/span&gt; &lt;span style=&#34;color:#000&#34;&gt;REPO&lt;/span&gt;&lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;=&lt;/span&gt;https://github.com/GoogleContainerTools/kpt.git
+kpt pkg get &lt;span style=&#34;color:#000&#34;&gt;$REPO&lt;/span&gt;/package-examples/helloworld-set@v0.3.0 helloworld
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;Fetch the &lt;code&gt;helloworld-set&lt;/code&gt; package at version &lt;code&gt;v0.3.0&lt;/code&gt;.&lt;/p&gt;
+&lt;h5 id=&#34;output&#34;&gt;Output&lt;/h5&gt;
+&lt;pre&gt;&lt;code&gt;fetching package /package-examples/helloworld-set from https://github.com/GoogleContainerTools/kpt to helloworld
+&lt;/code&gt;&lt;/pre&gt;
+
+&lt;div class=&#34;pageinfo pageinfo-info&#34;&gt;
+&lt;p&gt;Each subdirectory within a git repo may be tagged with its own version
+using the subdirectory path as a tag prefix, and kpt will automatically
+resolve the subdirectory version.&lt;/p&gt;
+&lt;p&gt;&lt;code&gt;package-examples/helloworld-set@v0.3.0&lt;/code&gt; is resolved to the tag
+&lt;code&gt;package-examples/helloworld-set/v0.3.0&lt;/code&gt; if it exists, otherwise it is
+resolved to the tag &lt;code&gt;v0.3.0&lt;/code&gt;.&lt;/p&gt;
+
+&lt;/div&gt;
+
+&lt;h2 id=&#34;edit-the-contents&#34;&gt;Edit the contents&lt;/h2&gt;
+&lt;p&gt;Edit the contents of the package by making changes to it.&lt;/p&gt;
+&lt;h5 id=&#34;old-local-configuration&#34;&gt;Old local configuration&lt;/h5&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-yaml&#34; data-lang=&#34;yaml&#34;&gt;&lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# helloworld/deploy.yaml (upstream)&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;&lt;/span&gt;...&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;        &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;image&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;gcr.io/kpt-dev/helloworld-gke&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;v0&lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;.1.0&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# {&amp;#34;$ref&amp;#34;:&amp;#34;#/definitions/io.k8s.cli.substitutions.image-tag&amp;#34;}&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;&lt;/span&gt;...&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;        &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;env&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;        &lt;/span&gt;- &lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;name&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;PORT&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;          &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;value&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#4e9a06&#34;&gt;&amp;#34;80&amp;#34;&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# {&amp;#34;$ref&amp;#34;:&amp;#34;#/definitions/io.k8s.cli.setters.http-port&amp;#34;}&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;&lt;/span&gt;...&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;The old package contents without local modifications.&lt;/p&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;vi helloworld/deploy.yaml
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;h5 id=&#34;new-local-configuration&#34;&gt;New local configuration&lt;/h5&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-yaml&#34; data-lang=&#34;yaml&#34;&gt;&lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# helloworld/deploy.yaml (locally modified)&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;&lt;/span&gt;...&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;        &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;image&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;gcr.io/kpt-dev/helloworld-gke&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;v0&lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;.1.0&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# {&amp;#34;$ref&amp;#34;:&amp;#34;#/definitions/io.k8s.cli.substitutions.image-tag&amp;#34;}&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;&lt;/span&gt;...&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;        &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;env&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;        &lt;/span&gt;- &lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;name&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;PORT&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;          &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;value&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#4e9a06&#34;&gt;&amp;#34;80&amp;#34;&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# {&amp;#34;$ref&amp;#34;:&amp;#34;#/definitions/io.k8s.cli.setters.http-port&amp;#34;}&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;        &lt;/span&gt;- &lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;name&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;NEW_ENV&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# This is a local package addition&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;          &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;value&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#4e9a06&#34;&gt;&amp;#34;local package edits&amp;#34;&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;&lt;/span&gt;...&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;The new package contents with local modifications.&lt;/p&gt;
+&lt;h2 id=&#34;commit-local-changes&#34;&gt;Commit local changes&lt;/h2&gt;
+
+
+&lt;div class=&#34;pageinfo pageinfo-warning&#34;&gt;
+&lt;p&gt;In order for updates to be easily undone, configuration must be
+committed to git prior to performing a package update.&lt;/p&gt;
+&lt;p&gt;kpt will throw an error if trying to update a package and the git repo
+has uncommitted changes.&lt;/p&gt;
+
+&lt;/div&gt;
+
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;git init
+git add .
+git commit -m &lt;span style=&#34;color:#4e9a06&#34;&gt;&amp;#34;add helloworld package at v0.3.0&amp;#34;&lt;/span&gt;
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;h2 id=&#34;merge-upstream-changes&#34;&gt;Merge upstream changes&lt;/h2&gt;
+&lt;p&gt;Package updates are performed by fetching the upstream package at the
+specified version and applying the upstream changes to the local package.&lt;/p&gt;
+&lt;h5 id=&#34;command-1&#34;&gt;Command&lt;/h5&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;kpt pkg update helloworld@v0.5.0 --strategy&lt;span style=&#34;color:#ce5c00;font-weight:bold&#34;&gt;=&lt;/span&gt;resource-merge
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;Update the local package to the upstream version v0.5.0 by doing a 3-way
+merge between 1) the original upstream commit, 2) the local (customized)
+package, 3) the new upstream reference.&lt;/p&gt;
+&lt;h5 id=&#34;output-1&#34;&gt;Output&lt;/h5&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;updating package helloworld to v0.5.0
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;h5 id=&#34;changes&#34;&gt;Changes&lt;/h5&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;--- a/helloworld/deploy.yaml
++++ b/helloworld/deploy.yaml
+@@ -31,7 +31,7 @@ spec:
+     spec:
+       containers:
+       - name: helloworld-gke
+-        image: gcr.io/kpt-dev/helloworld-gke:0.1.0 &lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# {&amp;#34;$ref&amp;#34;:&amp;#34;#/definitions/io.k8s.cli.substitutions.image-tag&amp;#34;}&lt;/span&gt;
++        image: gcr.io/kpt-dev/helloworld-gke:v0.3.0 &lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# {&amp;#34;$ref&amp;#34;:&amp;#34;#/definitions/io.k8s.cli.substitutions.image-tag&amp;#34;}&lt;/span&gt;
+         ports:
+         - name: http
+           containerPort: &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;80&lt;/span&gt; &lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# {&amp;#34;$ref&amp;#34;:&amp;#34;#/definitions/io.k8s.cli.setters.http-port&amp;#34;}&lt;/span&gt;
+diff --git a/helloworld/service.yaml b/helloworld/service.yaml
+index 0853ee1..c938fde &lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;100644&lt;/span&gt;
+--- a/helloworld/service.yaml
++++ b/helloworld/service.yaml
+@@ -22,7 +22,7 @@ metadata:
+   labels:
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;The Deployment was updated with a new image tag.&lt;/p&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;--- a/helloworld/service.yaml
++++ b/helloworld/service.yaml
+@@ -22,7 +22,7 @@ metadata:
+   labels:
+     app: hello
+ spec:
+-  type: LoadBalancer
++  type: NodePort
+   selector:
+     app: hello
+   ports:
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;The Service was updated with a new &lt;code&gt;type&lt;/code&gt;.&lt;/p&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-sh&#34; data-lang=&#34;sh&#34;&gt;--- a/helloworld/Kptfile
++++ b/helloworld/Kptfile
+@@ -5,10 +5,10 @@ metadata:
+ upstream:
+     type: git
+     git:
+-        commit: 3d721bafd701deb06aeb43c5ea5afda3134cfdd6
++        commit: 3f173ad974081896b47f6929b2c3cb595d71af94
+         repo: https://github.com/GoogleContainerTools/kpt
+         directory: /package-examples/helloworld-set
+-        ref: v0.3.0
++        ref: v0.5.0
+ openAPI:
+     definitions:
+         io.k8s.cli.setters.http-port:
+&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;The Kptfile was updated with the new upstream metadata.&lt;/p&gt;
+&lt;h2 id=&#34;view-new-package-contents&#34;&gt;View new package contents&lt;/h2&gt;
+&lt;div class=&#34;highlight&#34;&gt;&lt;pre style=&#34;background-color:#f8f8f8;-moz-tab-size:4;-o-tab-size:4;tab-size:4&#34;&gt;&lt;code class=&#34;language-yaml&#34; data-lang=&#34;yaml&#34;&gt;&lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# helloworld/deploy.yaml (updated from upstream)&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;&lt;/span&gt;...&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;        &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;image&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;gcr.io/kpt-dev/helloworld-gke&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;v0&lt;span style=&#34;color:#0000cf;font-weight:bold&#34;&gt;.3.0&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# {&amp;#34;$ref&amp;#34;:&amp;#34;#/definitions/io.k8s.cli.substitutions.image-tag&amp;#34;}&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;&lt;/span&gt;...&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;        &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;env&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;        &lt;/span&gt;- &lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;name&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;PORT&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;          &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;value&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#4e9a06&#34;&gt;&amp;#34;80&amp;#34;&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# {&amp;#34;$ref&amp;#34;:&amp;#34;#/definitions/io.k8s.cli.setters.http-port&amp;#34;}&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;        &lt;/span&gt;- &lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;name&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;NEW_ENV&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#8f5902;font-style:italic&#34;&gt;# This is a local package addition&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;          &lt;/span&gt;&lt;span style=&#34;color:#204a87;font-weight:bold&#34;&gt;value&lt;/span&gt;&lt;span style=&#34;color:#000;font-weight:bold&#34;&gt;:&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt; &lt;/span&gt;&lt;span style=&#34;color:#4e9a06&#34;&gt;&amp;#34;local package edits&amp;#34;&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;&lt;/span&gt;...&lt;span style=&#34;color:#f8f8f8;text-decoration:underline&#34;&gt;
+&lt;/span&gt;&lt;/code&gt;&lt;/pre&gt;&lt;/div&gt;&lt;p&gt;The updated local package contains &lt;em&gt;both&lt;/em&gt; the upstream changes (new image tag),
+and local modifications (additional environment variable).&lt;/p&gt;
+
       </description>
     </item>
     

--- a/docs/guides/consumer/set/index.html
+++ b/docs/guides/consumer/set/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerupdate">
+    <li class="collapse " id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerdisplay">
+    <li class="collapse " id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerapply">
+    <li class="collapse " id="kptguidesconsumerupdate">
       
       
       

--- a/docs/guides/consumer/substitute/index.html
+++ b/docs/guides/consumer/substitute/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerupdate">
+    <li class="collapse " id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerdisplay">
+    <li class="collapse " id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerapply">
+    <li class="collapse " id="kptguidesconsumerupdate">
       
       
       
@@ -1027,7 +1027,7 @@ package <a href="../../../api-reference/kptfile">Kptfile</a>.</p>
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 18, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/b6557dc5d43f4d95becaa24385a5202417005da5">Fix docsy hugo theme (b6557dc5)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified June 3, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4c9e64de7e255bbed3221a3ab42b505e82e52bf8">Small improvements to the consumer guides (4c9e64de)</a>
 </div>
 </div>
 

--- a/docs/guides/consumer/update/index.html
+++ b/docs/guides/consumer/update/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 active td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse show" id="kptguidesconsumerupdate">
+    <li class="collapse " id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerdisplay">
+    <li class="collapse " id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 active td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerapply">
+    <li class="collapse show" id="kptguidesconsumerupdate">
       
       
       
@@ -1080,7 +1080,7 @@ and local modifications (additional environment variable).</p>
 
 	
 	
-	<div class="text-muted mt-5 pt-3 border-top">Last modified March 30, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/fb3dff67e967fb7db958b9ca08d30519b10e5216">Set original and updated packages before resource merge (fb3dff67)</a>
+	<div class="text-muted mt-5 pt-3 border-top">Last modified June 3, 2020: <a  href="https://github.com/GoogleContainerTools/kpt/commit/4c9e64de7e255bbed3221a3ab42b505e82e52bf8">Small improvements to the consumer guides (4c9e64de)</a>
 </div>
 </div>
 

--- a/docs/guides/ecosystem/helm/index.html
+++ b/docs/guides/ecosystem/helm/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerupdate">
+    <li class="collapse " id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerdisplay">
+    <li class="collapse " id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerapply">
+    <li class="collapse " id="kptguidesconsumerupdate">
       
       
       

--- a/docs/guides/ecosystem/index.html
+++ b/docs/guides/ecosystem/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerupdate">
+    <li class="collapse " id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerdisplay">
+    <li class="collapse " id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerapply">
+    <li class="collapse " id="kptguidesconsumerupdate">
       
       
       
@@ -838,14 +838,14 @@ systems and work together with as much of the ecosystem as possible
             
         
             
+        
+            
                 <div class="entry">
                     <h5>
                         <a href="/kpt/guides/ecosystem/helm/">Helm</a>
                     </h5>
                     <p>Generate kpt packages from Helm charts</p>
                 </div>
-            
-        
             
         
             

--- a/docs/guides/ecosystem/kustomize/index.html
+++ b/docs/guides/ecosystem/kustomize/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerupdate">
+    <li class="collapse " id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerdisplay">
+    <li class="collapse " id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerapply">
+    <li class="collapse " id="kptguidesconsumerupdate">
       
       
       

--- a/docs/guides/ecosystem/oam/index.html
+++ b/docs/guides/ecosystem/oam/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerupdate">
+    <li class="collapse " id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerdisplay">
+    <li class="collapse " id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerapply">
+    <li class="collapse " id="kptguidesconsumerupdate">
       
       
       

--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -206,10 +206,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse show" id="kptguidesconsumerupdate">
+    <li class="collapse show" id="kptguidesconsumerdisplay">
       
       
       
@@ -275,10 +275,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse show" id="kptguidesconsumerdisplay">
+    <li class="collapse show" id="kptguidesconsumerapply">
       
       
       
@@ -298,10 +298,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse show" id="kptguidesconsumerapply">
+    <li class="collapse show" id="kptguidesconsumerupdate">
       
       
       
@@ -824,14 +824,14 @@
             
         
             
+        
+            
                 <div class="entry">
                     <h5>
                         <a href="/kpt/guides/producer/">Package Publishers</a>
                     </h5>
                     <p>Guides for publishing configuration packages for others to consume.</p>
                 </div>
-            
-        
             
         
             

--- a/docs/guides/producer/blueprint/index.html
+++ b/docs/guides/producer/blueprint/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerupdate">
+    <li class="collapse " id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerdisplay">
+    <li class="collapse " id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerapply">
+    <li class="collapse " id="kptguidesconsumerupdate">
       
       
       

--- a/docs/guides/producer/bootstrap/index.html
+++ b/docs/guides/producer/bootstrap/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerupdate">
+    <li class="collapse " id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerdisplay">
+    <li class="collapse " id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerapply">
+    <li class="collapse " id="kptguidesconsumerupdate">
       
       
       

--- a/docs/guides/producer/functions/container/index.html
+++ b/docs/guides/producer/functions/container/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerupdate">
+    <li class="collapse " id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerdisplay">
+    <li class="collapse " id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerapply">
+    <li class="collapse " id="kptguidesconsumerupdate">
       
       
       

--- a/docs/guides/producer/functions/exec/index.html
+++ b/docs/guides/producer/functions/exec/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerupdate">
+    <li class="collapse " id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerdisplay">
+    <li class="collapse " id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerapply">
+    <li class="collapse " id="kptguidesconsumerupdate">
       
       
       

--- a/docs/guides/producer/functions/golang/index.html
+++ b/docs/guides/producer/functions/golang/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerupdate">
+    <li class="collapse " id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerdisplay">
+    <li class="collapse " id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerapply">
+    <li class="collapse " id="kptguidesconsumerupdate">
       
       
       

--- a/docs/guides/producer/functions/index.html
+++ b/docs/guides/producer/functions/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerupdate">
+    <li class="collapse " id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerdisplay">
+    <li class="collapse " id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerapply">
+    <li class="collapse " id="kptguidesconsumerupdate">
       
       
       
@@ -1124,14 +1124,14 @@ functionConfig type.</p>
             
         
             
+        
+            
                 <div class="entry">
                     <h5>
                         <a href="/kpt/guides/producer/functions/exec/">Exec Runtime</a>
                     </h5>
                     <p>Writing and running functions as executables</p>
                 </div>
-            
-        
             
         
             
@@ -1158,10 +1158,6 @@ functionConfig type.</p>
             
         
             
-        
-            
-        
-            
                 <div class="entry">
                     <h5>
                         <a href="/kpt/guides/producer/functions/golang/">Go Function SDK</a>
@@ -1177,12 +1173,16 @@ functionConfig type.</p>
             
         
             
+        
+            
                 <div class="entry">
                     <h5>
                         <a href="/kpt/guides/producer/functions/ts/">TypeScript Function SDK</a>
                     </h5>
                     <p>Writing exec and container functions in TypeScript.</p>
                 </div>
+            
+        
             
         
             

--- a/docs/guides/producer/functions/starlark/index.html
+++ b/docs/guides/producer/functions/starlark/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerupdate">
+    <li class="collapse " id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerdisplay">
+    <li class="collapse " id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerapply">
+    <li class="collapse " id="kptguidesconsumerupdate">
       
       
       

--- a/docs/guides/producer/functions/ts/index.html
+++ b/docs/guides/producer/functions/ts/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerupdate">
+    <li class="collapse " id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerdisplay">
+    <li class="collapse " id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerapply">
+    <li class="collapse " id="kptguidesconsumerupdate">
       
       
       

--- a/docs/guides/producer/index.html
+++ b/docs/guides/producer/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerupdate">
+    <li class="collapse " id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerdisplay">
+    <li class="collapse " id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerapply">
+    <li class="collapse " id="kptguidesconsumerupdate">
       
       
       
@@ -851,6 +851,8 @@
             
         
             
+        
+            
                 <div class="entry">
                     <h5>
                         <a href="/kpt/guides/producer/setters/">Create Setters</a>
@@ -868,18 +870,14 @@
             
         
             
-        
-            
-        
-            
-        
-            
                 <div class="entry">
                     <h5>
                         <a href="/kpt/guides/producer/functions/">Functions</a>
                     </h5>
                     <p>Writing kpt functions to generated, transform, and validate resources.</p>
                 </div>
+            
+        
             
         
             
@@ -924,6 +922,8 @@
                     </h5>
                     <p>Bootstrap a package with content generated or published from another source.</p>
                 </div>
+            
+        
             
         
             

--- a/docs/guides/producer/init/index.html
+++ b/docs/guides/producer/init/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerupdate">
+    <li class="collapse " id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerdisplay">
+    <li class="collapse " id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerapply">
+    <li class="collapse " id="kptguidesconsumerupdate">
       
       
       

--- a/docs/guides/producer/setters/index.html
+++ b/docs/guides/producer/setters/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerupdate">
+    <li class="collapse " id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerdisplay">
+    <li class="collapse " id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerapply">
+    <li class="collapse " id="kptguidesconsumerupdate">
       
       
       

--- a/docs/guides/producer/substitutions/index.html
+++ b/docs/guides/producer/substitutions/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerupdate">
+    <li class="collapse " id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerdisplay">
+    <li class="collapse " id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerapply">
+    <li class="collapse " id="kptguidesconsumerupdate">
       
       
       

--- a/docs/guides/producer/variant/index.html
+++ b/docs/guides/producer/variant/index.html
@@ -209,10 +209,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
+    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerupdate">
+    <li class="collapse " id="kptguidesconsumerdisplay">
       
       
       
@@ -278,10 +278,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/display/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Display</a>
+    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerdisplay">
+    <li class="collapse " id="kptguidesconsumerapply">
       
       
       
@@ -301,10 +301,10 @@
 
 <ul class="td-sidebar-nav__section pr-md-3">
   <li class="td-sidebar-nav__section-title">
-    <a  href="/kpt/guides/consumer/apply/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Apply</a>
+    <a  href="/kpt/guides/consumer/update/" class="align-left pl-0 pr-2 collapsed td-sidebar-link td-sidebar-link__section">Update</a>
   </li>
   <ul>
-    <li class="collapse " id="kptguidesconsumerapply">
+    <li class="collapse " id="kptguidesconsumerupdate">
       
       
       

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -19,7 +19,7 @@
   
   <url>
     <loc>https://googlecontainertools.github.io/kpt/guides/consumer/get/</loc>
-    <lastmod>2020-05-26T11:32:33-07:00</lastmod>
+    <lastmod>2020-06-03T20:23:32-07:00</lastmod>
   </url>
   
   <url>
@@ -58,6 +58,11 @@
   </url>
   
   <url>
+    <loc>https://googlecontainertools.github.io/kpt/guides/consumer/display/</loc>
+    <lastmod>2020-06-03T20:23:32-07:00</lastmod>
+  </url>
+  
+  <url>
     <loc>https://googlecontainertools.github.io/kpt/guides/producer/functions/exec/</loc>
     <lastmod>2020-05-06T11:29:00-07:00</lastmod>
   </url>
@@ -80,11 +85,6 @@
   <url>
     <loc>https://googlecontainertools.github.io/kpt/guides/producer/setters/</loc>
     <lastmod>2020-05-29T17:02:30-07:00</lastmod>
-  </url>
-  
-  <url>
-    <loc>https://googlecontainertools.github.io/kpt/guides/consumer/update/</loc>
-    <lastmod>2020-03-30T20:54:38-07:00</lastmod>
   </url>
   
   <url>
@@ -123,11 +123,6 @@
   </url>
   
   <url>
-    <loc>https://googlecontainertools.github.io/kpt/guides/consumer/substitute/</loc>
-    <lastmod>2020-03-18T14:46:20-07:00</lastmod>
-  </url>
-  
-  <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/cfg/annotate/</loc>
     <lastmod>2020-04-24T15:55:16-07:00</lastmod>
   </url>
@@ -155,11 +150,6 @@
   <url>
     <loc>https://googlecontainertools.github.io/kpt/reference/cfg/create-subst/</loc>
     <lastmod>2020-04-29T15:53:27-07:00</lastmod>
-  </url>
-  
-  <url>
-    <loc>https://googlecontainertools.github.io/kpt/guides/consumer/display/</loc>
-    <lastmod>2020-03-18T14:46:20-07:00</lastmod>
   </url>
   
   <url>
@@ -203,6 +193,11 @@
   </url>
   
   <url>
+    <loc>https://googlecontainertools.github.io/kpt/guides/consumer/substitute/</loc>
+    <lastmod>2020-06-03T20:23:32-07:00</lastmod>
+  </url>
+  
+  <url>
     <loc>https://googlecontainertools.github.io/kpt/guides/producer/substitutions/</loc>
     <lastmod>2020-05-20T14:56:30-04:00</lastmod>
   </url>
@@ -228,8 +223,8 @@
   </url>
   
   <url>
-    <loc>https://googlecontainertools.github.io/kpt/guides/consumer/function/</loc>
-    <lastmod>2020-04-20T16:15:37-07:00</lastmod>
+    <loc>https://googlecontainertools.github.io/kpt/guides/consumer/update/</loc>
+    <lastmod>2020-06-03T20:23:32-07:00</lastmod>
   </url>
   
   <url>
@@ -240,6 +235,11 @@
   <url>
     <loc>https://googlecontainertools.github.io/kpt/guides/producer/bootstrap/</loc>
     <lastmod>2020-03-18T14:46:20-07:00</lastmod>
+  </url>
+  
+  <url>
+    <loc>https://googlecontainertools.github.io/kpt/guides/consumer/function/</loc>
+    <lastmod>2020-06-03T20:23:32-07:00</lastmod>
   </url>
   
   <url>

--- a/site/content/en/guides/consumer/display/_index.md
+++ b/site/content/en/guides/consumer/display/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Display local package contents"
 linkTitle: "Display"
-weight: 4
+weight: 2
 type: docs
 description: >
     Display the contents of a local package using kpt cfg for rendering.

--- a/site/content/en/guides/consumer/function/_index.md
+++ b/site/content/en/guides/consumer/function/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Running functions"
 linkTitle: "Running Functions"
-weight: 6
+weight: 7
 type: docs
 description: >
     Modify or validate the contents of a package by calling a function.

--- a/site/content/en/guides/consumer/get/_index.md
+++ b/site/content/en/guides/consumer/get/_index.md
@@ -68,6 +68,10 @@ The contents of the `staging/cockroachdb` subdirectory in the
   match the upstream directory name it is copied from
 - including `.git` as part of the repo name is optional but good practice to
   ensure the repo + subdirectory are parsed correctly by the tool.
+- Packages inside the same repo can be versioned individually by creating tags 
+  with the format `<path to package in repo>/<version>`, similar to how go
+  modules are versioned. For example, a tag named `staging/cockroachdb/v1.2.3` 
+  would be interpreted by kpt as version `v1.2.3` of the cockroachdb package.
 {{% /pageinfo %}}
 
 ## View the Kptfile

--- a/site/content/en/guides/consumer/substitute/_index.md
+++ b/site/content/en/guides/consumer/substitute/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Substitute a values into fields"
 linkTitle: "Substitute"
-weight: 3
+weight: 4
 type: docs
 description: >
     Customize a local package by substituting values into fields.

--- a/site/content/en/guides/consumer/update/_index.md
+++ b/site/content/en/guides/consumer/update/_index.md
@@ -1,7 +1,7 @@
 ---
 title: "Update a local package"
 linkTitle: "Update"
-weight: 2
+weight: 6
 type: docs
 description: >
     Update a customized local package with upstream (remote) package changes.


### PR DESCRIPTION
Small improvements to the consumer guide based on feedback. It rearranges the pages in the consumer guide and adds information about how kpt allows individual versioning of packages in a single repo.

ref: #664 