### PR TITLE
Fix incorrect substitution in package-examples/mysql-kustomize

### DIFF
--- a/package-examples/mysql-kustomize/Kptfile
+++ b/package-examples/mysql-kustomize/Kptfile
@@ -48,7 +48,7 @@ openAPI:
     io.k8s.cli.substitutions.skip-grant-tables:
       x-k8s-cli:
         substitution:
-          name: mysql-database
+          name: skip-grant-tables
           pattern: "skip-grant-tables=SKIP_GRANT_TABLES_SETTER"
           values:
           - marker: SKIP_GRANT_TABLES_SETTER


### PR DESCRIPTION
The `io.k8s.cli.substitutions.skip-grant-tables.name` is `mysql-database` but it should be `skip-grant-tables`. 