### PR TITLE
Goreleaser setup for kpt

### DIFF
--- a/release/tag/cloudbuild.yaml
+++ b/release/tag/cloudbuild.yaml
@@ -13,169 +13,147 @@
 # limitations under the License.
 
 steps:
+  - name: gcr.io/cloud-builders/git
+    args: ['clone', 'https://github.com/${_GITHUB_USER}/kpt.git']
+
+  - name: gcr.io/cloud-builders/git
+    dir: 'kpt'
+    args: ['checkout', '${TAG_NAME}']
+
   # Build the image that contains most of the tools we need (e.g. tar,
   # jq, gzip, golang, bash, etc.) to build kpt tarball. This image
   # (kpt-builder) is re-used on most steps.
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['build', '-f', '/workspace/release/Dockerfile.kpt-build', '-t', 'kpt-builder', '.']
-
-  # Generate and package the licenses and necessary source code.
-  - name: 'kpt-builder'
-    args: ['bash', '/workspace/scripts/create-licenses.sh']
-    volumes:
-      - name: go-modules
-        path: /go
-
-  - name: 'kpt-builder'
-    args: ['mkdir', '/workspace/latest']
-
-  # FYI: If cross-platform build issues happen, then stop caching the modules in the volume.
-  # build windows
-  - name: 'kpt-builder'
-    env: ['GOOS=windows', 'GOARCH=amd64', 'CGO_ENABLED=0', 'GO111MODULE=on']
-    args: ['go', 'build', '-ldflags', '-X github.com/GoogleContainerTools/kpt/run.version=${TAG_NAME}', '-o', '/workspace/releases/${TAG_NAME}/windows_amd64/kpt.exe', '.']
-    dir: '/workspace/'
-    volumes:
-      - name: go-modules
-        path: /go
-  - name: 'kpt-builder'
-    args: ['cp', '/workspace/LICENSES.txt', '/workspace/releases/${TAG_NAME}/windows_amd64']
-  - name: 'kpt-builder'
-    args: ['cp', '/workspace/lib.zip', '/workspace/releases/${TAG_NAME}/windows_amd64']
-  # Create the tarball containing the kpt binary and licenses.
-  - name: 'kpt-builder'
-    args: ['tar', '-cf',
-    '/workspace/releases/${TAG_NAME}/windows_amd64/kpt_windows_amd64-${TAG_NAME}.tar',
-    '-C', '/workspace/releases/${TAG_NAME}/windows_amd64',
-    'kpt.exe', 'LICENSES.txt', 'lib.zip']
-  - name: 'kpt-builder'
-    args: ['gzip', '/workspace/releases/${TAG_NAME}/windows_amd64/kpt_windows_amd64-${TAG_NAME}.tar']
-
-  # copy latest
-  - name: 'kpt-builder'
-    args: ['mkdir', '/workspace/latest/windows_amd64/']
-  - name: 'kpt-builder'
-    args: ['cp', '/workspace/releases/${TAG_NAME}/windows_amd64/kpt.exe', '/workspace/latest/windows_amd64/kpt.exe']
-  - name: 'kpt-builder'
-    args: ['cp', '/workspace/releases/${TAG_NAME}/windows_amd64/kpt_windows_amd64-${TAG_NAME}.tar.gz', '/workspace/latest/windows_amd64/kpt_windows_amd64.tar.gz']
-
-  # Cleanup by removing files that have been packaged into the
-  # tarball.
-  - name: 'kpt-builder'
-    args: ['rm', '-f',
-    '/workspace/releases/${TAG_NAME}/windows_amd64/kpt.exe',
-    '/workspace/releases/${TAG_NAME}/windows_amd64/LICENSES.txt',
-    '/workspace/releases/${TAG_NAME}/windows_amd64/lib.zip']
-
-  # build linux
-  - name: 'kpt-builder'
-    env: ['GOOS=linux', 'GOARCH=amd64', 'CGO_ENABLED=0', 'GO111MODULE=on']
-    args: ['go', 'build', '-ldflags', '-X github.com/GoogleContainerTools/kpt/run.version=${TAG_NAME}', '-o', '/workspace/releases/${TAG_NAME}/linux_amd64/kpt', '.']
-    dir: '/workspace/'
-    volumes:
-      - name: go-modules
-        path: /go
-  - name: 'kpt-builder'
-    args: ['cp', '/workspace/LICENSES.txt', '/workspace/releases/${TAG_NAME}/linux_amd64']
-  - name: 'kpt-builder'
-    args: ['cp', '/workspace/lib.zip', '/workspace/releases/${TAG_NAME}/linux_amd64']
-  # Create the tarball containing the kpt binary and licenses.
-  - name: 'kpt-builder'
-    args: ['tar', '-cf',
-    '/workspace/releases/${TAG_NAME}/linux_amd64/kpt_linux_amd64-${TAG_NAME}.tar',
-    '-C', '/workspace/releases/${TAG_NAME}/linux_amd64',
-    'kpt', 'LICENSES.txt', 'lib.zip']
-  - name: 'kpt-builder'
-    args: ['gzip', '/workspace/releases/${TAG_NAME}/linux_amd64/kpt_linux_amd64-${TAG_NAME}.tar']
-
-    # copy latest
-  - name: 'kpt-builder'
-    args: ['mkdir', '/workspace/latest/linux_amd64/']
-  - name: 'kpt-builder'
-    args: ['cp', '/workspace/releases/${TAG_NAME}/linux_amd64/kpt', '/workspace/latest/linux_amd64/kpt']
-  - name: 'kpt-builder'
-    args: ['cp', '/workspace/releases/${TAG_NAME}/linux_amd64/kpt_linux_amd64-${TAG_NAME}.tar.gz', '/workspace/latest/linux_amd64/kpt_linux_amd64.tar.gz']
-
-  # Cleanup by removing files that have been packaged into the
-  # tarball.
-  - name: 'kpt-builder'
-    args: ['rm', '-f',
-    '/workspace/releases/${TAG_NAME}/linux_amd64/kpt',
-    '/workspace/releases/${TAG_NAME}/linux_amd64/LICENSES.txt',
-    '/workspace/releases/${TAG_NAME}/linux_amd64/lib.zip']
-
-  # build darwin
-  - name: 'kpt-builder'
-    env: ['GOOS=darwin', 'GOARCH=amd64', 'CGO_ENABLED=0', 'GO111MODULE=on']
-    args: ['go', 'build', '-ldflags', '-X github.com/GoogleContainerTools/kpt/run.version=${TAG_NAME}', '-o', '/workspace/releases/${TAG_NAME}/darwin_amd64/kpt', '.']
-    dir: '/workspace/'
-    volumes:
-      - name: go-modules
-        path: /go
-  - name: 'kpt-builder'
-    args: ['cp', '/workspace/LICENSES.txt', '/workspace/releases/${TAG_NAME}/darwin_amd64']
-  - name: 'kpt-builder'
-    args: ['cp', '/workspace/lib.zip', '/workspace/releases/${TAG_NAME}/darwin_amd64']
-  # Create the tarball containing the kpt binary and licenses.
-  - name: 'kpt-builder'
-    args: ['tar', '-cf',
-    '/workspace/releases/${TAG_NAME}/darwin_amd64/kpt_darwin_amd64-${TAG_NAME}.tar',
-    '-C', '/workspace/releases/${TAG_NAME}/darwin_amd64',
-    'kpt', 'LICENSES.txt', 'lib.zip']
-  - name: 'kpt-builder'
-    args: ['gzip', '/workspace/releases/${TAG_NAME}/darwin_amd64/kpt_darwin_amd64-${TAG_NAME}.tar']
-
-  # copy latest
-  - name: 'kpt-builder'
-    args: ['mkdir', '/workspace/latest/darwin_amd64/']
-  - name: 'kpt-builder'
-    args: ['cp', '-r', '/workspace/releases/${TAG_NAME}/darwin_amd64/kpt', '/workspace/latest/darwin_amd64/kpt']
-  - name: 'kpt-builder'
-    args: ['cp', '/workspace/releases/${TAG_NAME}/darwin_amd64/kpt_darwin_amd64-${TAG_NAME}.tar.gz', '/workspace/latest/darwin_amd64/kpt_darwin_amd64.tar.gz']
-
-  # Cleanup by removing files that have been packaged into the
-  # tarball.
-  - name: 'kpt-builder'
-    args: ['rm', '-f',
-    '/workspace/releases/${TAG_NAME}/darwin_amd64/kpt',
-    '/workspace/releases/${TAG_NAME}/darwin_amd64/LICENSES.txt',
-    '/workspace/releases/${TAG_NAME}/darwin_amd64/lib.zip']
-
-  # build docker image
-  - name: 'gcr.io/cloud-builders/docker'
-    args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/kpt:${TAG_NAME}', '.' ]
-
-  - name: 'gcr.io/cloud-builders/docker'
-    args: [ 'tag', 'gcr.io/$PROJECT_ID/kpt:${TAG_NAME}',  'gcr.io/$PROJECT_ID/kpt:latest' ]
-
-  - name: 'gcr.io/cloud-builders/docker'
-    args: [ 'build', '-t', 'gcr.io/kpt-dev/example-functions:${TAG_NAME}', '-f', 'functions/examples/Dockerfile', '.' ]
-
-  - name: 'gcr.io/cloud-builders/docker'
-    args: [ 'tag', 'gcr.io/kpt-dev/example-functions:${TAG_NAME}',  'gcr.io/kpt-dev/example-functions:latest' ]
+    dir: 'kpt'
+    args: ['build', '-f', '/workspace/kpt/release/Dockerfile.kpt-build', '-t', 'kpt-builder', '.']
 
   # run e2e tests and linting
   - name: 'kpt-builder'
     args: ['git', 'config', '--global', 'user.email', 'you@example.com']
-    dir: '/workspace'
+    dir: 'kpt'
     volumes:
       - name: home
         path: /root
   - name: 'kpt-builder'
     args: ['git', 'config', '--global', 'user.name', 'Your Name']
-    dir: '/workspace'
+    dir: 'kpt'
     volumes:
       - name: home
         path: /root
   - name: 'kpt-builder'
     args: ['make', 'all']
     env: ['GO111MODULE=on']
-    dir: '/workspace'
+    dir: 'kpt'
     volumes:
       - name: go-modules
         path: /go
       - name: home
         path: /root
+
+  # remove any dirty files after running the build
+  - name: gcr.io/cloud-builders/git
+    dir: 'kpt'
+    args: ['reset', '--hard']
+
+  # Generate and package the licenses and necessary source code.
+  - name: 'kpt-builder'
+    dir: 'kpt'
+    args: ['bash', '/workspace/scripts/create-licenses.sh']
+    volumes:
+      - name: go-modules
+        path: /go
+
+  - name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    args: [ '-c', 'mkdir -p ~/.config/goreleaser && gcloud secrets versions access latest --secret=github-token > ~/.config/goreleaser/github_token' ]
+
+  - name: 'goreleaser/goreleaser'
+    dir: 'kpt'
+    args: ['release', '--skip-validate', '-f', 'release/tag/goreleaser.yaml']
+
+  # create a working folder for downloading release artifacts from github and pushing
+  # them to GCS
+  - name: 'launcher.gcr.io/google/ubuntu1604'
+    entrypoint: 'bash'
+    args: [ '-c', 'mkdir artifacts']
+
+  # download release artifacts from github
+  - name: 'launcher.gcr.io/google/ubuntu1604'
+    dir: 'artifacts'
+    args: [ 'curl', '-L',
+            '-O', 'https://github.com/${_GITHUB_USER}/kpt/releases/download/${TAG_NAME}/kpt_darwin_amd64_${_VERSION}.tar.gz',
+            '-O', 'https://github.com/${_GITHUB_USER}/kpt/releases/download/${TAG_NAME}/kpt_linux_amd64_${_VERSION}.tar.gz',
+            '-O', 'https://github.com/${_GITHUB_USER}/kpt/releases/download/${TAG_NAME}/kpt_windows_amd64_${_VERSION}.tar.gz'
+    ]
+
+  # upload the artifacts to GCS
+  - name: 'gcr.io/cloud-builders/gsutil'
+    dir: 'artifacts'
+    args: [ 'cp', '-a', 'public-read', 'kpt_darwin_amd64_${_VERSION}.tar.gz', 'gs://${_GCS_BUCKET}/releases/${TAG_NAME}/darwin_amd64/kpt_darwin_amd64_${TAG_NAME}.tar.gz' ]
+
+  - name: 'gcr.io/cloud-builders/gsutil'
+    dir: 'artifacts'
+    args: [ 'cp', '-a', 'public-read', 'kpt_darwin_amd64_${_VERSION}.tar.gz', 'gs://${_GCS_BUCKET}/latest/darwin_amd64/kpt_darwin_amd64.tar.gz' ]
+
+  - name: 'launcher.gcr.io/google/ubuntu1604'
+    dir: 'artifacts'
+    entrypoint: 'bash'
+    args: [ '-c', 'tar -xvf kpt_darwin_amd64_${_VERSION}.tar.gz kpt && mv kpt kpt_darwin_amd64' ]
+
+  - name: 'gcr.io/cloud-builders/gsutil'
+    dir: 'artifacts'
+    args: [ 'cp', '-a', 'public-read', 'kpt_darwin_amd64', 'gs://${_GCS_BUCKET}/latest/darwin_amd64/kpt' ]
+
+  - name: 'gcr.io/cloud-builders/gsutil'
+    dir: 'artifacts'
+    args: [ 'cp', '-a', 'public-read', 'kpt_linux_amd64_${_VERSION}.tar.gz', 'gs://${_GCS_BUCKET}/releases/${TAG_NAME}/linux_amd64/kpt_linux_amd64_${TAG_NAME}.tar.gz' ]
+
+  - name: 'gcr.io/cloud-builders/gsutil'
+    dir: 'artifacts'
+    args: [ 'cp', '-a', 'public-read', 'kpt_linux_amd64_${_VERSION}.tar.gz', 'gs://${_GCS_BUCKET}/latest/linux_amd64/kpt_linux_amd64.tar.gz' ]
+
+  - name: 'launcher.gcr.io/google/ubuntu1604'
+    dir: 'artifacts'
+    entrypoint: 'bash'
+    args: [ '-c', 'tar -xvf kpt_linux_amd64_${_VERSION}.tar.gz kpt && mv kpt kpt_linux_amd64' ]
+
+  - name: 'gcr.io/cloud-builders/gsutil'
+    dir: 'artifacts'
+    args: [ 'cp', '-a', 'public-read', 'kpt_linux_amd64', 'gs://${_GCS_BUCKET}/latest/linux_amd64/kpt' ]
+
+  - name: 'gcr.io/cloud-builders/gsutil'
+    dir: 'artifacts'
+    args: [ 'cp', '-a', 'public-read', 'kpt_windows_amd64_${_VERSION}.tar.gz', 'gs://${_GCS_BUCKET}/releases/${TAG_NAME}/windows_amd64/kpt_windows_amd64_${TAG_NAME}.tar.gz' ]
+
+  - name: 'gcr.io/cloud-builders/gsutil'
+    dir: 'artifacts'
+    args: [ 'cp', '-a', 'public-read', 'kpt_windows_amd64_${_VERSION}.tar.gz', 'gs://${_GCS_BUCKET}/latest/windows_amd64/kpt_windows_amd64.tar.gz' ]
+
+  - name: 'launcher.gcr.io/google/ubuntu1604'
+    dir: 'artifacts'
+    entrypoint: 'bash'
+    args: [ '-c', 'tar -xvf kpt_windows_amd64_${_VERSION}.tar.gz kpt.exe && mv kpt.exe kpt_windows_amd64.exe' ]
+
+  - name: 'gcr.io/cloud-builders/gsutil'
+    dir: 'artifacts'
+    args: [ 'cp', '-a', 'public-read', 'kpt_windows_amd64.exe', 'gs://${_GCS_BUCKET}/latest/windows_amd64/kpt.exe' ]
+
+  # build docker image
+  - name: 'gcr.io/cloud-builders/docker'
+    dir: 'kpt'
+    args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/kpt:${TAG_NAME}', '.' ]
+
+  - name: 'gcr.io/cloud-builders/docker'
+    dir: 'kpt'
+    args: [ 'tag', 'gcr.io/$PROJECT_ID/kpt:${TAG_NAME}',  'gcr.io/$PROJECT_ID/kpt:latest' ]
+
+  - name: 'gcr.io/cloud-builders/docker'
+    dir: 'kpt'
+    args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/example-functions:${TAG_NAME}', '-f', 'functions/examples/Dockerfile', '.' ]
+
+  - name: 'gcr.io/cloud-builders/docker'
+    dir: 'kpt'
+    args: [ 'tag', 'gcr.io/$PROJECT_ID/example-functions:${TAG_NAME}',  'gcr.io/$PROJECT_ID/example-functions:latest' ]
 
   # push the container image
   - name: 'gcr.io/cloud-builders/docker'
@@ -187,18 +165,10 @@ steps:
 
   # push the container image
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['push', 'gcr.io/kpt-dev/example-functions:${TAG_NAME}']
+    args: ['push', 'gcr.io/$PROJECT_ID/example-functions:${TAG_NAME}']
 
   # update latest tag on release
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['push', 'gcr.io/kpt-dev/example-functions:latest']
-
-  # push the binaries
-  - name: 'gcr.io/cloud-builders/gsutil'
-    args: ['cp', '-r', '-a', 'public-read', '/workspace/releases/', 'gs://kpt-dev/']
-
-  # update the latest binaries
-  - name: 'gcr.io/cloud-builders/gsutil'
-    args: ['cp', '-r', '-a', 'public-read', '/workspace/latest', 'gs://kpt-dev/']
+    args: ['push', 'gcr.io/$PROJECT_ID/example-functions:latest']
 
 timeout: '60m'

--- a/release/tag/goreleaser.yaml
+++ b/release/tag/goreleaser.yaml
@@ -1,0 +1,48 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+      - GO111MODULE=on
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}}
+archives:
+  - files:
+      - LICENSE*
+      - README*
+      - CHANGELOG*
+      - lib.zip*
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}_{{ .Version }}"
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "master"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - Merge pull request
+      - Merge branch
+release:
+  github:
+    owner: GoogleContainerTools
+    name: kpt


### PR DESCRIPTION
This sets up cloudbuild to use goreleaser to create relases. Just like before, it will only run whenever a new tag is pushed with a semver format.

It will create proper github releases and attach release notes. It will upload the binaries as part of the release, but will no longer upload the binaries to GCS. The images are still being generated in the same way as before.

@seans3 @phanimarupaka @jijiew 