### PR TITLE
Fail live apply/preview if required setters are not set by consumer

### DIFF
--- a/internal/util/setters/setters_test.go
+++ b/internal/util/setters/setters_test.go
@@ -82,3 +82,156 @@ openAPI:
 		})
 	}
 }
+
+func TestCheckRequiredSettersSet(t *testing.T) {
+	var tests = []struct {
+		name          string
+		inputKptfile  string
+		expectedError bool
+	}{
+		{
+			name: "no required, no isSet",
+			inputKptfile: `
+apiVersion: v1alpha1
+kind: Kptfile
+openAPI:
+  definitions:
+    io.k8s.cli.setters.gcloud.project.projectNumber:
+      description: hello world
+      x-k8s-cli:
+        setter:
+          name: gcloud.project.projectNumber
+          value: 123
+          setBy: me
+    io.k8s.cli.setters.replicas:
+      description: hello world
+      x-k8s-cli:
+        setter:
+          name: replicas
+          value: "3"
+          setBy: me
+ `,
+			expectedError: false,
+		},
+		{
+			name: "required true, no isSet",
+			inputKptfile: `
+apiVersion: v1alpha1
+kind: Example
+openAPI:
+  definitions:
+    io.k8s.cli.setters.replicas:
+      description: hello world
+      x-k8s-cli:
+        setter:
+          name: replicas
+          value: "3"
+          setBy: me
+          required: true
+ `,
+			expectedError: true,
+		},
+		{
+			name: "required true, isSet true",
+			inputKptfile: `
+apiVersion: v1alpha1
+kind: Example
+openAPI:
+  definitions:
+    io.k8s.cli.setters.replicas:
+      description: hello world
+      x-k8s-cli:
+        setter:
+          name: replicas
+          value: "3"
+          setBy: me
+          required: true
+          isSet: true
+ `,
+			expectedError: false,
+		},
+
+		{
+			name: "required false, isSet true",
+			inputKptfile: `
+apiVersion: v1alpha1
+kind: Kptfile
+openAPI:
+  definitions:
+    io.k8s.cli.setters.gcloud.project.projectNumber:
+      description: hello world
+      x-k8s-cli:
+        setter:
+          name: gcloud.project.projectNumber
+          value: 123
+          setBy: me
+    io.k8s.cli.setters.replicas:
+      description: hello world
+      x-k8s-cli:
+        setter:
+          name: replicas
+          value: "3"
+          setBy: me
+          required: false
+          isSet: true
+ `,
+			expectedError: false,
+		},
+
+		{
+			name: "required true, isSet false",
+			inputKptfile: `
+apiVersion: v1alpha1
+kind: Kptfile
+openAPI:
+  definitions:
+    io.k8s.cli.setters.gcloud.project.projectNumber:
+      description: hello world
+      x-k8s-cli:
+        setter:
+          name: gcloud.project.projectNumber
+          value: 123
+          setBy: me
+    io.k8s.cli.setters.replicas:
+      description: hello world
+      x-k8s-cli:
+        setter:
+          name: replicas
+          value: "3"
+          setBy: me
+          required: true
+          isSet: false
+ `,
+			expectedError: true,
+		},
+
+		{
+			name:          "no Kptfile",
+			inputKptfile:  ``,
+			expectedError: false,
+		},
+	}
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			openapi.ResetOpenAPI()
+			defer openapi.ResetOpenAPI()
+			dir, err := ioutil.TempDir("", "")
+			assert.NoError(t, err)
+			defer os.RemoveAll(dir)
+			if test.inputKptfile != "" {
+				err = ioutil.WriteFile(filepath.Join(dir, "Kptfile"), []byte(test.inputKptfile), 0600)
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+			}
+			err = CheckRequiredSettersSet(dir)
+			if test.expectedError && !assert.Error(t, err) {
+				t.FailNow()
+			}
+			if !test.expectedError && !assert.NoError(t, err) {
+				t.FailNow()
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR is to make check for all the Kpt setters and throw error during apply/preview operation if a package consumer didn't set the setters marked as required by package consumer. This is a follow up PR for the PR in kustomize https://github.com/kubernetes-sigs/kustomize/pull/2635. Description in the kustomize PR and test cases in current PR clearly describe the expected behavior. 

The motivation for this PR is to address the feature request https://github.com/GoogleContainerTools/kpt/issues/261