### PR TITLE
Fix kpt google search by indexing pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ gencatalog:
 
 gendocs:
 	rm -rf docs/
-	(cd site && go run github.com/gohugoio/hugo)
+	(cd site && env HUGO_ENV="production" hugo)
 
 docs: gencatalog gendocs license
 

--- a/docs/api-reference/index.html
+++ b/docs/api-reference/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/api-reference/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="API Reference"/>
 <meta name="twitter:description" content="Overview of kpt declarative APIs
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/api-reference/kptfile/index.html
+++ b/docs/api-reference/kptfile/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/api-reference/kptfile/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Kptfile"/>
 <meta name="twitter:description" content="Reference for the Kptfile schema
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/concepts/api-conventions/index.html
+++ b/docs/concepts/api-conventions/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/concepts/api-conventions/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="API Conventions"/>
 <meta name="twitter:description" content="Kpt API Conventions
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/concepts/architecture/index.html
+++ b/docs/concepts/architecture/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/concepts/architecture/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Architecture"/>
 <meta name="twitter:description" content="Kpt Architecture
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/concepts/functions/index.html
+++ b/docs/concepts/functions/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/concepts/functions/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Functions"/>
 <meta name="twitter:description" content="Functions goals and specification
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/concepts/index.html
+++ b/docs/concepts/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/concepts/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Concepts"/>
 <meta name="twitter:description" content="Concepts
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/concepts/packaging/index.html
+++ b/docs/concepts/packaging/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/concepts/packaging/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Packaging"/>
 <meta name="twitter:description" content="Packaging goals and design decisions
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/contact/index.html
+++ b/docs/contact/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/contact/index.xml">
 
@@ -41,6 +41,19 @@
 <meta itemprop="description" content="Kubernetes configuration package management"><meta name="twitter:card" content="summary"/>
 <meta name="twitter:title" content="Contact"/>
 <meta name="twitter:description" content="Kubernetes configuration package management"/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/faq/index.html
+++ b/docs/faq/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/faq/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="FAQ"/>
 <meta name="twitter:description" content="Frequently asked questions
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/consumer/apply/index.html
+++ b/docs/guides/consumer/apply/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/consumer/apply/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Apply a local package"/>
 <meta name="twitter:description" content="Apply the contents of a local package to a remote cluster.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/consumer/display/index.html
+++ b/docs/guides/consumer/display/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/consumer/display/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Display local package contents"/>
 <meta name="twitter:description" content="Display the contents of a local package using kpt cfg for rendering.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/consumer/function/catalog/catalog/node_modules/markdown-table/readme/index.html
+++ b/docs/guides/consumer/function/catalog/catalog/node_modules/markdown-table/readme/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 
 
@@ -64,6 +64,19 @@ npm install markdown-table Usage Normal usage (defaults to left-alignment):
 var table = require(&#39;markdown-table&#39;) table([ [&#39;Branch&#39;, &#39;Commit&#39;], [&#39;master&#39;, &#39;0123456789abcdef&#39;], [&#39;staging&#39;, &#39;fedcba9876543210&#39;] ]) Yields:
 | Branch | Commit | | ------- | ---------------- | | master | 0123456789abcdef | | staging | fedcba9876543210 | With alignment:
 table( [ [&#39;Beep&#39;, &#39;No.&#39;, &#39;Boop&#39;], [&#39;beep&#39;, &#39;1024&#39;, &#39;xyz&#39;], [&#39;boop&#39;, &#39;3388450&#39;, &#39;tuv&#39;], [&#39;foo&#39;, &#39;10106&#39;, &#39;qrstuv&#39;], [&#39;bar&#39;, &#39;45&#39;, &#39;lmno&#39;] ], { align: [&#39;l&#39;, &#39;c&#39;, &#39;r&#39;] } ) Yields:"/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/consumer/function/catalog/docs/helm-template/usage/index.html
+++ b/docs/guides/consumer/function/catalog/docs/helm-template/usage/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 
 
@@ -49,6 +49,19 @@
 <meta name="twitter:title" content="Helm-template Usage"/>
 <meta name="twitter:description" content="Helm-template Usage.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/consumer/function/catalog/index.html
+++ b/docs/guides/consumer/function/catalog/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/consumer/function/catalog/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Functions Catalog"/>
 <meta name="twitter:description" content="Catalog of Config Functions.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/consumer/function/index.html
+++ b/docs/guides/consumer/function/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/consumer/function/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Running functions"/>
 <meta name="twitter:description" content="Modify or validate the contents of a package by calling a function.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/consumer/function/pipeline/index.html
+++ b/docs/guides/consumer/function/pipeline/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/consumer/function/pipeline/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Running a functions pipeline"/>
 <meta name="twitter:description" content="Compose functions into a pipeline.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/consumer/get/index.html
+++ b/docs/guides/consumer/get/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/consumer/get/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Get a remote package"/>
 <meta name="twitter:description" content="Fetch a package from a remote git repository and apply its contents to a cluster
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/consumer/index.html
+++ b/docs/guides/consumer/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/consumer/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Package Consumers"/>
 <meta name="twitter:description" content="Guides for workflows related to consume packages published by other teams or organizations.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/consumer/set/index.html
+++ b/docs/guides/consumer/set/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/consumer/set/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Set field values"/>
 <meta name="twitter:description" content="Customize a local package by setting field values.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/consumer/substitute/index.html
+++ b/docs/guides/consumer/substitute/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/consumer/substitute/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Substitute a values into fields"/>
 <meta name="twitter:description" content="Customize a local package by substituting values into fields.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/consumer/update/index.html
+++ b/docs/guides/consumer/update/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/consumer/update/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Update a local package"/>
 <meta name="twitter:description" content="Update a customized local package with upstream (remote) package changes.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/ecosystem/helm/index.html
+++ b/docs/guides/ecosystem/helm/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/ecosystem/helm/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Helm"/>
 <meta name="twitter:description" content="Generate kpt packages from Helm charts
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/ecosystem/index.html
+++ b/docs/guides/ecosystem/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/ecosystem/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Ecosystem"/>
 <meta name="twitter:description" content="Guides for using kpt with the Kubernetes ecosystem.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/ecosystem/kustomize/index.html
+++ b/docs/guides/ecosystem/kustomize/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/ecosystem/kustomize/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Kustomize"/>
 <meta name="twitter:description" content="Publish kustomize bundles as packages of configuration 
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/ecosystem/oam/index.html
+++ b/docs/guides/ecosystem/oam/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/ecosystem/oam/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Open Application Model (OAM)"/>
 <meta name="twitter:description" content="Using kpt to manage custom Kubernetes applications defined by Open Application Model (OAM)
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/index.html
+++ b/docs/guides/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/index.xml">
 
@@ -41,6 +41,19 @@
 <meta itemprop="description" content="Kubernetes configuration package management"><meta name="twitter:card" content="summary"/>
 <meta name="twitter:title" content="Guides"/>
 <meta name="twitter:description" content="Kubernetes configuration package management"/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/producer/blueprint/index.html
+++ b/docs/guides/producer/blueprint/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/producer/blueprint/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Publishing a blueprint"/>
 <meta name="twitter:description" content="Writing effective blueprint packages
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/producer/bootstrap/index.html
+++ b/docs/guides/producer/bootstrap/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/producer/bootstrap/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Bootstrapping"/>
 <meta name="twitter:description" content="Bootstrap a package with content generated or published from another source.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/producer/functions/container/index.html
+++ b/docs/guides/producer/functions/container/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/producer/functions/container/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Container Runtime"/>
 <meta name="twitter:description" content="Writing and running functions as containers
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/producer/functions/exec/index.html
+++ b/docs/guides/producer/functions/exec/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/producer/functions/exec/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Exec Runtime"/>
 <meta name="twitter:description" content="Writing and running functions as executables
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/producer/functions/golang/index.html
+++ b/docs/guides/producer/functions/golang/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/producer/functions/golang/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Go Function SDK"/>
 <meta name="twitter:description" content="Writing exec and container functions in Golang.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/producer/functions/index.html
+++ b/docs/guides/producer/functions/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/producer/functions/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Functions"/>
 <meta name="twitter:description" content="Writing config functions to generated, transform, and validate resources.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/producer/functions/starlark/index.html
+++ b/docs/guides/producer/functions/starlark/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/producer/functions/starlark/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Starlark Runtime and SDK"/>
 <meta name="twitter:description" content="Writing and running functions as Starlark scripts
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/producer/functions/ts/develop/index.html
+++ b/docs/guides/producer/functions/ts/develop/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/producer/functions/ts/develop/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="TypeScript Developer Guide"/>
 <meta name="twitter:description" content="Developing functions in TypeScript.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/producer/functions/ts/index.html
+++ b/docs/guides/producer/functions/ts/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/producer/functions/ts/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="TypeScript Function SDK"/>
 <meta name="twitter:description" content="Writing functions in TypeScript.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/producer/index.html
+++ b/docs/guides/producer/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/producer/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Package Publishers"/>
 <meta name="twitter:description" content="Guides for publishing configuration packages for others to consume.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/producer/init/index.html
+++ b/docs/guides/producer/init/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/producer/init/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Init"/>
 <meta name="twitter:description" content="Initialize and publish a new package
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/producer/setters/index.html
+++ b/docs/guides/producer/setters/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/producer/setters/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Create Setters"/>
 <meta name="twitter:description" content="Create high-level setters to provide imperative configuration editing commands.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/producer/substitutions/index.html
+++ b/docs/guides/producer/substitutions/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/producer/substitutions/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Create Substitutions"/>
 <meta name="twitter:description" content="Create high-level substitutions to provide substitute field values using setters.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/guides/producer/variant/index.html
+++ b/docs/guides/producer/variant/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/guides/producer/variant/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Publishing a variants"/>
 <meta name="twitter:description" content="Publishing a package with variants for multiple environments.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/index.xml">
 
@@ -43,6 +43,19 @@
 <meta name="twitter:image" content="https://googlecontainertools.github.io/kpt/featured-background.jpg"/>
 <meta name="twitter:title" content="Kpt"/>
 <meta name="twitter:description" content="Kubernetes configuration package management"/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/index.json
+++ b/docs/index.json
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 
 
@@ -46,6 +46,19 @@
 <meta itemprop="keywords" content="" /><meta name="twitter:card" content="summary"/>
 <meta name="twitter:title" content=""/>
 <meta name="twitter:description" content=""/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/installation/binaries/index.html
+++ b/docs/installation/binaries/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/installation/binaries/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="binaries"/>
 <meta name="twitter:description" content="Download and run statically compiled go binaries.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/installation/gcloud/index.html
+++ b/docs/installation/gcloud/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/installation/gcloud/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="gcloud"/>
 <meta name="twitter:description" content="Install as a gcloud component.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/installation/homebrew/index.html
+++ b/docs/installation/homebrew/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/installation/homebrew/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="homebrew"/>
 <meta name="twitter:description" content="Install as a brew tap.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/installation/index.html
+++ b/docs/installation/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/installation/index.xml">
 
@@ -41,6 +41,19 @@
 <meta itemprop="description" content="Kubernetes configuration package management"><meta name="twitter:card" content="summary"/>
 <meta name="twitter:title" content="Installation"/>
 <meta name="twitter:description" content="Kubernetes configuration package management"/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/installation/source/index.html
+++ b/docs/installation/source/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/installation/source/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="source code"/>
 <meta name="twitter:description" content="Dust off your go compiler and install from source.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/cfg/annotate/index.html
+++ b/docs/reference/cfg/annotate/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/cfg/annotate/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Annotate"/>
 <meta name="twitter:description" content="Set an annotation on one or more resources
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/cfg/cat/index.html
+++ b/docs/reference/cfg/cat/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/cfg/cat/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Cat"/>
 <meta name="twitter:description" content="Print the resources in a package
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/cfg/count/index.html
+++ b/docs/reference/cfg/count/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/cfg/count/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Count"/>
 <meta name="twitter:description" content="Print resource counts for a package
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/cfg/create-setter/index.html
+++ b/docs/reference/cfg/create-setter/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/cfg/create-setter/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Create-setter"/>
 <meta name="twitter:description" content="Create a setter for one or more field
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/cfg/create-subst/index.html
+++ b/docs/reference/cfg/create-subst/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/cfg/create-subst/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Create-subst"/>
 <meta name="twitter:description" content="Create a substitution for one or more fields
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/cfg/fmt/index.html
+++ b/docs/reference/cfg/fmt/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/cfg/fmt/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Fmt"/>
 <meta name="twitter:description" content="Format configuration files
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/cfg/grep/index.html
+++ b/docs/reference/cfg/grep/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/cfg/grep/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Grep"/>
 <meta name="twitter:description" content="Filter resources by their field values
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/cfg/index.html
+++ b/docs/reference/cfg/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/cfg/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Cfg"/>
 <meta name="twitter:description" content="Display and modify JSON or YAML configuration
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/cfg/list-setters/index.html
+++ b/docs/reference/cfg/list-setters/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/cfg/list-setters/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="List Setters"/>
 <meta name="twitter:description" content="List setters for a package
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/cfg/set/index.html
+++ b/docs/reference/cfg/set/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/cfg/set/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Set"/>
 <meta name="twitter:description" content="Set one or more field values
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/cfg/tree/index.html
+++ b/docs/reference/cfg/tree/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/cfg/tree/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Tree"/>
 <meta name="twitter:description" content="Render resources using a tree structure
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/fn/export/index.html
+++ b/docs/reference/fn/export/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/fn/export/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Export"/>
 <meta name="twitter:description" content="Auto-generating function pipelines for different workflow orchestrators
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/fn/index.html
+++ b/docs/reference/fn/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/fn/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Fn"/>
 <meta name="twitter:description" content="Generate, transform, and validate configuration files.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/fn/run/index.html
+++ b/docs/reference/fn/run/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/fn/run/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Run"/>
 <meta name="twitter:description" content="Locally execute one or more functions in containers
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/fn/sink/index.html
+++ b/docs/reference/fn/sink/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/fn/sink/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Sink"/>
 <meta name="twitter:description" content="Explicitly specify an output sink for a function
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/fn/source/index.html
+++ b/docs/reference/fn/source/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/fn/source/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Source"/>
 <meta name="twitter:description" content="Explicitly specify an input source for a function
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Command Reference"/>
 <meta name="twitter:description" content="Overview of kpt commands
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/live/apply/index.html
+++ b/docs/reference/live/apply/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/live/apply/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Apply"/>
 <meta name="twitter:description" content="Apply a package to the cluster (create, update, delete)
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/live/destroy/index.html
+++ b/docs/reference/live/destroy/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/live/destroy/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Destroy"/>
 <meta name="twitter:description" content="Remove all previously applied resources in a package from the cluster
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/live/diff/index.html
+++ b/docs/reference/live/diff/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/live/diff/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Diff"/>
 <meta name="twitter:description" content="Diff the local package config against the live cluster resources
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/live/fetch-k8s-schema/index.html
+++ b/docs/reference/live/fetch-k8s-schema/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/live/fetch-k8s-schema/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Fetch-k8s-schema"/>
 <meta name="twitter:description" content="Fetch the OpenAPI schema from the cluster
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/live/index.html
+++ b/docs/reference/live/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/live/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Live"/>
 <meta name="twitter:description" content="Reconcile configuration files with the live state
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/live/init/index.html
+++ b/docs/reference/live/init/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/live/init/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Init"/>
 <meta name="twitter:description" content="Initialize a package with a object to track previously applied resources
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/live/preview/index.html
+++ b/docs/reference/live/preview/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/live/preview/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Preview"/>
 <meta name="twitter:description" content="Preview prints the changes apply would make to the cluster
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/pkg/desc/index.html
+++ b/docs/reference/pkg/desc/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/pkg/desc/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Desc"/>
 <meta name="twitter:description" content="Display upstream package metadata
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/pkg/diff/index.html
+++ b/docs/reference/pkg/diff/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/pkg/diff/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Diff"/>
 <meta name="twitter:description" content="Diff a local package against upstream
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/pkg/get/index.html
+++ b/docs/reference/pkg/get/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/pkg/get/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Get"/>
 <meta name="twitter:description" content="Fetch a package from a git repo.
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/pkg/index.html
+++ b/docs/reference/pkg/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/pkg/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Pkg"/>
 <meta name="twitter:description" content="Fetch, update, and sync configuration files using git
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/pkg/init/index.html
+++ b/docs/reference/pkg/init/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/pkg/init/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Init"/>
 <meta name="twitter:description" content="Initialize an empty package
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/reference/pkg/update/index.html
+++ b/docs/reference/pkg/update/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 <link rel="alternate" type="application/rss&#43;xml" href="https://googlecontainertools.github.io/kpt/reference/pkg/update/index.xml">
 
@@ -44,6 +44,19 @@
 <meta name="twitter:title" content="Update"/>
 <meta name="twitter:description" content="Apply upstream package updates
 "/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/docs/search/index.html
+++ b/docs/search/index.html
@@ -16,7 +16,7 @@
 
 <meta name="generator" content="Hugo 0.68.3" />
 
-<META NAME="ROBOTS" CONTENT="NOINDEX, NOFOLLOW">
+<META NAME="ROBOTS" CONTENT="INDEX, FOLLOW">
 
 
 
@@ -46,6 +46,19 @@
 <meta itemprop="keywords" content="" /><meta name="twitter:card" content="summary"/>
 <meta name="twitter:title" content="Search Results"/>
 <meta name="twitter:description" content=""/>
+
+
+<script type="application/javascript">
+var doNotTrack = false;
+if (!doNotTrack) {
+	window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
+	ga('create', 'UA-171557011-1', 'auto');
+	
+	ga('send', 'pageview');
+}
+</script>
+<script async src='https://www.google-analytics.com/analytics.js'></script>
+
 
 
 

--- a/site/config.toml
+++ b/site/config.toml
@@ -49,7 +49,7 @@ anchor = "smart"
 [services]
 [services.googleAnalytics]
 # Comment out the next line to disable GA tracking. Also disables the feature described in [params.ui.feedback].
-#id = "UA-00000000-0"
+id = "UA-171557011-1"
 
 # Language configuration
 


### PR DESCRIPTION
The google search bar on the kpt homepage is broken because hugo by default adds "NOINDEX" and "NOFOLLOW" tags to all pages. I found this out in the Google Search Console for our site: https://search.google.com/search-console/index/drilldown?resource_id=https%3A%2F%2Fgooglecontainertools.github.io%2Fkpt%2F&item_key=CAMYCCAC&hl=en
We can publish to hugo using the "production" tag to publish the website with "INDEX" and "FOLLOW" tags which will tell google to index all pages. This should make google search work on the kpt website.

Related to https://github.com/GoogleContainerTools/kpt/issues/784