### PR TITLE
Add --workflow flag to kpt fn export

### DIFF
--- a/internal/cmdexport/cmdexport_test.go
+++ b/internal/cmdexport/cmdexport_test.go
@@ -38,18 +38,23 @@ type TestCase struct {
 
 var testCases = []TestCase{
 	{
-		description: "fails on not providing enough args",
-		params:      []string{"github-actions"},
-		err:         "accepts 2 args, received 1",
+		description: "fails on providing too many args",
+		params:      []string{"dir", "extra"},
+		err:         "accepts 1 arg(s), received 2",
 	},
 	{
-		description: "fails on an unsupported orchestrator",
-		params:      []string{"random-orchestrator", "."},
-		err:         "unsupported orchestrator random-orchestrator",
+		description: "fails on not providing working orchestrator",
+		params:      []string{"dir"},
+		err:         "--workflow flag is required. It must be one of cloud-build, github-actions, gitlab-ci",
+	},
+	{
+		description: "fails on an unsupported workflow orchestrator",
+		params:      []string{".", "--workflow", "random-orchestrator"},
+		err:         "unsupported orchestrator random-orchestrator. It must be one of cloud-build, github-actions, gitlab-ci",
 	},
 	{
 		description: "exports a GitHub Actions pipeline",
-		params:      []string{"github-actions", "."},
+		params:      []string{".", "--workflow", "github-actions"},
 		expected: `
 name: kpt
 on:
@@ -69,8 +74,9 @@ jobs:
 	{
 		description: "exports a GitHub Actions pipeline with --output",
 		params: []string{
-			"github-actions",
 			".",
+			"-w",
+			"github-actions",
 			"--output",
 			"main.yaml",
 		},
@@ -95,7 +101,7 @@ jobs:
 		files: map[string]string{
 			"function.yaml": "",
 		},
-		params: []string{"github-actions", ".", "--fn-path", "function.yaml"},
+		params: []string{".", "--fn-path", "function.yaml", "-w", "github-actions"},
 		expected: `
 name: kpt
 on:
@@ -118,12 +124,13 @@ jobs:
 			"functions/function.yaml": "",
 		},
 		params: []string{
-			"cloud-build",
 			".",
 			"--fn-path",
 			"functions/",
 			"--output",
 			"cloudbuild.yaml",
+			"-w",
+			"cloud-build",
 		},
 		expected: `
 steps:
@@ -139,12 +146,13 @@ steps:
 	{
 		description: "fails to export a Cloud Build pipeline with outside function paths",
 		params: []string{
-			"cloud-build",
 			".",
 			"--fn-path",
 			"../functions/functions.yaml",
 			"--fn-path",
 			"../functions/functions2.yaml",
+			"-w",
+			"cloud-build",
 			"--output",
 			"cloudbuild.yaml",
 		},
@@ -159,9 +167,10 @@ function paths are not within the current working directory:
 			"functions/function.yaml": "",
 		},
 		params: []string{
-			"cloud-build",
 			// NOTE: `{DIR}` is a macro variable and will be replaced with cwd before test cases are executed.
 			"{DIR}",
+			"-w",
+			"cloud-build",
 			"--fn-path",
 			"{DIR}/functions/",
 			"--output",
@@ -185,10 +194,11 @@ steps:
 			"functions/function.yaml": "",
 		},
 		params: []string{
-			"gitlab-ci",
 			"resources",
 			"--fn-path",
 			"functions",
+			"-w",
+			"gitlab-ci",
 			"--output",
 			".gitlab-ci.yml",
 		},

--- a/internal/docs/generated/fndocs/docs.go
+++ b/internal/docs/generated/fndocs/docs.go
@@ -39,20 +39,19 @@ var FnExamples = `
 
 var ExportShort = `Auto-generating function pipelines for different workflow orchestrators`
 var ExportLong = `
-  kpt fn export ORCHESTRATOR DIR/ [--fn-path FUNCTIONS_DIR/] [--output OUTPUT_FILENAME]
+  kpt fn export DIR/ [--fn-path FUNCTIONS_DIR/] --workflow ORCHESTRATOR [--output OUTPUT_FILENAME]
   
-  ORCHESTRATOR:
-    Supported orchestrators are github-actions, cloud-build, and gitlab-ci.
   DIR:
     Path to a package directory. If you do not specify the --fn-path flag, this command will discover functions in DIR and run them against resources in it.
 `
 var ExportExamples = `
-  # read functions from DIR, run them against it as one step
-  # write the generated GitHub Actions pipeline to main.yaml
-  kpt fn export github-actions DIR/ --output main.yaml
+  # read functions from DIR, run them against it as one step.
+  # write the generated GitHub Actions pipeline to main.yaml.
+  kpt fn export DIR/ --output main.yaml --workflow github-actions
 
-  # discover functions in FUNCTIONS_DIR and run them against Resource in DIR.
-  kpt fn export github-actions DIR/ --fn-path FUNCTIONS_DIR/
+  # discover functions in FUNCTIONS_DIR and run them against resource in DIR.
+  # write the generated Cloud Build pipeline to stdout.
+  kpt fn export DIR/ --fn-path FUNCTIONS_DIR/ --workflow cloud-build
 `
 
 var RunShort = `Locally execute one or more functions in containers`

--- a/site/content/en/reference/fn/export/_index.md
+++ b/site/content/en/reference/fn/export/_index.md
@@ -14,24 +14,23 @@ Auto-generating function pipelines for different workflow orchestrators.
 ### Examples
 <!--mdtogo:Examples-->
 ```sh
-# read functions from DIR, run them against it as one step
-# write the generated GitHub Actions pipeline to main.yaml
-kpt fn export github-actions DIR/ --output main.yaml
+# read functions from DIR, run them against it as one step.
+# write the generated GitHub Actions pipeline to main.yaml.
+kpt fn export DIR/ --output main.yaml --workflow github-actions
 ```
 
 ```sh
-# discover functions in FUNCTIONS_DIR and run them against Resource in DIR.
-kpt fn export github-actions DIR/ --fn-path FUNCTIONS_DIR/
+# discover functions in FUNCTIONS_DIR and run them against resource in DIR.
+# write the generated Cloud Build pipeline to stdout.
+kpt fn export DIR/ --fn-path FUNCTIONS_DIR/ --workflow cloud-build
 ```
 <!--mdtogo-->
 
 ### Synopsis
 <!--mdtogo:Long-->
 ```
-kpt fn export ORCHESTRATOR DIR/ [--fn-path FUNCTIONS_DIR/] [--output OUTPUT_FILENAME]
+kpt fn export DIR/ [--fn-path FUNCTIONS_DIR/] --workflow ORCHESTRATOR [--output OUTPUT_FILENAME]
 
-ORCHESTRATOR:
-  Supported orchestrators are github-actions, cloud-build, and gitlab-ci.
 DIR:
   Path to a package directory. If you do not specify the --fn-path flag, this command will discover functions in DIR and run them against resources in it.
 ```


### PR DESCRIPTION
Use the `--workflow` flag to specify the workflow orchestrator. Now `DIR` is the first argument in consistent with other subcommands.