### PR TITLE
Set proper Kptfile name when running init in current dir

### DIFF
--- a/internal/cmdinit/cmdinit.go
+++ b/internal/cmdinit/cmdinit.go
@@ -67,12 +67,17 @@ type Runner struct {
 	URL         string
 }
 
-func (r *Runner) preRunE(c *cobra.Command, args []string) error {
-	if len(args) == 0 {
-		args = []string{"."}
-	}
+func (r *Runner) preRunE(_ *cobra.Command, args []string) error {
 	if r.Name == "" {
-		r.Name = filepath.Base(args[0])
+		if len(args) == 0 || args[0] == "." {
+			path, err := os.Getwd()
+			if err != nil {
+				return errors.Errorf("can't lookup current directory: %v", err)
+			}
+			r.Name = filepath.Base(path)
+		} else {
+			r.Name = filepath.Base(args[0])
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
If running `kpt pkg init .`, the name of the Kptfile will be set to `.`. With this change, we instead use the name of the current directory.

Fixes: #687 
