### PR TITLE
Bundle docker into the kpt image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN go build -v -o /usr/local/bin/kpt ./
 
 FROM alpine:3.11
 RUN apk update && apk upgrade && \
-        apk add --no-cache git less man diffutils bash openssh && \
+    apk add --no-cache git less man diffutils bash openssh docker-cli && \
     rm -rf /var/lib/apt/lists/* && \
     rm /var/cache/apk/*
 COPY --from=0 /usr/local/bin/kpt /usr/local/bin/kpt


### PR DESCRIPTION
Ref #226, bundle docker into the kpt image to enable `kpt fn run` in containers.