### PR TITLE
Guide command must have exactly one argument

### DIFF
--- a/commands/guidecmd.go
+++ b/commands/guidecmd.go
@@ -128,7 +128,7 @@ func GetGuideCommand(name string) *cobra.Command {
 		Use:   "guide [NAME]",
 		Short: `Print kpt guides`,
 		Long:  getLongDescription(),
-		Args:  cobra.MaximumNArgs(1),
+		Args:  cobra.ExactArgs(1),
 		Example: `
   # Print the Apply tutorial
   kpt guide Apply`,


### PR DESCRIPTION
Users must specify which guide that should be printed. With this change, an error will be printed if the name of the guide is not provided.

Fixes: #841 