### PR TITLE
Change default k8s schema source to be the builtin schema

### DIFF
--- a/internal/util/openapi/openapi.go
+++ b/internal/util/openapi/openapi.go
@@ -23,34 +23,31 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/openapi/kustomizationapi"
 )
 
+const (
+	SchemaSourceBuiltin = "builtin"
+	SchemaSourceFile    = "file"
+	SchemaSourceCluster = "cluster"
+)
+
 // ConfigureOpenAPI sets the openAPI schema in kyaml. It can either
 // fetch the schema from a cluster, read it from file, or just the
 // schema built into kyaml.
 func ConfigureOpenAPI(factory util.Factory, k8sSchemaSource, k8sSchemaPath string) error {
 	switch k8sSchemaSource {
-	case "":
-		openAPISchema, err := FetchOpenAPISchemaFromCluster(factory)
-		if err != nil {
-			// The default behavior is to try to fetch the schema from the
-			// cluster, but fall back on using the builtin one if that doesn't
-			// work
-			return nil
-		}
-		return ConfigureOpenAPISchema(openAPISchema)
-	case "cluster":
+	case SchemaSourceCluster:
 		openAPISchema, err := FetchOpenAPISchemaFromCluster(factory)
 		if err != nil {
 			return fmt.Errorf("error fetching schema from cluster: %v", err)
 		}
 		return ConfigureOpenAPISchema(openAPISchema)
-	case "file":
+	case SchemaSourceFile:
 		openAPISchema, err := ReadOpenAPISchemaFromDisk(k8sSchemaPath)
 		if err != nil {
 			return fmt.Errorf("error reading file at path %s: %v",
 				k8sSchemaPath, err)
 		}
 		return ConfigureOpenAPISchema(openAPISchema)
-	case "builtin":
+	case SchemaSourceBuiltin:
 		return nil
 	default:
 		return fmt.Errorf("unknown schema source %s. Must be one of file, cluster, builtin",

--- a/internal/util/openapi/openapi_test.go
+++ b/internal/util/openapi/openapi_test.go
@@ -41,20 +41,10 @@ func TestSomething(t *testing.T) {
 		expectError          bool
 	}{
 		{
-			name:         "no schemaSource provided with fallback to builtin",
-			schemaSource: "",
-			response: &http.Response{StatusCode: http.StatusNotFound,
-				Header: cmdtesting.DefaultHeader(), Body: cmdtesting.StringBody("")},
+			name:              "no schemaSource provided should lead to error",
+			schemaSource:      "",
 			includesRefString: "#/definitions/io.k8s.api.core.v1.PodSpec",
-			expectError:       false,
-		},
-		{
-			name:         "no schemaSource provided with cluster available",
-			schemaSource: "",
-			response: &http.Response{StatusCode: http.StatusOK,
-				Header: cmdtesting.DefaultHeader(), Body: getSchema(t, "clusterschema.json")},
-			includesRefString: "#/definitions/io.k8s.clusterSchema",
-			expectError:       false,
+			expectError:       true,
 		},
 		{
 			name:         "schemaSource cluster with successful fetch",

--- a/run/run.go
+++ b/run/run.go
@@ -141,9 +141,8 @@ func GetMain() *cobra.Command {
 	cmd.PersistentFlags().BoolVar(&cmdutil.StackOnError, "stack-trace", false,
 		"print a stack-trace on failure")
 
-	cmd.PersistentFlags().StringVar(&cmdutil.K8sSchemaSource, "k8s-schema-source", "",
-		"source for the kubernetes openAPI schema. Default is to first try to fetch "+
-			"it from the cluster given by the context and fall back to the builtin schema")
+	cmd.PersistentFlags().StringVar(&cmdutil.K8sSchemaSource, "k8s-schema-source",
+		kptopenapi.SchemaSourceBuiltin, "source for the kubernetes openAPI schema")
 	cmd.PersistentFlags().StringVar(&cmdutil.K8sSchemaPath, "k8s-schema-path",
 		"./openapi.json", "path to the kubernetes openAPI schema file")
 


### PR DESCRIPTION
This changes the default schema source for kpt to be the built-in schema rather than the cluster. This addresses reported issues about kpt being very slow.


