### PR TITLE
Update kpt image in fn export

### DIFF
--- a/internal/cmdexport/cmdexport_test.go
+++ b/internal/cmdexport/cmdexport_test.go
@@ -66,7 +66,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
           - name: Run all kpt functions
-            uses: docker://gongpu/kpt:latest
+            uses: docker://gcr.io/kpt-dev/kpt:latest
             with:
                 args: fn run .
 `,
@@ -91,7 +91,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
           - name: Run all kpt functions
-            uses: docker://gongpu/kpt:latest
+            uses: docker://gcr.io/kpt-dev/kpt:latest
             with:
                 args: fn run .
 `,
@@ -113,7 +113,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
           - name: Run all kpt functions
-            uses: docker://gongpu/kpt:latest
+            uses: docker://gcr.io/kpt-dev/kpt:latest
             with:
                 args: fn run . --fn-path function.yaml
 `,
@@ -134,7 +134,7 @@ jobs:
 		},
 		expected: `
 steps:
-  - name: gongpu/kpt:latest
+  - name: gcr.io/kpt-dev/kpt:latest
     args:
       - fn
       - run
@@ -178,7 +178,7 @@ function paths are not within the current working directory:
 		},
 		expected: `
 steps:
-  - name: gongpu/kpt:latest
+  - name: gcr.io/kpt-dev/kpt:latest
     args:
       - fn
       - run
@@ -210,7 +210,7 @@ kpt:
     image: docker
     services:
       - docker:dind
-    script: docker run -v $PWD:/app -v /var/run/docker.sock:/var/run/docker.sock gongpu/kpt:latest
+    script: docker run -v $PWD:/app -v /var/run/docker.sock:/var/run/docker.sock gcr.io/kpt-dev/kpt:latest
         fn run /app/resources --fn-path /app/functions
 `,
 	},
@@ -234,7 +234,7 @@ pipeline {
                     docker run \
                     -v $PWD:/app \
                     -v /var/run/docker.sock:/var/run/docker.sock \
-                    gongpu/kpt:latest \
+                    gcr.io/kpt-dev/kpt:latest \
                     fn run /app/resources
                 '''
             }
@@ -267,7 +267,7 @@ pipeline {
                     docker run \
                     -v $PWD:/app \
                     -v /var/run/docker.sock:/var/run/docker.sock \
-                    gongpu/kpt:latest \
+                    gcr.io/kpt-dev/kpt:latest \
                     fn run /app/resources \
                     --fn-path /app/functions/label-namespace.yaml \
                     --fn-path /app/functions/gate-keeper.yaml
@@ -292,7 +292,7 @@ orbs:
         executors:
             kpt-container:
                 docker:
-                  - image: gongpu/kpt:latest
+                  - image: gcr.io/kpt-dev/kpt:latest
         commands:
             kpt-fn-run:
                 steps:
@@ -325,7 +325,7 @@ orbs:
         executors:
             kpt-container:
                 docker:
-                  - image: gongpu/kpt:latest
+                  - image: gcr.io/kpt-dev/kpt:latest
         commands:
             kpt-fn-run:
                 steps:

--- a/internal/cmdexport/orchestrators/circleci_test.go
+++ b/internal/cmdexport/orchestrators/circleci_test.go
@@ -47,7 +47,7 @@ var circleCIOrbTestCases = []circleCIOrbTestCase{
 executors:
     kpt-container:
         docker:
-          - image: gongpu/kpt:latest
+          - image: gcr.io/kpt-dev/kpt:latest
 commands:
     run-functions:
         steps:
@@ -78,7 +78,7 @@ jobs:
 executors:
     kpt-container:
         docker:
-          - image: gongpu/kpt:latest
+          - image: gcr.io/kpt-dev/kpt:latest
 commands:
     run-functions:
         steps:
@@ -124,7 +124,7 @@ orbs:
         executors:
             kpt-container:
                 docker:
-                  - image: gongpu/kpt:latest
+                  - image: gcr.io/kpt-dev/kpt:latest
         commands:
             kpt-fn-run:
                 steps:
@@ -154,7 +154,7 @@ orbs:
         executors:
             kpt-container:
                 docker:
-                  - image: gongpu/kpt:latest
+                  - image: gcr.io/kpt-dev/kpt:latest
         commands:
             kpt-fn-run:
                 steps:

--- a/internal/cmdexport/orchestrators/cloudbuild_test.go
+++ b/internal/cmdexport/orchestrators/cloudbuild_test.go
@@ -25,7 +25,7 @@ var cloudBuildTestCases = []testCase{
 		},
 		expected: `
 steps:
-  - name: gongpu/kpt:latest
+  - name: gcr.io/kpt-dev/kpt:latest
     args:
       - fn
       - run
@@ -40,7 +40,7 @@ steps:
 		},
 		expected: `
 steps:
-  - name: gongpu/kpt:latest
+  - name: gcr.io/kpt-dev/kpt:latest
     args:
       - fn
       - run
@@ -57,7 +57,7 @@ steps:
 		},
 		expected: `
 steps:
-  - name: gongpu/kpt:latest
+  - name: gcr.io/kpt-dev/kpt:latest
     args:
       - fn
       - run

--- a/internal/cmdexport/orchestrators/githubactions_test.go
+++ b/internal/cmdexport/orchestrators/githubactions_test.go
@@ -35,7 +35,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
           - name: Run all kpt functions
-            uses: docker://gongpu/kpt:latest
+            uses: docker://gcr.io/kpt-dev/kpt:latest
             with:
                 args: fn run .
 `,
@@ -57,7 +57,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
           - name: Run all kpt functions
-            uses: docker://gongpu/kpt:latest
+            uses: docker://gcr.io/kpt-dev/kpt:latest
             with:
                 args: fn run . --fn-path functions/
 `,
@@ -79,7 +79,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
           - name: Run all kpt functions
-            uses: docker://gongpu/kpt:latest
+            uses: docker://gcr.io/kpt-dev/kpt:latest
             with:
                 args: fn run . --fn-path functions1/ functions2/
 `,

--- a/internal/cmdexport/orchestrators/gitlabci_test.go
+++ b/internal/cmdexport/orchestrators/gitlabci_test.go
@@ -30,7 +30,7 @@ kpt:
     image: docker
     services:
       - docker:dind
-    script: docker run -v $PWD:/app -v /var/run/docker.sock:/var/run/docker.sock gongpu/kpt:latest
+    script: docker run -v $PWD:/app -v /var/run/docker.sock:/var/run/docker.sock gcr.io/kpt-dev/kpt:latest
         fn run /app
 `,
 	},
@@ -51,7 +51,7 @@ kpt:
     image: docker
     services:
       - docker:dind
-    script: docker run -v $PWD:/app -v /var/run/docker.sock:/var/run/docker.sock gongpu/kpt:latest
+    script: docker run -v $PWD:/app -v /var/run/docker.sock:/var/run/docker.sock gcr.io/kpt-dev/kpt:latest
         fn run /app/resources --fn-path /app/config/label-namespace.yaml /app/config/application-cr.yaml
 `,
 	},

--- a/internal/cmdexport/orchestrators/jenkins_test.go
+++ b/internal/cmdexport/orchestrators/jenkins_test.go
@@ -33,7 +33,7 @@ func TestGenerateJenkinsStageStep(t *testing.T) {
 docker run \
 -v $PWD:/app \
 -v /var/run/docker.sock:/var/run/docker.sock \
-gongpu/kpt:latest \
+gcr.io/kpt-dev/kpt:latest \
 fn run /app/resources \
 --fn-path /app/function1.yaml \
 --fn-path /app/function2.yaml`
@@ -61,7 +61,7 @@ pipeline {
                     docker run \
                     -v $PWD:/app \
                     -v /var/run/docker.sock:/var/run/docker.sock \
-                    gongpu/kpt:latest \
+                    gcr.io/kpt-dev/kpt:latest \
                     fn run /app/resources
                 '''
             }
@@ -89,7 +89,7 @@ pipeline {
                     docker run \
                     -v $PWD:/app \
                     -v /var/run/docker.sock:/var/run/docker.sock \
-                    gongpu/kpt:latest \
+                    gcr.io/kpt-dev/kpt:latest \
                     fn run /app/resources \
                     --fn-path /app/functions.yaml
                 '''

--- a/internal/cmdexport/orchestrators/pipeline.go
+++ b/internal/cmdexport/orchestrators/pipeline.go
@@ -16,8 +16,7 @@ package orchestrators
 
 import "github.com/GoogleContainerTools/kpt/internal/cmdexport/types"
 
-// TODO: update
-const KptImage = "gongpu/kpt:latest"
+const KptImage = "gcr.io/kpt-dev/kpt:latest"
 
 // Pipeline is an abstraction of different workflow orchestrators.
 type Pipeline interface {

--- a/internal/cmdexport/orchestrators/tekton_test.go
+++ b/internal/cmdexport/orchestrators/tekton_test.go
@@ -49,7 +49,7 @@ spec:
         mountPath: /source
     steps:
       - name: run-kpt-functions
-        image: gongpu/kpt:latest
+        image: gcr.io/kpt-dev/kpt:latest
         args:
           - fn
           - run
@@ -84,7 +84,7 @@ spec:
         mountPath: /source
     steps:
       - name: run-kpt-functions
-        image: gongpu/kpt:latest
+        image: gcr.io/kpt-dev/kpt:latest
         args:
           - fn
           - run
@@ -121,7 +121,7 @@ spec:
         mountPath: /source
     steps:
       - name: run-kpt-functions
-        image: gongpu/kpt:latest
+        image: gcr.io/kpt-dev/kpt:latest
         args:
           - fn
           - run
@@ -174,7 +174,7 @@ spec:
         mountPath: /source
     steps:
       - name: run-kpt-functions
-        image: gongpu/kpt:latest
+        image: gcr.io/kpt-dev/kpt:latest
         args:
           - fn
           - run
@@ -221,7 +221,7 @@ spec:
         mountPath: /source
     steps:
       - name: run-kpt-functions
-        image: gongpu/kpt:latest
+        image: gcr.io/kpt-dev/kpt:latest
         args:
           - fn
           - run
@@ -270,7 +270,7 @@ spec:
         mountPath: /source
     steps:
       - name: run-kpt-functions
-        image: gongpu/kpt:latest
+        image: gcr.io/kpt-dev/kpt:latest
         args:
           - fn
           - run


### PR DESCRIPTION
Update the kpt image used in `kpt fn export` to `gcr.io/kpt-dev/kpt:latest`.