### PR TITLE
Avoid ugly Kptfile indentation on get/update

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -49,10 +49,10 @@ func TestKptGetSet(t *testing.T) {
 			replacements: map[string][]string{
 				"deploy.yaml": {"replicas: 5", "replicas: 7"},
 				"Kptfile": {
-					`                    setBy: package-default
-                    value: "5"`,
-					`                    value: "7"
-                    isSet: true`,
+					`          setBy: package-default
+          value: "5"`,
+					`          value: "7"
+          isSet: true`,
 				},
 			},
 		},
@@ -61,10 +61,10 @@ func TestKptGetSet(t *testing.T) {
 			replacements: map[string][]string{
 				"deploy.yaml": {"replicas: 5", "replicas: 7"},
 				"Kptfile": {
-					`                    setBy: package-default
-                    value: "5"`,
-					`                    value: "7"
-                    isSet: true`,
+					`          setBy: package-default
+          value: "5"`,
+					`          value: "7"
+          isSet: true`,
 				},
 			},
 		},
@@ -72,10 +72,10 @@ func TestKptGetSet(t *testing.T) {
 			replacements: map[string][]string{
 				"deploy.yaml": {"replicas: 5", "replicas: 7"},
 				"Kptfile": {
-					`                    setBy: package-default
-                    value: "5"`,
-					`                    value: "7"
-                    isSet: true`,
+					`          setBy: package-default
+          value: "5"`,
+					`          value: "7"
+          isSet: true`,
 				},
 			},
 		},
@@ -84,10 +84,10 @@ func TestKptGetSet(t *testing.T) {
 			replacements: map[string][]string{
 				"deploy.yaml": {"replicas: 5", "replicas: 7"},
 				"Kptfile": {
-					`                    setBy: package-default
-                    value: "5"`,
-					`                    value: "7"
-                    isSet: true`,
+					`          setBy: package-default
+          value: "5"`,
+					`          value: "7"
+          isSet: true`,
 				},
 			},
 		},
@@ -96,11 +96,11 @@ func TestKptGetSet(t *testing.T) {
 			replacements: map[string][]string{
 				"deploy.yaml": {"replicas: 5", "replicas: 7"},
 				"Kptfile": {
-					`                    setBy: package-default
-                    value: "5"`,
-					`                    setBy: foo
-                    value: "7"
-                    isSet: true`,
+					`          setBy: package-default
+          value: "5"`,
+					`          setBy: foo
+          value: "7"
+          isSet: true`,
 				},
 			},
 		},
@@ -116,10 +116,10 @@ func TestKptGetSet(t *testing.T) {
 					`    app: hello
     foo: bar`},
 				"Kptfile": {
-					`                    setBy: package-default
-                    value: "5"`,
-					`                    value: "7"
-                    isSet: true`,
+					`          setBy: package-default
+          value: "5"`,
+					`          value: "7"
+          isSet: true`,
 				},
 			},
 		},

--- a/internal/kptfile/kptfileutil/util.go
+++ b/internal/kptfile/kptfileutil/util.go
@@ -58,8 +58,20 @@ func WriteFile(dir string, k kptfile.KptFile) error {
 		return err
 	}
 
+	// convert to rNode and back to string to make indentation consistent
+	// with rest of the yaml serialization to avoid unwanted diffs
+	rNode, err := yaml.Parse(string(b))
+	if err != nil {
+		return err
+	}
+
+	kptFileStr, err := rNode.String()
+	if err != nil {
+		return err
+	}
+
 	// fyi: perm is ignored if the file already exists
-	return ioutil.WriteFile(filepath.Join(dir, kptfile.KptFileName), b, 0600)
+	return ioutil.WriteFile(filepath.Join(dir, kptfile.KptFileName), []byte(kptFileStr), 0600)
 }
 
 // ReadFileStrict reads a Kptfile for a package and validates that it contains required

--- a/internal/util/get/get.go
+++ b/internal/util/get/get.go
@@ -277,11 +277,5 @@ func (c *Command) upsertKptfile(spec *git.RepoSpec) error {
 		Git:  c.Git,
 	}
 	kpgfile.Upstream.Git.Commit = commit
-
-	// update the KptFile with the new values
-	contents, err := yaml.Marshal(kpgfile)
-	if err != nil {
-		return err
-	}
-	return ioutil.WriteFile(filepath.Join(c.Destination, kptfile.KptFileName), contents, 0600)
+	return kptfileutil.WriteFile(c.Destination, kpgfile)
 }


### PR DESCRIPTION
This PR fixes the ugly indentation in Kptfile on get/update commands

Issue: https://github.com/GoogleContainerTools/kpt/issues/507