### PR TITLE
Silence long usage message for errors

### DIFF
--- a/commands/configcmd.go
+++ b/commands/configcmd.go
@@ -94,9 +94,6 @@ func GetConfigCommand(name string) *cobra.Command {
 	listSetters.Example = cfgdocs.ListSettersExamples
 
 	set := SetCommand(name)
-	set.Short = cfgdocs.SetShort
-	set.Long = cfgdocs.SetShort + "\n" + cfgdocs.SetLong
-	set.Example = cfgdocs.SetExamples
 
 	tree := configcobra.Tree(name)
 	tree.Short = cfgdocs.TreeShort
@@ -129,6 +126,10 @@ func SetCommand(parent string) *cobra.Command {
 	fieldmeta.SetShortHandRef(ShortHandRef)
 	kustomizeCmd := configcobra.Set(parent)
 	setCmd := *kustomizeCmd
+	kustomizeCmd.Short = cfgdocs.SetShort
+	kustomizeCmd.Long = cfgdocs.SetShort + "\n" + cfgdocs.SetLong
+	kustomizeCmd.Example = cfgdocs.SetExamples
+	kustomizeCmd.SilenceUsage = true
 	var autoRun bool
 	setCmd.Flags().BoolVar(&autoRun, "auto-run", true,
 		`Automatically run functions after setting (if enabled for the package)`)

--- a/run/run.go
+++ b/run/run.go
@@ -158,6 +158,7 @@ func GetMain() *cobra.Command {
 
 	cmd.AddCommand(versionCmd)
 	hideFlags(cmd)
+	silenceUsage(cmd)
 	return cmd
 }
 
@@ -231,6 +232,15 @@ var versionCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("%s\n", version)
 	},
+}
+
+// silenceUsage silences the usage for all the sub commands recursively
+// so that we don't display long usage messages for all errors
+func silenceUsage(cmd *cobra.Command) {
+	for _, subCmd := range cmd.Commands() {
+		subCmd.SilenceUsage = true
+		silenceUsage(subCmd)
+	}
 }
 
 // hideFlags hides any cobra flags that are unlikely to be used by


### PR DESCRIPTION
This PR is to silence the long usage messages upon errors. Users can see clear specific error message with this change. They can always leverage -h flag for detailed usage help messages. 