### PR TITLE
Check if pkg being updated is checked into git

### DIFF
--- a/internal/util/update/update.go
+++ b/internal/util/update/update.go
@@ -152,8 +152,8 @@ func (u Command) Run() error {
 	}
 
 	// require package is checked into git before trying to update it
-	g := gitutil.NewLocalGitRunner("./")
-	if err := g.Run("status", "-s", u.Path); err != nil {
+	g := gitutil.NewLocalGitRunner("./" + u.Path)
+	if err := g.Run("status", "-s"); err != nil {
 		return errors.Errorf(
 			"kpt packages must be checked into a git repo before they are updated: %v", err)
 	}


### PR DESCRIPTION
Currently kpt requires the directory from which the update command is being run to be tracked by git which is not necessary. The actual package being updated should be tracked by git and not the directory from which the command is being run. This PR is to address that. No additional tests are needed as the current tests already cover this behavior.

User issue: https://github.com/GoogleContainerTools/kpt/issues/885