### PR TITLE
Remove files from release artifacts and improve naming

### DIFF
--- a/release/tag/goreleaser.yaml
+++ b/release/tag/goreleaser.yaml
@@ -25,11 +25,9 @@ builds:
     ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}}
 archives:
   - files:
-      - LICENSE*
-      - README*
-      - CHANGELOG*
+      - LICENSES*
       - lib.zip*
-    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}_{{ .Version }}"
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}-{{ .Version }}"
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
Remove the `README.md` and `LICENSE` files from the release artifacts and fix the naming. This fixes some issues with adding kpt to the gcloud release.