### PR TITLE
Add make target for updating the main deps to master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,11 @@ buildall:
 	GOOS=linux go build -o /dev/null
 	GOOS=darwin go build -o /dev/null
 
+update-deps-to-head:
+	go get sigs.k8s.io/cli-utils@master
+	go get sigs.k8s.io/kustomize/cmd/config@master
+	go get sigs.k8s.io/kustomize/kyaml@master
+
 fix:
 	go fix ./...
 


### PR DESCRIPTION
Make it easier to update kpt to use the latest versions of the upstream kyaml, cmd/config and cli-utils libraries.
