### PR TITLE
ResourceGroup implementing Inventory interface

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,6 +43,10 @@ linters:
     - varcheck
 #    - whitespace
 
+issues:
+  exclude:
+     - Using the variable on range scope `tc` in function literal
+
 linters-settings:
   dupl:
     threshold: 400

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	k8s.io/apimachinery v0.17.3
 	k8s.io/cli-runtime v0.17.3
 	k8s.io/client-go v0.17.3
+	k8s.io/klog v1.0.0
 	// Currently, we have to import the latest version of kubectl.
 	// Once there is a 0.18 release, we can import a semver release.
 	k8s.io/kubectl v0.0.0-20191219154910-1528d4eea6dd

--- a/internal/live/example-resource-group-crd.yaml
+++ b/internal/live/example-resource-group-crd.yaml
@@ -1,0 +1,213 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Example ResourceGroup custom resource definition. This CRD is used
+# to keep track of the resources that are applied together by
+# storing references to the applied resources (aka inventory).
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.2.5
+  name: resourcegroups.configmanagement.gke.io
+spec:
+  group: configmanagement.gke.io
+  names:
+    kind: ResourceGroup
+    listKind: ResourceGroupList
+    plural: resourcegroups
+    singular: resourcegroup
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: ResourceGroup is the Schema for the resourcegroups API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: ResourceGroupSpec defines the desired state of ResourceGroup
+          properties:
+            descriptor:
+              description: Descriptor regroups the information and metadata about
+                a resource group
+              properties:
+                description:
+                  description: Description is a brief description of a group of resources
+                  type: string
+                links:
+                  description: Links are a list of descriptive URLs intended to be
+                    used to surface additional information
+                  items:
+                    properties:
+                      description:
+                        description: Description explains the purpose of the link
+                        type: string
+                      url:
+                        description: Url is the URL of the link
+                        type: string
+                    required:
+                    - description
+                    - url
+                    type: object
+                  type: array
+                revision:
+                  description: Revision is an optional revision for a group of resources
+                  type: string
+                type:
+                  description: Type can contain prefix, such as Application/WordPress
+                    or Service/Spanner
+                  type: string
+              type: object
+            resources:
+              description: Resources contains a list of resources that form the resource group
+              items:
+                description: ObjMetadata organizes and stores the identifying information
+                  for an object. This struct (as a string) is stored in a grouping
+                  object to keep track of sets of applied objects.
+                properties:
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                - namespace
+                type: object
+              type: array
+          type: object
+        status:
+          description: ResourceGroupStatus defines the observed state of ResourceGroup
+          properties:
+            conditions:
+              description: Conditions lists the conditions of the current status for
+                the group
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: last time the condition transit from one status to
+                      another
+                    format: date-time
+                    type: string
+                  message:
+                    description: human-readable message indicating details about last
+                      transition
+                    type: string
+                  reason:
+                    description: one-word CamelCase reason for the condition's last
+                      transition
+                    type: string
+                  status:
+                    description: Status of the condition
+                    type: string
+                  type:
+                    description: Type of the condition
+                    type: string
+                required:
+                - status
+                - type
+                type: object
+              type: array
+            observedGeneration:
+              description: ObservedGeneration is the most recent generation observed.
+                It corresponds to the Object's generation, which is updated on mutation
+                by the API Server. Everytime the controller does a successful reconcile,
+                it sets ObservedGeneration to match ResourceGroup.metadata.generation.
+              format: int64
+              type: integer
+            resourceStatuses:
+              description: ResourceStatuses lists the status for each resource in
+                the group
+              items:
+                description: ResourceStatus contains the status of a given resource
+                  uniquely identified by its group, kind, name and namespace.
+                properties:
+                  conditions:
+                    items:
+                      properties:
+                        lastTransitionTime:
+                          description: last time the condition transit from one status
+                            to another
+                          format: date-time
+                          type: string
+                        message:
+                          description: human-readable message indicating details about
+                            last transition
+                          type: string
+                        reason:
+                          description: one-word CamelCase reason for the condition’s
+                            last transition
+                          type: string
+                        status:
+                          description: Status of the condition
+                          type: string
+                        type:
+                          description: Type of the condition
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                  group:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                  status:
+                    description: Status describes the status of a resource
+                    type: string
+                required:
+                - group
+                - kind
+                - name
+                - namespace
+                - status
+                type: object
+              type: array
+          required:
+          - observedGeneration
+          type: object
+      type: object
+  version: v1beta1
+  versions:
+  - name: v1beta1
+    served: true
+    storage: true
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/internal/live/example-resource-group.yaml
+++ b/internal/live/example-resource-group.yaml
@@ -1,0 +1,31 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Example ResourceGroup custom resource with references to
+# two ConfigMaps in the inventory.
+apiVersion: "configmanagement.gke.io/v1beta1"
+kind: ResourceGroup
+metadata:
+  namespace: default
+  name: example-inventory
+spec:
+  resources:
+   - group: ""
+     kind: ConfigMap
+     namespace: default
+     name: cm-a
+   - group: ""
+     kind: ConfigMap
+     namespace: default
+     name: cm-b

--- a/internal/live/inventoryrg.go
+++ b/internal/live/inventoryrg.go
@@ -1,0 +1,153 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package live
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/klog"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+// InventoryResourceGroup wraps a ResourceGroup resource and implements
+// the Inventory interface. This wrapper loads and stores the
+// object metadata (inventory) to and from the wrapped ResourceGroup.
+type InventoryResourceGroup struct {
+	inv      *resource.Info
+	objMetas []object.ObjMetadata
+}
+
+// WrapInventoryObj takes a passed ResourceGroup (as a resource.Info),
+// wraps it with the InventoryResourceGroup and upcasts the wrapper as
+// an the Inventory interface.
+func WrapInventoryObj(info *resource.Info) inventory.Inventory {
+	klog.V(4).Infof("wrapping inventory info")
+	return &InventoryResourceGroup{inv: info}
+}
+
+// Load is an Inventory interface function returning the set of
+// object metadata from the wrapped ResourceGroup, or an error.
+func (icm *InventoryResourceGroup) Load() ([]object.ObjMetadata, error) {
+	objs := []object.ObjMetadata{}
+	if icm.inv == nil {
+		return objs, fmt.Errorf("inventory info is nil")
+	}
+	klog.V(4).Infof("loading inventory...")
+	inventoryObj, ok := icm.inv.Object.(*unstructured.Unstructured)
+	if !ok {
+		err := fmt.Errorf("inventory object is not an Unstructured: %#v", inventoryObj)
+		return objs, err
+	}
+	items, exists, err := unstructured.NestedSlice(inventoryObj.Object, "spec", "resources")
+	if err != nil {
+		err := fmt.Errorf("error retrieving object metadata from inventory object")
+		return objs, err
+	}
+	if !exists {
+		klog.V(4).Infof("Inventory (spec.resources) does not exist")
+		return objs, nil
+	}
+	klog.V(4).Infof("loading %d inventory items", len(items))
+	for _, itemUncast := range items {
+		item := itemUncast.(map[string]interface{})
+		namespace, _, err := unstructured.NestedString(item, "namespace")
+		if err != nil {
+			return []object.ObjMetadata{}, err
+		}
+		name, _, err := unstructured.NestedString(item, "name")
+		if err != nil {
+			return []object.ObjMetadata{}, err
+		}
+		group, _, err := unstructured.NestedString(item, "group")
+		if err != nil {
+			return []object.ObjMetadata{}, err
+		}
+		kind, _, err := unstructured.NestedString(item, "kind")
+		if err != nil {
+			return []object.ObjMetadata{}, err
+		}
+		groupKind := schema.GroupKind{
+			Group: strings.TrimSpace(group),
+			Kind:  strings.TrimSpace(kind),
+		}
+		klog.V(4).Infof("creating obj metadata: %s/%s/%s", namespace, name, groupKind)
+		objMeta, err := object.CreateObjMetadata(namespace, name, groupKind)
+		if err != nil {
+			return []object.ObjMetadata{}, err
+		}
+		objs = append(objs, objMeta)
+	}
+	return objs, nil
+}
+
+// Store is an Inventory interface function implemented to store
+// the object metadata in the wrapped ResourceGroup. Actual storing
+// happens in "GetObject".
+func (icm *InventoryResourceGroup) Store(objMetas []object.ObjMetadata) error {
+	icm.objMetas = objMetas
+	return nil
+}
+
+// GetObject returns the wrapped object (ResourceGroup) as a resource.Info
+// or an error if one occurs.
+func (icm *InventoryResourceGroup) GetObject() (*resource.Info, error) {
+	if icm.inv == nil {
+		return nil, fmt.Errorf("inventory info is nil")
+	}
+	klog.V(4).Infof("getting inventory resource group")
+	// Verify the ResourceGroup is in Unstructured format.
+	obj := icm.inv.Object
+	if obj == nil {
+		return nil, fmt.Errorf("inventory info has nil Object")
+	}
+	iot, ok := obj.(*unstructured.Unstructured)
+	if !ok {
+		return nil, fmt.Errorf("inventory ResourceGroup is not in Unstructured format")
+	}
+	// Create a slice of Resources as empty Interface
+	klog.V(4).Infof("Creating list of %d resources", len(icm.objMetas))
+	var objs []interface{}
+	for _, objMeta := range icm.objMetas {
+		klog.V(4).Infof("storing inventory obj refercence: %s/%s", objMeta.Namespace, objMeta.Name)
+		objs = append(objs, map[string]interface{}{
+			"group":     objMeta.GroupKind.Group,
+			"kind":      objMeta.GroupKind.Kind,
+			"namespace": objMeta.Namespace,
+			"name":      objMeta.Name,
+		})
+	}
+	// Create the inventory object by copying the template.
+	invCopy := iot.DeepCopy()
+	// Adds the inventory ObjMetadata to the ResourceGroup "spec.resources" section
+	klog.V(4).Infof("storing inventory resources")
+	err := unstructured.SetNestedSlice(invCopy.UnstructuredContent(),
+		objs, "spec", "resources")
+	if err != nil {
+		return nil, err
+	}
+	return &resource.Info{
+		Client:    icm.inv.Client,
+		Mapping:   icm.inv.Mapping,
+		Source:    "generated",
+		Name:      invCopy.GetName(),
+		Namespace: invCopy.GetNamespace(),
+		Object:    invCopy,
+	}, nil
+}

--- a/internal/live/inventoryrg_test.go
+++ b/internal/live/inventoryrg_test.go
@@ -1,0 +1,158 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package live
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/cli-runtime/pkg/resource"
+	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+var testNamespace = "test-inventory-namespace"
+var inventoryObjName = "test-inventory-obj"
+var testInventoryLabel = "test-inventory-label"
+
+var inventoryObj = unstructured.Unstructured{
+	Object: map[string]interface{}{
+		"apiVersion": "configmanagement.gke.io/v1beta1",
+		"kind":       "ResourceGroup",
+		"metadata": map[string]interface{}{
+			"name":      inventoryObjName,
+			"namespace": testNamespace,
+			"labels": map[string]interface{}{
+				common.InventoryLabel: testInventoryLabel,
+			},
+		},
+		"spec": map[string]interface{}{
+			"resources": []interface{}{},
+		},
+	},
+}
+
+var invInfo = &resource.Info{
+	Namespace: testNamespace,
+	Name:      inventoryObjName,
+	Mapping: &meta.RESTMapping{
+		Scope: meta.RESTScopeNamespace,
+	},
+	Object: &inventoryObj,
+}
+
+var invInfoNilObject = &resource.Info{
+	Namespace: testNamespace,
+	Name:      inventoryObjName,
+	Mapping: &meta.RESTMapping{
+		Scope: meta.RESTScopeNamespace,
+	},
+	Object: nil,
+}
+
+var testDeployment = object.ObjMetadata{
+	Namespace: testNamespace,
+	Name:      "test-deployment",
+	GroupKind: schema.GroupKind{
+		Group: "apps",
+		Kind:  "Deployment",
+	},
+}
+
+var testService = object.ObjMetadata{
+	Namespace: testNamespace,
+	Name:      "test-deployment",
+	GroupKind: schema.GroupKind{
+		Group: "apps",
+		Kind:  "Service",
+	},
+}
+
+var testPod = object.ObjMetadata{
+	Namespace: testNamespace,
+	Name:      "test-pod",
+	GroupKind: schema.GroupKind{
+		Group: "",
+		Kind:  "Pod",
+	},
+}
+
+func TestLoadStore(t *testing.T) {
+	tests := map[string]struct {
+		invInfo *resource.Info
+		objs    []object.ObjMetadata
+		isError bool
+	}{
+		"Nil inventory is error": {
+			invInfo: nil,
+			objs:    []object.ObjMetadata{},
+			isError: true,
+		},
+		"Inventory with nil object is error": {
+			invInfo: invInfoNilObject,
+			objs:    []object.ObjMetadata{},
+			isError: true,
+		},
+		"No inventory objects is valid": {
+			invInfo: invInfo,
+			objs:    []object.ObjMetadata{},
+			isError: false,
+		},
+		"Simple test": {
+			invInfo: invInfo,
+			objs:    []object.ObjMetadata{testPod},
+			isError: false,
+		},
+		"Test two objects": {
+			invInfo: invInfo,
+			objs:    []object.ObjMetadata{testDeployment, testService},
+			isError: false,
+		},
+		"Test three objects": {
+			invInfo: invInfo,
+			objs:    []object.ObjMetadata{testDeployment, testService, testPod},
+			isError: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			wrapped := WrapInventoryObj(tc.invInfo)
+			_ = wrapped.Store(tc.objs)
+			invStored, err := wrapped.GetObject()
+			if tc.isError {
+				if err == nil {
+					t.Fatalf("expected error but received none")
+				}
+				return
+			}
+			if !tc.isError && err != nil {
+				t.Fatalf("unexpected error %v received", err)
+				return
+			}
+			wrapped = WrapInventoryObj(invStored)
+			objs, err := wrapped.Load()
+			if !tc.isError && err != nil {
+				t.Fatalf("unexpected error %v received", err)
+				return
+			}
+			if !object.SetEquals(tc.objs, objs) {
+				t.Fatalf("expected inventory objs (%v), got (%v)", tc.objs, objs)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Adds the code to `Load`, `Store`, and `GetObject` for the `ResourceGroup`. Together this implements code for the `Inventory` interface for the `ResourceGroup` CRD. This code is not yet wired to provide the `ResourceGroup` as the inventory object, so it will continue to use the default `ConfigMap` as the inventory object. This code can not currently affect `kpt` functionality.
* Adds unit tests for this code. 77% unit test coverage.
* Adds the example `ResourceGroup` custom resource definition.
* Adds an example of a `ResourceGroup` custom resource storing two `ConfigMaps` as `Inventory`.