### PR TITLE
Generate site with Cloud Build

### DIFF
--- a/release/branch/cloudbuild.yaml
+++ b/release/branch/cloudbuild.yaml
@@ -13,73 +13,214 @@
 # limitations under the License.
 
 steps:
+  # Fetch the private ssh key for the kpt-robot account from secret manager.
+  - name: 'gcr.io/cloud-builders/gcloud'
+    entrypoint: 'bash'
+    args: [ '-c', 'mkdir -p /root/.ssh && gcloud secrets versions access latest --secret=kpt-robot-ssh > /root/.ssh/id_github' ]
+    volumes:
+      - name: home
+        path: /root
+
+  # Set up git with key and domain
+  - name: 'gcr.io/cloud-builders/git'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        chmod 600 /root/.ssh/id_github
+        cat <<EOF >/root/.ssh/config
+        Hostname github.com
+        IdentityFile /root/.ssh/id_github
+        EOF
+        ssh-keyscan -t rsa github.com > /root/.ssh/known_hosts
+    volumes:
+      - name: home
+        path: /root
+
+  # Set name and email for git.
+  - name: 'gcr.io/cloud-builders/git'
+    args: ['config', '--global', 'user.email', '${_GIT_EMAIL}']
+    volumes:
+      - name: home
+        path: /root
+
+  - name: 'gcr.io/cloud-builders/git'
+    args: ['config', '--global', 'user.name', '${_GIT_USER}']
+    volumes:
+      - name: home
+        path: /root
+
+  # Clone the kpt repo. The code already set up by cloud build is a copy
+  # and not actually a git checkout, so we need to do this manually.
+  - name: 'gcr.io/cloud-builders/git'
+    args: ['clone', 'git@github.com:${_GITHUB_USER}/kpt.git']
+    volumes:
+      - name: home
+        path: /root
+
+  # Make sure we check out the version of the code that triggered the run.
+  - name: 'gcr.io/cloud-builders/git'
+    dir: 'kpt'
+    args: ['checkout', '${COMMIT_SHA}']
+    volumes:
+      - name: home
+        path: /root
+
+  # Build the image that contains most of the tools we need (e.g. tar,
+  # jq, gzip, golang, bash, etc.) to build kpt tarball. This image
+  # (kpt-builder) is re-used on most steps.
+  - name: 'gcr.io/cloud-builders/docker'
+    dir: 'kpt'
+    args: ['build', '-f', '/workspace/kpt/release/Dockerfile.kpt-build', '-t', 'kpt-builder', '.']
+
+  # run e2e tests and linting
+  - name: 'kpt-builder'
+    args: ['make', 'all']
+    env: ['GO111MODULE=on']
+    dir: 'kpt'
+    volumes:
+      - name: go-modules
+        path: /go
+      - name: home
+        path: /root
+
+  # remove any dirty files after running the build
+  - name: gcr.io/cloud-builders/git
+    dir: 'kpt'
+    args: ['reset', '--hard']
+    id: 'git-reset'
+
   # FYI: If cross-platform build issues happen, then stop caching the modules in the volume.
   # build windows
   - name: 'mirror.gcr.io/library/golang'
     env: ['GOOS=windows', 'GOARCH=amd64', 'CGO_ENABLED=0', 'GO111MODULE=on']
     args: ['go', 'build', '-ldflags', '-X main.version=${BRANCH_NAME}', '-o', '/workspace/bin/${BRANCH_NAME}/windows_amd64/kpt.exe', '.']
-    dir: '/workspace/'
+    dir: 'kpt'
     volumes:
       - name: go-modules
         path: /go
+    waitFor: ['git-reset']
 
   # build linux
   - name: 'mirror.gcr.io/library/golang'
     env: ['GOOS=linux', 'GOARCH=amd64', 'CGO_ENABLED=0', 'GO111MODULE=on']
     args: ['go', 'build', '-ldflags', '-X main.version=${BRANCH_NAME}', '-o', '/workspace/bin/${BRANCH_NAME}/linux_amd64/kpt', '.']
-    dir: '/workspace/'
+    dir: 'kpt'
     volumes:
       - name: go-modules
         path: /go
+    waitFor: ['git-reset']
 
   # build darwin
   - name: 'mirror.gcr.io/library/golang'
     env: ['GOOS=darwin', 'GOARCH=amd64', 'CGO_ENABLED=0', 'GO111MODULE=on']
     args: ['go', 'build', '-ldflags', '-X main.version=${BRANCH_NAME}', '-o', '/workspace/bin/${BRANCH_NAME}/darwin_amd64/kpt', '.']
-    dir: '/workspace/'
+    dir: 'kpt'
     volumes:
       - name: go-modules
         path: /go
+    waitFor: ['git-reset']
 
   # build docker image
   - name: 'gcr.io/cloud-builders/docker'
     args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/kpt:${BRANCH_NAME}', '.' ]
-
+    dir: 'kpt'
   - name: 'gcr.io/cloud-builders/docker'
-    args: [ 'build', '-t', 'gcr.io/kpt-dev/example-functions:${BRANCH_NAME}', '-f', 'functions/examples/Dockerfile', '.' ]
-
-  # run e2e tests and linting
-  - name: 'mirror.gcr.io/library/golang'
-    args: ['git', 'config', '--global', 'user.email', 'you@example.com']
-    dir: '/workspace'
-    volumes:
-      - name: home
-        path: /root
-  - name: 'mirror.gcr.io/library/golang'
-    args: ['git', 'config', '--global', 'user.name', 'Your Name']
-    dir: '/workspace'
-    volumes:
-      - name: home
-        path: /root
-  - name: 'mirror.gcr.io/library/golang'
-    args: ['make', 'all']
-    env: ['GO111MODULE=on']
-    dir: '/workspace'
-    volumes:
-      - name: go-modules
-        path: /go
-      - name: home
-        path: /root
+    args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/example-functions:${BRANCH_NAME}', '-f', 'functions/examples/Dockerfile', '.' ]
+    dir: 'kpt'
 
   # push the container image
   - name: 'gcr.io/cloud-builders/docker'
     args: ['push', 'gcr.io/$PROJECT_ID/kpt:${BRANCH_NAME}']
-
+    dir: 'kpt'
   - name: 'gcr.io/cloud-builders/docker'
-    args: ['push', 'gcr.io/kpt-dev/example-functions:${BRANCH_NAME}']
+    args: ['push', 'gcr.io/$PROJECT_ID/example-functions:${BRANCH_NAME}']
+    dir: 'kpt'
 
   # push the binaries
   - name: 'gcr.io/cloud-builders/gsutil'
-    args: ['cp', '-r', '-a', 'public-read', '/workspace/bin/', 'gs://kpt-dev/']
+    args: ['cp', '-r', '-a', 'public-read', '/workspace/bin/', 'gs://${_GCS_BUCKET}/']
+    dir: 'kpt'
+
+  # Check out the gh-pages branch under the public directory
+  - name: 'gcr.io/cloud-builders/git'
+    args: ['worktree', 'add', '-B', 'gh-pages', 'public', 'origin/gh-pages']
+    dir: 'kpt'
+    volumes:
+      - name: home
+        path: /root
+
+  # Fetch the Hugo binary
+  - name: 'gcr.io/cloud-builders/wget'
+    args:
+      - '--quiet'
+      - '-O'
+      - '/hugo/hugo.tar.gz'
+      - 'https://github.com/gohugoio/hugo/releases/download/v${_HUGO_VERSION}/hugo_extended_${_HUGO_VERSION}_Linux-64bit.tar.gz'
+    waitFor: ['-']
+    volumes:
+      - name: hugo
+        path: /hugo
+
+  # Delete the existing content of the public folder and regenerate the
+  # site with Hugo.
+  # This updates the path for the generated content for Hugo. This is temporary
+  # so we can start generating new content on a separate branch before switching
+  # the site over to use that branch.
+  - name: 'node:14-stretch'
+    args:
+      - 'bash'
+      - '-c'
+      - |
+        tar -C /hugo -xzf /hugo/hugo.tar.gz
+        sed -i 's/"..\/docs"/"..\/public"/g' site/config.toml
+        rm -fr public/*
+        (cd site && HUGO_ENV="production" /hugo/hugo)
+    dir: 'kpt'
+    volumes:
+      - name: hugo
+        path: /hugo
+
+  # Add the new content of the public folder
+  - name: 'gcr.io/cloud-builders/git'
+    args: ['add', '.']
+    dir: 'kpt/public'
+    volumes:
+      - name: home
+        path: /root
+
+  # Create a new commit referencing the source commit on the master branch
+  - name: 'gcr.io/cloud-builders/git'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        if [ -n "$(git status --porcelain)" ]; then
+          git commit -m "Site gen from revision ${COMMIT_SHA}"
+        else
+          echo "no changes";
+        fi
+    dir: 'kpt/public'
+    volumes:
+      - name: home
+        path: /root
+
+  # Force push the changes to the gh-pages branch. We use force here to make
+  # sure that we get the changes in even if another job committed other changes
+  # in between the checkout and the commit.
+  - name: 'gcr.io/cloud-builders/git'
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        if git log -1 --pretty=%B | cat | grep -q "${COMMIT_SHA}"; then
+          git push origin gh-pages -f
+        else
+          echo "no changes, skipping push"
+        fi
+    dir: 'kpt/public'
+    volumes:
+      - name: home
+        path: /root
 
 timeout: '60m'


### PR DESCRIPTION
Updates the Cloud Build job that runs after every commit to generate the web site for kpt. It does this in the following way:
 * On every commit, the job (which already runs the tests) will also generate the site.
 * The cloud build job will then commit the changes back into the kpt repo. But instead of committing back to the master branch, it will commit the changes to the gh-pages branch.
 * The site will be served from the gh-pages branch instead of master, so we will be able to delete the docs folder from the master branch.

This means users will no longer need to include the generated content with the PRs. Since the job commits changes to a separate branch, we can run the job for a while to verify that it works before switching the site to be served from the gh-pages branch.