### PR TITLE
Remove the use of LocalPackageReader from resource merge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	// Currently, we have to import the latest version of kubectl.
 	// Once there is a 0.18 release, we can import a semver release.
 	k8s.io/kubectl v0.0.0-20191219154910-1528d4eea6dd
-	sigs.k8s.io/cli-utils v0.19.2
-	sigs.k8s.io/kustomize/cmd/config v0.7.0
-	sigs.k8s.io/kustomize/kyaml v0.7.1
+	sigs.k8s.io/cli-utils v0.19.3-0.20200901170551-5a58b8941377
+	sigs.k8s.io/kustomize/cmd/config v0.7.1-0.20200901182351-ba0f583ee5cc
+	sigs.k8s.io/kustomize/kyaml v0.7.2-0.20200901182351-ba0f583ee5cc
 )

--- a/go.sum
+++ b/go.sum
@@ -300,6 +300,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9AWI=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
+github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 h1:n6/2gBQ3RWajuToeY6ZtZTIKv2v7ThUy5KKusIT0yc0=
+github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00/go.mod h1:Pm3mSP3c5uWn86xMLZ5Sa7JB9GsEZySvHYXCTK4E9q4=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
@@ -659,6 +661,8 @@ sigs.k8s.io/cli-utils v0.19.1-0.20200821220340-1e5fb03eaa7d h1:ZSwyTEFU6ibLjZ9kD
 sigs.k8s.io/cli-utils v0.19.1-0.20200821220340-1e5fb03eaa7d/go.mod h1:B7KdqkSkHNIUn3cFbaR4aKUZMKtr+Benboi1w/HW/Fg=
 sigs.k8s.io/cli-utils v0.19.2 h1:BwidWPZ3Qop4RBOl27MU8uN/BSEZPQ8rw1mwsNofXfw=
 sigs.k8s.io/cli-utils v0.19.2/go.mod h1:ulIQPERYwkYksNriRknJRbGECDR/ZZROpkiThlXBtB4=
+sigs.k8s.io/cli-utils v0.19.3-0.20200901170551-5a58b8941377 h1:o5aB6N3nszCNdQVj1MAlCLLW6nndJ4QYYeodWX+Dm0U=
+sigs.k8s.io/cli-utils v0.19.3-0.20200901170551-5a58b8941377/go.mod h1:ulIQPERYwkYksNriRknJRbGECDR/ZZROpkiThlXBtB4=
 sigs.k8s.io/controller-runtime v0.4.0 h1:wATM6/m+3w8lj8FXNaO6Fs/rq/vqoOjO1Q116Z9NPsg=
 sigs.k8s.io/controller-runtime v0.4.0/go.mod h1:ApC79lpY3PHW9xj/w9pj+lYkLgwAAUZwfXkME1Lajns=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
@@ -675,6 +679,8 @@ sigs.k8s.io/kustomize/cmd/config v0.6.1-0.20200821211955-ff3f39d84bc8 h1:KeFdYzV
 sigs.k8s.io/kustomize/cmd/config v0.6.1-0.20200821211955-ff3f39d84bc8/go.mod h1:ZZoulwUOBeva15nGEnY9/yEc+TVg78EdW7jgADptBCc=
 sigs.k8s.io/kustomize/cmd/config v0.7.0 h1:lLp+LQJB4pZtD5mgMxVlGSbdb2qjt3IiGr27mWL9nTE=
 sigs.k8s.io/kustomize/cmd/config v0.7.0/go.mod h1:ORl2Fv3uSV4Wr8FKynZUFe8Xb5ct/bVZrzbiz+/GEFs=
+sigs.k8s.io/kustomize/cmd/config v0.7.1-0.20200901182351-ba0f583ee5cc h1:UxWoxrwzhxWJjYjK9XG1hPRtT9CXxy6Te4iXuJJgJHc=
+sigs.k8s.io/kustomize/cmd/config v0.7.1-0.20200901182351-ba0f583ee5cc/go.mod h1:Hf7Qf/NCo3PEglHxO/2YkV2L9J5mL5eJTiNqzb+V5ww=
 sigs.k8s.io/kustomize/kyaml v0.4.0 h1:jMQrJOJmiUz5Y018ki0mXWpEreEXjvad1NRfXTdi9vU=
 sigs.k8s.io/kustomize/kyaml v0.4.0/go.mod h1:XJL84E6sOFeNrQ7CADiemc1B0EjIxHo3OhW4o1aJYNw=
 sigs.k8s.io/kustomize/kyaml v0.5.0 h1:xufpSxgpugQxtd0aN1ZsWnr3Kj0fpAi7GN4dnEs4oPg=
@@ -689,6 +695,8 @@ sigs.k8s.io/kustomize/kyaml v0.6.1-0.20200821211955-ff3f39d84bc8 h1:Taf2IRt1OB+W
 sigs.k8s.io/kustomize/kyaml v0.6.1-0.20200821211955-ff3f39d84bc8/go.mod h1:bEzbO5pN9OvlEeCLvFHo8Pu7SA26Herc2m60UeWZBdI=
 sigs.k8s.io/kustomize/kyaml v0.7.1 h1:Ih6SJPvfKYfZaIFWUa2YAyg/0ZSTpA3LFjR/hv7+8ao=
 sigs.k8s.io/kustomize/kyaml v0.7.1/go.mod h1:ne3F9JPhW2wrVaLslxBsEe6MQJQ9YK5rUutrdhBWXwI=
+sigs.k8s.io/kustomize/kyaml v0.7.2-0.20200901182351-ba0f583ee5cc h1:Qm8rWTBPRAILfFFws0RwkiTWq6g/sqH4sz0BITVG1u8=
+sigs.k8s.io/kustomize/kyaml v0.7.2-0.20200901182351-ba0f583ee5cc/go.mod h1:UTm64bSWVdBUA8EQoYCxVOaBQxUdIOr5LKWxA4GNbkw=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
 sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06/go.mod h1:/ULNhyfzRopfcjskuui0cTITekDduZ7ycKN3oUT9R18=

--- a/internal/util/update/update_test.go
+++ b/internal/util/update/update_test.go
@@ -861,6 +861,10 @@ func TestReplaceNonKRMFiles(t *testing.T) {
 				err = ioutil.WriteFile(filepath.Join(expectedLocal, "somefunction.py"), []byte("Print some other thing"), 0600)
 				assert.NoError(t, err)
 			}
+			// Add a yaml file in updated that should never be moved to
+			// expectedLocal.
+			err = ioutil.WriteFile(filepath.Join(updated, "new.yaml"), []byte("a: b"), 0600)
+			assert.NoError(t, err)
 			err = ReplaceNonKRMFiles(updated, original, local)
 			assert.NoError(t, err)
 			tg := testutil.TestGitRepo{}


### PR DESCRIPTION
The current implementation of `getSubDirsAndNonKrmFiles` use the `LocalPackageReader` in a strange way. This removes the use of the `LocalPackageReader` and avoids the issue with the `IgnoreFilesMatcher`.
