### PR TITLE
docs: Document the status command

### DIFF
--- a/internal/docs/generated/livedocs/docs.go
+++ b/internal/docs/generated/livedocs/docs.go
@@ -182,3 +182,49 @@ var PreviewExamples = `
   # preview destroy for a package
   kpt live preview --destroy my-dir/
 `
+
+var StatusShort = `Status shows the status for the resources in the cluster`
+var StatusLong = `
+  kpt live status (DIR | STDIN) [flags]
+
+Args:
+
+  DIR | STDIN:
+    Path to a directory if an argument is provided or reading from stdin if left
+    blank. In both situations one of the manifests must contain exactly one
+    ConfigMap with the inventory template annotation.
+
+Flags:
+
+  --poll-period (duration):
+    The frequency with which the cluster will be polled to determine the status
+    of the applied resources. The default value is every 2 seconds.
+  
+  --poll-until (string):
+    When to stop polling for status and exist. Must be one of the following:
+      known:   Exit when the status for all resources have been found.
+      current: Exit when the status for all resources have reached the Current status.
+      deleted: Exit when the status for all resources have reached the NotFound
+               status, i.e. all the resources have been deleted from the live state.
+      forever: Keep polling for status until interrupted.
+    The default value is ‘known’.
+  
+  --output (string):
+    Determines the output format for the status information. Must be one of the following:
+      events: The output will be a list of the status events as they become available.
+      table:  The output will be presented as a table that will be updated inline
+              as the status of resources become available.
+    The default value is ‘events’.
+  
+  --timeout (duration):
+    Determines how long the command should run before exiting. This deadline will
+    be enforced regardless of the value of the --poll-until flag. The default is
+    to wait forever.
+`
+var StatusExamples = `
+  # Monitor status for a set of resources based on manifests. Output in table format:
+  kpt live status my-app/ --poll-until=forever --output=table
+
+  # Check status for a set of resources read from stdin with output in events format
+  kpt cfg cat my-app | kpt live status
+`

--- a/site/content/en/reference/live/apply/_index.md
+++ b/site/content/en/reference/live/apply/_index.md
@@ -63,33 +63,30 @@ When the updated package is applied, `config-map-1` is automatically
 deleted (pruned) since it is omitted.
 
 In order to take advantage of this automatic clean-up, a package must contain
-a **grouping object template**, which is a ConfigMap with a special label. An example is:
+an **Inventory Template**, which is a ConfigMap with a special label. An example is:
 
 ```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: test-grouping-object
+  name: inventory-78889725
+  namespace: default
   labels:
-    cli-utils.sigs.k8s.io/inventory-id: test-group
+    cli-utils.sigs.k8s.io/inventory-id: b49dd93f-28db-4626-b42d-749dd4c5ba2f
 ```
 
 And the special label is:
 
 ```
-cli-utils.sigs.k8s.io/inventory-id: *group-name*
+cli-utils.sigs.k8s.io/inventory-id: *b49dd93f-28db-4626-b42d-749dd4c5ba2f*
 ```
 
 `kpt live apply` recognizes this template from the special label, and based
-on this kpt will create new grouping object with the metadata of all applied
+on this kpt will create new inventory object with the metadata of all applied
 objects in the ConfigMap's data field. Subsequent `kpt live apply` commands can
-then query the grouping object, and calculate the omitted objects, cleaning up
-accordingly. When a grouping object is created in the cluster, a hash suffix
-is added to the name. Example:
-
-```
-test-grouping-object-17b4dba8
-```
+then query the inventory object, and calculate the omitted objects, cleaning up
+accordingly. On every subsequent apply operation, the inventory object is updated
+to reflect the current set of resources.
 
 ### Status (reconcile-timeout=\<DURATION\>)
 
@@ -201,7 +198,7 @@ kpt live apply DIR [flags]
 ```
 DIR:
   Path to a package directory.  The directory must contain exactly
-  one ConfigMap with the grouping object annotation.
+  one ConfigMap with the inventory object annotation.
 ```
 
 #### Flags

--- a/site/content/en/reference/live/status/_index.md
+++ b/site/content/en/reference/live/status/_index.md
@@ -10,13 +10,19 @@ description: >
 -->
 
 The status command will print the status for all resources in the live state
-that belong to the current inventory. It will use the inventory template to
+that belong to the current inventory. It will use the [Inventory Template] to
 look up the set of resources in the inventory in the live state and poll all
 those resources for their status until either an exit criteria has been met
 or the process is cancelled.
 
 ### Examples
 <!--mdtogo:Examples-->
+```sh
+# Monitor status for a set of resources based on manifests. Wait until all
+# resources have reconciled.
+kpt live status my-app/
+```
+
 ```sh
 # Monitor status for a set of resources based on manifests. Output in table format:
 kpt live status my-app/ --poll-until=forever --output=table
@@ -72,3 +78,5 @@ DIR | STDIN:
   to wait forever.
 ```
 <!--mdtogo-->
+
+[Inventory Template]: https://googlecontainertools.github.io/kpt/reference/live/apply/#prune

--- a/site/content/en/reference/live/status/_index.md
+++ b/site/content/en/reference/live/status/_index.md
@@ -1,0 +1,74 @@
+---
+title: "Status"
+linkTitle: "status"
+type: docs
+description: >
+   Status shows the status for the resources in the cluster
+---
+<!--mdtogo:Short
+    Status shows the status for the resources in the cluster
+-->
+
+The status command will print the status for all resources in the live state
+that belong to the current inventory. It will use the inventory template to
+look up the set of resources in the inventory in the live state and poll all
+those resources for their status until either an exit criteria has been met
+or the process is cancelled.
+
+### Examples
+<!--mdtogo:Examples-->
+```sh
+# Monitor status for a set of resources based on manifests. Output in table format:
+kpt live status my-app/ --poll-until=forever --output=table
+```
+
+```sh
+# Check status for a set of resources read from stdin with output in events format
+kpt cfg cat my-app | kpt live status
+```
+<!--mdtogo-->
+
+### Synopsis
+<!--mdtogo:Long-->
+```
+kpt live status (DIR | STDIN) [flags]
+```
+
+#### Args
+
+```
+DIR | STDIN:
+  Path to a directory if an argument is provided or reading from stdin if left
+  blank. In both situations one of the manifests must contain exactly one
+  ConfigMap with the inventory template annotation.
+```
+
+#### Flags
+
+```
+--poll-period (duration):
+  The frequency with which the cluster will be polled to determine the status
+  of the applied resources. The default value is every 2 seconds.
+
+--poll-until (string):
+  When to stop polling for status and exist. Must be one of the following:
+    known:   Exit when the status for all resources have been found.
+    current: Exit when the status for all resources have reached the Current status.
+    deleted: Exit when the status for all resources have reached the NotFound
+             status, i.e. all the resources have been deleted from the live state.
+    forever: Keep polling for status until interrupted.
+  The default value is ‘known’.
+
+--output (string):
+  Determines the output format for the status information. Must be one of the following:
+    events: The output will be a list of the status events as they become available.
+    table:  The output will be presented as a table that will be updated inline
+            as the status of resources become available.
+  The default value is ‘events’.
+
+--timeout (duration):
+  Determines how long the command should run before exiting. This deadline will
+  be enforced regardless of the value of the --poll-until flag. The default is
+  to wait forever.
+```
+<!--mdtogo-->


### PR DESCRIPTION
Adds documentation for the `kpt live status` command.
