### PR TITLE
Add support for .kptignore file

### DIFF
--- a/internal/cmdget/cmdget.go
+++ b/internal/cmdget/cmdget.go
@@ -23,7 +23,6 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/util/get"
 	"github.com/GoogleContainerTools/kpt/internal/util/get/getioreader"
 	"github.com/GoogleContainerTools/kpt/internal/util/parse"
-	"github.com/GoogleContainerTools/kpt/internal/util/setters"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/kyaml/kio/filters"
 )
@@ -72,6 +71,7 @@ func (r *Runner) preRunE(c *cobra.Command, args []string) error {
 	}
 	r.Get.Git = t.Git
 	r.Get.Destination = t.Destination
+	r.Get.AutoSet = r.AutoSet
 	return nil
 }
 
@@ -82,15 +82,5 @@ func (r *Runner) runE(c *cobra.Command, args []string) error {
 
 	fmt.Fprintf(c.OutOrStdout(), "fetching package %s from %s to %s\n",
 		r.Get.Directory, r.Get.Repo, r.Get.Destination)
-	if err := r.Get.Run(); err != nil {
-		return err
-	}
-
-	if r.AutoSet {
-		if err := setters.PerformSetters(r.Get.Destination); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return r.Get.Run()
 }

--- a/internal/testutil/testdata/dataset-with-ignorefile/.kptignore
+++ b/internal/testutil/testdata/dataset-with-ignorefile/.kptignore
@@ -1,0 +1,2 @@
+invalid.yaml
+helm-chart

--- a/internal/testutil/testdata/dataset-with-ignorefile/helm-chart/templates/deployment.yaml
+++ b/internal/testutil/testdata/dataset-with-ignorefile/helm-chart/templates/deployment.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "helloworld-chart.fullname" . }}
+  labels:
+    {{- include "helloworld-chart.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}

--- a/internal/testutil/testdata/dataset-with-ignorefile/invalid.yaml
+++ b/internal/testutil/testdata/dataset-with-ignorefile/invalid.yaml
@@ -1,0 +1,1 @@
+{{ include "helloworld-chart.fullname" . }}

--- a/internal/testutil/testdata/dataset-with-ignorefile/manifest.yaml
+++ b/internal/testutil/testdata/dataset-with-ignorefile/manifest.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-cm
+data:
+  foo: bar

--- a/internal/testutil/testdata/dataset-with-ignorefile/subpkg/.kptignore
+++ b/internal/testutil/testdata/dataset-with-ignorefile/subpkg/.kptignore
@@ -1,0 +1,1 @@
+helm-chart

--- a/internal/testutil/testdata/dataset-with-ignorefile/subpkg/Kptfile
+++ b/internal/testutil/testdata/dataset-with-ignorefile/subpkg/Kptfile
@@ -1,0 +1,4 @@
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: subpkg

--- a/internal/testutil/testdata/dataset-with-ignorefile/subpkg/helm-chart/templates/deployment.yaml
+++ b/internal/testutil/testdata/dataset-with-ignorefile/subpkg/helm-chart/templates/deployment.yaml
@@ -1,0 +1,8 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "helloworld-chart.fullname" . }}
+  labels:
+    {{- include "helloworld-chart.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -49,6 +49,7 @@ const (
 	HelloWorldSet         = "helloworld-set"
 	HelloWorldFn          = "helloworld-fn"
 	HelloWorldFnNoKptfile = "helloworld-fn-no-kptfile"
+	DatasetWithIgnoreFile = "dataset-with-ignorefile"
 )
 
 // TestGitRepo manages a local git repository for testing
@@ -490,9 +491,16 @@ func CopyKptfile(t *testing.T, src, dest string) {
 // SetupDefaultRepoAndWorkspace handles setting up a default repo to clone, and a workspace to clone into.
 // returns a cleanup function to remove the git repo and workspace.
 func SetupDefaultRepoAndWorkspace(t *testing.T) (*TestGitRepo, string, func()) {
+	return SetupRepoAndWorkspace(t, Dataset1)
+}
+
+// SetupRepoAndWorkspace handles setting up a repo to clone using the provided
+// dataset, and a workspace to clone into. Returns a cleanup function to remove
+// the git repo and workspace.
+func SetupRepoAndWorkspace(t *testing.T, dataset string) (*TestGitRepo, string, func()) {
 	// setup the repo to clone from
 	g := &TestGitRepo{}
-	err := g.SetupTestGitRepo(Dataset1)
+	err := g.SetupTestGitRepo(dataset)
 	assert.NoError(t, err)
 
 	// setup the directory to clone to

--- a/internal/util/get/get.go
+++ b/internal/util/get/get.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/GoogleContainerTools/kpt/internal/util/git"
+	"github.com/GoogleContainerTools/kpt/internal/util/setters"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
 	"sigs.k8s.io/kustomize/kyaml/copyutil"
@@ -47,6 +48,9 @@ type Command struct {
 
 	// Remove directory before copying to it.
 	Clean bool
+
+	// Automatically run the gcloud setters.
+	AutoSet bool
 }
 
 // Run runs the Command.
@@ -93,6 +97,12 @@ func (c Command) Run() error {
 	// create or update the KptFile with the values from git
 	if err = (&c).upsertKptfile(r); err != nil {
 		return errors.Wrap(err)
+	}
+
+	if c.AutoSet {
+		if err := setters.PerformSetters(c.Destination); err != nil {
+			return errors.Wrap(err)
+		}
 	}
 	return nil
 }

--- a/pkg/kptfile/pkgfile.go
+++ b/pkg/kptfile/pkgfile.go
@@ -22,6 +22,9 @@ import (
 // KptFileName is the name of the KptFile
 const KptFileName = "Kptfile"
 
+// KptIgnoreFileName is the name of the ignore file for kpt
+const KptIgnoreFileName = ".kptignore"
+
 // TypeMeta is the TypeMeta for KptFile instances.
 var TypeMeta = yaml.ResourceMeta{
 	TypeMeta: yaml.TypeMeta{

--- a/run/run.go
+++ b/run/run.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/util/factory"
 	"sigs.k8s.io/kustomize/cmd/config/ext"
 	"sigs.k8s.io/kustomize/kyaml/commandutil"
+	kyamlext "sigs.k8s.io/kustomize/kyaml/ext"
 	"sigs.k8s.io/kustomize/kyaml/openapi"
 )
 
@@ -81,6 +82,9 @@ func GetMain() *cobra.Command {
 	f := newFactory(cmd)
 
 	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		kyamlext.IgnoreFileName = func() string {
+			return kptfile.KptIgnoreFileName
+		}
 		// register function to use Kptfile for OpenAPI
 		ext.KRMFileName = func() string {
 			return kptfile.KptFileName


### PR DESCRIPTION
This adds support for `.kptignore` files based on the logic for `.krmignore` files in kyaml. The only real change here is to override the name of the `.krmignore` file in `kyaml` to instead use the `.kptignore` file. The other changes are just adding tests to verify that the functionality works and a small refactoring to make testing easier.

This is a follow-up from the changes in https://github.com/kubernetes-sigs/kustomize/pull/2941 and https://github.com/kubernetes-sigs/kustomize/pull/2898.