### PR TITLE
Fixed minor typo in TypeScript developer documentation

### DIFF
--- a/site/content/en/guides/producer/functions/ts/develop/_index.md
+++ b/site/content/en/guides/producer/functions/ts/develop/_index.md
@@ -70,7 +70,7 @@ running in a local container.
 
 #### Using a GKE Cluster
 
-You can also use a deployed cluster in GKE. The beta k8s feature is avilable
+You can also use a deployed cluster in GKE. The beta k8s feature is available
 only when using GKE's `--enable-kubernetes-alpha` flag, as seen here:
 
 ```sh


### PR DESCRIPTION
Updated a typo in the TypeScript developer documentation.

* a description of the change - Minor change to typescript developer documentation. Fixed spelling of "available"
* the motivation for the change - Good documentation
