### PR TITLE
ManifestReader based on kyaml that handles nested packages and ignorefiles

### DIFF
--- a/internal/live/manifestreader/kyaml_path.go
+++ b/internal/live/manifestreader/kyaml_path.go
@@ -1,0 +1,144 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifestreader
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/cli-runtime/pkg/resource"
+	"sigs.k8s.io/cli-utils/pkg/manifestreader"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
+	"sigs.k8s.io/kustomize/kyaml/pathutil"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+// KyamlPathManifestReader provides functionality for reading manifests
+// and returning them as infos objects. It will ignore resources with the
+// config.kubernetes.io/local-config annotation and set the namespace for
+// namespace-scoped resources without a namespace.
+type KyamlPathManifestReader struct {
+	Path string
+
+	manifestreader.ReaderOptions
+}
+
+// Read reads the manifests and returns them as Info objects.
+func (p *KyamlPathManifestReader) Read() ([]*resource.Info, error) {
+	var infos []*resource.Info
+	paths, err := pathutil.DirsWithFile(p.Path, kptfile.KptFileName, true)
+	if err != nil {
+		return infos, err
+	}
+
+	_, err = os.Stat(filepath.Join(p.Path, kptfile.KptFileName))
+	if err != nil {
+		return infos, err
+	}
+
+	for _, p := range paths {
+		nodes, err := (&kio.LocalPackageReader{
+			PackagePath:     p,
+			PackageFileName: kptfile.KptFileName,
+		}).Read()
+		if err != nil {
+			return infos, err
+		}
+
+		for _, n := range nodes {
+			fileName, err := extractFileName(n)
+			if err != nil {
+				return infos, err
+			}
+
+			err = removeAnnotations(n)
+			if err != nil {
+				return infos, err
+			}
+			inf, err := kyamlNodeToInfo(n, fileName)
+			if err != nil {
+				return infos, err
+			}
+			infos = append(infos, inf)
+		}
+	}
+
+	infos = manifestreader.FilterLocalConfig(infos)
+
+	err = manifestreader.SetNamespaces(p.Factory, infos, p.Namespace, p.EnforceNamespace)
+	return infos, err
+}
+
+// extractFileName looks up the fileName from which the resource was read
+// by lookup up the Path annotation set by the LocalPackageReader.
+func extractFileName(n *yaml.RNode) (string, error) {
+	val, err := n.Pipe(yaml.GetAnnotation(kioutil.PathAnnotation))
+	if err != nil {
+		return "", err
+	}
+	return val.YNode().Value, nil
+}
+
+var annotations = []kioutil.AnnotationKey{
+	kioutil.PathAnnotation,
+	kioutil.IndexAnnotation,
+}
+
+// removeAnnotations removes any Path or Index annotations from the
+// resource.
+func removeAnnotations(n *yaml.RNode) error {
+	for _, a := range annotations {
+		err := n.PipeE(yaml.ClearAnnotation(a))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// kyamlNodeToInfo take a resource represented as a kyaml RNode and
+// turns it into an info object with the underlying object represented
+// as an unstructured. The provided fileName is used to set the source
+// of the info.
+func kyamlNodeToInfo(n *yaml.RNode, fileName string) (*resource.Info, error) {
+	meta, err := n.GetMeta()
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := n.MarshalJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	var m map[string]interface{}
+	err = json.Unmarshal(b, &m)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resource.Info{
+		Object: &unstructured.Unstructured{
+			Object: m,
+		},
+		Name:      meta.Name,
+		Namespace: meta.Namespace,
+		Source:    fileName,
+	}, nil
+}

--- a/internal/live/manifestreader/kyaml_path_test.go
+++ b/internal/live/manifestreader/kyaml_path_test.go
@@ -1,0 +1,222 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package manifestreader
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+	"sigs.k8s.io/cli-utils/pkg/manifestreader"
+	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
+)
+
+func TestKyamlPathManifestReader_Read_resource(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		manifestName           string
+		manifest               string
+		readerNamespace        string
+		readerEnforceNamespace bool
+		expectError            bool
+		expectedNamespace      string
+		expectedAnnoCount      int
+	}{
+		{
+			name:         "namespaced resource with namespace",
+			manifestName: "deployment.yaml",
+			manifest: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: default
+`,
+			readerNamespace:        "default",
+			readerEnforceNamespace: false,
+			expectedNamespace:      "default",
+			expectedAnnoCount:      0,
+		},
+		{
+			name:         "namespaced resource without namespace",
+			manifestName: "my-dep.yaml",
+			manifest: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  annotations:
+    foo: bar
+`,
+			readerNamespace:        "bar",
+			readerEnforceNamespace: false,
+			expectedNamespace:      "bar",
+			expectedAnnoCount:      1,
+		},
+		{
+			name:         "clusterscoped resource",
+			manifestName: "my-ns.yaml",
+			manifest: `
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: foo
+  annotations:
+    HuskerDu: New Day Rising
+`,
+			readerNamespace:        "bar",
+			readerEnforceNamespace: true,
+			expectedNamespace:      "",
+			expectedAnnoCount:      1,
+		},
+		{
+			name:         "enforce namespace",
+			manifestName: "my-dep.yaml",
+			manifest: `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: foo
+  namespace: default
+`,
+			readerNamespace:        "bar",
+			readerEnforceNamespace: true,
+			expectError:            true,
+		},
+	}
+
+	for i := range testCases {
+		test := testCases[i]
+		t.Run(test.name, func(t *testing.T) {
+			tf := cmdtesting.NewTestFactory().WithNamespace("default")
+			defer tf.Cleanup()
+
+			d, err := ioutil.TempDir("", "")
+			assert.NoError(t, err)
+			err = ioutil.WriteFile(
+				filepath.Join(d, test.manifestName), []byte(test.manifest), 0600)
+			assert.NoError(t, err)
+			err = ioutil.WriteFile(
+				filepath.Join(d, kptfile.KptFileName), []byte(`Kptfile`), 0600)
+			assert.NoError(t, err)
+
+			infos, err := (&KyamlPathManifestReader{
+				Path: d,
+				ReaderOptions: manifestreader.ReaderOptions{
+					Factory:          tf,
+					Namespace:        test.readerNamespace,
+					EnforceNamespace: test.readerEnforceNamespace,
+				},
+			}).Read()
+
+			if test.expectError {
+				assert.Error(t, err)
+				return
+			}
+
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			assert.Equal(t, 1, len(infos))
+			inf := infos[0]
+
+			assert.Equal(t, test.expectedNamespace, inf.Namespace)
+
+			u := inf.Object.(*unstructured.Unstructured)
+			annos, found, err := unstructured.NestedStringMap(u.Object, "metadata", "annotations")
+			assert.NoError(t, err)
+
+			if !found {
+				annos = make(map[string]string)
+			}
+
+			_, found = annos[kioutil.IndexAnnotation]
+			assert.False(t, found)
+			_, found = annos[kioutil.PathAnnotation]
+			assert.False(t, found)
+			assert.Equal(t, test.expectedAnnoCount, len(annos))
+			assert.NotEmpty(t, inf.Name)
+			assert.Equal(t, test.manifestName, inf.Source)
+		})
+	}
+}
+
+func TestKyamlPathManifestReader_Read_packages(t *testing.T) {
+	//old := kyamlext.IgnoreFileName
+	//defer func() { kyamlext.IgnoreFileName = old }()
+	//kyamlext.IgnoreFileName = func() string {
+	//	return kptfile.KptIgnoreFileName
+	//}
+
+	testCases := []struct {
+		name          string
+		path          string
+		expectedCount int
+		expectedError bool
+	}{
+		//TODO: Uncomment test when the testset is merged.
+		//{
+		//	name:          "ignorefiles should be checked",
+		//	path:          "../../testutil/testdata/dataset-with-ignorefile",
+		//	expectedCount: 1,
+		//},
+		{
+			name:          "nested packages",
+			path:          "../../testutil/testdata/dataset-with-autosetters/mysql",
+			expectedCount: 3,
+		},
+		{
+			name:          "no nesting",
+			path:          "../../testutil/testdata/helloworld-fn",
+			expectedCount: 2,
+		},
+		{
+			name:          "no Kptfile should lead to error",
+			path:          "../../testutil/testdata/helloworld-fn-no-kptfile",
+			expectedError: true,
+		},
+	}
+
+	for i := range testCases {
+		test := testCases[i]
+		t.Run(test.name, func(t *testing.T) {
+			tf := cmdtesting.NewTestFactory().WithNamespace("default")
+			defer tf.Cleanup()
+
+			infos, err := (&KyamlPathManifestReader{
+				Path: test.path,
+				ReaderOptions: manifestreader.ReaderOptions{
+					Factory:   tf,
+					Namespace: "default",
+				},
+			}).Read()
+
+			if test.expectedError {
+				assert.Error(t, err)
+				return
+			}
+
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			assert.Equal(t, test.expectedCount, len(infos))
+		})
+	}
+}


### PR DESCRIPTION
This leverages the LocalManifestReader from kyaml to read manifests. Similar to how we read files for the cfg commands, it will first identify all the nested packages and then read each of them. This will also automatically handle ignorefiles once #1024 is merged.
