### PR TITLE
Inherit setter values from parent package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,6 @@ require (
 	// Once there is a 0.18 release, we can import a semver release.
 	k8s.io/kubectl v0.0.0-20191219154910-1528d4eea6dd
 	sigs.k8s.io/cli-utils v0.20.7-0.20201016204101-35a4eb0f63f9
-	sigs.k8s.io/kustomize/cmd/config v0.8.3
-	sigs.k8s.io/kustomize/kyaml v0.9.2
+	sigs.k8s.io/kustomize/cmd/config v0.8.4-0.20201022184337-55b4448862b7
+	sigs.k8s.io/kustomize/kyaml v0.9.3-0.20201022184337-55b4448862b7
 )

--- a/go.sum
+++ b/go.sum
@@ -739,8 +739,12 @@ sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbL
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/kustomize/cmd/config v0.8.3 h1:enT5nNDHht+stIsxt8LC4LyNfT3oUoxT6Iiu8NB6neY=
 sigs.k8s.io/kustomize/cmd/config v0.8.3/go.mod h1:c7sIYoV9UOfM9tkVTOCNE8ycUMloWrUoaZp+kOuf+kc=
+sigs.k8s.io/kustomize/cmd/config v0.8.4-0.20201022184337-55b4448862b7 h1:X3FMOWGdMnCrEP6f0IrjtsZlSVbKi7PzC3OcayLuHb4=
+sigs.k8s.io/kustomize/cmd/config v0.8.4-0.20201022184337-55b4448862b7/go.mod h1:NgL9AMLDYJ+ju+D1OIB4SjH8Rq/y52hNsdLakEq0m8U=
 sigs.k8s.io/kustomize/kyaml v0.9.2 h1:QNP1Lg4V2wOgBeUim9Kmz1+2GqHtRyfoVEUQH0omrCI=
 sigs.k8s.io/kustomize/kyaml v0.9.2/go.mod h1:UTm64bSWVdBUA8EQoYCxVOaBQxUdIOr5LKWxA4GNbkw=
+sigs.k8s.io/kustomize/kyaml v0.9.3-0.20201022184337-55b4448862b7 h1:Ivr+7ZwKizIY3K1NE9ybFhmyoghJPyCc5TNBccTlO8Q=
+sigs.k8s.io/kustomize/kyaml v0.9.3-0.20201022184337-55b4448862b7/go.mod h1:UTm64bSWVdBUA8EQoYCxVOaBQxUdIOr5LKWxA4GNbkw=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
 sigs.k8s.io/structured-merge-diff v1.0.1-0.20191108220359-b1b620dd3f06/go.mod h1:/ULNhyfzRopfcjskuui0cTITekDduZ7ycKN3oUT9R18=

--- a/internal/cmdget/cmdget.go
+++ b/internal/cmdget/cmdget.go
@@ -87,7 +87,11 @@ func (r *Runner) runE(c *cobra.Command, args []string) error {
 	}
 
 	if r.AutoSet {
-		if err := setters.PerformAutoSetters(r.Get.Destination); err != nil {
+		a := setters.AutoSet{
+			Writer:      c.OutOrStdout(),
+			PackagePath: r.Get.Destination,
+		}
+		if err := a.PerformAutoSetters(); err != nil {
 			return err
 		}
 	}

--- a/internal/cmdupdate/cmdupdate.go
+++ b/internal/cmdupdate/cmdupdate.go
@@ -47,6 +47,8 @@ func NewRunner(parent string) *Runner {
 			strings.Join(update.Strategies, ","))
 	c.Flags().BoolVar(&r.Update.DryRun, "dry-run", false,
 		"print the git patch rather than merging it.")
+	c.Flags().BoolVar(&r.AutoSet, "auto-set", true,
+		"automatically perform setters based off the environment")
 	c.Flags().BoolVar(&r.Update.Verbose, "verbose", false,
 		"print verbose logging information.")
 	cmdutil.FixDocs("kpt", parent, c)
@@ -62,6 +64,7 @@ func NewCommand(parent string) *cobra.Command {
 // TODO, support listing versions
 type Runner struct {
 	strategy string
+	AutoSet  bool
 	Update   update.Command
 	Command  *cobra.Command
 }
@@ -76,6 +79,7 @@ func (r *Runner) preRunE(c *cobra.Command, args []string) error {
 	if len(parts) > 1 {
 		r.Update.Ref = parts[1]
 	}
+	r.Update.AutoSet = r.AutoSet
 
 	return nil
 }

--- a/internal/util/openapi/openapi.go
+++ b/internal/util/openapi/openapi.go
@@ -83,5 +83,5 @@ func ConfigureOpenAPISchema(openAPISchema []byte) error {
 	// of where we got the Kubernetes openAPI schema.
 	// TODO: Refactor the openapi package in kyaml so we don't need to
 	// know the name of the kustomize asset here.
-	return openapi.AddSchema(kustomizationapi.MustAsset("openapi/kustomizationapi/swagger.json"))
+	return openapi.AddSchema(kustomizationapi.MustAsset("kustomizationapi/swagger.json"))
 }

--- a/internal/util/setters/setters.go
+++ b/internal/util/setters/setters.go
@@ -16,6 +16,8 @@ package setters
 
 import (
 	"fmt"
+	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -29,7 +31,9 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/openapi"
 	"sigs.k8s.io/kustomize/kyaml/pathutil"
 	"sigs.k8s.io/kustomize/kyaml/setters"
+	"sigs.k8s.io/kustomize/kyaml/setters2"
 	"sigs.k8s.io/kustomize/kyaml/setters2/settersutil"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 const (
@@ -37,14 +41,37 @@ const (
 	GcloudProjectNumber = "gcloud.project.projectNumber"
 )
 
-func PerformAutoSetters(path string) error {
+type AutoSet struct {
+	// Writer is the output writer
+	Writer io.Writer
+
+	// PackagePath is the path of the package to apply auto-setters
+	PackagePath string
+}
+
+// PerformAutoSetters auto-fills the setter values from the local environment
+// in the target path for the setters which are not already set previously
+// Auto setters are applied in the following order of precedence
+// 1. Setter values from the parent package
+// 2. Setter values from the environment variables
+// 3. Setter values from gcloud configs
+// The auto setters are applied for all the subpackages with in the directory
+// tree of input PackagePath
+// Only the setters which are NOT set locally (identified by isSet flag in setter
+// definition of Kptfile), are only set by this operation
+func (a AutoSet) PerformAutoSetters() error {
+	// auto-fill setter values from parent package
+	if err := a.SetInheritedSetters(); err != nil {
+		return err
+	}
+
 	// auto-fill setters from environment
-	if err := SetEnvAutoSetters(path); err != nil {
+	if err := a.SetEnvAutoSetters(); err != nil {
 		return err
 	}
 
 	// auto-fill setters from gcloud config
-	if err := SetGcloudAutoSetters(path); err != nil {
+	if err := a.SetGcloudAutoSetters(); err != nil {
 		return err
 	}
 
@@ -52,7 +79,7 @@ func PerformAutoSetters(path string) error {
 }
 
 // SetGcloudAutoSetters auto-fills setters from gcloud config
-func SetGcloudAutoSetters(path string) error {
+func (a AutoSet) SetGcloudAutoSetters() error {
 	gcloudConfig := []string{"compute.region", "compute.zone", "core.project"}
 	for _, c := range gcloudConfig {
 		gcloudCmd := exec.Command("gcloud",
@@ -68,12 +95,12 @@ func SetGcloudAutoSetters(path string) error {
 			continue
 		}
 
-		err = SetV1AutoSetter(fmt.Sprintf("gcloud.%s", c), v, path)
+		err = SetV1AutoSetter(fmt.Sprintf("gcloud.%s", c), v, a.PackagePath)
 		if err != nil {
 			return err
 		}
 
-		err = SetV2AutoSetter(fmt.Sprintf("gcloud.%s", c), v, path)
+		err = SetV2AutoSetter(fmt.Sprintf("gcloud.%s", c), v, a.PackagePath, a.Writer)
 		if err != nil {
 			return err
 		}
@@ -133,35 +160,32 @@ func SetV1AutoSetter(name, value, path string) error {
 
 // SetV2AutoSetter sets the input auto setter recursively in all the sub-packages of root
 // Sets GcloudProjectNumber as well, if input setter is GcloudProject
-func SetV2AutoSetter(name, value, root string) error {
+func SetV2AutoSetter(name, value, root string, w io.Writer) error {
 	resourcePackagesPaths, err := pathutil.DirsWithFile(root, kptfile.KptFileName, true)
 	if err != nil {
 		return err
 	}
 	for _, resourcesPath := range resourcePackagesPaths {
+		if !DefExists(resourcesPath, name) || isSet(name, filepath.Join(resourcesPath, kptfile.KptFileName)) {
+			continue
+		}
 		fs := &settersutil.FieldSetter{
-			Name:               name,
-			Value:              value,
-			SetBy:              "kpt",
-			OpenAPIPath:        filepath.Join(resourcesPath, kptfile.KptFileName),
-			OpenAPIFileName:    kptfile.KptFileName,
-			ResourcesPath:      resourcesPath,
-			RecurseSubPackages: true,
+			Name:            name,
+			Value:           value,
+			SetBy:           "kpt",
+			OpenAPIPath:     filepath.Join(resourcesPath, kptfile.KptFileName),
+			OpenAPIFileName: kptfile.KptFileName,
+			ResourcesPath:   resourcesPath,
+			IsSet:           true,
 		}
-		rw := &kio.LocalPackageReadWriter{
-			PackagePath:           resourcesPath,
-			KeepReaderAnnotations: false,
-			PackageFileName:       kptfile.KptFileName,
-		}
-		err = kio.Pipeline{
-			Inputs:  []kio.Reader{rw},
-			Filters: []kio.Filter{fs},
-			Outputs: []kio.Writer{rw},
-		}.Execute()
+		format := "automatically set %d field(s) for setter %q to value %q in package %q derived from gcloud config\n"
+		count, err := fs.Set()
 		if err != nil {
-			return err
+			fmt.Fprintf(w, "failed to set %q automatically in package %q with error: %s\n", name, resourcesPath, err.Error())
+		} else {
+			fmt.Fprintf(w, format, count, name, value, resourcesPath)
 		}
-		if name == GcloudProject && fs.Count > 0 {
+		if name == GcloudProject && count > 0 {
 			projectID := value
 			// set the projectNumber if the projectID is set
 			projectNumber, err := GetProjectNumberFromProjectID(projectID)
@@ -169,22 +193,23 @@ func SetV2AutoSetter(name, value, root string) error {
 				return err
 			}
 			if DefExists(resourcesPath, GcloudProjectNumber) && projectNumber != "" {
-				fs = &settersutil.FieldSetter{
-					Name:               GcloudProjectNumber,
-					Value:              projectNumber,
-					SetBy:              "kpt",
-					OpenAPIPath:        filepath.Join(resourcesPath, kptfile.KptFileName),
-					OpenAPIFileName:    kptfile.KptFileName,
-					ResourcesPath:      resourcesPath,
-					RecurseSubPackages: true,
+				if isSet(GcloudProjectNumber, filepath.Join(resourcesPath, kptfile.KptFileName)) {
+					continue
 				}
-				err = kio.Pipeline{
-					Inputs:  []kio.Reader{rw},
-					Filters: []kio.Filter{fs},
-					Outputs: []kio.Writer{rw},
-				}.Execute()
+				fs = &settersutil.FieldSetter{
+					Name:            GcloudProjectNumber,
+					Value:           projectNumber,
+					SetBy:           "kpt",
+					OpenAPIPath:     filepath.Join(resourcesPath, kptfile.KptFileName),
+					OpenAPIFileName: kptfile.KptFileName,
+					ResourcesPath:   resourcesPath,
+					IsSet:           true,
+				}
+				count, err := fs.Set()
 				if err != nil {
-					return err
+					fmt.Fprintf(w, "failed setting auto-setter %q in package %q with error: %s\n", GcloudProjectNumber, resourcesPath, err.Error())
+				} else {
+					fmt.Fprintf(w, format, count, GcloudProjectNumber, projectNumber, resourcesPath)
 				}
 			}
 		}
@@ -204,8 +229,8 @@ var GetProjectNumberFromProjectID = func(projectID string) (string, error) {
 }
 
 // SetEnvAutoSetters auto-fills setters from the environment
-func SetEnvAutoSetters(root string) error {
-	resourcePackagesPaths, err := pathutil.DirsWithFile(root, kptfile.KptFileName, true)
+func (a AutoSet) SetEnvAutoSetters() error {
+	resourcePackagesPaths, err := pathutil.DirsWithFile(a.PackagePath, kptfile.KptFileName, true)
 	if err != nil {
 		return err
 	}
@@ -223,9 +248,8 @@ func SetEnvAutoSetters(root string) error {
 
 		for _, resourcesPath := range resourcePackagesPaths {
 			rw := &kio.LocalPackageReadWriter{
-				PackagePath:           resourcesPath,
-				KeepReaderAnnotations: false,
-				PackageFileName:       kptfile.KptFileName,
+				PackagePath:     resourcesPath,
+				PackageFileName: kptfile.KptFileName,
 			}
 
 			setter := &setters.PerformSetters{Name: k, Value: v, SetBy: "kpt"}
@@ -239,21 +263,25 @@ func SetEnvAutoSetters(root string) error {
 				return err
 			}
 
-			setter2 := &settersutil.FieldSetter{
-				Name:          k,
-				Value:         v,
-				SetBy:         "kpt",
-				ResourcesPath: resourcesPath,
-				OpenAPIPath:   filepath.Join(resourcesPath, kptfile.KptFileName),
+			if !DefExists(resourcesPath, k) || isSet(k, filepath.Join(resourcesPath, kptfile.KptFileName)) {
+				continue
 			}
-			err = kio.Pipeline{
-				Inputs:  []kio.Reader{rw},
-				Filters: []kio.Filter{setter2},
-				Outputs: []kio.Writer{rw},
-			}.Execute()
 
+			fs := &settersutil.FieldSetter{
+				Name:            k,
+				Value:           v,
+				SetBy:           "kpt",
+				ResourcesPath:   resourcesPath,
+				OpenAPIPath:     filepath.Join(resourcesPath, kptfile.KptFileName),
+				OpenAPIFileName: kptfile.KptFileName,
+				IsSet:           true,
+			}
+			count, err := fs.Set()
 			if err != nil {
-				return err
+				fmt.Fprintf(a.Writer, "failed to set %q automatically in package %q with error: %s\n", k, resourcesPath, err.Error())
+			} else {
+				format := "automatically set %d field(s) for setter %q to value %q in package %q derived from environment\n"
+				fmt.Fprintf(a.Writer, format, count, k, v, resourcesPath)
 			}
 		}
 	}
@@ -261,6 +289,134 @@ func SetEnvAutoSetters(root string) error {
 }
 
 var environmentVariables = os.Environ
+
+// SetInheritedSetters traverses the absolute parentPath all the way to the root
+// of file system to find a kpt package with Kptfile and auto-fills the setter
+// values in targetPath and all its subpackages
+func (a AutoSet) SetInheritedSetters() error {
+	// get all the subpackage paths(including itself) in PackagePath
+	targetPackagesPaths, err := pathutil.DirsWithFile(a.PackagePath, kptfile.KptFileName, true)
+	if err != nil {
+		return err
+	}
+
+	// for each subpackage find its parent on local and inherit the setter values
+	for _, targetPath := range targetPackagesPaths {
+		parentKptfilePath, err := parentDirWithKptfile(filepath.Dir(targetPath))
+		if err != nil {
+			return err
+		}
+
+		if parentKptfilePath == "" {
+			// continue to next package if there is no parent package for current targetPath
+			continue
+		}
+
+		if err := openapi.AddSchemaFromFile(parentKptfilePath); err != nil {
+			return err
+		}
+
+		targetPkgRefs, err := openapi.DefinitionRefs(filepath.Join(targetPath, kptfile.KptFileName))
+		if err != nil {
+			return err
+		}
+
+		// for each setter in target path, derive the setter values from parent package
+		// openAPI schema definitions and set them
+		for _, ref := range targetPkgRefs {
+			sch := openapi.Schema().Definitions[ref]
+			cliExt, err := setters2.GetExtFromSchema(&sch)
+			if cliExt == nil || cliExt.Setter == nil || err != nil {
+				// if the ref doesn't exist in global schema or if it is not a setter
+				// continue, as there might be setters which are not present global schema
+				continue
+			}
+			kptfilePath := filepath.Join(targetPath, kptfile.KptFileName)
+			if isSet(cliExt.Setter.Name, kptfilePath) {
+				// skip if the setter is already set on local
+				continue
+			}
+			fs := &settersutil.FieldSetter{
+				Name:            cliExt.Setter.Name,
+				Value:           cliExt.Setter.Value,
+				ListValues:      cliExt.Setter.ListValues,
+				OpenAPIPath:     kptfilePath,
+				OpenAPIFileName: kptfile.KptFileName,
+				ResourcesPath:   targetPath,
+				// turn isSet to true on child Kptfile iff the value derived from parent
+				// is set by user, don't set isSet to true for inheriting default values from parent
+				IsSet: isSet(cliExt.Setter.Name, parentKptfilePath),
+			}
+
+			count, err := fs.Set()
+			if err != nil {
+				fmt.Fprintf(a.Writer, "failed to set %q automatically in package %q with error: %s\n", cliExt.Setter.Name, targetPath, err.Error())
+			} else {
+
+				format := "automatically set %d field(s) for setter %q to value %q in package %q derived from parent %q\n"
+
+				if len(cliExt.Setter.ListValues) == 0 {
+					fmt.Fprintf(a.Writer, format, count, cliExt.Setter.Name, cliExt.Setter.Value, targetPath, parentKptfilePath)
+				} else {
+					fmt.Fprintf(a.Writer, format, count, cliExt.Setter.Name, cliExt.Setter.ListValues, targetPath, parentKptfilePath)
+				}
+			}
+		}
+
+		if err := openapi.DeleteSchemaInFile(parentKptfilePath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// isSet checks the openAPI file and returns true iff the openAPI definition
+// for for given setter has isSet flag set to true
+func isSet(setterName, openAPIFile string) bool {
+	b, err := ioutil.ReadFile(openAPIFile)
+	if err != nil {
+		return false
+	}
+	node, err := yaml.Parse(string(b))
+	if err != nil {
+		return false
+	}
+	isSetNode, err := node.Pipe(yaml.Lookup(
+		openapi.SupplementaryOpenAPIFieldName,
+		openapi.Definitions,
+		fieldmeta.SetterDefinitionPrefix+setterName, setters2.K8sCliExtensionKey,
+		"setter", "isSet"))
+	if err != nil {
+		return false
+	}
+	isSetVal, err := isSetNode.String()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(isSetVal) == "true"
+}
+
+// parentDirWithKptfile traverses the parentPath till the root of the file system
+// and returns the Kptfile path first encountered
+func parentDirWithKptfile(parentPath string) (string, error) {
+	parentPath = filepath.Clean(parentPath)
+	absParentPath, err := filepath.Abs(parentPath)
+	if err != nil {
+		return "", err
+	}
+	for {
+		openAPIPath := filepath.Join(absParentPath, kptfile.KptFileName)
+		_, err := os.Stat(openAPIPath)
+		if !os.IsNotExist(err) {
+			return openAPIPath, nil
+		}
+		// terminal condition: stop if there is no parent dir for absParentPath
+		if absParentPath == filepath.Dir(absParentPath) {
+			return "", nil
+		}
+		absParentPath = filepath.Dir(absParentPath)
+	}
+}
 
 // DefExists returns true if the setterName exists in Kptfile definitions
 func DefExists(resourcePath, setterName string) bool {

--- a/internal/util/sync/sync.go
+++ b/internal/util/sync/sync.go
@@ -88,7 +88,11 @@ func (c Command) Run() error {
 		}
 		path := filepath.Join(c.Dir, dep.Name)
 		if dep.AutoSet {
-			if err := setters.PerformAutoSetters(path); err != nil {
+			a := setters.AutoSet{
+				Writer:      c.StdOut,
+				PackagePath: path,
+			}
+			if err := a.PerformAutoSetters(); err != nil {
 				return err
 			}
 		}
@@ -183,6 +187,7 @@ func (c Command) update(dependency kptfile.Dependency, k *kptfile.KptFile) error
 		Repo:     dependency.Git.Repo,
 		Strategy: update.StrategyType(dependency.Strategy),
 		Verbose:  c.Verbose,
+		AutoSet:  dependency.AutoSet,
 	}.Run()
 }
 

--- a/internal/util/update/resource-merge.go
+++ b/internal/util/update/resource-merge.go
@@ -25,7 +25,6 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/gitutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/get"
 	"github.com/GoogleContainerTools/kpt/internal/util/git"
-	"github.com/GoogleContainerTools/kpt/internal/util/setters"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
 	"sigs.k8s.io/kustomize/kyaml/copyutil"
@@ -64,11 +63,6 @@ func (u ResourceMergeUpdater) Update(options UpdateOptions) error {
 		return errors.Errorf("failed to clone git repo: updated source: %v", err)
 	}
 	defer os.RemoveAll(updated.AbsPath())
-
-	err = setters.PerformAutoSetters(updated.AbsPath())
-	if err != nil {
-		return err
-	}
 
 	kf, err := u.updatedKptfile(updated.AbsPath(), original.AbsPath(), options)
 	if err != nil {
@@ -218,6 +212,7 @@ func MergeSubPackages(localRoot, updatedRoot, originalRoot string) error {
 		if fileExists(filepath.Join(originalPkgPath, kptfile.KptFileName)) {
 			dirsForSettersUpdate = append(dirsForSettersUpdate, originalPkgPath)
 		}
+
 		err = settersutil.SetAllSetterDefinitions(
 			false,
 			filepath.Join(localPkgPath, kptfile.KptFileName),


### PR DESCRIPTION
@mortent @morgante 

This PR is to organize auto-setters and add new feature to auto-setters to inherit the values of parent package setters when the package is being fetched during get and update operations. The setters with isSet not true in setter definitions of fetched/updated packages are only auto-set
