### PR TITLE
duplicate error removal.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,9 @@ kpt/kpt
 
 # Emacs temp files
 *~
+
+# VS Code individual configurations
+.vscode/
+
+# local tmp directory (in case you download packages here)
+tmp/

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -43,8 +43,7 @@ func GetAnthosCommands(name string) []*cobra.Command {
 
 // NormalizeCommand will modify commands to be consistent, e.g. silencing errors
 func NormalizeCommand(c ...*cobra.Command) {
-	for i := range c {
-		cmd := c[i]
+	for _, cmd := range c {
 		cmd.Short = strings.TrimPrefix(cmd.Short, "[Alpha] ")
 		NormalizeCommand(cmd.Commands()...)
 	}

--- a/commands/configcmd.go
+++ b/commands/configcmd.go
@@ -140,6 +140,7 @@ func SetCommand(parent string) *cobra.Command {
 	kustomizeCmd.Long = cfgdocs.SetShort + "\n" + cfgdocs.SetLong
 	kustomizeCmd.Example = cfgdocs.SetExamples
 	kustomizeCmd.SilenceUsage = true
+	kustomizeCmd.SilenceErrors = true
 	var autoRun bool
 	setCmd.Flags().BoolVar(&autoRun, "auto-run", true,
 		`Automatically run functions after setting (if enabled for the package)`)


### PR DESCRIPTION
The change addresses issue #1052 
The issue shows that `set` command prints out errors two times.  `kpt` is using a strategy of silencing the error output in the `cobra` command processing and instead provide top level user messages.  The command instantiation in configcmd.go didn't initialize both fo the flags for silencing and doesn't take a pointer to the parent which would allow to inherit those flags.

A larger/better fix could be to take that pointer and start with cloning the parent command and all of it's settings.  This is a quicker fix which might be sufficient for now.

In addition to that PR there is also a quick addition to the .gitignore file.  The file now allows you to have a /tmp directory where you can pull down packages off the web and not have to deal with excluding them while pushing changes as well as excluding the `.vscode` folder.

Additional work that could be done here is to add an automated test for this scenario.  If the maintainers feel like it would be good to do that, I am open to adding a test here as well.
