### PR TITLE
Introduce 3 issue templates and links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -14,7 +14,7 @@ assignees: ""
 ### Information
 
 <!-- Please include any additional information related to your issue -->
-<!-- EX: Operating System -->
+<!-- EX: -->
 <!--     Kpt Version (you may find this by running `kpt version` in your shell) -->
 <!--     Kpt Package that can demonstrate the error. Ex: https://github.com/kubernetes/examples/staging/cockroachdb -->
 

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -15,7 +15,7 @@ assignees: ""
 
 <!-- Please include any additional information related to your issue -->
 <!-- EX: Operating System -->
-<!--     Kpt Version -->
-<!--     Kpt Package that can demonstrate the error -->
+<!--     Kpt Version (you may find this by running `kpt version` in your shell) -->
+<!--     Kpt Package that can demonstrate the error. Ex: https://github.com/kubernetes/examples/staging/cockroachdb -->
 
 ### Steps to reproduce the behavior

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,19 @@
+---
+name: 🐞 Bug Report
+about: Report an issue with kpt
+title: ""
+labels:
+  - kind/bug
+assignees: ""
+---
+
+### Expected behavior
+
+### Actual behavior
+
+### Information
+
+<!-- Please include any additional information related to your issue -->
+<!-- EX: Operating System -->
+
+### Steps to reproduce the behavior

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -3,7 +3,7 @@ name: 🐞 Bug Report
 about: Report an issue with kpt
 title: ""
 labels:
-  - kind/bug
+  - bug
 assignees: ""
 ---
 
@@ -15,5 +15,7 @@ assignees: ""
 
 <!-- Please include any additional information related to your issue -->
 <!-- EX: Operating System -->
+<!--     Kpt Version -->
+<!--     Kpt Package that can demonstrate the error -->
 
 ### Steps to reproduce the behavior

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -7,5 +7,5 @@ contact_links:
     url: https://googlecontainertools.github.io/kpt/guides/
     about: Learn more about using kpt with these guides
   - name: Kpt Mailing List
-    url: https://groups.google.com/forum/?oldui=1#!forum/kpt-users
+    url: https://groups.google.com/forum/#!forum/kpt-users
     about: Join the Kpt mailing list

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -6,3 +6,6 @@ contact_links:
   - name: Kpt Guides
     url: https://googlecontainertools.github.io/kpt/guides/
     about: Learn more about using kpt with these guides
+  - name: Kpt Mailing List
+    url: https://groups.google.com/forum/?oldui=1#!forum/kpt-users
+    about: Join the Kpt mailing list

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Kpt Slack Channel
+    url: https://kubernetes.slack.com/app_redirect?channel=kpt
+    about: Discuss Kpt Topics with the Kpt Team on Slack
+  - name: Kpt Guides
+    url: https://googlecontainertools.github.io/kpt/guides/
+    about: Learn more about using kpt with these guides

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: 💡 Feature Request
 about: Suggest an idea for kpt
 title: ""
 labels:
-  - kind/feature
+  - enhancement
   - size/M
 assignees: ""
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,8 +4,12 @@ about: Suggest an idea for kpt
 title: ""
 labels:
   - kind/feature
+  - size/M
 assignees: ""
 ---
+
+If the size of effort this feature requires is known, please update the label
+accordingly.
 
 ### Is your feature request related to a problem? Please describe.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,12 +4,8 @@ about: Suggest an idea for kpt
 title: ""
 labels:
   - enhancement
-  - size/M
 assignees: ""
 ---
-
-If the size of effort this feature requires is known, please update the label
-accordingly.
 
 ### Is your feature request related to a problem? Please describe.
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: 💡 Feature Request
+about: Suggest an idea for kpt
+title: ""
+labels:
+  - kind/feature
+assignees: ""
+---
+
+### Is your feature request related to a problem? Please describe.
+
+### Describe the solution you'd like
+
+### Describe alternatives you've considered
+
+### Additional context

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,9 @@
+---
+name: ❓ Question
+about: Ask a question about kpt
+title: "[Question]"
+labels: ""
+assignees: ""
+---
+
+<!-- Describe your question here -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -2,7 +2,8 @@
 name: ❓ Question
 about: Ask a question about kpt
 title: "[Question]"
-labels: ""
+labels:
+  - question
 assignees: ""
 ---
 


### PR DESCRIPTION
Fixes #1096

Intended to streamline the process of opening new kpt issues.

Introduces three issue templates for the kpt repository for:

* Feature Requests
* Bug Reports
* Kpt Questions

Also introduces two links for new issues that link to:

* Kpt channel in the kubernetes.slack.com slack server
* The Kpt Guides

These links are presented as part of the "New Issue" flow.


Comments on phrasing and styling appreciated.