### PR TITLE
Docs: fixing an error when running kpt pkg update from outside local git repo

### DIFF
--- a/site/content/en/guides/consumer/update/_index.md
+++ b/site/content/en/guides/consumer/update/_index.md
@@ -79,11 +79,11 @@ updated to later versions to merge in upstream changes.
 
 ### Initialize local Repository
 
+<!-- @InitRepo @verifyGuides-->
 ```sh
 mkdir workspace
 cd workspace
 git init
-
 ```
 
 ### Fetch Command
@@ -114,10 +114,10 @@ resolved to the tag `v0.3.0`.
 
 ### Commit Local Repository 1st Version
 
+<!-- @commitLocalRepository @verifyGuides-->
 ```sh
 git add .
 git commit -m "init"
-
 ```
 
 ## Edit the contents

--- a/site/content/en/guides/consumer/update/_index.md
+++ b/site/content/en/guides/consumer/update/_index.md
@@ -166,6 +166,8 @@ kpt will throw an error if trying to update a package and the git repo
 has uncommitted changes.
 {{% /pageinfo %}}
 
+Move into the directory where you cloned the repo (helloworld in thie example)
+
 <!-- @commitLocalChanges @verifyGuides-->
 ```sh
 git init
@@ -180,9 +182,11 @@ specified version and applying the upstream changes to the local package.
 
 ### Merge Command
 
+You need to perform the command below from the directory where you cloned the repo (helloworld in thie example)
+
 <!-- @mergeUpdates @verifyGuides-->
 ```sh
-kpt pkg update helloworld@v0.5.0 --strategy=resource-merge
+kpt pkg update .@v0.5.0 --strategy=resource-merge
 ```
 
 Update the local package to the upstream version v0.5.0 by doing a 3-way

--- a/site/content/en/guides/consumer/update/_index.md
+++ b/site/content/en/guides/consumer/update/_index.md
@@ -196,8 +196,6 @@ specified version and applying the upstream changes to the local package.
 
 ### Merge Command
 
-You need to perform the command below from the directory where you cloned the repo (helloworld in thie example)
-
 <!-- @mergeUpdates @verifyGuides-->
 ```sh
 kpt pkg update helloworld@v0.5.0 --strategy=resource-merge

--- a/site/content/en/guides/consumer/update/_index.md
+++ b/site/content/en/guides/consumer/update/_index.md
@@ -183,7 +183,6 @@ kpt will throw an error if trying to update a package and the git repo
 has uncommitted changes.
 {{% /pageinfo %}}
 
-
 <!-- @commitLocalChanges @verifyGuides-->
 ```sh
 git add .

--- a/site/content/en/guides/consumer/update/_index.md
+++ b/site/content/en/guides/consumer/update/_index.md
@@ -77,6 +77,15 @@ in this guide.
 Packages can be fetched at specific versions defined by git tags, and have
 updated to later versions to merge in upstream changes.
 
+### Initialize local Repository
+
+```sh
+mkdir workspace
+cd workspace
+git init
+
+```
+
 ### Fetch Command
 
 <!-- @fetchPackage @verifyGuides-->
@@ -102,6 +111,15 @@ resolve the subdirectory version.
 `package-examples/helloworld-set/v0.3.0` if it exists, otherwise it is
 resolved to the tag `v0.3.0`.
 {{% /pageinfo %}}
+
+### Commit Local Repository 1st Version
+
+```sh
+git add .
+git commit -m "init"
+
+```
+
 
 ## Edit the contents
 
@@ -166,13 +184,11 @@ kpt will throw an error if trying to update a package and the git repo
 has uncommitted changes.
 {{% /pageinfo %}}
 
-Move into the directory where you cloned the repo (helloworld in thie example)
 
 <!-- @commitLocalChanges @verifyGuides-->
 ```sh
-git init
 git add .
-git commit -m "add helloworld package at v0.3.0"
+git commit -m "local package edits"
 ```
 
 ## Merge upstream changes
@@ -186,7 +202,7 @@ You need to perform the command below from the directory where you cloned the re
 
 <!-- @mergeUpdates @verifyGuides-->
 ```sh
-kpt pkg update .@v0.5.0 --strategy=resource-merge
+kpt pkg update helloworld@v0.5.0 --strategy=resource-merge
 ```
 
 Update the local package to the upstream version v0.5.0 by doing a 3-way

--- a/site/content/en/guides/consumer/update/_index.md
+++ b/site/content/en/guides/consumer/update/_index.md
@@ -120,7 +120,6 @@ git commit -m "init"
 
 ```
 
-
 ## Edit the contents
 
 Edit the contents of the package by making changes to it.


### PR DESCRIPTION
Had an error when tried to run kpt pkg update helloworld@v0.5.0 --strategy=resource-merge from outside the local git repo using the folder name "helloworld", to make this work had to move inside the helloworld directory, where i performed git init before, and use . as path.
Propose to change the content to match the above instructions.

<!--  Thanks for sending a pull request!  Here are some tips for you:

In your PR, please ensure that you include the following information:
* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

If you are updating the documentation, please do it in separate PRs from
code changes and the commit message should start with `Docs:`.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
