### PR TITLE
Support git master rename to main

### DIFF
--- a/internal/cmddiff/cmddiff.go
+++ b/internal/cmddiff/cmddiff.go
@@ -91,9 +91,6 @@ func (r *Runner) preRunE(c *cobra.Command, args []string) error {
 	} else {
 		r.DiffType = diff.DiffType(r.diffType)
 	}
-	if version == "" {
-		version = "master"
-	}
 
 	r.Path = dir
 	r.Ref = version

--- a/internal/cmdinit/cmdinit_test.go
+++ b/internal/cmdinit/cmdinit_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/kpt/internal/cmdinit"
+	"github.com/GoogleContainerTools/kpt/internal/gitutil"
+	"github.com/GoogleContainerTools/kpt/internal/testutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/man"
 	"github.com/stretchr/testify/assert"
 )
@@ -134,5 +136,61 @@ func TestCmd_failNotExists(t *testing.T) {
 	err = r.Command.Execute()
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "does not exist")
+	}
+}
+
+func TestGitUtil_DefaultRef(t *testing.T) {
+	// set up git repo with both main and master branches
+	g, _, clean := testutil.SetupDefaultRepoAndWorkspace(t)
+	defer clean()
+
+	// check if master is picked as default if both main and master branches exist
+	defaultRef, err := gitutil.DefaultRef("file://" + g.RepoDirectory)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	if !assert.Equal(t, "master", defaultRef) {
+		t.FailNow()
+	}
+	if !assert.Equal(t, "master", defaultRef) {
+		t.FailNow()
+	}
+
+	err = g.CheckoutBranch("main", false)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	// delete master branch and check if main is selected as default
+	err = g.DeleteBranch("master")
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	defaultRef, err = gitutil.DefaultRef("file://" + g.RepoDirectory)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	if !assert.Equal(t, "main", defaultRef) {
+		t.FailNow()
+	}
+
+	err = g.CheckoutBranch("master", true)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	// delete main branch and check if master is selected as default
+	err = g.DeleteBranch("main")
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	defaultRef, err = gitutil.DefaultRef("file://" + g.RepoDirectory)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	if !assert.Equal(t, "master", defaultRef) {
+		t.FailNow()
 	}
 }

--- a/internal/util/diff/diff.go
+++ b/internal/util/diff/diff.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/GoogleContainerTools/kpt/internal/gitutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/get"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
@@ -131,6 +132,13 @@ func (c *Command) Run() error {
 	}()
 
 	var upstreamTargetPkg string
+
+	if c.Ref == "" {
+		c.Ref, err = gitutil.DefaultRef(kptFile.Upstream.Git.Repo)
+		if err != nil {
+			return err
+		}
+	}
 
 	if c.DiffType == DiffTypeRemote ||
 		c.DiffType == DiffTypeCombined ||

--- a/internal/util/get/get_test.go
+++ b/internal/util/get/get_test.go
@@ -607,7 +607,7 @@ func TestCommand_Run_failInvalidRepo(t *testing.T) {
 	if !assert.Error(t, err) {
 		t.FailNow()
 	}
-	if !assert.Contains(t, err.Error(), "trouble fetching") {
+	if !assert.Contains(t, err.Error(), "failed to lookup master(or main) branch") {
 		t.FailNow()
 	}
 }

--- a/internal/util/update/fastforward.go
+++ b/internal/util/update/fastforward.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/GoogleContainerTools/kpt/internal/gitutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/get"
 	"github.com/GoogleContainerTools/kpt/internal/util/git"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
@@ -58,7 +59,11 @@ func errorIfChanged(g kptfile.Git, pkgPath string) error {
 		Path:    g.Directory,
 		Ref:     g.Commit,
 	}
-	err := get.ClonerUsingGitExec(original)
+	defaultRef, err := gitutil.DefaultRef(g.Repo)
+	if err != nil {
+		return err
+	}
+	err = get.ClonerUsingGitExec(original, defaultRef)
 	if err != nil {
 		return errors.Errorf("failed cloning git repo: %v", err)
 	}

--- a/internal/util/update/gitpatch.go
+++ b/internal/util/update/gitpatch.go
@@ -131,7 +131,11 @@ func (u *GitPatchUpdater) patchLocalPackage() error {
 			fmt.Fprintf(os.Stderr, "cleanup remote failed: %v\n", err)
 		}
 	}()
-	if err := g.Run("fetch", alphaGitPatchRemote, "master"); err != nil {
+	defaultRef, err := gitutil.DefaultRef(u.UpdateOptions.ToRepo)
+	if err != nil {
+		return err
+	}
+	if err := g.Run("fetch", alphaGitPatchRemote, defaultRef); err != nil {
 		return errors.Errorf("update failed: failure running git fetch %v: %s %s",
 			err, g.Stderr.String(), g.Stdout.String())
 	}


### PR DESCRIPTION
@mortent @mikebz 

This PR is to support git master rename to main. https://github.com/github/renaming#later-this-year

To support backwards compatibility, `master` will be considered as default if master branch exists.

Related Issue: https://github.com/GoogleContainerTools/kpt/issues/1115

Tests were passing on my local but are failing here. Will figure it out.