### PR TITLE
Adds labels/annotations to inventory section of Kptfile

### DIFF
--- a/pkg/kptfile/pkgfile.go
+++ b/pkg/kptfile/pkgfile.go
@@ -61,7 +61,9 @@ type Inventory struct {
 	Namespace string `yaml:"namespace,omitempty"`
 	Name      string `yaml:"name,omitempty"`
 	// Unique label to identify inventory object in cluster.
-	InventoryID string `yaml:"inventoryID,omitempty"`
+	InventoryID string            `yaml:"inventoryID,omitempty"`
+	Labels      map[string]string `yaml:"labels,omitempty"`
+	Annotations map[string]string `yaml:"annotations,omitempty"`
 }
 
 type Functions struct {


### PR DESCRIPTION
* Adds `Labels` and `Annotations` fields to the `Inventory` section of the `Kptfile` struct.
* Addresses the following kpt issue: https://github.com/GoogleContainerTools/kpt/issues/1082