### PR TITLE
Improve test coverage for updates of packages

### DIFF
--- a/e2e/e2eutils.go
+++ b/e2e/e2eutils.go
@@ -34,7 +34,7 @@ func SetupGitRepo(t *testing.T) (*testutil.TestGitRepo, string, func()) {
 		t.FailNow()
 	}
 
-	g, _, c := testutil.SetupDefaultRepoAndWorkspace(t)
+	g, _, c := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	upstream := g.RepoDirectory
 
 	clean := func() {

--- a/internal/cmddiff/cmddiff_test.go
+++ b/internal/cmddiff/cmddiff_test.go
@@ -45,9 +45,9 @@ func TestCmdInvalidDiffTool(t *testing.T) {
 }
 
 func TestCmdExecute(t *testing.T) {
-	g, dir, clean := testutil.SetupDefaultRepoAndWorkspace(t)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
-	dest := filepath.Join(dir, g.RepoName)
+	dest := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 
 	getRunner := cmdget.NewRunner("")
 	getRunner.Command.SetArgs([]string{"file://" + g.RepoDirectory + ".git/", "./"})

--- a/internal/cmdget/cmdget_test.go
+++ b/internal/cmdget/cmdget_test.go
@@ -32,9 +32,9 @@ import (
 
 // TestCmd_execute tests that get is correctly invoked.
 func TestCmd_execute(t *testing.T) {
-	g, dir, clean := testutil.SetupDefaultRepoAndWorkspace(t)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
-	dest := filepath.Join(dir, g.RepoName)
+	dest := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 
 	r := cmdget.NewRunner("kpt")
 	r.Command.SetArgs([]string{"file://" + g.RepoDirectory + ".git/", "./"})
@@ -73,9 +73,9 @@ func TestCmd_execute(t *testing.T) {
 // is main and master branch doesn't exist
 func TestCmdMainBranch_execute(t *testing.T) {
 	// set up git repository with master and main branches
-	g, dir, clean := testutil.SetupDefaultRepoAndWorkspace(t)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
-	dest := filepath.Join(dir, g.RepoName)
+	dest := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	err := g.CheckoutBranch("main", false)
 	if !assert.NoError(t, err) {
 		t.FailNow()

--- a/internal/cmdinit/cmdinit_test.go
+++ b/internal/cmdinit/cmdinit_test.go
@@ -141,7 +141,7 @@ func TestCmd_failNotExists(t *testing.T) {
 
 func TestGitUtil_DefaultRef(t *testing.T) {
 	// set up git repo with both main and master branches
-	g, _, clean := testutil.SetupDefaultRepoAndWorkspace(t)
+	g, _, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
 
 	// check if master is picked as default if both main and master branches exist

--- a/internal/cmdupdate/cmdupdate_test.go
+++ b/internal/cmdupdate/cmdupdate_test.go
@@ -32,13 +32,13 @@ import (
 
 // TestCmd_execute verifies that update is correctly invoked.
 func TestCmd_execute(t *testing.T) {
-	g, dir, clean := testutil.SetupDefaultRepoAndWorkspace(t)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
-	dest := filepath.Join(dir, g.RepoName)
+	dest := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 
 	// clone the repo
 	getCmd := cmdget.NewRunner("kpt")
-	getCmd.Command.SetArgs([]string{"file://" + g.RepoDirectory + ".git", dir})
+	getCmd.Command.SetArgs([]string{"file://" + g.RepoDirectory + ".git", w.WorkspaceDirectory})
 	err := getCmd.Command.Execute()
 	if !assert.NoError(t, err) {
 		return
@@ -46,7 +46,7 @@ func TestCmd_execute(t *testing.T) {
 	if !g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset1), dest) {
 		return
 	}
-	gitRunner := gitutil.NewLocalGitRunner(dir)
+	gitRunner := gitutil.NewLocalGitRunner(w.WorkspaceDirectory)
 	if !assert.NoError(t, gitRunner.Run("add", ".")) {
 		return
 	}
@@ -64,7 +64,7 @@ func TestCmd_execute(t *testing.T) {
 
 	// update the cloned package
 	updateCmd := cmdupdate.NewRunner("kpt")
-	if !assert.NoError(t, os.Chdir(dir)) {
+	if !assert.NoError(t, os.Chdir(w.WorkspaceDirectory)) {
 		return
 	}
 	updateCmd.Command.SetArgs([]string{g.RepoName, "--strategy", "fast-forward"})
@@ -106,13 +106,13 @@ func TestCmd_execute(t *testing.T) {
 }
 
 func TestCmd_failUnCommitted(t *testing.T) {
-	g, dir, clean := testutil.SetupDefaultRepoAndWorkspace(t)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
-	dest := filepath.Join(dir, g.RepoName)
+	dest := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 
 	// clone the repo
 	getCmd := cmdget.NewRunner("kpt")
-	getCmd.Command.SetArgs([]string{"file://" + g.RepoDirectory + ".git", dir})
+	getCmd.Command.SetArgs([]string{"file://" + g.RepoDirectory + ".git", w.WorkspaceDirectory})
 	err := getCmd.Command.Execute()
 	if !assert.NoError(t, err) {
 		return
@@ -132,7 +132,7 @@ func TestCmd_failUnCommitted(t *testing.T) {
 
 	// update the cloned package
 	updateCmd := cmdupdate.NewRunner("kpt")
-	if !assert.NoError(t, os.Chdir(dir)) {
+	if !assert.NoError(t, os.Chdir(w.WorkspaceDirectory)) {
 		return
 	}
 	updateCmd.Command.SetArgs([]string{g.RepoName})

--- a/internal/testutil/dataset/builder.go
+++ b/internal/testutil/dataset/builder.go
@@ -1,0 +1,172 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dataset
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+var (
+	deploymentResourceManifest = `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment
+  labels:
+    app: nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80
+`
+
+	configMapResourceManifest = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configmap
+data:
+  foo: bar
+`
+)
+
+var (
+	DeploymentResource = "deployment"
+	ConfigMapResource  = "configmap"
+	resources          = map[string]resourceInfo{
+		DeploymentResource: {
+			filename: "deployment.yaml",
+			manifest: deploymentResourceManifest,
+		},
+		ConfigMapResource: {
+			filename: "configmap.yaml",
+			manifest: configMapResourceManifest,
+		},
+	}
+)
+
+type resourceInfo struct {
+	filename string
+	manifest string
+}
+
+// Pkg represents a package that can be created on the file system
+// by using the Build function
+type Pkg struct {
+	name string
+
+	kptfile bool
+
+	resources []string
+
+	subPkgs []*Pkg
+}
+
+// NewPackage creates a new package for testing.
+func NewPackage(name string) *Pkg {
+	return &Pkg{
+		name: name,
+	}
+}
+
+// WithKptfile configures the current package to have a Kptfile
+func (p *Pkg) WithKptfile() *Pkg {
+	p.kptfile = true
+	return p
+}
+
+// WithResource configures the package to include the provided resource
+func (p *Pkg) WithResource(resource string) *Pkg {
+	p.resources = append(p.resources, resource)
+	return p
+}
+
+// WithSubPackages adds the provided packages as subpackages to the current
+// package
+func (p *Pkg) WithSubPackages(ps ...*Pkg) *Pkg {
+	p.subPkgs = append(p.subPkgs, ps...)
+	return p
+}
+
+// Build outputs the current data structure as a set of (nested) package
+// in the provided path.
+func (p *Pkg) Build(path string) error {
+	_, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	return buildRecursive(path, p)
+}
+
+// Name returns the name of the current package
+func (p *Pkg) Name() string {
+	return p.name
+}
+
+func buildRecursive(path string, pkg *Pkg) error {
+	pkgPath := filepath.Join(path, pkg.name)
+	err := os.Mkdir(pkgPath, 0700)
+	if err != nil {
+		return err
+	}
+
+	if pkg.kptfile {
+		err := ioutil.WriteFile(filepath.Join(pkgPath, "Kptfile"), []byte(`
+apiVersion: krm.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: kpt
+`), 0600)
+		if err != nil {
+			return err
+		}
+	}
+
+	for i := range pkg.resources {
+		r := pkg.resources[i]
+		info, ok := resources[r]
+		if !ok {
+			return fmt.Errorf("unknown resource %s", r)
+		}
+		err = ioutil.WriteFile(filepath.Join(pkgPath, info.filename), []byte(info.manifest), 0600)
+		if err != nil {
+			return err
+		}
+	}
+
+	for i := range pkg.subPkgs {
+		subPkg := pkg.subPkgs[i]
+		err = buildRecursive(pkgPath, subPkg)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/util/diff/diff_test.go
+++ b/internal/util/diff/diff_test.go
@@ -44,7 +44,7 @@ import (
 // 5. Run remote diff between master and cloned
 func TestCommand_RunRemoteDiff(t *testing.T) {
 	t.SkipNow()
-	g, dir, clean := testutil.SetupDefaultRepoAndWorkspace(t)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
 
 	// create a commit with dataset2 and tag it v2, then add another commit on top with dataset3
@@ -72,7 +72,7 @@ func TestCommand_RunRemoteDiff(t *testing.T) {
 		Destination: filepath.Base(g.RepoDirectory)}.Run()
 	assert.NoError(t, err)
 
-	localPkg := filepath.Join(dir, g.RepoName)
+	localPkg := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 
 	diffOutput := &bytes.Buffer{}
 
@@ -116,7 +116,7 @@ func TestCommand_RunRemoteDiff(t *testing.T) {
 // 5. add more data to the master branch, commit it
 // 5. Run combined diff between master and cloned
 func TestCommand_RunCombinedDiff(t *testing.T) {
-	g, dir, clean := testutil.SetupDefaultRepoAndWorkspace(t)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
 
 	// create a commit with dataset2 and tag it v2, then add another commit on top with dataset3
@@ -144,7 +144,7 @@ func TestCommand_RunCombinedDiff(t *testing.T) {
 		Destination: filepath.Base(g.RepoDirectory)}.Run()
 	assert.NoError(t, err)
 
-	localPkg := filepath.Join(dir, g.RepoName)
+	localPkg := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 
 	diffOutput := &bytes.Buffer{}
 
@@ -189,7 +189,7 @@ func TestCommand_RunCombinedDiff(t *testing.T) {
 // 5. Update cloned package with dataset3
 // 6. Run remote diff and verify the output
 func TestCommand_Run_LocalDiff(t *testing.T) {
-	g, dir, clean := testutil.SetupDefaultRepoAndWorkspace(t)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
 
 	// create a commit with dataset2 and tag it v2, then add another commit on top with dataset3
@@ -210,7 +210,7 @@ func TestCommand_Run_LocalDiff(t *testing.T) {
 		Destination: filepath.Base(g.RepoDirectory)}.Run()
 	assert.NoError(t, err)
 
-	localPkg := filepath.Join(dir, g.RepoName)
+	localPkg := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 
 	// make changes in local package
 	err = copyutil.CopyDir(filepath.Join(g.DatasetDirectory, testutil.Dataset3), localPkg)

--- a/internal/util/get/get_test.go
+++ b/internal/util/get/get_test.go
@@ -43,7 +43,7 @@ func TestCommand_Run_failNoRevision(t *testing.T) {
 // - destination directory should match the base name of the repo
 // - KptFile should be populated with values pointing to the origin
 func TestCommand_Run(t *testing.T) {
-	g, dir, clean := testutil.SetupDefaultRepoAndWorkspace(t)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
 
 	err := Command{Git: kptfile.Git{
@@ -55,7 +55,7 @@ func TestCommand_Run(t *testing.T) {
 	assert.NoError(t, err)
 
 	// verify the cloned contents matches the repository
-	r := filepath.Join(dir, g.RepoName)
+	r := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset1), r)
 
 	// verify the KptFile contains the expected values
@@ -91,7 +91,7 @@ func TestCommand_Run(t *testing.T) {
 // - KptFile should have the subdir listed
 func TestCommand_Run_subdir(t *testing.T) {
 	subdir := "java"
-	g, dir, clean := testutil.SetupDefaultRepoAndWorkspace(t)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
 
 	err := Command{Git: kptfile.Git{
@@ -101,7 +101,7 @@ func TestCommand_Run_subdir(t *testing.T) {
 	assert.NoError(t, err)
 
 	// verify the cloned contents matches the repository
-	r := filepath.Join(dir, subdir)
+	r := filepath.Join(w.WorkspaceDirectory, subdir)
 	g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset1, subdir), r)
 
 	// verify the KptFile contains the expected values
@@ -135,14 +135,14 @@ func TestCommand_Run_subdir(t *testing.T) {
 // than using the name of the source repo.
 func TestCommand_Run_destination(t *testing.T) {
 	dest := "my-dataset"
-	g, dir, clean := testutil.SetupDefaultRepoAndWorkspace(t)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
 
 	err := Command{Git: kptfile.Git{Repo: g.RepoDirectory, Ref: "master", Directory: "/"}, Destination: dest}.Run()
 	assert.NoError(t, err)
 
 	// verify the cloned contents matches the repository
-	r := filepath.Join(dir, dest)
+	r := filepath.Join(w.WorkspaceDirectory, dest)
 	g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset1), r)
 
 	// verify the KptFile contains the expected values
@@ -179,7 +179,7 @@ func TestCommand_Run_destination(t *testing.T) {
 func TestCommand_Run_subdirAndDestination(t *testing.T) {
 	subdir := "java"
 	dest := "new-java"
-	g, dir, clean := testutil.SetupDefaultRepoAndWorkspace(t)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
 
 	err := Command{
@@ -189,7 +189,7 @@ func TestCommand_Run_subdirAndDestination(t *testing.T) {
 	assert.NoError(t, err)
 
 	// verify the cloned contents matches the repository
-	r := filepath.Join(dir, dest)
+	r := filepath.Join(w.WorkspaceDirectory, dest)
 	g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset1, subdir), r)
 
 	// verify the KptFile contains the expected values
@@ -227,7 +227,7 @@ func TestCommand_Run_subdirAndDestination(t *testing.T) {
 // 4. clone the new branch
 // 5. verify contents match the new branch
 func TestCommand_Run_branch(t *testing.T) {
-	g, dir, clean := testutil.SetupDefaultRepoAndWorkspace(t)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
 
 	// add commits to the exp branch
@@ -251,7 +251,7 @@ func TestCommand_Run_branch(t *testing.T) {
 	assert.NoError(t, err)
 
 	// verify the cloned contents matches the repository
-	r := filepath.Join(dir, g.RepoName)
+	r := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset2), r)
 
 	// verify the KptFile contains the expected values
@@ -287,7 +287,7 @@ func TestCommand_Run_branch(t *testing.T) {
 // 4. clone at the tag
 // 5. verify the clone has the data from the tagged version
 func TestCommand_Run_tag(t *testing.T) {
-	g, dir, clean := testutil.SetupDefaultRepoAndWorkspace(t)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
 
 	// create a commit with dataset2 and tag it v2, then add another commit on top with dataset3
@@ -316,7 +316,7 @@ func TestCommand_Run_tag(t *testing.T) {
 	assert.NoError(t, err)
 
 	// verify the cloned contents matches the repository
-	r := filepath.Join(dir, g.RepoName)
+	r := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset2), r)
 
 	// verify the KptFile contains the expected values
@@ -351,7 +351,7 @@ func TestCommand_Run_tag(t *testing.T) {
 // 3. clone the master branch again
 // 4. verify the new master branch data is present
 func TestCommand_Run_clean(t *testing.T) {
-	g, dir, clean := testutil.SetupDefaultRepoAndWorkspace(t)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
 
 	err := Command{
@@ -364,7 +364,7 @@ func TestCommand_Run_clean(t *testing.T) {
 	assert.NoError(t, err)
 
 	// verify the cloned contents matches the repository
-	r := filepath.Join(dir, g.RepoName)
+	r := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset1), r)
 
 	g.AssertKptfile(t, r, kptfile.KptFile{
@@ -439,7 +439,7 @@ func TestCommand_Run_clean(t *testing.T) {
 // 2. clone a non-existing branch
 // 3. verify the master branch data is still present
 func TestCommand_Run_failClean(t *testing.T) {
-	g, dir, clean := testutil.SetupDefaultRepoAndWorkspace(t)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
 
 	err := Command{Git: kptfile.Git{
@@ -453,7 +453,7 @@ func TestCommand_Run_failClean(t *testing.T) {
 	assert.NoError(t, err)
 
 	// verify the cloned contents matches the repository
-	r := filepath.Join(dir, g.RepoName)
+	r := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset1), r)
 	g.AssertKptfile(t, r, kptfile.KptFile{
 		ResourceMeta: yaml.ResourceMeta{
@@ -523,7 +523,7 @@ func TestCommand_Run_failClean(t *testing.T) {
 // TestCommand_Run_failExistingDir verifies that command will fail without changing anything if the
 // directory already exists
 func TestCommand_Run_failExistingDir(t *testing.T) {
-	g, dir, clean := testutil.SetupDefaultRepoAndWorkspace(t)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
 
 	err := Command{
@@ -536,7 +536,7 @@ func TestCommand_Run_failExistingDir(t *testing.T) {
 	assert.NoError(t, err)
 
 	// verify the cloned contents matches the repository
-	r := filepath.Join(dir, g.RepoName)
+	r := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset1), r)
 	g.AssertKptfile(t, r, kptfile.KptFile{
 		ResourceMeta: yaml.ResourceMeta{
@@ -600,7 +600,7 @@ func TestCommand_Run_failExistingDir(t *testing.T) {
 }
 
 func TestCommand_Run_failInvalidRepo(t *testing.T) {
-	_, _, clean := testutil.SetupDefaultRepoAndWorkspace(t)
+	_, _, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
 
 	err := Command{Git: kptfile.Git{Repo: "foo", Directory: "/", Ref: "refs/heads/master"}, Destination: "foo"}.Run()
@@ -613,7 +613,7 @@ func TestCommand_Run_failInvalidRepo(t *testing.T) {
 }
 
 func TestCommand_Run_failInvalidBranch(t *testing.T) {
-	g, _, clean := testutil.SetupDefaultRepoAndWorkspace(t)
+	g, _, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
 
 	err := Command{Git: kptfile.Git{Repo: g.RepoDirectory, Directory: "/", Ref: "refs/heads/foo"}, Destination: filepath.Base(g.RepoDirectory)}.Run()
@@ -629,7 +629,7 @@ func TestCommand_Run_failInvalidBranch(t *testing.T) {
 }
 
 func TestCommand_Run_failInvalidTag(t *testing.T) {
-	g, _, clean := testutil.SetupDefaultRepoAndWorkspace(t)
+	g, _, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
 
 	err := Command{Git: kptfile.Git{Repo: g.RepoDirectory, Directory: "/", Ref: "refs/tags/foo"}, Destination: filepath.Base(g.RepoDirectory)}.Run()


### PR DESCRIPTION
This PR adds some additional tests to cover handling of subdirectories and subpackages during update. In order to be able to test some of the scenarios, the test framework has been updated. 
Note that some of the added tests do have some surprising results, that most likely means there are bugs. This PR does not try to fix those, I will look at that in subsequent PRs. This only affects tests and test code.