### PR TITLE
docs: fix broken links for fn

### DIFF
--- a/site/content/en/concepts/functions/_index.md
+++ b/site/content/en/concepts/functions/_index.md
@@ -98,7 +98,7 @@ pipeline. Get detailed tutorials on how to use `kpt fn export` from the
 
 [architecture influences]: ../architecture/#influences
 [sources catalog]: ../../guides/consumer/function/sources
-[sinks catalog]: ../../guides/consumer/function/sinks
+[sinks catalog]: ../../guides/consumer/function/catalog/sinks
 [spec]: https://github.com/kubernetes-sigs/kustomize/blob/master/cmd/config/docs/api-conventions/functions-spec.md
 [Export a Workflow]: ../../guides/consumer/function/export/
 [function producer docs]: ../../guides/producer/functions/

--- a/site/content/en/faq/_index.md
+++ b/site/content/en/faq/_index.md
@@ -114,7 +114,7 @@ A: [Please reach out!][contact]
 [declarative application management in kubernetes]: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/declarative-application-management.md
 [setters]: ../reference/cfg/set/
 [functions]: ../reference/fn/run/
-[source functions]: ../guides/consumer/function/sources
+[source functions]: ../guides/consumer/function/catalog/sources
 [Functions User Guide]: ../guides/consumer/function/
 [updating]: ../reference/pkg/update/
 [gcr.io/kpt-dev/kpt]: https://gcr.io/kpt-dev/kpt

--- a/site/content/en/guides/consumer/function/catalog/generators/_index.md
+++ b/site/content/en/guides/consumer/function/catalog/generators/_index.md
@@ -25,4 +25,4 @@ a namespace with organization-mandated config defaults.
 
 - Learn more ways of using the kpt fn command from the [reference] doc.
 
-[reference]: ../../../../reference/fn/run/
+[reference]: ../../../../../reference/fn/run/

--- a/site/content/en/guides/consumer/function/catalog/sinks/_index.md
+++ b/site/content/en/guides/consumer/function/catalog/sinks/_index.md
@@ -27,4 +27,4 @@ Instead, the function typically writes configurations to an external system
 
 - Learn more ways of using the kpt fn command from the [reference] doc.
 
-[reference]: ../../../../reference/fn/run/
+[reference]: ../../../../../reference/fn/run/

--- a/site/content/en/guides/consumer/function/catalog/sources/_index.md
+++ b/site/content/en/guides/consumer/function/catalog/sources/_index.md
@@ -29,4 +29,4 @@ from an external system (e.g. reading files from a filesystem).
 
 - Learn more ways of using the kpt fn command from the [reference] doc.
 
-[reference]: ../../../../reference/fn/run/
+[reference]: ../../../../../reference/fn/run/

--- a/site/content/en/guides/consumer/function/catalog/transformers/_index.md
+++ b/site/content/en/guides/consumer/function/catalog/transformers/_index.md
@@ -29,4 +29,4 @@ the image used in a pod, without adding new resources.
 
 - Learn more ways of using the kpt fn command from the [reference] doc.
 
-[reference]: ../../../../reference/fn/run/
+[reference]: ../../../../../reference/fn/run/

--- a/site/content/en/guides/consumer/function/catalog/validators/_index.md
+++ b/site/content/en/guides/consumer/function/catalog/validators/_index.md
@@ -33,4 +33,4 @@ using a validator function.
 
 - Learn more ways of using the kpt fn command from the [reference] doc.
 
-[reference]: ../../../../reference/fn/run/
+[reference]: ../../../../../reference/fn/run/

--- a/site/content/en/guides/producer/functions/_index.md
+++ b/site/content/en/guides/producer/functions/_index.md
@@ -166,8 +166,8 @@ results:
 [Go Fn Lib]: ./golang/
 [TS SDK]: ./ts/
 [`kpt fn source`]: ../../../reference/fn/source/
-[`helm-template`]: gcr.io/kpt-functions/helm-template/
-[`kpt fn sink`]: ../../../refernce/fn/sink/
+[`helm-template`]: https://gcr.io/kpt-functions/helm-template/
+[`kpt fn sink`]: ../../../reference/fn/sink/
 [run functions]: ../../consumer/function/
 [functions concepts]: ../../../concepts/functions/
 [fn command reference]: ../../../reference/fn/

--- a/site/content/en/guides/producer/functions/container/_index.md
+++ b/site/content/en/guides/producer/functions/container/_index.md
@@ -67,5 +67,5 @@ the example.
 [kpt-functions-sdk]: https://github.com/GoogleContainerTools/kpt-functions-sdk
 [go libraries]: ../golang/
 [Functions Developer Guide]: ../
-[functions concepts]: ../../../../../concepts/functions/
+[functions concepts]: ../../../../concepts/functions/
 [fn command reference]: ../../../../reference/fn/

--- a/site/content/en/guides/producer/functions/golang/_index.md
+++ b/site/content/en/guides/producer/functions/golang/_index.md
@@ -351,5 +351,5 @@ cmd := framework.Command(resourceList, func() error {
 [RNode link]: https://pkg.go.dev/sigs.k8s.io/kustomize/kyaml/yaml/#RNode
 [Pipe link]: https://pkg.go.dev/sigs.k8s.io/kustomize/kyaml/yaml/#RNode.Pipe
 [run functions]: ../../../consumer/function/
-[fn command reference]: ../../../reference/fn/
-[functions concepts]: ../../../concepts/functions/
+[fn command reference]: ../../../../reference/fn/
+[functions concepts]: ../../../../concepts/functions/

--- a/site/content/en/reference/fn/sink/_index.md
+++ b/site/content/en/reference/fn/sink/_index.md
@@ -48,4 +48,4 @@ DIR:
 
 [sink function]: ../../../concepts/functions/#sink-function
 [functions concepts]: ../../../concepts/functions/
-[catalog]: ../../guides/consumer/function/sinks
+[catalog]: ../../../guides/consumer/function/catalog/sinks

--- a/site/content/en/reference/fn/source/_index.md
+++ b/site/content/en/reference/fn/source/_index.md
@@ -50,4 +50,4 @@ DIR:
 
 [source function]: ../../../concepts/functions/#source-function
 [functions concepts]: ../../../concepts/functions/
-[catalog]: ../../guides/consumer/function/sources
+[catalog]: ../../../guides/consumer/function/catalog/sources


### PR DESCRIPTION
Fixed a couple of broken links in kpt fn.

Some of the issues are related to either too few or too many `..`. 

An alternative is to always start from the root directory.
e.g. using the first file as an example. We use `/kpt/reference/fn/run/` instead of `../../../../../reference/fn/run/`
If we all agree that starting from root is better, we probably should change all of the docs.
