### PR TITLE
Fixes bug when validating ResourceGroup after storing zero inventory

### DIFF
--- a/pkg/live/inventoryrg.go
+++ b/pkg/live/inventoryrg.go
@@ -128,12 +128,18 @@ func (icm *InventoryResourceGroup) GetObject() (*unstructured.Unstructured, erro
 	}
 	// Create the inventory object by copying the template.
 	invCopy := icm.inv.DeepCopy()
-	// Adds the inventory ObjMetadata to the ResourceGroup "spec.resources" section
-	klog.V(4).Infof("storing inventory resources")
-	err := unstructured.SetNestedSlice(invCopy.UnstructuredContent(),
-		objs, "spec", "resources")
-	if err != nil {
-		return nil, err
+	// Adds or clears the inventory ObjMetadata to the ResourceGroup "spec.resources" section
+	if len(objs) == 0 {
+		klog.V(4).Infoln("clearing inventory resources")
+		unstructured.RemoveNestedField(invCopy.UnstructuredContent(),
+			"spec", "resources")
+	} else {
+		klog.V(4).Infof("storing inventory (%d) resources", len(objs))
+		err := unstructured.SetNestedSlice(invCopy.UnstructuredContent(),
+			objs, "spec", "resources")
+		if err != nil {
+			return nil, err
+		}
 	}
 	return invCopy, nil
 }


### PR DESCRIPTION
Fixes: https://github.com/GoogleContainerTools/kpt/issues/1209

* Fixes validation bug by properly clearing `spec.resources` field when there is no inventory.
* Tested manually, since this is a validation error from the API server.

Before:
```
$ kpt live apply ~/testdata/testdata-no-resources/
0 resource(s) applied. 0 created, 0 unchanged, 0 configured
pod/pod-c pruned
pod/pod-b pruned
pod/pod-a pruned
namespace/test-namespace prune skipped
The ResourceGroup "inventory-55488594" is invalid: spec.resources: Invalid value: "null": spec.resources in body must be of type array: "null"
```

After:
```
$ kpt live apply ~/testdata/testdata-no-resources/
0 resource(s) applied. 0 created, 0 unchanged, 0 configured
pod/pod-c pruned
pod/pod-b pruned
pod/pod-a pruned
namespace/test-namespace prune skipped
3 resource(s) pruned, 1 skipped

```