### PR TITLE
Fix ReadFile in kptfileutil to avoid reading Kptfile in wrong directory

### DIFF
--- a/pkg/kptfile/kptfileutil/util.go
+++ b/pkg/kptfile/kptfileutil/util.go
@@ -32,7 +32,7 @@ func ReadFile(dir string) (kptfile.KptFile, error) {
 
 	// if we are in a package subdirectory, find the parent dir with the Kptfile.
 	// this is necessary to parse the duck-commands for sub-directories of a package
-	for os.IsNotExist(err) && filepath.Dir(dir) != dir {
+	for os.IsNotExist(err) && filepath.Base(dir) == kptfile.KptFileName {
 		dir = filepath.Dir(dir)
 		f, err = os.Open(filepath.Join(dir, kptfile.KptFileName))
 	}


### PR DESCRIPTION
The `ReadFile` function kptfileutil would try to look for a Kptfile in the parent folder if one didn't exist in the current folder. This leads to situations where we end up reading the wrong Kptfile. 
This PR changes the behavior so we will strip of the last element of the path if it points to a Kptfile, but never look in any other directory.
