### PR TITLE
Remove use of golangplus test framework

### DIFF
--- a/internal/util/search/pathparser_test.go
+++ b/internal/util/search/pathparser_test.go
@@ -3,7 +3,7 @@ package search
 import (
 	"testing"
 
-	"github.com/golangplus/testing/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 type test struct {
@@ -78,7 +78,7 @@ func TestPathMatch(t *testing.T) {
 				ByPath: test.byPath,
 			}
 			actual := sr.pathMatch(test.traversedPath)
-			if !assert.Equal(t, "", actual, test.shouldMatch) {
+			if !assert.Equal(t, actual, test.shouldMatch) {
 				t.FailNow()
 			}
 		})


### PR DESCRIPTION
All other tests in the project use the github.com/stretchr/testify/assert framwork, so we should avoid using different testing frameworks.
