### PR TITLE
Package aware merge

### DIFF
--- a/internal/util/merge/merge3.go
+++ b/internal/util/merge/merge3.go
@@ -1,0 +1,165 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package merge
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/kio/filters"
+	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
+	"sigs.k8s.io/kustomize/kyaml/pathutil"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+const (
+	mergeSourceAnnotation = "config.kubernetes.io/merge-source"
+	mergeSourceOriginal   = "original"
+	mergeSourceUpdated    = "updated"
+	mergeSourceDest       = "dest"
+)
+
+// Merge3 performs a 3-way merge on the original, upstream and
+// destination packages. It provides support for doing this only for
+// the parent package and ignore any subpackages. Whenever the boundaries
+// of a package differs between original, upstream and destination, the
+// boundaries in destination will be used.
+type Merge3 struct {
+	OriginalPath       string
+	UpdatedPath        string
+	DestPath           string
+	MatchFilesGlob     []string
+	MergeOnPath        bool
+	IncludeSubPackages bool
+}
+
+func (m Merge3) Merge() error {
+	// If subpackages are not included when doing the merge, first
+	// look up the known subpackages in destination so we can make sure
+	// those are ignored when reading files from original and updated.
+	var relPaths []string
+	if !m.IncludeSubPackages {
+		var err error
+		relPaths, err = m.findExclusions()
+		if err != nil {
+			return err
+		}
+	}
+
+	var inputs []kio.Reader
+	dest := &kio.LocalPackageReadWriter{
+		PackagePath:        m.DestPath,
+		MatchFilesGlob:     m.MatchFilesGlob,
+		SetAnnotations:     map[string]string{mergeSourceAnnotation: mergeSourceDest},
+		IncludeSubpackages: m.IncludeSubPackages,
+		PackageFileName:    kptfile.KptFileName,
+	}
+	inputs = append(inputs, dest)
+
+	// Read the original package
+	inputs = append(inputs, PruningLocalPackageReader{
+		LocalPackageReader: kio.LocalPackageReader{
+			PackagePath:        m.OriginalPath,
+			MatchFilesGlob:     m.MatchFilesGlob,
+			SetAnnotations:     map[string]string{mergeSourceAnnotation: mergeSourceOriginal},
+			IncludeSubpackages: m.IncludeSubPackages,
+			PackageFileName:    kptfile.KptFileName,
+		},
+		Exclusions: relPaths,
+	})
+
+	// Read the updated package
+	inputs = append(inputs, PruningLocalPackageReader{
+		LocalPackageReader: kio.LocalPackageReader{
+			PackagePath:        m.UpdatedPath,
+			MatchFilesGlob:     m.MatchFilesGlob,
+			SetAnnotations:     map[string]string{mergeSourceAnnotation: mergeSourceUpdated},
+			IncludeSubpackages: m.IncludeSubPackages,
+			PackageFileName:    kptfile.KptFileName,
+		},
+		Exclusions: relPaths,
+	})
+
+	kyamlMerge := filters.Merge3{
+		MergeOnPath: m.MergeOnPath,
+	}
+
+	return kio.Pipeline{
+		Inputs:  inputs,
+		Filters: []kio.Filter{kyamlMerge},
+		Outputs: []kio.Writer{dest},
+	}.Execute()
+}
+
+func (m Merge3) findExclusions() ([]string, error) {
+	var relPaths []string
+	paths, err := pathutil.DirsWithFile(m.DestPath, kptfile.KptFileName, true)
+	if err != nil {
+		return relPaths, err
+	}
+
+	for _, p := range paths {
+		rel, err := filepath.Rel(m.DestPath, p)
+		if err != nil {
+			return relPaths, err
+		}
+		if rel == "." {
+			continue
+		}
+		relPaths = append(relPaths, rel)
+	}
+	return relPaths, nil
+}
+
+// PruningLocalPackageReader implements the Reader interface. It is similar
+// to the LocalPackageReader but allows for exclusion of subdirectories.
+type PruningLocalPackageReader struct {
+	LocalPackageReader kio.LocalPackageReader
+	Exclusions         []string
+}
+
+func (p PruningLocalPackageReader) Read() ([]*yaml.RNode, error) {
+	// Delegate reading the resources to the LocalPackageReader.
+	nodes, err := p.LocalPackageReader.Read()
+	if err != nil {
+		return nil, err
+	}
+
+	// Exclude any resources that exist underneath an excluded path.
+	var filteredNodes []*yaml.RNode
+	for _, node := range nodes {
+		n, err := node.Pipe(yaml.GetAnnotation(kioutil.PathAnnotation))
+		if err != nil {
+			return nil, err
+		}
+		path := n.YNode().Value
+		if p.isExcluded(path) {
+			continue
+		}
+		filteredNodes = append(filteredNodes, node)
+	}
+	return filteredNodes, nil
+}
+
+func (p PruningLocalPackageReader) isExcluded(path string) bool {
+	for _, e := range p.Exclusions {
+		if strings.HasPrefix(path, e) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/util/merge/merge3_test.go
+++ b/internal/util/merge/merge3_test.go
@@ -1,0 +1,182 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package merge
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/kpt/internal/testutil/pkgbuilder"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/kustomize/kyaml/copyutil"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+func TestMerge3_Nested_packages(t *testing.T) {
+	annotationSetter := yaml.SetAnnotation("foo", "bar")
+	labelSetter := yaml.SetLabel("bar", "foo")
+
+	testCases := []struct {
+		name               string
+		includeSubPackages bool
+		original           *pkgbuilder.Pkg
+		upstream           *pkgbuilder.Pkg
+		local              *pkgbuilder.Pkg
+		expected           *pkgbuilder.Pkg
+	}{
+		{
+			name:               "subpackages are merged if included",
+			includeSubPackages: true,
+			original:           createPkg(),
+			upstream:           createPkg(annotationSetter),
+			local:              createPkg(labelSetter),
+			expected:           createPkg(labelSetter, annotationSetter),
+		},
+		{
+			name:               "subpackages are not merged if not included",
+			includeSubPackages: false,
+			original:           createPkg(),
+			upstream:           createPkg(annotationSetter),
+			local:              createPkg(labelSetter),
+			expected: createPkgMultipleMutators(
+				[]yaml.Filter{
+					labelSetter,
+					annotationSetter,
+				},
+				[]yaml.Filter{
+					labelSetter,
+				},
+			),
+		},
+		{
+			name:               "local copy defines the package boundaries if different from upstream",
+			includeSubPackages: false,
+			original: pkgbuilder.NewPackage("base").
+				WithKptfile().
+				WithResource(pkgbuilder.DeploymentResource).
+				WithSubPackages(
+					pkgbuilder.NewPackage("a").
+						WithKptfile().
+						WithResource(pkgbuilder.DeploymentResource),
+				),
+			upstream: pkgbuilder.NewPackage("base").
+				WithKptfile().
+				WithResource(pkgbuilder.DeploymentResource, annotationSetter).
+				WithSubPackages(
+					pkgbuilder.NewPackage("a").
+						WithResource(pkgbuilder.DeploymentResource, annotationSetter),
+				),
+			local: pkgbuilder.NewPackage("base").
+				WithKptfile().
+				WithResource(pkgbuilder.DeploymentResource, labelSetter).
+				WithSubPackages(
+					pkgbuilder.NewPackage("a").
+						WithKptfile().
+						WithResource(pkgbuilder.DeploymentResource, labelSetter),
+				),
+			expected: pkgbuilder.NewPackage("base").
+				WithKptfile().
+				WithResource(pkgbuilder.DeploymentResource, labelSetter, annotationSetter).
+				WithSubPackages(
+					pkgbuilder.NewPackage("a").
+						WithKptfile().
+						WithResource(pkgbuilder.DeploymentResource, labelSetter),
+				),
+		},
+		{
+			name:               "upstream changes not included if in a different package",
+			includeSubPackages: false,
+			original: pkgbuilder.NewPackage("base").
+				WithKptfile().
+				WithResource(pkgbuilder.DeploymentResource).
+				WithSubPackages(
+					pkgbuilder.NewPackage("a").
+						WithKptfile().
+						WithResource(pkgbuilder.DeploymentResource),
+				),
+			upstream: pkgbuilder.NewPackage("base").
+				WithKptfile().
+				WithResource(pkgbuilder.DeploymentResource, annotationSetter).
+				WithSubPackages(
+					pkgbuilder.NewPackage("a").
+						WithKptfile().
+						WithResource(pkgbuilder.DeploymentResource, annotationSetter),
+				),
+			local: pkgbuilder.NewPackage("base").
+				WithKptfile().
+				WithResource(pkgbuilder.DeploymentResource, labelSetter).
+				WithSubPackages(
+					pkgbuilder.NewPackage("a"). // No Kptfile
+									WithResource(pkgbuilder.DeploymentResource, labelSetter),
+				),
+			expected: pkgbuilder.NewPackage("base").
+				WithKptfile().
+				WithResource(pkgbuilder.DeploymentResource, labelSetter, annotationSetter).
+				WithSubPackages(
+					pkgbuilder.NewPackage("a").
+						WithResource(pkgbuilder.DeploymentResource, labelSetter),
+				),
+		},
+	}
+
+	for i := range testCases {
+		test := testCases[i]
+		t.Run(test.name, func(t *testing.T) {
+			original := pkgbuilder.ExpandPkg(t, test.original)
+			updated := pkgbuilder.ExpandPkg(t, test.upstream)
+			local := pkgbuilder.ExpandPkg(t, test.local)
+			expected := pkgbuilder.ExpandPkg(t, test.expected)
+			err := Merge3{
+				OriginalPath:       original,
+				UpdatedPath:        updated,
+				DestPath:           local,
+				MergeOnPath:        true,
+				IncludeSubPackages: test.includeSubPackages,
+			}.Merge()
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			diffs, err := copyutil.Diff(local, expected)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			if !assert.Empty(t, diffs.List()) {
+				t.FailNow()
+			}
+		})
+	}
+}
+
+func createPkg(mutators ...yaml.Filter) *pkgbuilder.Pkg {
+	return createPkgMultipleMutators(mutators, mutators)
+}
+
+func createPkgMultipleMutators(packageMutators, subPackageMutators []yaml.Filter) *pkgbuilder.Pkg {
+	return pkgbuilder.NewPackage("base").
+		WithKptfile().
+		WithResource(pkgbuilder.DeploymentResource, packageMutators...).
+		WithSubPackages(
+			pkgbuilder.NewPackage("a").
+				WithKptfile().
+				WithResource(pkgbuilder.DeploymentResource, subPackageMutators...),
+			pkgbuilder.NewPackage("b").
+				WithResource(pkgbuilder.DeploymentResource, packageMutators...).
+				WithSubPackages(
+					pkgbuilder.NewPackage("c").
+						WithKptfile().
+						WithResource(pkgbuilder.DeploymentResource, subPackageMutators...),
+				),
+		)
+}


### PR DESCRIPTION
This provides 3-way merge functionality that is aware of kpt packages. It is a wrapper around the existing 3-way merge available in kyaml, but doesn't merge resources that belong in subpackages.

