### PR TITLE
Adds kpt live install-resource-group command

### DIFF
--- a/commands/installrg.go
+++ b/commands/installrg.go
@@ -1,0 +1,58 @@
+// Copyright 2020 Google LLC.
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/GoogleContainerTools/kpt/pkg/live"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/i18n"
+)
+
+// InstallRGRunner encapsulates fields for the kpt live install-resource-group command.
+type InstallRGRunner struct {
+	Command   *cobra.Command
+	ioStreams genericclioptions.IOStreams
+	factory   cmdutil.Factory
+}
+
+// GetInstallRGRunner returns a pointer to an initial InstallRGRunner structure.
+func GetInstallRGRunner(factory cmdutil.Factory, ioStreams genericclioptions.IOStreams) *InstallRGRunner {
+	r := &InstallRGRunner{
+		factory:   factory,
+		ioStreams: ioStreams,
+	}
+	cmd := &cobra.Command{
+		Use:                   "install-resource-group",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Install ResourceGroup custom resource definition as inventory object into APIServer"),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return r.Run(ioStreams.In, args)
+		},
+	}
+
+	r.Command = cmd
+	return r
+}
+
+// NewCmdInstallRG returns the cobra command for the install-resource-group command.
+func NewCmdInstallRG(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	return GetInstallRGRunner(f, ioStreams).Command
+}
+
+// Run executes the installation of the ResourceGroup custom resource definition. Uses
+// the current context of the kube config file (or the kube config flags) to
+// determine the APIServer to install the CRD.
+func (ir *InstallRGRunner) Run(reader io.Reader, args []string) error {
+	// Validate the number of arguments.
+	if len(args) > 0 {
+		return fmt.Errorf("too many arguments; install-resource-group takes no arguments")
+	}
+	// Apply the ResourceGroup CRD to the cluster, ignoring if it already exists.
+	return live.ApplyResourceGroupCRD(ir.factory)
+}

--- a/commands/livecmd.go
+++ b/commands/livecmd.go
@@ -127,7 +127,8 @@ func GetLiveCommand(name string, f util.Factory) *cobra.Command {
 		cmLoader := manifestreader.NewManifestLoader(f)
 		rgLoader := live.NewResourceGroupManifestLoader(f)
 		migrateCmd := GetMigrateRunner(cmProvider, rgProvider, cmLoader, rgLoader, ioStreams).Command
-		liveCmd.AddCommand(migrateCmd)
+		installRGCmd := GetInstallRGRunner(f, ioStreams).Command
+		liveCmd.AddCommand(migrateCmd, installRGCmd)
 	}
 
 	return liveCmd

--- a/e2e/live/testdata/install-rg-crd/example-resource-group.yaml
+++ b/e2e/live/testdata/install-rg-crd/example-resource-group.yaml
@@ -1,0 +1,20 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Example ResourceGroup custom resource
+apiVersion: "kpt.dev/v1alpha1"
+kind: ResourceGroup
+metadata:
+  namespace: default
+  name: example-inventory

--- a/e2e/live/testdata/inventory-template.yaml
+++ b/e2e/live/testdata/inventory-template.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # NOTE: auto-generated. Some fields should NOT be modified.
 # Date: 2020-11-19 12:50:49 PST
 #

--- a/e2e/live/testdata/test-case-1a/inventory-template.yaml
+++ b/e2e/live/testdata/test-case-1a/inventory-template.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # NOTE: auto-generated. Some fields should NOT be modified.
 # Date: 2020-11-17 02:17:32 PST
 #

--- a/e2e/live/testdata/test-case-1b/inventory-template.yaml
+++ b/e2e/live/testdata/test-case-1b/inventory-template.yaml
@@ -1,3 +1,17 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # NOTE: auto-generated. Some fields should NOT be modified.
 # Date: 2020-11-17 02:17:32 PST
 #

--- a/go.sum
+++ b/go.sum
@@ -683,8 +683,6 @@ k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89 h1:d4vVOjXm687F1iLSP2q3lyPPuyvTU
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7/go.mod h1:PHgbrJT7lCHcxMU+mDHEm+nx46H4zuuHZkDP6icnhu0=
-sigs.k8s.io/cli-utils v0.22.0 h1:IlobQOJxDvPAB2O1AO93Ve6prnTkQ29Z6NZuEao/Vj0=
-sigs.k8s.io/cli-utils v0.22.0/go.mod h1:Mt1gLc/Nfa7Z3Lhbfk72uT2Kc4GNyuX4oMqEN9FbPMs=
 sigs.k8s.io/cli-utils v0.22.1-0.20201117031003-fd39030f0508 h1:uty/Bj8/fa2xX6CUpeehTy0JeOj0CykbWB7asovZ1PU=
 sigs.k8s.io/cli-utils v0.22.1-0.20201117031003-fd39030f0508/go.mod h1:Mt1gLc/Nfa7Z3Lhbfk72uT2Kc4GNyuX4oMqEN9FbPMs=
 sigs.k8s.io/controller-runtime v0.6.0 h1:Fzna3DY7c4BIP6KwfSlrfnj20DJ+SeMBK8HSFvOk9NM=

--- a/internal/util/search/pathparser.go
+++ b/internal/util/search/pathparser.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package search
 
 import (

--- a/internal/util/search/pathparser_test.go
+++ b/internal/util/search/pathparser_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package search
 
 import (


### PR DESCRIPTION
* Adds `kpt live install-resource-group` command to add the ResourceGroup CRD to the cluster.
* Adds end-to-end test to test `kpt live install-resource-group` command
* Refactors `kpt live migrate` command to place the common CRD installation code into `inventoryrg.go`
* Refactors cluster deletion/creation for clean test suites in `end-to-end-test.sh`

Example output from relevant part of end-to-end test:
```
Setting Up Test Suite...
Deleting kind cluster...
Deleting kind cluster...COMPLETED
Creating kind cluster...
Creating kind cluster...COMPLETED
Setting Up Test Suite...COMPLETED

Testing kpt live install-resource-group
kpt live install-resource-group
.....SUCCESS
```