### PR TITLE
change group version of Kptfile to constants

### DIFF
--- a/pkg/kptfile/pkgfile.go
+++ b/pkg/kptfile/pkgfile.go
@@ -20,12 +20,17 @@ import (
 )
 
 // KptFileName is the name of the KptFile
-const KptFileName = "Kptfile"
+const (
+	KptFileName = "Kptfile"
+	KptFileGroup = "kpt.dev"
+	KptFileVersion = "v1alpha1"
+	KptFileAPIVersion = KptFileGroup + "/" + KptFileVersion
+)
 
 // TypeMeta is the TypeMeta for KptFile instances.
 var TypeMeta = yaml.ResourceMeta{
 	TypeMeta: yaml.TypeMeta{
-		APIVersion: "kpt.dev/v1alpha1",
+		APIVersion: KptFileAPIVersion,
 		Kind:       KptFileName,
 	},
 }


### PR DESCRIPTION
Move the Kptfile group, version, kind to package level constants so they can be used by consumer of the library.