### PR TITLE
change the inventory field to pointer

### DIFF
--- a/commands/initcmd.go
+++ b/commands/initcmd.go
@@ -130,7 +130,7 @@ func (io *KptInitOptions) updateKptfile() error {
 		return err
 	}
 	// Finally, set the inventory parameters in the Kptfile and write it.
-	kf.Inventory = kptfile.Inventory{
+	kf.Inventory = &kptfile.Inventory{
 		Namespace:   io.namespace,
 		Name:        io.name,
 		InventoryID: io.inventoryID,
@@ -160,17 +160,8 @@ func (io *KptInitOptions) validate() error {
 
 // kptfileInventoryEmpty returns true if the Inventory structure
 // in the Kptfile is empty; false otherwise.
-func kptfileInventoryEmpty(inv kptfile.Inventory) bool {
-	if len(inv.Name) > 0 {
-		return false
-	}
-	if len(inv.Namespace) > 0 {
-		return false
-	}
-	if len(inv.InventoryID) > 0 {
-		return false
-	}
-	return true
+func kptfileInventoryEmpty(inv *kptfile.Inventory) bool {
+	return inv == nil
 }
 
 // NewCmdInit returns the cobra command for the init command.

--- a/commands/migratecmd_test.go
+++ b/commands/migratecmd_test.go
@@ -167,16 +167,8 @@ func TestKptMigrate_updateKptfile(t *testing.T) {
 				if len(kf.Inventory.InventoryID) == 0 {
 					t.Errorf("inventory id not set in Kptfile")
 				}
-			} else {
-				if len(kf.Inventory.Namespace) != 0 {
-					t.Errorf("inventory name not set in Kptfile")
-				}
-				if len(kf.Inventory.Name) != 0 {
-					t.Errorf("inventory name not set in Kptfile")
-				}
-				if len(kf.Inventory.InventoryID) != 0 {
-					t.Errorf("inventory id not set in Kptfile")
-				}
+			} else if kf.Inventory != nil {
+				t.Errorf("inventory shouldn't be set during dryrun")
 			}
 		})
 	}

--- a/pkg/kptfile/pkgfile.go
+++ b/pkg/kptfile/pkgfile.go
@@ -21,9 +21,9 @@ import (
 
 // KptFileName is the name of the KptFile
 const (
-	KptFileName = "Kptfile"
-	KptFileGroup = "kpt.dev"
-	KptFileVersion = "v1alpha1"
+	KptFileName       = "Kptfile"
+	KptFileGroup      = "kpt.dev"
+	KptFileVersion    = "v1alpha1"
 	KptFileAPIVersion = KptFileGroup + "/" + KptFileVersion
 )
 
@@ -57,7 +57,7 @@ type KptFile struct {
 	Functions Functions `yaml:"functions,omitempty"`
 
 	// Parameters for inventory object.
-	Inventory Inventory `yaml:"inventory,omitempty"`
+	Inventory *Inventory `yaml:"inventory,omitempty"`
 }
 
 // Inventory encapsulates the parameters for the inventory object. All of the

--- a/pkg/live/rgpath.go
+++ b/pkg/live/rgpath.go
@@ -53,7 +53,7 @@ func (p *ResourceGroupPathManifestReader) Read() ([]*unstructured.Unstructured, 
 
 // generateInventoryObj returns the ResourceGroupInventory object using the
 // passed information.
-func generateInventoryObj(inv kptfile.Inventory) (*unstructured.Unstructured, error) {
+func generateInventoryObj(inv *kptfile.Inventory) (*unstructured.Unstructured, error) {
 	// Validate the parameters
 	name := strings.TrimSpace(inv.Name)
 	if name == "" {


### PR DESCRIPTION
This change is to use `inventory==nil` to determine if the inventory information is empty.
This check is also needed in Config Sync.