### PR TITLE
Fixes panic when inventory is empty

### DIFF
--- a/pkg/kptfile/kptfileutil/util.go
+++ b/pkg/kptfile/kptfileutil/util.go
@@ -15,9 +15,11 @@
 package kptfileutil
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
 	"sigs.k8s.io/kustomize/kyaml/errors"
@@ -109,4 +111,25 @@ func ReadFileStrict(pkgPath string) (kptfile.KptFile, error) {
 		}
 	}
 	return kf, nil
+}
+
+// ValidateInventory returns true and a nil error if the passed inventory
+// is valid; otherwise, false and the reason the inventory is not valid
+// is returned. A valid inventory must have a non-empty namespace, name,
+// and id.
+func ValidateInventory(inv *kptfile.Inventory) (bool, error) {
+	if inv == nil {
+		return false, fmt.Errorf("kptfile missing inventory section")
+	}
+	// Validate the name, namespace, and inventory id
+	if strings.TrimSpace(inv.Name) == "" {
+		return false, fmt.Errorf("kptfile inventory empty name")
+	}
+	if strings.TrimSpace(inv.Namespace) == "" {
+		return false, fmt.Errorf("kptfile inventory empty namespace")
+	}
+	if strings.TrimSpace(inv.InventoryID) == "" {
+		return false, fmt.Errorf("kptfile inventory missing inventoryID")
+	}
+	return true, nil
 }

--- a/pkg/kptfile/kptfileutil/util_test.go
+++ b/pkg/kptfile/kptfileutil/util_test.go
@@ -1,0 +1,56 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kptfileutil
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
+)
+
+// TestValidateInventory tests the ValidateInventory function.
+func TestValidateInventory(t *testing.T) {
+	// nil inventory should not validate
+	isValid, err := ValidateInventory(nil)
+	if isValid || err == nil {
+		t.Errorf("nil inventory should not validate")
+	}
+	// Empty inventory should not validate
+	inv := &kptfile.Inventory{}
+	isValid, err = ValidateInventory(inv)
+	if isValid || err == nil {
+		t.Errorf("empty inventory should not validate")
+	}
+	// Empty inventory parameters strings should not validate
+	inv = &kptfile.Inventory{
+		Namespace:   "",
+		Name:        "",
+		InventoryID: "",
+	}
+	isValid, err = ValidateInventory(inv)
+	if isValid || err == nil {
+		t.Errorf("empty inventory parameters strings should not validate")
+	}
+	// Inventory with non-empty namespace, name, and id should validate.
+	inv = &kptfile.Inventory{
+		Namespace:   "test-namespace",
+		Name:        "test-name",
+		InventoryID: "test-id",
+	}
+	isValid, err = ValidateInventory(inv)
+	if !isValid || err != nil {
+		t.Errorf("inventory with non-empty namespace, name, and id should validate")
+	}
+}


### PR DESCRIPTION
* Fixes panic in `rgpath.Read()` when inventory is not specified in the Kptfile.
* Bug introduced by https://github.com/GoogleContainerTools/kpt/pull/1254.
* Adds new inventory validation function `ValidateInventory` and unit tests.

From `end-to-end-test.sh`:
```
kpt live init e2e/live/testdata/migrate-case-1a
..SUCCESS

Testing kpt live apply with ConfigMap inventory
kpt live apply e2e/live/testdata/migrate-case-1a
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x16fe8a3]

goroutine 1 [running]:
github.com/GoogleContainerTools/kpt/pkg/live.(*ResourceGroupPathManifestReader).Read(0xc00057dd80, 0x1d0bd60, 0xc000134000, 0xc000414f10, 0x1, 0x1)
	/home/sean/go/src/github.com/GoogleContainerTools/kpt/pkg/live/rgpath.go:40 +0x303
github.com/GoogleContainerTools/kpt/pkg/live.(*DualDelegatingManifestReader).ManifestReader(0xc000414860, 0x1d0bd60, 0xc000134000, 0xc000414f10, 0x1, 0x1, 0x0, 0xc002f64ffb, 0x0, 0x0)
	/home/sean/go/src/github.com/GoogleContainerTools/kpt/pkg/live/dual-delegating-loader.go:40 +0xb3
sigs.k8s.io/cli-utils/cmd/apply.(*ApplyRunner).RunE(0xc000847a40, 0xc0006ce000, 0xc000414f10, 0x1, 0x1, 0x0, 0x0)
	/home/sean/go/pkg/mod/sigs.k8s.io/cli-utils@v0.22.1-0.20201117031003-fd39030f0508/cmd/apply/cmdapply.go:109 +0x187
github.com/spf13/cobra.(*Command).execute(0xc0006ce000, 0xc000414ee0, 0x1, 0x1, 0xc0006ce000, 0xc000414ee0)
	/home/sean/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:842 +0x47c
github.com/spf13/cobra.(*Command).ExecuteC(0xc0006c3600, 0x278f320, 0xc000000180, 0xc0004b1f78)
	/home/sean/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/home/sean/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
main.main()
```