### PR TITLE
Documentation for ResourceGroup inventory and migration

### DIFF
--- a/site/content/en/reference/live/_index.md
+++ b/site/content/en/reference/live/_index.md
@@ -20,4 +20,129 @@ description: >
 
 Live contains the next-generation versions of apply related commands for
 deploying local configuration packages to a cluster.
+
+### How to Upgrade to the Next Generation Inventory Object
+
+#### What is an Inventory Object
+
+An inventory object is the automatically generated object which keeps track
+of the set of objects applied together. The current inventory object type
+is a ConfigMap, and it is usually defined in a package file called
+**inventory-template.yaml**. This file is created from an invocation of
+`kpt live init`. A typical use of the inventory object is to prune (delete)
+objects omitted locally.
+
+#### What is a Next Generation Inventory Object
+
+The next generation inventory object is a **ResourceGroup** custom resource
+replacing the current ConfigMap. Because the new inventory object is a
+custom resource, you must have permissions to add a custom resource
+definition (CRD) to the cluster. The individual command to add the
+**ResourceGroup** CRD is:
+
+```
+export RESOURCE_GROUP_INVENTORY=1
+kpt live install-resource-group
+```
+
+#### Upgrade Scenario 1: New (Uninitialized) Packages
+
+Packages which are newly downloaded and uninitialized should follow the
+following steps:
+
+1. `export RESOURCE_GROUP_INVENTORY=1`
+2. `kpt live init <PACKAGE DIR>`
+3. `kpt live install-resource-group`
+
+The `init` step should have added an `inventory` section in the
+package Kptfile. The `install-resource-group` step installs the
+**ResourceGroup** CRD in the cluster, allowing **ResourceGroup**
+custom resources to be created. After these steps, the package
+is eligible to be applied: `kpt live apply <PACKAGE DIR>`.
+
+#### Upgrade Scenario 2: Existing (Initialized) Packages
+
+Existing packages which have already been initialized, should follow
+the following steps:
+
+1. `export RESOURCE_GROUP_INVENTORY=1`
+2. `kpt live migrate <PACKAGE DIR>`
+
+Initially, the `migrate` command applies the **ResourceGroup** CRD.
+Then the `migrate` command replaces the ConfigMap inventory object in
+the cluster (if it exists) with a **ResourceGroup** custom resource.
+The `migrate` command also deletes the local inventory ConfigMap
+config file (usually inventory-template.yaml). If this local
+ConfigMap file is stored in a github repository, the removal
+needs to be committed to the repository to finalize the removal.
+Finally, the `migrate` command should have added an `inventory`
+section to the Kptfile if it did not already exist. Updates to
+the package can now be applied using `kpt live apply <PACKAGE DIR>`.
+
+#### Troubleshooting and Verifying
+
+* Error: unable to apply **ResourceGroup** CRD
+
+```
+$ kpt live install-resource-group
+error: unable to add resourcegroups.kpt.dev
+```
+
+This message means the user does not have permissions to add the
+**ResourceGroup** CRD to the cluster. Until the user is able to
+find someone with sufficient privileges to apply the CRD, the
+user can continue to use the previous ConfigMap inventory object
+by unsetting the environment variable:
+
+```
+unset RESOURCE_GROUP_INVENTORY
+```
+
+* Error: configuration already created initialization error
+
+```
+$ kpt live init <PACKAGE DIR>
+error: ResourceGroup configuration has already been created. Changing
+them after a package has been applied to the cluster can lead to
+undesired results. Use the --force flag to suppress this error.
+```
+
+This message means the **ResourceGroup** initialization has
+*already* happened. Unless, you want to `--force` new values,
+this can safely be ignored.
+
+* How to check if the **ResourceGroup** CRD has *not* been
+successfully applied to the cluster
+
+```
+$ kubectl get resourcegroups.kpt.dev
+error: the server doesn't have a resource type "resourcegroups"
+```
+
+If a `No resources found` message is returned, the
+**ResourceGroup** CRD *has* been successfully applied,
+but there are no **ResourceGroup** custom resources
+found in the namespace. Example:
+
+```
+$ kubectl get resourcegroups.kpt.dev
+No resources found in default namespace.
+```
+
+* How to check if the applied inventory object in the cluster has
+been upgraded to a **ResourceGroup** custom resource
+
+```
+$ kubectl get resourcegroups.kpt.dev -n <PKG NAMESPACE> --selector='cli-utils.sigs.k8s.io/inventory-id' -o name
+resourcegroup.kpt.dev/inventory-62308923
+```
+
+* How to check if the applied inventory object in the cluster is
+not upgraded and is still a **ConfigMap**
+
+```
+$ kubectl get cm -n <PKG NAMESPACE> --selector='cli-utils.sigs.k8s.io/inventory-id' -o name
+configmap/inventory-62308923
+```
+
 <!--mdtogo-->

--- a/site/content/en/reference/live/init/_index.md
+++ b/site/content/en/reference/live/init/_index.md
@@ -15,7 +15,12 @@ The init command initializes a package with a template resource which will
 be used to track previously applied resources so that they can be pruned
 when they are deleted.
 
-The template resource is required by other live commands
+Alternatively, if the RESOURCE_GROUP_INVENTORY environment variable is set,
+the init command will initialize a package using the next generation inventory
+object (**ResourceGroup** custom resource). See commands `migrate` and
+`install-resource-group` for more information.
+
+The inventory object is required by other live commands
 such as apply, preview and destroy.
 
 ### Examples
@@ -28,6 +33,12 @@ kpt live init my-dir/
 ```sh
 # initialize a package with a specific name for the group of resources
 kpt live init --namespace=test my-dir/
+```
+
+```sh
+# initialize a package with the next generation inventory metadata
+export RESOURCE_GROUP_INVENTORY=1
+kpt live init my-dir/
 ```
 <!--mdtogo-->
 
@@ -42,7 +53,9 @@ kpt live init DIRECTORY [flags]
 ```
 DIR:
   Path to a package directory.  The directory must contain exactly
-  one ConfigMap with the grouping object annotation.
+  one ConfigMap with the grouping object annotation. If the
+  RESOURCE_GROUP_INVENTORY environment variable is set, the
+  package must have a Kptfile.
 ```
 
 #### Flags

--- a/site/content/en/reference/live/install-resource-group/_index.md
+++ b/site/content/en/reference/live/install-resource-group/_index.md
@@ -1,0 +1,44 @@
+---
+title: "Install-resource-group"
+linkTitle: "install-resource-group"
+type: docs
+description: >
+   Apply ResourceGroup custom resource definition to the cluster
+---
+<!--mdtogo:Short
+    Apply ResourceGroup custom resource definition to the cluster
+-->
+
+NOTE: This command is not available unless the RESOURCE_GROUP_INVENTORY
+environment variable is set.
+
+The install-resource-group command applies the ResourceGroup
+custom resource definition (CRD) to the cluster. This CRD allows
+ResourceGroup custom resources to be created, acting as inventory
+objects. The ResourceGroup custom resource is the next generation
+inventory object after the ConfigMap.
+
+### Examples
+<!--mdtogo:Examples-->
+```sh
+# install the ResourceGroup CRD
+export RESOURCE_GROUP_INVENTORY=1
+kpt live install-resource-group
+```
+<!--mdtogo-->
+
+### Synopsis
+<!--mdtogo:Long-->
+```
+kpt live install-resource-group
+```
+
+#### Args
+
+None
+
+#### Flags
+
+None
+
+<!--mdtogo-->

--- a/site/content/en/reference/live/migrate/_index.md
+++ b/site/content/en/reference/live/migrate/_index.md
@@ -1,0 +1,81 @@
+---
+title: "Migrate"
+linkTitle: "migrate"
+type: docs
+description: >
+   Migrate the package inventory object to a ResourceGroup custom resource
+---
+<!--mdtogo:Short
+    Migrate the package inventory object to a ResourceGroup custom resource
+-->
+
+NOTE: This command is not available unless the RESOURCE_GROUP_INVENTORY
+environment variable is set.
+
+The migrate command upgrades the inventory object from a ConfigMap to
+a ResourceGroup custom resource. The migrate performs the following steps:
+
+1. Applies the ResourceGroup custom resource definition (see
+   `kpt live install-resource-group`)
+2. If a ConfigMap inventory object exists in the cluster, the inventory
+   object is upgraded to a ResourceGroup custom resource (deleting the
+   previous ConfigMap).
+3. If it has not already been created, the Kptfile inventory section
+   is filled in. These values are used to create the ResourceGroup
+   custom resource inventory object when the package is applied.
+4. Deletes the local ConfigMap file (usually inventory-template.yaml).
+
+### Examples
+<!--mdtogo:Examples-->
+```sh
+# migrate from ConfigMap to ResourceGroup inventory object
+export RESOURCE_GROUP_INVENTORY=1
+kpt live migrate my-dir/
+```
+
+```sh
+# check the steps that will occur for the migrate, but
+# do not actually run them.
+export RESOURCE_GROUP_INVENTORY=1
+kpt live migrate my-dir/ --dry-run
+```
+
+```sh
+# migrate from ConfigMap to ResourceGroup inventory object, forcing
+# new values for the inventory object to be written to the Kptfile.
+export RESOURCE_GROUP_INVENTORY=1
+kpt live migrate my-dir/ --force
+```
+<!--mdtogo-->
+
+### Synopsis
+<!--mdtogo:Long-->
+```
+kpt live migrate DIRECTORY [flags]
+```
+
+#### Args
+
+```
+DIR:
+  Path to a package directory. The package must contain a Kptfile.
+  If the package directory contains a ConfigMap inventory template
+  file (usually named inventory-template.yaml), then this file
+  will be deleted.
+```
+
+#### Flags
+
+```
+--dry-run:
+  Do not actually run the migrate; only print out the steps that
+  will occur.
+--force:
+  Set inventory values even if already set in Kptfile.
+--name:
+  Set the inventory object name, instead of default generated
+  name (e.g. inventory-62308923). The user must make sure the
+  inventory name does not collide with other inventory objects
+  in the same namespace.
+```
+<!--mdtogo-->


### PR DESCRIPTION
* Adds documentation in the `live` command to migrate to the next generation `ResourceGroup` inventory object.
* Adds documentation for the `kpt live migrate` command
* Adds documentation for the `kpt live install-resource-group` command
* Updates the documentation for the `kpt live init` command to add new information about initialization for the `ResourceGroup` inventory object.