### PR TITLE
Adds option to kpt e2e test to build using dependencies at HEAD

### DIFF
--- a/e2e/live/testdata/migrate-case-1a/Kptfile
+++ b/e2e/live/testdata/migrate-case-1a/Kptfile
@@ -9,7 +9,4 @@ upstream:
     repo: git@github.com:yuwenma/blueprint-helloworld
     directory: /
     ref: master
-inventory:
-  namespace: test-rg-namespace
-  name: inventory-62308923
-  inventoryID: bad7c50de3c41e2e801032dbe4cdc111102d9ae0-1605844107990241514
+

--- a/e2e/live/testdata/migrate-case-1b/Kptfile
+++ b/e2e/live/testdata/migrate-case-1b/Kptfile
@@ -9,7 +9,4 @@ upstream:
     repo: git@github.com:yuwenma/blueprint-helloworld
     directory: /
     ref: master
-inventory:
-  namespace: test-rg-namespace
-  name: inventory-62308923
-  inventoryID: bad7c50de3c41e2e801032dbe4cdc111102d9ae0-1605844107990241514
+

--- a/e2e/live/testdata/migrate-error/Kptfile
+++ b/e2e/live/testdata/migrate-error/Kptfile
@@ -9,7 +9,4 @@ upstream:
     repo: git@github.com:yuwenma/blueprint-helloworld
     directory: /
     ref: master
-inventory:
-  namespace: test-rg-namespace
-  name: inventory-71512828
-  inventoryID: 94885c00356ee5beb002a465801e7fa7df4f0f69-1605818723418805142
+


### PR DESCRIPTION
* Adds option to kpt e2e test to build kpt binary using the dependencies at HEAD (instead of version defined in go.mod). The default is to still build kpt from current directory.
* Small cleanup to not modify test files by the end of the e2e test
```
$ ./e2e/live/end-to-end-test.sh 
kpt end-to-end test

Temp Dir: /tmp/kpt-e2e-9rUkXKjsoX

Building kpt using dependencies at HEAD...

Downloading kpt repository at HEAD...
Downloading kpt repository at HEAD...SUCCESS
Downloading cli-utils repository at HEAD...
Downloading cli-utils repository at HEAD...SUCCESS
Downloading kustomize repository at HEAD...
Downloading kustomize repository at HEAD...SUCCESS
Updating kpt/go.mod to reference locally downloaded repositories...
Updating kpt/go.mod to reference locally downloaded repositories...SUCCESS
Building kpt...
Building kpt...SUCCESS

Building kpt using dependencies at HEAD...SUCCESS
```
