### PR TITLE
Setup golang build action for 'next' branch

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,23 +15,23 @@
 name: Go
 on:
   # Trigger the workflow on push or pull request,
-  # but only for the master branch
+  # but only for the 'next' branch
   push:
     branches:
-      - master
+      - next
   pull_request:
     branches:
-      - master
+      - next
 jobs:
 
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.13
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1


### PR DESCRIPTION
Makes sure we run the build on PRs against the `next` branch.