### PR TITLE
Unify ResourceGroup CRD installation output

### DIFF
--- a/commands/installrg.go
+++ b/commands/installrg.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/GoogleContainerTools/kpt/pkg/live"
 	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
@@ -53,6 +54,17 @@ func (ir *InstallRGRunner) Run(reader io.Reader, args []string) error {
 	if len(args) > 0 {
 		return fmt.Errorf("too many arguments; install-resource-group takes no arguments")
 	}
-	// Apply the ResourceGroup CRD to the cluster, ignoring if it already exists.
-	return live.ApplyResourceGroupCRD(ir.factory)
+	fmt.Fprint(ir.ioStreams.Out, "installing ResourceGroup custom resource definition...")
+	// Apply the ResourceGroup CRD to the cluster, swallowing an "AlreadyExists" error.
+	err := live.ApplyResourceGroupCRD(ir.factory)
+	if apierrors.IsAlreadyExists(err) {
+		fmt.Fprint(ir.ioStreams.Out, "already installed...")
+		err = nil
+	}
+	if err != nil {
+		fmt.Fprintln(ir.ioStreams.Out, "failed")
+	} else {
+		fmt.Fprintln(ir.ioStreams.Out, "success")
+	}
+	return err
 }

--- a/e2e/live/end-to-end-test.sh
+++ b/e2e/live/end-to-end-test.sh
@@ -503,7 +503,7 @@ cp -f e2e/live/testdata/inventory-template.yaml e2e/live/testdata/migrate-error
 echo "Testing kpt live migrate with no objects in cluster"
 echo "kpt live migrate e2e/live/testdata/migrate-error"
 ${BIN_DIR}/kpt live migrate e2e/live/testdata/migrate-error > $OUTPUT_DIR/status 2>&1
-assertContains "ensuring ResourceGroup CRD exists in cluster...success"
+assertContains "ensuring ResourceGroup CRD exists in cluster...already installed...success"
 assertContains "updating Kptfile inventory values...values already exist...success"
 assertContains "retrieve the current ConfigMap inventory...success (0 inventory objects)"
 assertContains "deleting inventory template file:"
@@ -549,6 +549,7 @@ kubectl get resourcegroups.kpt.dev > $OUTPUT_DIR/status 2>&1
 assertContains "error: the server doesn't have a resource type \"resourcegroups\""
 # Next, add the ResourceGroup CRD
 ${BIN_DIR}/kpt live install-resource-group > $OUTPUT_DIR/status
+assertContains "installing ResourceGroup custom resource definition...success"
 kubectl get resourcegroups.kpt.dev > $OUTPUT_DIR/status 2>&1
 assertContains "No resources found"
 # Add a simple ResourceGroup custom resource, and verify it exists in the cluster.
@@ -557,8 +558,8 @@ assertContains "resourcegroup.kpt.dev/example-inventory created"
 kubectl get resourcegroups.kpt.dev --no-headers > $OUTPUT_DIR/status
 assertContains "example-inventory"
 # Finally, add the ResourceGroup CRD again, and check it says it already exists.
-${BIN_DIR}/kpt live install-resource-group -v=4 > $OUTPUT_DIR/status 2>&1
-assertContains "ResourceGroup CRD already exists"
+${BIN_DIR}/kpt live install-resource-group > $OUTPUT_DIR/status 2>&1
+assertContains "...already installed...success"
 printResult
 
 # Clean-up the k8s cluster

--- a/pkg/live/inventoryrg.go
+++ b/pkg/live/inventoryrg.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"strings"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/resource"
@@ -215,8 +214,8 @@ var crdGroupKind = schema.GroupKind{
 
 // ApplyResourceGroupCRD applies the custom resource definition for the
 // ResourceGroup. The apiextensions version applied is based on the RESTMapping
-// returned by the RESTMapper. Returns an error if one occurs; "Already Exists"
-// error is changed to nil error.
+// returned by the RESTMapper. Returns an error if one occurs, including an
+// "Already Exists" error.
 func ApplyResourceGroupCRD(factory cmdutil.Factory) error {
 	// Create the mapping from the CustomResourceDefinision GroupKind.
 	mapper, err := factory.ToRESTMapper()
@@ -255,15 +254,7 @@ func ApplyResourceGroupCRD(factory cmdutil.Factory) error {
 	helper := resource.NewHelper(client, mapping)
 	klog.V(4).Infoln("applying ResourceGroup CRD...")
 	_, err = helper.Create(emptyNamespace, clearResourceVersion, crd)
-	if err != nil {
-		if apierrors.IsAlreadyExists(err) {
-			klog.V(4).Infoln("ResourceGroup CRD already exists")
-			return nil
-		}
-		return err
-	}
-	klog.V(4).Infoln("ResourceGroup CRD successfully applied")
-	return nil
+	return err
 }
 
 // stringToUnstructured transforms a single resource represented by


### PR DESCRIPTION
* Updates and unifies the output from the ResourceGroup installation commands
* Adds kpt e2e tests to verify output
```
$ ./e2e/live/end-to-end-test.sh 
kpt end-to-end test

Temp Dir: /tmp/kpt-e2e-jtyptAUV3f

Building kpt locally...
Building kpt locally...SUCCESS

Setting Up Test Suite...

Deleting kind cluster...
Deleting kind cluster...COMPLETED
Creating kind cluster...
Creating kind cluster...COMPLETED

Setting Up Test Suite...COMPLETED

Waiting for default service account...-
Waiting for default service account...CREATED

Testing basic ConfigMap init
kpt live init e2e/live/testdata/test-case-1a
..SUCCESS

Testing initial preview
kpt live preview e2e/live/testdata/test-case-1a
......SUCCESS

Testing basic apply
kpt live apply e2e/live/testdata/test-case-1a
........SUCCESS

Testing basic preview
kpt live preview e2e/live/testdata/test-case-1b
............SUCCESS

Testing basic prune
kpt live apply e2e/live/testdata/test-case-1b
.............SUCCESS

Testing basic destroy
kpt live destroy e2e/live/testdata/test-case-1b
........SUCCESS

kpt live init e2e/live/testdata/migrate-case-1a
..SUCCESS

Testing kpt live apply with ConfigMap inventory
kpt live apply e2e/live/testdata/migrate-case-1a
...........SUCCESS

Testing migrate from ConfigMap to ResourceGroup inventory
kpt live migrate e2e/live/testdata/migrate-case-1a
...........SUCCESS

Testing kpt live preview with ResourceGroup inventory
kpt live preview e2e/live/testdata/migrate-case-1a
..........SUCCESS

Testing kpt live apply/prune with ResourceGroup inventory
kpt live apply e2e/live/testdata/migrate-case-1b
............SUCCESS

Testing kpt destroy with ResourceGroup inventory
kpt live destroy e2e/live/testdata/migrate-case-1b
........SUCCESS

Testing kpt live init for Kptfile (ResourceGroup inventory)
kpt live init e2e/live/testdata/migrate-error
....SUCCESS

Testing kpt live migrate with missing inventory-template.yaml should fail
kpt live migrate e2e/live/testdata/migrate-error
.SUCCESS

Testing kpt live migrate with no objects in cluster
kpt live migrate e2e/live/testdata/migrate-error
......SUCCESS

Testing kpt apply ResourceGroup inventory
kpt live apply e2e/live/testdata/migrate-error
.......SUCCESS


Setting Up Test Suite...

Deleting kind cluster...
Deleting kind cluster...COMPLETED
Creating kind cluster...
Creating kind cluster...COMPLETED

Setting Up Test Suite...COMPLETED

Testing kpt live install-resource-group
kpt live install-resource-group
......SUCCESS

Cleaning up cluster
Deleting cluster "kind" ...
FINISHED
```