### PR TITLE
kpt run CRD installation before live apply

### DIFF
--- a/commands/applycmd.go
+++ b/commands/applycmd.go
@@ -1,0 +1,59 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"os"
+
+	"github.com/GoogleContainerTools/kpt/pkg/live"
+	"github.com/spf13/cobra"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/klog"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/cli-utils/cmd/apply"
+	"sigs.k8s.io/cli-utils/pkg/manifestreader"
+	"sigs.k8s.io/cli-utils/pkg/provider"
+)
+
+// Get ApplyRunner returns a wrapper around the cli-utils apply command ApplyRunner. Sets
+// up the Run on this wrapped runner to be the ApplyRunnerWrapper run.
+func GetApplyRunner(provider provider.Provider, loader manifestreader.ManifestLoader, ioStreams genericclioptions.IOStreams) *ApplyRunnerWrapper {
+	applyRunner := apply.GetApplyRunner(provider, loader, ioStreams)
+	w := &ApplyRunnerWrapper{
+		applyRunner: applyRunner,
+		factory:     provider.Factory(),
+	}
+	// Set the wrapper run to be the RunE function for the wrapped command.
+	applyRunner.Command.RunE = w.RunE
+	return w
+}
+
+// ApplyRunnerWrapper encapsulates the cli-utils apply command ApplyRunner as well
+// as structures necessary to run.
+type ApplyRunnerWrapper struct {
+	applyRunner *apply.ApplyRunner
+	factory     cmdutil.Factory
+}
+
+// Command returns the wrapped ApplyRunner cobraCommand structure.
+func (w *ApplyRunnerWrapper) Command() *cobra.Command {
+	return w.applyRunner.Command
+}
+
+// RunE runs the ResourceGroup CRD installation as a pre-step if an
+// environment variable exists. Then the wrapped ApplyRunner is
+// invoked. Returns an error if one happened. Swallows the
+// "AlreadyExists" error for CRD installation.
+func (w *ApplyRunnerWrapper) RunE(cmd *cobra.Command, args []string) error {
+	if _, exists := os.LookupEnv(resourceGroupEnv); exists {
+		klog.V(4).Infoln("wrapper applyRunner detected environment variable")
+		err := live.ApplyResourceGroupCRD(w.factory)
+		if err != nil && !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+	}
+	klog.V(4).Infoln("wrapper applyRunner run...")
+	return w.applyRunner.RunE(cmd, args)
+}

--- a/commands/livecmd.go
+++ b/commands/livecmd.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/klog"
 	"k8s.io/kubectl/pkg/cmd/util"
-	"sigs.k8s.io/cli-utils/cmd/apply"
 	"sigs.k8s.io/cli-utils/cmd/destroy"
 	"sigs.k8s.io/cli-utils/cmd/diff"
 	"sigs.k8s.io/cli-utils/cmd/initcmd"
@@ -85,7 +84,7 @@ func GetLiveCommand(name string, f util.Factory) *cobra.Command {
 	initCmd.Long = livedocs.InitShort + "\n" + livedocs.InitLong
 	initCmd.Example = livedocs.InitExamples
 
-	applyCmd := apply.GetApplyRunner(p, l, ioStreams).Command
+	applyCmd := GetApplyRunner(p, l, ioStreams).Command()
 	_ = applyCmd.Flags().MarkHidden("no-prune")
 	applyCmd.Short = livedocs.ApplyShort
 	applyCmd.Long = livedocs.ApplyShort + "\n" + livedocs.ApplyLong
@@ -116,8 +115,9 @@ func GetLiveCommand(name string, f util.Factory) *cobra.Command {
 	liveCmd.AddCommand(initCmd, applyCmd, previewCmd, diffCmd, destroyCmd,
 		fetchOpenAPICmd, statusCmd)
 
-	// If the magic env var exists, then add the migrate command to change
-	// from ConfigMap to ResourceGroup inventory object.
+	// If the magic env var exists, then add the migrate to change
+	// from ConfigMap to ResourceGroup inventory object. Also add
+	// the install-resource-group command.
 	if _, exists := os.LookupEnv(resourceGroupEnv); exists {
 		klog.V(2).Infoln("adding kpt live migrate command")
 		// Create a ConfigMap and a ResourceGroup provider for the


### PR DESCRIPTION
* Adds `ApplyRunnerWrapper` in `kpt` to run a pre-step before invoking the cli-utils `ApplyRunner`.
* if the `ResourceGroup` inventory environment variable exists, `kpt live apply` installs the `ResourceGroup` custom resource definition before running the rest of cli-utils apply.
* Tested by running the entire e2e test suite...passed.