### PR TITLE
Adds output to kpt live init for ResourceGroup and flag

### DIFF
--- a/commands/initcmd.go
+++ b/commands/initcmd.go
@@ -45,6 +45,7 @@ type KptInitOptions struct {
 	name        string // Inventory object name
 	namespace   string // Inventory object namespace
 	inventoryID string // Inventory object unique identifier label
+	Quiet       bool   // Print output or not
 }
 
 // NewKptInitOptions returns a pointer to an initial KptInitOptions structure.
@@ -52,6 +53,7 @@ func NewKptInitOptions(f cmdutil.Factory, ioStreams genericclioptions.IOStreams)
 	return &KptInitOptions{
 		factory:   f,
 		ioStreams: ioStreams,
+		Quiet:     false,
 	}
 }
 
@@ -83,8 +85,17 @@ func (io *KptInitOptions) Run(args []string) error {
 		return err
 	}
 	io.inventoryID = id
+	if !io.Quiet {
+		fmt.Fprintf(io.ioStreams.Out, "namespace: %s is used for inventory object\n", io.namespace)
+	}
 	// Finally, update these values in the Inventory section of the Kptfile.
-	return io.updateKptfile()
+	if err := io.updateKptfile(); err != nil {
+		return err
+	}
+	if !io.Quiet {
+		fmt.Fprintf(io.ioStreams.Out, "Initialized: %s/Kptfile\n", io.dir)
+	}
+	return nil
 }
 
 // generateID returns the string which is a SHA1 hash of the passed namespace
@@ -177,5 +188,6 @@ func NewCmdInit(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra
 	}
 	cmd.Flags().StringVar(&io.name, "name", "", "Inventory object name")
 	cmd.Flags().BoolVar(&io.force, "force", false, "Set inventory values even if already set in Kptfile")
+	cmd.Flags().BoolVar(&io.Quiet, "quiet", false, "If true, do not print output during initialization of Kptfile")
 	return cmd
 }

--- a/commands/migratecmd.go
+++ b/commands/migratecmd.go
@@ -53,6 +53,7 @@ func GetMigrateRunner(cmProvider provider.Provider, rgProvider provider.Provider
 		rgLoader:    rgLoader,
 		dir:         "",
 	}
+	r.initOptions.Quiet = true // Do not print output during migration
 	cmd := &cobra.Command{
 		Use:                   "migrate DIRECTORY",
 		DisableFlagsInUseLine: true,

--- a/e2e/live/end-to-end-test.sh
+++ b/e2e/live/end-to-end-test.sh
@@ -552,6 +552,9 @@ cp -f e2e/live/testdata/Kptfile e2e/live/testdata/migrate-error
 echo "Testing kpt live init for Kptfile (ResourceGroup inventory)"
 echo "kpt live init e2e/live/testdata/migrate-error"
 ${BIN_DIR}/kpt live init e2e/live/testdata/migrate-error > $OUTPUT_DIR/status 2>&1
+assertContains "namespace: test-rg-namespace is used for inventory object"
+assertContains "Initialized: "
+assertContains "Kptfile"
 # Difference in Kptfile should have inventory data
 diff e2e/live/testdata/Kptfile e2e/live/testdata/migrate-error/Kptfile > $OUTPUT_DIR/status 2>&1
 assertContains "inventory:"


### PR DESCRIPTION
* Adds optional output for `kpt live init` command for ResourceGroup (when RESOURCE_GROUP_INVENTORY env var is set) by adding `--quiet` flag.
* Turns off init output for `kpt live migrate`
* Adds e2e tests to prove this works
