### PR TITLE
Functionality for creating a diff between two packages while ignoring subpackages and upstream information

### DIFF
--- a/internal/util/diff/pkgdiff.go
+++ b/internal/util/diff/pkgdiff.go
@@ -1,0 +1,119 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diff
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/GoogleContainerTools/kpt/internal/util/pkgutil"
+	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
+	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
+	"sigs.k8s.io/kustomize/kyaml/sets"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+func PkgDiff(pkg1, pkg2 string) (sets.String, error) {
+	pkg1Files, err := pkgSet(pkg1)
+	if err != nil {
+		return sets.String{}, err
+	}
+
+	pkg2Files, err := pkgSet(pkg2)
+	if err != nil {
+		return sets.String{}, err
+	}
+
+	diff := pkg1Files.SymmetricDifference(pkg2Files)
+
+	for _, f := range pkg1Files.Intersection(pkg2Files).List() {
+		fi, err := os.Stat(filepath.Join(pkg1, f))
+		if err != nil {
+			return diff, err
+		}
+
+		if fi.IsDir() {
+			continue
+		}
+
+		fileName := filepath.Base(f)
+		if fileName == kptfile.KptFileName {
+			equal, err := kptfilesEqual(pkg1, pkg2, f)
+			if err != nil {
+				return diff, err
+			}
+			if !equal {
+				diff.Insert(f)
+			}
+		} else {
+			b1, err := ioutil.ReadFile(filepath.Join(pkg1, f))
+			if err != nil {
+				return diff, err
+			}
+			b2, err := ioutil.ReadFile(filepath.Join(pkg2, f))
+			if err != nil {
+				return diff, err
+			}
+			if !bytes.Equal(b1, b2) {
+				diff.Insert(f)
+			}
+		}
+	}
+	return diff, nil
+}
+
+func kptfilesEqual(pkg1, pkg2, filePath string) (bool, error) {
+	pkg1Kf, err := kptfileutil.ReadFile(filepath.Join(pkg1, filepath.Dir(filePath)))
+	if err != nil {
+		return false, err
+	}
+	pkg2Kf, err := kptfileutil.ReadFile(filepath.Join(pkg2, filepath.Dir(filePath)))
+	if err != nil {
+		return false, err
+	}
+
+	pkg1Kf.Upstream = kptfile.Upstream{}
+	pkg2Kf.Upstream = kptfile.Upstream{}
+
+	pkg1Bytes, err := yaml.Marshal(pkg1Kf)
+	if err != nil {
+		return false, err
+	}
+	pkg2Bytes, err := yaml.Marshal(pkg2Kf)
+	if err != nil {
+		return false, err
+	}
+	return bytes.Equal(pkg1Bytes, pkg2Bytes), nil
+}
+
+func pkgSet(pkgPath string) (sets.String, error) {
+	pkgFiles := sets.String{}
+	if err := pkgutil.WalkPackage(pkgPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		relPath, err := filepath.Rel(pkgPath, path)
+		if err != nil {
+			return err
+		}
+		pkgFiles.Insert(relPath)
+		return nil
+	}); err != nil {
+		return sets.String{}, err
+	}
+	return pkgFiles, nil
+}

--- a/internal/util/diff/pkgdiff_test.go
+++ b/internal/util/diff/pkgdiff_test.go
@@ -1,0 +1,149 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package diff
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/kpt/internal/testutil/pkgbuilder"
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/kustomize/kyaml/sets"
+)
+
+func TestPkgDiff(t *testing.T) {
+	testCases := []struct {
+		name string
+		pkg1 *pkgbuilder.RootPkg
+		pkg2 *pkgbuilder.RootPkg
+		diff sets.String
+	}{
+		{
+			name: "equal packages doesn't have a diff",
+			pkg1: pkgbuilder.NewRootPkg().
+				WithKptfile(pkgbuilder.NewKptfile().
+					WithSetters(
+						pkgbuilder.NewSetter("foo", "bar"),
+					),
+				).
+				WithResource(pkgbuilder.DeploymentResource),
+			pkg2: pkgbuilder.NewRootPkg().
+				WithKptfile(pkgbuilder.NewKptfile().
+					WithSetters(
+						pkgbuilder.NewSetter("foo", "bar"),
+					),
+				).
+				WithResource(pkgbuilder.DeploymentResource),
+			diff: toStringSet(),
+		},
+		{
+			name: "different files between packages",
+			pkg1: pkgbuilder.NewRootPkg().
+				WithKptfile().
+				WithResource(pkgbuilder.DeploymentResource),
+			pkg2: pkgbuilder.NewRootPkg().
+				WithKptfile().
+				WithResource(pkgbuilder.ConfigMapResource),
+			diff: toStringSet("configmap.yaml", "deployment.yaml"),
+		},
+		{
+			name: "different setters in Kptfile is a diff",
+			pkg1: pkgbuilder.NewRootPkg().
+				WithKptfile(pkgbuilder.NewKptfile().
+					WithSetters(
+						pkgbuilder.NewSetter("foo", "bar"),
+					),
+				).
+				WithResource(pkgbuilder.DeploymentResource),
+			pkg2: pkgbuilder.NewRootPkg().
+				WithKptfile(pkgbuilder.NewKptfile().
+					WithSetters(
+						pkgbuilder.NewSetter("foo", "notBar"),
+					),
+				).
+				WithResource(pkgbuilder.DeploymentResource),
+			diff: toStringSet("Kptfile"),
+		},
+		{
+			name: "different upstream in Kptfile is not a diff",
+			pkg1: pkgbuilder.NewRootPkg().
+				WithKptfile(pkgbuilder.NewKptfile().
+					WithUpstream("github.com/GoogleContainerTools/kpt", "master").
+					WithSetters(
+						pkgbuilder.NewSetter("foo", "bar"),
+					),
+				).
+				WithResource(pkgbuilder.DeploymentResource),
+			pkg2: pkgbuilder.NewRootPkg().
+				WithKptfile(pkgbuilder.NewKptfile().
+					WithUpstream("github.com/GoogleContainerTools/kpt", "kpt/v1").
+					WithSetters(
+						pkgbuilder.NewSetter("foo", "bar"),
+					),
+				).
+				WithResource(pkgbuilder.DeploymentResource),
+			diff: toStringSet(),
+		},
+		{
+			name: "subpackages are not included",
+			pkg1: pkgbuilder.NewRootPkg().
+				WithKptfile().
+				WithResource(pkgbuilder.DeploymentResource).
+				WithSubPackages(
+					pkgbuilder.NewSubPkg("subpackage").
+						WithKptfile(pkgbuilder.NewKptfile().
+							WithSetters(
+								pkgbuilder.NewSetter("foo", "bar"),
+							),
+						).
+						WithResource(pkgbuilder.DeploymentResource),
+				),
+			pkg2: pkgbuilder.NewRootPkg().
+				WithKptfile().
+				WithResource(pkgbuilder.DeploymentResource).
+				WithSubPackages(
+					pkgbuilder.NewSubPkg("subpackage").
+						WithKptfile(pkgbuilder.NewKptfile().
+							WithSetters(
+								pkgbuilder.NewSetter("bar", "foo"),
+							),
+						).
+						WithResource(pkgbuilder.ConfigMapResource),
+				),
+			diff: toStringSet(),
+		},
+	}
+
+	for i := range testCases {
+		test := testCases[i]
+		t.Run(test.name, func(t *testing.T) {
+			pkg1Dir := pkgbuilder.ExpandPkg(t, test.pkg1)
+			pkg2Dir := pkgbuilder.ExpandPkg(t, test.pkg2)
+			diff, err := PkgDiff(pkg1Dir, pkg2Dir)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			assert.Equal(t, 0, len(diff.SymmetricDifference(test.diff)))
+		})
+	}
+}
+
+func toStringSet(files ...string) sets.String {
+	s := sets.String{}
+	for _, f := range files {
+		s.Insert(f)
+	}
+	return s
+}

--- a/internal/util/pkgutil/pkgutil.go
+++ b/internal/util/pkgutil/pkgutil.go
@@ -1,0 +1,60 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkgutil
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
+	"sigs.k8s.io/kustomize/kyaml/copyutil"
+)
+
+// walkPackage walks the package defined at src and provides a callback for
+// every folder and file. Any subpackages and the .git folder are excluded.
+func WalkPackage(src string, c func(string, os.FileInfo, error) error) error {
+	excludedDirs := make(map[string]bool)
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return c(path, info, err)
+		}
+		// don't copy the .git dir
+		if path != src {
+			rel := strings.TrimPrefix(path, src)
+			if copyutil.IsDotGitFolder(rel) {
+				return nil
+			}
+		}
+
+		for dir := range excludedDirs {
+			if strings.HasPrefix(path, dir) {
+				return nil
+			}
+		}
+
+		if info.IsDir() {
+			_, err := os.Stat(filepath.Join(path, kptfile.KptFileName))
+			if err != nil && !os.IsNotExist(err) {
+				return c(path, info, err)
+			}
+			if err == nil && path != src {
+				excludedDirs[path] = true
+				return nil
+			}
+		}
+		return c(path, info, err)
+	})
+}


### PR DESCRIPTION
A lot of the update functionality in kpt is dependent on knowing whether there are local changes to a package. We use this to determine whether `FastForward` strategy is applicable, and whether local packages should be deleted if they are deleted from upstream. This adds a function for computing the diff between two packages, while ignoring any subpackages. It also ignores the `Upstream` section of the Kptfile.
