### PR TITLE
Per-package updates with FastForward strategy

### DIFF
--- a/internal/util/get/get.go
+++ b/internal/util/get/get.go
@@ -31,7 +31,6 @@ import (
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
 	"sigs.k8s.io/kustomize/kyaml/copyutil"
 	"sigs.k8s.io/kustomize/kyaml/errors"
-	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 // Command fetches a package from a git repository and copies it to a local directory.
@@ -260,19 +259,7 @@ func (c *Command) upsertKptfile(spec *git.RepoSpec) error {
 	kpgfile, err := kptfileutil.ReadFile(c.Destination)
 	if err != nil {
 		// no KptFile present, create a default
-		kpgfile = kptfile.KptFile{
-			ResourceMeta: yaml.ResourceMeta{
-				TypeMeta: yaml.TypeMeta{
-					APIVersion: kptfile.TypeMeta.APIVersion,
-					Kind:       kptfile.TypeMeta.Kind,
-				},
-				ObjectMeta: yaml.ObjectMeta{
-					NameMeta: yaml.NameMeta{
-						Name: c.Name,
-					},
-				},
-			},
-		}
+		kpgfile = kptfileutil.DefaultKptfile(c.Name)
 	}
 
 	// find the git commit sha that we cloned the package at so we can write it to the KptFile

--- a/internal/util/update/common.go
+++ b/internal/util/update/common.go
@@ -1,0 +1,94 @@
+package update
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
+	"sigs.k8s.io/kustomize/kyaml/pathutil"
+)
+
+// findAllSubpackages traverses the provided package paths
+// and finds all subpackages. A subpackage is a subdirectory underneath the
+// root that has a Kptfile in it.
+// The list is sorted in increasing order based on the depth of the subpackage
+// relative to the root package.
+func findAllSubpackages(pkgPaths ...string) ([]string, error) {
+	uniquePaths := make(map[string]bool)
+	for _, path := range pkgPaths {
+		paths, err := pathutil.DirsWithFile(path, kptfile.KptFileName, true)
+		if err != nil {
+			return []string{}, err
+		}
+		for _, p := range paths {
+			relPath, err := filepath.Rel(path, p)
+			if err != nil {
+				return []string{}, err
+			}
+			uniquePaths[relPath] = true
+		}
+	}
+	var paths []string
+	for p := range uniquePaths {
+		paths = append(paths, p)
+	}
+	sort.Slice(paths, rootPkgFirstSorter(paths))
+	return paths, nil
+}
+
+// rootPkgFirstSorter returns a "less" function that can be used with the
+// sort.Slice function to correctly sort package paths so parent packages
+// are always before subpackages.
+func rootPkgFirstSorter(paths []string) func(i, j int) bool {
+	return func(i, j int) bool {
+		iPath := paths[i]
+		jPath := paths[j]
+		if iPath == "." {
+			return true
+		}
+		if jPath == "." {
+			return false
+		}
+		iSegmentCount := len(strings.Split(iPath, "/"))
+		jSegmentCount := len(strings.Split(jPath, "/"))
+		return iSegmentCount < jSegmentCount
+	}
+}
+
+// subPkgFirstSorter returns a "less" function that can be used with the
+// sort.Slice function to correctly sort package paths so subpackages are
+// always before parent packages.
+func subPkgFirstSorter(paths []string) func(i, j int) bool {
+	sorter := rootPkgFirstSorter(paths)
+	return func(i, j int) bool {
+		return !sorter(i, j)
+	}
+}
+
+// lookupCommit looks up the sha of the current commit on the repo at the
+// provided path.
+func lookupCommit(repoPath string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--verify", "HEAD")
+	cmd.Dir = repoPath
+	cmd.Env = os.Environ()
+	cmd.Stderr = os.Stderr
+	b, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	commit := strings.TrimSpace(string(b))
+	return commit, nil
+}
+
+// exists returns true if a file or directory exists on the provided path,
+// and false otherwise.
+func exists(path string) (bool, error) {
+	_, err := os.Stat(path)
+	if err != nil && !os.IsNotExist(err) {
+		return false, err
+	}
+	return !os.IsNotExist(err), nil
+}

--- a/internal/util/update/update_test.go
+++ b/internal/util/update/update_test.go
@@ -728,7 +728,7 @@ func TestCommand_Run_subpackages(t *testing.T) {
 			},
 			expectedResults: []resultForStrategy{
 				{
-					strategies: []StrategyType{KResourceMerge},
+					strategies: []StrategyType{KResourceMerge, FastForward},
 					expectedLocal: pkgbuilder.NewRootPkg().
 						WithKptfile().
 						WithSubPackages(
@@ -774,6 +774,10 @@ func TestCommand_Run_subpackages(t *testing.T) {
 								WithKptfile(),
 						),
 				},
+				{
+					strategies:     []StrategyType{FastForward},
+					expectedErrMsg: "use a different update --strategy",
+				},
 			},
 		},
 		{
@@ -818,6 +822,10 @@ func TestCommand_Run_subpackages(t *testing.T) {
 								WithKptfile(),
 						),
 				},
+				{
+					strategies:     []StrategyType{FastForward},
+					expectedErrMsg: "use a different update --strategy",
+				},
 			},
 		},
 		{
@@ -853,6 +861,10 @@ func TestCommand_Run_subpackages(t *testing.T) {
 					strategies:     []StrategyType{KResourceMerge},
 					expectedErrMsg: "subpackage \"abc\" added in both upstream and local",
 				},
+				{
+					strategies:     []StrategyType{FastForward},
+					expectedErrMsg: "use a different update --strategy",
+				},
 			},
 		},
 		{
@@ -869,7 +881,7 @@ func TestCommand_Run_subpackages(t *testing.T) {
 			},
 			expectedResults: []resultForStrategy{
 				{
-					strategies: []StrategyType{KResourceMerge},
+					strategies: []StrategyType{KResourceMerge, FastForward},
 					expectedLocal: pkgbuilder.NewRootPkg().
 						WithKptfile(),
 				},
@@ -893,7 +905,7 @@ func TestCommand_Run_subpackages(t *testing.T) {
 			},
 			expectedResults: []resultForStrategy{
 				{
-					strategies: []StrategyType{KResourceMerge},
+					strategies: []StrategyType{KResourceMerge, FastForward},
 					expectedLocal: pkgbuilder.NewRootPkg().
 						WithKptfile().
 						WithSubPackages(
@@ -1045,6 +1057,10 @@ func TestCommand_Run_subpackages(t *testing.T) {
 								),
 						),
 				},
+				{
+					strategies:     []StrategyType{FastForward},
+					expectedErrMsg: "use a different update --strategy",
+				},
 			},
 		},
 		{
@@ -1069,6 +1085,9 @@ func TestCommand_Run_subpackages(t *testing.T) {
 					),
 			},
 			expectedResults: []resultForStrategy{
+				// TODO(mortent): Revisit this. Not clear that the Kptfile
+				// shouldn't be deleted here since it doesn't really have any
+				// local changes.
 				{
 					strategies: []StrategyType{KResourceMerge},
 					expectedLocal: pkgbuilder.NewRootPkg().
@@ -1080,6 +1099,15 @@ func TestCommand_Run_subpackages(t *testing.T) {
 										pkgbuilder.NewSetter("name", "my-name"),
 									),
 								).
+								WithResource(pkgbuilder.DeploymentResource),
+						),
+				},
+				{
+					strategies: []StrategyType{FastForward},
+					expectedLocal: pkgbuilder.NewRootPkg().
+						WithKptfile().
+						WithSubPackages(
+							pkgbuilder.NewSubPkg("bar").
 								WithResource(pkgbuilder.DeploymentResource),
 						),
 				},
@@ -1131,6 +1159,10 @@ func TestCommand_Run_subpackages(t *testing.T) {
 								WithResource(pkgbuilder.ConfigMapResource),
 						),
 				},
+				{
+					strategies:     []StrategyType{FastForward},
+					expectedErrMsg: "use a different update --strategy",
+				},
 			},
 		},
 		{
@@ -1152,7 +1184,7 @@ func TestCommand_Run_subpackages(t *testing.T) {
 			},
 			expectedResults: []resultForStrategy{
 				{
-					strategies: []StrategyType{KResourceMerge},
+					strategies: []StrategyType{KResourceMerge, FastForward},
 					expectedLocal: pkgbuilder.NewRootPkg().
 						WithKptfile(),
 				},
@@ -1204,6 +1236,10 @@ func TestCommand_Run_subpackages(t *testing.T) {
 								WithResource(pkgbuilder.DeploymentResource,
 									pkgbuilder.SetFieldPath("34", "spec", "replicas")),
 						),
+				},
+				{
+					strategies:     []StrategyType{FastForward},
+					expectedErrMsg: "use a different update --strategy",
 				},
 			},
 		},
@@ -1271,6 +1307,10 @@ func TestCommand_Run_subpackages(t *testing.T) {
 							),
 					),
 				},
+				{
+					strategies:     []StrategyType{FastForward},
+					expectedErrMsg: "use a different update --strategy",
+				},
 			},
 		},
 		{
@@ -1306,7 +1346,7 @@ func TestCommand_Run_subpackages(t *testing.T) {
 			},
 			expectedResults: []resultForStrategy{
 				{
-					strategies: []StrategyType{KResourceMerge},
+					strategies: []StrategyType{KResourceMerge, FastForward},
 					expectedLocal: pkgbuilder.NewRootPkg().
 						WithKptfile(pkgbuilder.NewKptfile().
 							WithUpstream("github.com/foo/bar", "somebranch"),
@@ -1343,7 +1383,7 @@ func TestCommand_Run_subpackages(t *testing.T) {
 			},
 			expectedResults: []resultForStrategy{
 				{
-					strategies: []StrategyType{KResourceMerge},
+					strategies: []StrategyType{KResourceMerge, FastForward},
 					expectedLocal: pkgbuilder.NewRootPkg().
 						WithKptfile().
 						WithResource(pkgbuilder.DeploymentResource).
@@ -1377,7 +1417,7 @@ func TestCommand_Run_subpackages(t *testing.T) {
 			},
 			expectedResults: []resultForStrategy{
 				{
-					strategies: []StrategyType{KResourceMerge},
+					strategies: []StrategyType{KResourceMerge, FastForward},
 					expectedLocal: pkgbuilder.NewRootPkg().
 						WithKptfile(pkgbuilder.NewKptfile()).
 						WithFile("data.txt", "updated content").
@@ -1410,6 +1450,10 @@ func TestCommand_Run_subpackages(t *testing.T) {
 					expectedLocal: pkgbuilder.NewRootPkg().
 						WithKptfile(pkgbuilder.NewKptfile()).
 						WithFile("data.txt", "local content"),
+				},
+				{
+					strategies:     []StrategyType{FastForward},
+					expectedErrMsg: "use a different update --strategy",
 				},
 			},
 		},

--- a/pkg/kptfile/kptfileutil/util.go
+++ b/pkg/kptfile/kptfileutil/util.go
@@ -133,3 +133,20 @@ func ValidateInventory(inv *kptfile.Inventory) (bool, error) {
 	}
 	return true, nil
 }
+
+// DefaultKptfile returns a new minimal Kptfile.
+func DefaultKptfile(name string) kptfile.KptFile {
+	return kptfile.KptFile{
+		ResourceMeta: yaml.ResourceMeta{
+			TypeMeta: yaml.TypeMeta{
+				APIVersion: kptfile.TypeMeta.APIVersion,
+				Kind:       kptfile.TypeMeta.Kind,
+			},
+			ObjectMeta: yaml.ObjectMeta{
+				NameMeta: yaml.NameMeta{
+					Name: name,
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
This is similar to https://github.com/GoogleContainerTools/kpt/pull/1277, but updates the `FastForward` strategy to do updates on a per-package basis.
