### PR TITLE
Update the owning-inventory for existing objects during migration

### DIFF
--- a/commands/migratecmd_test.go
+++ b/commands/migratecmd_test.go
@@ -308,7 +308,7 @@ func TestKptMigrate_migrateObjs(t *testing.T) {
 			cmLoader := manifestreader.NewManifestLoader(tf)
 			rgLoader := live.NewResourceGroupManifestLoader(tf)
 			migrateRunner := GetMigrateRunner(cmProvider, rgProvider, cmLoader, rgLoader, ioStreams)
-			err := migrateRunner.migrateObjs(tc.objs, strings.NewReader(tc.invObj), []string{})
+			err := migrateRunner.migrateObjs(tc.objs, "", strings.NewReader(tc.invObj), []string{})
 			// Check if there should be an error
 			if tc.isError {
 				if err == nil {

--- a/commands/previewcmd.go
+++ b/commands/previewcmd.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package commands
 
 import (

--- a/e2e/live/end-to-end-test.sh
+++ b/e2e/live/end-to-end-test.sh
@@ -427,8 +427,8 @@ assertContains "namespace/test-namespace created (preview)"
 assertContains "pod/pod-a created (preview)"
 assertContains "pod/pod-b created (preview)"
 assertContains "pod/pod-c created (preview)"
-assertContains "4 resource(s) applied. 4 created, 0 unchanged, 0 configured"
-assertContains "0 resource(s) pruned, 0 skipped"
+assertContains "4 resource(s) applied. 4 created, 0 unchanged, 0 configured, 0 failed"
+assertContains "0 resource(s) pruned, 0 skipped, 0 failed"
 printResult
 
 # Test 3: Basic kpt live apply
@@ -442,8 +442,8 @@ assertContains "namespace/test-namespace"
 assertContains "pod/pod-a created"
 assertContains "pod/pod-b created"
 assertContains "pod/pod-c created"
-assertContains "4 resource(s) applied. 3 created, 1 unchanged, 0 configured"
-assertContains "0 resource(s) pruned, 0 skipped"
+assertContains "4 resource(s) applied. 3 created, 1 unchanged, 0 configured, 0 failed"
+assertContains "0 resource(s) pruned, 0 skipped, 0 failed"
 wait 2
 # Validate resources in the cluster
 # ConfigMap inventory with four inventory items.
@@ -461,9 +461,9 @@ assertContains "namespace/test-namespace configured (preview)"
 assertContains "pod/pod-b configured (preview)"
 assertContains "pod/pod-c configured (preview)"
 assertContains "pod/pod-d created (preview)"
-assertContains "4 resource(s) applied. 1 created, 0 unchanged, 3 configured (preview)"
+assertContains "4 resource(s) applied. 1 created, 0 unchanged, 3 configured, 0 failed (preview)"
 assertContains "pod/pod-a pruned (preview)"
-assertContains "1 resource(s) pruned, 0 skipped (preview)"
+assertContains "1 resource(s) pruned, 0 skipped, 0 failed (preview)"
 wait 2
 # Validate resources in the cluster
 # ConfigMap inventory with four inventory items.
@@ -482,9 +482,9 @@ assertContains "namespace/test-namespace unchanged"
 assertContains "pod/pod-b unchanged"
 assertContains "pod/pod-c unchanged"
 assertContains "pod/pod-d created"
-assertContains "4 resource(s) applied. 1 created, 3 unchanged, 0 configured"
+assertContains "4 resource(s) applied. 1 created, 3 unchanged, 0 configured, 0 failed"
 assertContains "pod/pod-a pruned"
-assertContains "1 resource(s) pruned, 0 skipped"
+assertContains "1 resource(s) pruned, 0 skipped, 0 failed"
 wait 2
 # Validate resources in the cluster
 # ConfigMap inventory with four inventory items.
@@ -552,8 +552,8 @@ assertContains "namespace/test-rg-namespace unchanged"
 assertContains "pod/pod-a created"
 assertContains "pod/pod-b created"
 assertContains "pod/pod-c created"
-assertContains "4 resource(s) applied. 3 created, 1 unchanged, 0 configured"
-assertContains "0 resource(s) pruned, 0 skipped"
+assertContains "4 resource(s) applied. 3 created, 1 unchanged, 0 configured, 0 failed"
+assertContains "0 resource(s) pruned, 0 skipped, 0 failed"
 # Validate resources in the cluster
 assertCMInventory "test-rg-namespace" "4"
 assertPodExists "pod-a" "test-rg-namespace"
@@ -613,8 +613,8 @@ assertContains "namespace/test-rg-namespace configured (preview)"
 assertContains "pod/pod-a configured (preview)"
 assertContains "pod/pod-b configured (preview)"
 assertContains "pod/pod-c configured (preview)"
-assertContains "4 resource(s) applied. 0 created, 0 unchanged, 4 configured (preview)"
-assertContains "0 resource(s) pruned, 0 skipped (preview)"
+assertContains "4 resource(s) applied. 0 created, 0 unchanged, 4 configured, 0 failed (preview)"
+assertContains "0 resource(s) pruned, 0 skipped, 0 failed (preview)"
 # Validate resources in the cluster
 assertRGInventory "test-rg-namespace"
 assertPodExists "pod-a" "test-rg-namespace"
@@ -634,8 +634,8 @@ assertContains "pod/pod-a pruned"
 assertContains "pod/pod-b unchanged"
 assertContains "pod/pod-c unchanged"
 assertContains "pod/pod-d created"
-assertContains "4 resource(s) applied. 1 created, 3 unchanged, 0 configured"
-assertContains "1 resource(s) pruned, 0 skipped"
+assertContains "4 resource(s) applied. 1 created, 3 unchanged, 0 configured, 0 failed"
+assertContains "1 resource(s) pruned, 0 skipped, 0 failed"
 # Validate resources in the cluster
 assertRGInventory "test-rg-namespace"
 assertPodExists "pod-b" "test-rg-namespace"
@@ -664,7 +664,7 @@ cp -f e2e/live/testdata/Kptfile e2e/live/testdata/migrate-error
 echo "Testing kpt live init for Kptfile (ResourceGroup inventory)"
 echo "kpt live init e2e/live/testdata/migrate-error"
 ${BIN_DIR}/kpt live init e2e/live/testdata/migrate-error > $OUTPUT_DIR/status 2>&1
-assertContains "namespace: test-rg-namespace is used for inventory object"
+assertContains "namespace: test-namespace-migrate-error is used for inventory object"
 assertContains "Initialized: "
 assertContains "Kptfile"
 # Difference in Kptfile should have inventory data

--- a/internal/testutil/setup_manager.go
+++ b/internal/testutil/setup_manager.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package testutil
 
 import (

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,0 +1,103 @@
+// Copyright 2020 Google LLC.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/kubectl/pkg/scheme"
+	"k8s.io/kubectl/pkg/util"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+// client is the client to update object in the API server.
+type client struct {
+	client     dynamic.Interface
+	restMapper meta.RESTMapper
+}
+
+func NewClient(d dynamic.Interface, mapper meta.RESTMapper) *client {
+	return &client{
+		client:     d,
+		restMapper: mapper,
+	}
+}
+
+// Update updates an object using dynamic client
+func (uc *client) Update(ctx context.Context, meta object.ObjMetadata, obj *unstructured.Unstructured, options *metav1.UpdateOptions) error {
+	r, err := uc.resourceInterface(meta)
+	if err != nil {
+		return err
+	}
+	if options == nil {
+		options = &metav1.UpdateOptions{}
+	}
+	_, err = r.Update(ctx, obj, *options)
+	return err
+}
+
+// Get fetches the requested object into the input obj using dynamic client
+func (uc *client) Get(ctx context.Context, meta object.ObjMetadata) (*unstructured.Unstructured, error) {
+	r, err := uc.resourceInterface(meta)
+	if err != nil {
+		return nil, err
+	}
+	return r.Get(ctx, meta.Name, metav1.GetOptions{})
+}
+
+func (uc *client) resourceInterface(meta object.ObjMetadata) (dynamic.ResourceInterface, error) {
+	mapping, err := uc.restMapper.RESTMapping(meta.GroupKind)
+	if err != nil {
+		return nil, err
+	}
+	namespacedClient := uc.client.Resource(mapping.Resource).Namespace(meta.Namespace)
+	return namespacedClient, nil
+}
+
+// UpdateAnnotation updates the object owning inventory annotation
+// to the new ID when the owning inventory annotation is either empty or the old ID.
+// It returns if the annotation is updated.
+func UpdateAnnotation(obj *unstructured.Unstructured, oldID, newID string) (bool, error) {
+	key := "config.k8s.io/owning-inventory"
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	val, found := annotations[key]
+	if !found || val == oldID {
+		annotations[key] = newID
+		// Since the annotation is updated, we also need to update the
+		// last applied configuration annotation.
+		u := getOriginalObj(obj)
+		if u != nil {
+			u.SetAnnotations(annotations)
+			err := util.CreateOrUpdateAnnotation(false, u, scheme.DefaultJSONEncoder())
+			obj.SetAnnotations(u.GetAnnotations())
+			return true, err
+		}
+		obj.SetAnnotations(annotations)
+		return true, nil
+	}
+	return false, nil
+}
+
+func getOriginalObj(obj *unstructured.Unstructured) *unstructured.Unstructured {
+	annotations := obj.GetAnnotations()
+	lastApplied, found := annotations[v1.LastAppliedConfigAnnotation]
+	if !found {
+		return nil
+	}
+	u := &unstructured.Unstructured{}
+	err := json.Unmarshal([]byte(lastApplied), u)
+	if err != nil {
+		return nil
+	}
+	return u
+}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,0 +1,73 @@
+// Copyright 2020 Google LLC.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestUpdateAnnotation(t *testing.T) {
+	testcases := []struct {
+		name         string
+		annotations  map[string]string
+		oldID        string
+		newID        string
+		shouldUpdate bool
+	}{
+		{
+			name:         "empty owning-inventory is changed to newID",
+			annotations:  nil,
+			oldID:        "old",
+			newID:        "new",
+			shouldUpdate: true,
+		},
+		{
+			name: "oldID is changed to newID",
+			annotations: map[string]string{
+				"config.k8s.io/owning-inventory": "old",
+			},
+			oldID:        "old",
+			newID:        "new",
+			shouldUpdate: true,
+		},
+		{
+			name: "non empty unmatched id won't be changed to newID",
+			annotations: map[string]string{
+				"config.k8s.io/owning-inventory": "random",
+			},
+			oldID:        "old",
+			newID:        "new",
+			shouldUpdate: false,
+		},
+	}
+	deployment := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "deployment",
+				"namespace": "test",
+			},
+		},
+	}
+	for _, tc := range testcases {
+		deployment.SetAnnotations(tc.annotations)
+		updated, err := UpdateAnnotation(deployment, tc.oldID, tc.newID)
+		if err != nil {
+			t.Errorf("unexpected error %v", err)
+		}
+		if tc.shouldUpdate {
+			if !updated {
+				t.Errorf("owning-inventory should be updated")
+			}
+			if deployment.GetAnnotations()["config.k8s.io/owning-inventory"] != tc.newID {
+				t.Errorf("the owning-inventory annotation is not correctly updated")
+			}
+		} else if updated {
+			t.Errorf("owning-inventory shouldn't be changed")
+		}
+	}
+}


### PR DESCRIPTION
After we add the InventoryPolicy in the cli-utils library, we need to update the migrate command so that the owning-inventory annotations are pointed to the ResourceGroup object. The change is to loop over the resources that are included in the ConfigMap inventory object and change their `owning-inventory` annotation to the new ResourceGroup CR.

When updating the `owning-inventory` annotation, we also update the last-applied-configuration annotation.

Fix #1306 This is a different approach compared with #1307. 