### PR TITLE
Create arm64 binaries for kpt releases

### DIFF
--- a/release/tag/goreleaser.yaml
+++ b/release/tag/goreleaser.yaml
@@ -22,6 +22,7 @@ builds:
       - windows
     goarch:
       - amd64
+      - arm64
     ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}}
 archives:
   - files:


### PR DESCRIPTION
Adds arm64 arch to goreleaser.

Ref: https://github.com/GoogleContainerTools/kpt/issues/1319
