### PR TITLE
Avoid changing cwd in the test framework

### DIFF
--- a/internal/cmddiff/cmddiff_test.go
+++ b/internal/cmddiff/cmddiff_test.go
@@ -47,6 +47,9 @@ func TestCmdInvalidDiffTool(t *testing.T) {
 func TestCmdExecute(t *testing.T) {
 	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
+
+	defer testutil.Chdir(t, w.WorkspaceDirectory)()
+
 	dest := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 
 	getRunner := cmdget.NewRunner("")

--- a/internal/cmdget/cmdget.go
+++ b/internal/cmdget/cmdget.go
@@ -71,7 +71,13 @@ func (r *Runner) preRunE(c *cobra.Command, args []string) error {
 		return err
 	}
 	r.Get.Git = t.Git
-	r.Get.Destination = t.Destination
+
+	_, absDestPath, err := cmdutil.ResolveAbsAndRelPaths(t.Destination)
+	if err != nil {
+		return err
+	}
+
+	r.Get.Destination = absDestPath
 	return nil
 }
 

--- a/internal/cmdupdate/cmdupdate.go
+++ b/internal/cmdupdate/cmdupdate.go
@@ -17,8 +17,6 @@ package cmdupdate
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"strings"
 
 	docs "github.com/GoogleContainerTools/kpt/internal/docs/generated/pkgdocs"
@@ -79,9 +77,13 @@ func (r *Runner) preRunE(c *cobra.Command, args []string) error {
 	}
 
 	var err error
-	r.Update.Path, r.Update.FullPackagePath, err = resolveAbsAndRelPaths(parts[0])
+	r.Update.Path, r.Update.FullPackagePath, err = cmdutil.ResolveAbsAndRelPaths(parts[0])
 	if err != nil {
 		return err
+	}
+
+	if strings.HasPrefix(r.Update.Path, "../") {
+		return errors.Errorf("package path must be under current working directory")
 	}
 
 	if len(parts) > 1 {
@@ -105,33 +107,4 @@ func (r *Runner) runE(c *cobra.Command, args []string) error {
 	}
 
 	return nil
-}
-
-func resolveAbsAndRelPaths(path string) (string, string, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", "", err
-	}
-
-	var relPath string
-	var absPath string
-	if filepath.IsAbs(path) {
-		// If the provided path is absolute, we find the relative path by
-		// comparing it to the current working directory.
-		relPath, err = filepath.Rel(cwd, path)
-		if err != nil {
-			return "", "", err
-		}
-		absPath = filepath.Clean(path)
-	} else {
-		// If the provided path is relative, we find the absolute path by
-		// combining the current working directory with the relative path.
-		relPath = filepath.Clean(path)
-		absPath = filepath.Join(cwd, path)
-	}
-
-	if strings.HasPrefix(relPath, "../") {
-		return "", "", errors.Errorf("package path must be under current working directory")
-	}
-	return relPath, absPath, nil
 }

--- a/internal/cmdupdate/cmdupdate_test.go
+++ b/internal/cmdupdate/cmdupdate_test.go
@@ -36,6 +36,9 @@ import (
 func TestCmd_execute(t *testing.T) {
 	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
+
+	defer testutil.Chdir(t, w.WorkspaceDirectory)()
+
 	dest := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 
 	// clone the repo
@@ -66,9 +69,6 @@ func TestCmd_execute(t *testing.T) {
 
 	// update the cloned package
 	updateCmd := cmdupdate.NewRunner("kpt")
-	if !assert.NoError(t, os.Chdir(w.WorkspaceDirectory)) {
-		return
-	}
 	updateCmd.Command.SetArgs([]string{g.RepoName, "--strategy", "fast-forward"})
 	if !assert.NoError(t, updateCmd.Command.Execute()) {
 		return
@@ -110,6 +110,9 @@ func TestCmd_execute(t *testing.T) {
 func TestCmd_failUnCommitted(t *testing.T) {
 	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
+
+	defer testutil.Chdir(t, w.WorkspaceDirectory)()
+
 	dest := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 
 	// clone the repo
@@ -134,9 +137,6 @@ func TestCmd_failUnCommitted(t *testing.T) {
 
 	// update the cloned package
 	updateCmd := cmdupdate.NewRunner("kpt")
-	if !assert.NoError(t, os.Chdir(w.WorkspaceDirectory)) {
-		return
-	}
 	updateCmd.Command.SetArgs([]string{g.RepoName})
 	err = updateCmd.Command.Execute()
 	if !assert.Error(t, err) {
@@ -282,17 +282,7 @@ func TestCmd_path(t *testing.T) {
 	for i := range testCases {
 		test := testCases[i]
 		t.Run(test.name, func(t *testing.T) {
-			currentWD, err := os.Getwd()
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
-			defer func() {
-				_ = os.Chdir(currentWD)
-			}()
-			err = os.Chdir(test.currentWD)
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
+			defer testutil.Chdir(t, test.currentWD)()
 
 			r := cmdupdate.NewRunner("kpt")
 			r.Command.RunE = func(cmd *cobra.Command, args []string) error {

--- a/internal/testutil/setup_manager.go
+++ b/internal/testutil/setup_manager.go
@@ -95,21 +95,14 @@ func (g *TestSetupManager) Init(dataset string) bool {
 	} else {
 		g.targetDir = filepath.Base(g.GetSubDirectory)
 	}
-	if !assert.NoError(g.T, os.Chdir(g.UpstreamRepo.RepoDirectory)) {
-		return false
-	}
+	g.LocalWorkspace.PackageDir = g.targetDir
 
 	if err := updateGitDir(g.T, g.UpstreamRepo, g.UpstreamInit); err != nil {
 		return false
 	}
 
-	// Fetch the source repo
-	if !assert.NoError(g.T, os.Chdir(g.LocalWorkspace.WorkspaceDirectory)) {
-		return false
-	}
-
 	if !assert.NoError(g.T, get.Command{
-		Destination: g.targetDir,
+		Destination: filepath.Join(g.LocalWorkspace.WorkspaceDirectory, g.targetDir),
 		Git: kptfile.Git{
 			Repo:      g.UpstreamRepo.RepoDirectory,
 			Ref:       g.GetRef,

--- a/internal/util/cmdutil/cmdutil.go
+++ b/internal/util/cmdutil/cmdutil.go
@@ -17,6 +17,7 @@ package cmdutil
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/go-errors/errors"
@@ -55,3 +56,29 @@ var K8sSchemaSource string
 // K8sSchemaPath defines the path to the openAPI schema if we are reading from
 // a file
 var K8sSchemaPath string
+
+func ResolveAbsAndRelPaths(path string) (string, string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", "", err
+	}
+
+	var relPath string
+	var absPath string
+	if filepath.IsAbs(path) {
+		// If the provided path is absolute, we find the relative path by
+		// comparing it to the current working directory.
+		relPath, err = filepath.Rel(cwd, path)
+		if err != nil {
+			return "", "", err
+		}
+		absPath = filepath.Clean(path)
+	} else {
+		// If the provided path is relative, we find the absolute path by
+		// combining the current working directory with the relative path.
+		relPath = filepath.Clean(path)
+		absPath = filepath.Join(cwd, path)
+	}
+
+	return relPath, absPath, nil
+}

--- a/internal/util/diff/diff_test.go
+++ b/internal/util/diff/diff_test.go
@@ -119,6 +119,8 @@ func TestCommand_RunCombinedDiff(t *testing.T) {
 	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
 
+	defer testutil.Chdir(t, w.WorkspaceDirectory)()
+
 	// create a commit with dataset2 and tag it v2, then add another commit on top with dataset3
 	commit0, err := g.GetCommit()
 	assert.NoError(t, err)
@@ -139,12 +141,11 @@ func TestCommand_RunCombinedDiff(t *testing.T) {
 	assert.NotEqual(t, commit, commit0)
 	assert.NotEqual(t, commit, commit2)
 
+	localPkg := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	err = get.Command{Git: kptfile.Git{
 		Repo: g.RepoDirectory, Ref: "refs/tags/v2", Directory: "/"},
-		Destination: filepath.Base(g.RepoDirectory)}.Run()
+		Destination: localPkg}.Run()
 	assert.NoError(t, err)
-
-	localPkg := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 
 	diffOutput := &bytes.Buffer{}
 
@@ -192,6 +193,8 @@ func TestCommand_Run_LocalDiff(t *testing.T) {
 	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
 	defer clean()
 
+	defer testutil.Chdir(t, w.WorkspaceDirectory)()
+
 	// create a commit with dataset2 and tag it v2, then add another commit on top with dataset3
 	commit0, err := g.GetCommit()
 	assert.NoError(t, err)
@@ -205,12 +208,11 @@ func TestCommand_Run_LocalDiff(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotEqual(t, commit, commit0)
 
+	localPkg := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	err = get.Command{Git: kptfile.Git{
 		Repo: g.RepoDirectory, Ref: "refs/tags/v2", Directory: "/"},
-		Destination: filepath.Base(g.RepoDirectory)}.Run()
+		Destination: localPkg}.Run()
 	assert.NoError(t, err)
-
-	localPkg := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 
 	// make changes in local package
 	err = copyutil.CopyDir(filepath.Join(g.DatasetDirectory, testutil.Dataset3), localPkg)

--- a/internal/util/get/get.go
+++ b/internal/util/get/get.go
@@ -244,6 +244,10 @@ func (c *Command) DefaultValues() error {
 		return errors.Errorf("must specify remote subdirectory")
 	}
 
+	if !filepath.IsAbs(c.Destination) {
+		return errors.Errorf("destination must be an absolute path")
+	}
+
 	// default the name to the destination name
 	if len(c.Name) == 0 {
 		c.Name = filepath.Base(c.Destination)

--- a/internal/util/update/update.go
+++ b/internal/util/update/update.go
@@ -142,7 +142,7 @@ func (u Command) Run() error {
 		u.Output = os.Stdout
 	}
 
-	kptfile, err := kptfileutil.ReadFileStrict(u.Path)
+	kptfile, err := kptfileutil.ReadFileStrict(u.FullPackagePath)
 	if err != nil {
 		return errors.Errorf("unable to read package Kptfile: %v", err)
 	}
@@ -156,8 +156,8 @@ func (u Command) Run() error {
 	}
 
 	// require package is checked into git before trying to update it
-	g := gitutil.NewLocalGitRunner("./")
-	if err := g.Run("status", "-s", u.Path); err != nil {
+	g := gitutil.NewLocalGitRunner(u.FullPackagePath)
+	if err := g.Run("status", "-s"); err != nil {
 		return errors.Errorf(
 			"kpt packages must be checked into a git repo before they are updated: %v", err)
 	}
@@ -191,7 +191,7 @@ func (u Command) Run() error {
 	// perform auto-setters after the package is updated
 	a := setters.AutoSet{
 		Writer:      u.Output,
-		PackagePath: u.Path,
+		PackagePath: u.FullPackagePath,
 	}
 	return a.PerformAutoSetters()
 }


### PR DESCRIPTION
Update the kpt commands to translate from relative to absolute paths. The rest of the implementation, including the test framework, always works with absolute paths.
