### PR TITLE
Update testing framework to handle remote subpackages

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -159,13 +159,15 @@ func TestKptGetSet(t *testing.T) {
 				// diff requires a kptfile exists
 				testutil.CopyKptfile(t, localDir, upstreamGit.RepoDirectory)
 
-				testutil.AssertPkgEqual(t, upstreamGit,
-					filepath.Join(expected, test.subdir), localDir)
+				if !testutil.AssertPkgEqual(t, filepath.Join(expected, test.subdir), localDir) {
+					t.FailNow()
+				}
 				return
 			}
 
-			testutil.AssertPkgEqual(t, upstreamGit,
-				filepath.Join(expected, test.subdir), localDir)
+			if !testutil.AssertPkgEqual(t, filepath.Join(expected, test.subdir), localDir) {
+				t.FailNow()
+			}
 
 			// Run Set
 			cmd = run.GetMain()
@@ -189,9 +191,10 @@ func TestKptGetSet(t *testing.T) {
 			testutil.Compare(t,
 				filepath.Join(expected, test.subdir, "Kptfile"),
 				filepath.Join(localDir, "Kptfile"))
-			testutil.AssertPkgEqual(t, upstreamGit,
-				filepath.Join(expected, test.subdir),
-				localDir)
+			if !testutil.AssertPkgEqual(t, filepath.Join(expected, test.subdir),
+				localDir) {
+				t.FailNow()
+			}
 		})
 	}
 }

--- a/e2e/e2eutils.go
+++ b/e2e/e2eutils.go
@@ -34,7 +34,7 @@ func SetupGitRepo(t *testing.T) (*testutil.TestGitRepo, string, func()) {
 		t.FailNow()
 	}
 
-	g, _, c := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
+	g, _, c := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
 	upstream := g.RepoDirectory
 
 	clean := func() {

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,9 @@ require (
 	github.com/go-errors/errors v1.0.1
 	github.com/go-openapi/spec v0.19.5
 	github.com/olekukonko/tablewriter v0.0.4
+	// TODO: find a library that have proper releases or just implement
+	// topsort in kpt.
+	github.com/philopon/go-toposort v0.0.0-20170620085441-9be86dbd762f
 	github.com/pkg/errors v0.9.1
 	github.com/posener/complete/v2 v2.0.1-alpha.12
 	github.com/spf13/cobra v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -352,6 +352,8 @@ github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
+github.com/philopon/go-toposort v0.0.0-20170620085441-9be86dbd762f h1:WyCn68lTiytVSkk7W1K9nBiSGTSRlUOdyTnSjwrIlok=
+github.com/philopon/go-toposort v0.0.0-20170620085441-9be86dbd762f/go.mod h1:/iRjX3DdSK956SzsUdV55J+wIsQ+2IBWmBrB4RvZfk4=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/internal/cmddiff/cmddiff_test.go
+++ b/internal/cmddiff/cmddiff_test.go
@@ -45,7 +45,7 @@ func TestCmdInvalidDiffTool(t *testing.T) {
 }
 
 func TestCmdExecute(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()

--- a/internal/cmdget/cmdget_test.go
+++ b/internal/cmdget/cmdget_test.go
@@ -33,7 +33,7 @@ import (
 
 // TestCmd_execute tests that get is correctly invoked.
 func TestCmd_execute(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -77,7 +77,7 @@ func TestCmd_execute(t *testing.T) {
 // is main and master branch doesn't exist
 func TestCmdMainBranch_execute(t *testing.T) {
 	// set up git repository with master and main branches
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -193,7 +193,7 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 		pathPrefix = "/private"
 	}
 
-	_, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
+	_, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()

--- a/internal/cmdinit/cmdinit_test.go
+++ b/internal/cmdinit/cmdinit_test.go
@@ -141,7 +141,7 @@ func TestCmd_failNotExists(t *testing.T) {
 
 func TestGitUtil_DefaultRef(t *testing.T) {
 	// set up git repo with both main and master branches
-	g, _, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
+	g, _, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
 	defer clean()
 
 	// check if master is picked as default if both main and master branches exist

--- a/internal/cmdupdate/cmdupdate_test.go
+++ b/internal/cmdupdate/cmdupdate_test.go
@@ -34,7 +34,7 @@ import (
 
 // TestCmd_execute verifies that update is correctly invoked.
 func TestCmd_execute(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -108,7 +108,7 @@ func TestCmd_execute(t *testing.T) {
 }
 
 func TestCmd_failUnCommitted(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()

--- a/internal/util/diff/diff_test.go
+++ b/internal/util/diff/diff_test.go
@@ -44,7 +44,7 @@ import (
 // 5. Run remote diff between master and cloned
 func TestCommand_RunRemoteDiff(t *testing.T) {
 	t.SkipNow()
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
 	defer clean()
 
 	// create a commit with dataset2 and tag it v2, then add another commit on top with dataset3
@@ -116,7 +116,7 @@ func TestCommand_RunRemoteDiff(t *testing.T) {
 // 5. add more data to the master branch, commit it
 // 5. Run combined diff between master and cloned
 func TestCommand_RunCombinedDiff(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -190,7 +190,7 @@ func TestCommand_RunCombinedDiff(t *testing.T) {
 // 5. Update cloned package with dataset3
 // 6. Run remote diff and verify the output
 func TestCommand_Run_LocalDiff(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()

--- a/internal/util/diff/pkgdiff_test.go
+++ b/internal/util/diff/pkgdiff_test.go
@@ -128,8 +128,8 @@ func TestPkgDiff(t *testing.T) {
 	for i := range testCases {
 		test := testCases[i]
 		t.Run(test.name, func(t *testing.T) {
-			pkg1Dir := pkgbuilder.ExpandPkg(t, test.pkg1)
-			pkg2Dir := pkgbuilder.ExpandPkg(t, test.pkg2)
+			pkg1Dir := pkgbuilder.ExpandPkg(t, test.pkg1, map[string]string{})
+			pkg2Dir := pkgbuilder.ExpandPkg(t, test.pkg2, map[string]string{})
 			diff, err := PkgDiff(pkg1Dir, pkg2Dir)
 			if !assert.NoError(t, err) {
 				t.FailNow()

--- a/internal/util/get/get_test.go
+++ b/internal/util/get/get_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
+	"github.com/GoogleContainerTools/kpt/internal/testutil/pkgbuilder"
 	. "github.com/GoogleContainerTools/kpt/internal/util/get"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
 	"github.com/stretchr/testify/assert"
@@ -43,7 +44,7 @@ func TestCommand_Run_failNoRevision(t *testing.T) {
 // - destination directory should match the base name of the repo
 // - KptFile should be populated with values pointing to the origin
 func TestCommand_Run(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -93,7 +94,7 @@ func TestCommand_Run(t *testing.T) {
 // - KptFile should have the subdir listed
 func TestCommand_Run_subdir(t *testing.T) {
 	subdir := "java"
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -139,7 +140,7 @@ func TestCommand_Run_subdir(t *testing.T) {
 // than using the name of the source repo.
 func TestCommand_Run_destination(t *testing.T) {
 	dest := "my-dataset"
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -192,7 +193,7 @@ func TestCommand_Run_destination(t *testing.T) {
 func TestCommand_Run_subdirAndDestination(t *testing.T) {
 	subdir := "java"
 	dest := "new-java"
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -246,7 +247,7 @@ func TestCommand_Run_subdirAndDestination(t *testing.T) {
 // 4. clone the new branch
 // 5. verify contents match the new branch
 func TestCommand_Run_branch(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -313,7 +314,7 @@ func TestCommand_Run_branch(t *testing.T) {
 // 4. clone at the tag
 // 5. verify the clone has the data from the tagged version
 func TestCommand_Run_tag(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -384,7 +385,7 @@ func TestCommand_Run_tag(t *testing.T) {
 // 3. clone the master branch again
 // 4. verify the new master branch data is present
 func TestCommand_Run_clean(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -485,7 +486,7 @@ func TestCommand_Run_clean(t *testing.T) {
 // 2. clone a non-existing branch
 // 3. verify the master branch data is still present
 func TestCommand_Run_failClean(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -579,7 +580,7 @@ func TestCommand_Run_failClean(t *testing.T) {
 // TestCommand_Run_failExistingDir verifies that command will fail without changing anything if the
 // directory already exists
 func TestCommand_Run_failExistingDir(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -668,7 +669,7 @@ func TestCommand_Run_failExistingDir(t *testing.T) {
 }
 
 func TestCommand_Run_failInvalidRepo(t *testing.T) {
-	_, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
+	_, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
 	defer clean()
 
 	absPath := filepath.Join(w.WorkspaceDirectory, "foo")
@@ -689,7 +690,7 @@ func TestCommand_Run_failInvalidRepo(t *testing.T) {
 }
 
 func TestCommand_Run_failInvalidBranch(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
 	defer clean()
 
 	absPath := filepath.Join(w.WorkspaceDirectory, g.RepoDirectory)
@@ -713,7 +714,7 @@ func TestCommand_Run_failInvalidBranch(t *testing.T) {
 }
 
 func TestCommand_Run_failInvalidTag(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1)
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
 	defer clean()
 
 	err := Command{
@@ -750,4 +751,157 @@ func TestCommand_DefaultValues_AtVersion(t *testing.T) {
 
 	c = Command{Git: kptfile.Git{Repo: "foo", Directory: "/", Ref: "r"}}
 	assert.EqualError(t, c.DefaultValues(), "must specify destination")
+}
+
+func TestCommand_Run_subpackages(t *testing.T) {
+	testCases := []struct {
+		name            string
+		directory       string
+		ref             string
+		upstream        testutil.Content
+		refRepos        map[string][]testutil.Content
+		expectedResults *pkgbuilder.RootPkg
+	}{
+		{
+			name:      "basic package",
+			directory: "/",
+			ref:       "master",
+			upstream: testutil.Content{
+				Pkg: pkgbuilder.NewRootPkg().
+					WithKptfile().
+					WithResource(pkgbuilder.DeploymentResource),
+			},
+			expectedResults: pkgbuilder.NewRootPkg().
+				WithKptfile().
+				WithResource(pkgbuilder.DeploymentResource),
+		},
+		{
+			name:      "package with subpackages",
+			directory: "/",
+			ref:       "master",
+			upstream: testutil.Content{
+				Pkg: pkgbuilder.NewRootPkg().
+					WithKptfile().
+					WithResource(pkgbuilder.DeploymentResource).
+					WithSubPackages(
+						pkgbuilder.NewSubPkg("subpkg").
+							WithKptfile().
+							WithResource(pkgbuilder.ConfigMapResource),
+					),
+			},
+			expectedResults: pkgbuilder.NewRootPkg().
+				WithKptfile().
+				WithResource(pkgbuilder.DeploymentResource).
+				WithSubPackages(
+					pkgbuilder.NewSubPkg("subpkg").
+						WithKptfile().
+						WithResource(pkgbuilder.ConfigMapResource),
+				),
+		},
+		{
+			name:      "package with remote subpackages",
+			directory: "/",
+			ref:       "master",
+			upstream: testutil.Content{
+				Pkg: pkgbuilder.NewRootPkg().
+					WithKptfile(
+						pkgbuilder.NewKptfile().
+							WithSubpackages(
+								pkgbuilder.NewSubpackage("foo", "/", "master", "fast-forward"),
+							),
+					).
+					WithResource(pkgbuilder.DeploymentResource).
+					WithSubPackages(
+						pkgbuilder.NewSubPkg("subpkg").
+							WithResource(pkgbuilder.ConfigMapResource),
+					),
+			},
+			refRepos: map[string][]testutil.Content{
+				"foo": {
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithKptfile().
+							WithResource(pkgbuilder.DeploymentResource).
+							WithSubPackages(
+								pkgbuilder.NewSubPkg("subpkg").
+									WithKptfile(
+										pkgbuilder.NewKptfile().
+											WithSubpackages(
+												pkgbuilder.NewSubpackage("bar", "/foobar", "v1.2", "fast-forward"),
+											),
+									).
+									WithResource(pkgbuilder.ConfigMapResource),
+							),
+					},
+				},
+				"bar": {
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithKptfile().
+							WithResource(pkgbuilder.DeploymentResource),
+					},
+				},
+			},
+			expectedResults: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithSubpackages(
+							pkgbuilder.NewSubpackage("foo", "/", "master", "fast-forward"),
+						),
+				).
+				WithResource(pkgbuilder.DeploymentResource).
+				WithSubPackages(
+					pkgbuilder.NewSubPkg("subpkg").
+						WithResource(pkgbuilder.ConfigMapResource),
+				),
+		},
+	}
+
+	for i := range testCases {
+		test := testCases[i]
+		t.Run(test.name, func(t *testing.T) {
+			refRepos, err := testutil.SetupRepos(t, test.refRepos)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			repoPaths := make(map[string]string)
+			for name, tgr := range refRepos {
+				repoPaths[name] = tgr.RepoDirectory
+			}
+
+			dir := pkgbuilder.ExpandPkg(t, pkgbuilder.NewRootPkg(), repoPaths)
+			g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, dir, repoPaths)
+			defer clean()
+
+			err = testutil.UpdateGitDir(t, g, []testutil.Content{test.upstream}, repoPaths)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			var targetDir string
+			if test.directory == "/" {
+				targetDir = filepath.Base(g.RepoName)
+			} else {
+				targetDir = filepath.Base(test.directory)
+			}
+			w.PackageDir = targetDir
+			destinationDir := filepath.Join(w.WorkspaceDirectory, targetDir)
+
+			err = Command{
+				Git: kptfile.Git{
+					Repo:      g.RepoDirectory,
+					Directory: test.directory,
+					Ref:       test.ref,
+				},
+				Destination: destinationDir,
+			}.Run()
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			expectedPath := pkgbuilder.ExpandPkg(t, test.expectedResults, repoPaths)
+			testutil.AssertPkgEqual(t, expectedPath, w.FullPackagePath())
+		})
+	}
 }

--- a/internal/util/merge/merge3_test.go
+++ b/internal/util/merge/merge3_test.go
@@ -133,10 +133,10 @@ func TestMerge3_Nested_packages(t *testing.T) {
 	for i := range testCases {
 		test := testCases[i]
 		t.Run(test.name, func(t *testing.T) {
-			original := pkgbuilder.ExpandPkg(t, test.original)
-			updated := pkgbuilder.ExpandPkg(t, test.upstream)
-			local := pkgbuilder.ExpandPkg(t, test.local)
-			expected := pkgbuilder.ExpandPkg(t, test.expected)
+			original := pkgbuilder.ExpandPkg(t, test.original, map[string]string{})
+			updated := pkgbuilder.ExpandPkg(t, test.upstream, map[string]string{})
+			local := pkgbuilder.ExpandPkg(t, test.local, map[string]string{})
+			expected := pkgbuilder.ExpandPkg(t, test.expected, map[string]string{})
 			err := Merge3{
 				OriginalPath:       original,
 				UpdatedPath:        updated,

--- a/internal/util/update/update_test.go
+++ b/internal/util/update/update_test.go
@@ -1464,7 +1464,8 @@ func TestCommand_Run_subpackages(t *testing.T) {
 		for i := range strategies {
 			strategy := strategies[i]
 			t.Run(fmt.Sprintf("%s#%s", test.name, string(strategy)), func(t *testing.T) {
-				dir := pkgbuilder.ExpandPkg(t, test.initialUpstream)
+				var emptyMap map[string]string
+				dir := pkgbuilder.ExpandPkg(t, test.initialUpstream, emptyMap)
 
 				g := &testutil.TestSetupManager{
 					T: t,
@@ -1521,9 +1522,9 @@ func TestCommand_Run_subpackages(t *testing.T) {
 
 				var expectedPath string
 				if test.initialUpstream.HasKptfile() {
-					expectedPath = pkgbuilder.ExpandPkg(t, result.expectedLocal)
+					expectedPath = pkgbuilder.ExpandPkg(t, result.expectedLocal, emptyMap)
 				} else {
-					expectedPath = pkgbuilder.ExpandPkgWithName(t, result.expectedLocal, g.LocalWorkspace.PackageDir)
+					expectedPath = pkgbuilder.ExpandPkgWithName(t, result.expectedLocal, g.LocalWorkspace.PackageDir, emptyMap)
 				}
 
 				if !g.AssertLocalDataEquals(expectedPath) {

--- a/pkg/kptfile/pkgfile.go
+++ b/pkg/kptfile/pkgfile.go
@@ -47,6 +47,8 @@ type KptFile struct {
 
 	Dependencies []Dependency `yaml:"dependencies,omitempty"`
 
+	Subpackages []Subpackage `yaml:"subpackages,omitempty"`
+
 	// OpenAPI contains additional schema for the resources in this package
 	// Uses interface{} instead of Node to work around yaml serialization issues
 	// See https://github.com/go-yaml/yaml/issues/518 and
@@ -255,6 +257,12 @@ type Dependency struct {
 	EnsureNotExists bool   `yaml:"ensureNotExists,omitempty"`
 	Strategy        string `yaml:"updateStrategy,omitempty"`
 	AutoSet         bool   `yaml:"autoSet,omitempty"`
+}
+
+type Subpackage struct {
+	LocalDir       string `yaml:"localDir,omitempty"`
+	Git            Git    `yaml:"git,omitempty"`
+	UpdateStrategy string `yaml:"updateStrategy,omitempty"`
 }
 
 type PackageMeta struct {


### PR DESCRIPTION
Update testing framework to handle remote subpackages. This is needed to be able to test complex scenarios for `get` and `update`.