### PR TITLE
Docs: Fix a few typos in Functions Developer Guide

### DIFF
--- a/site/content/en/guides/producer/functions/_index.md
+++ b/site/content/en/guides/producer/functions/_index.md
@@ -4,7 +4,7 @@ linkTitle: "Functions"
 weight: 4
 type: docs
 description: >
-   Writing config functions to generated, transform, and validate resources.
+   Writing config functions to generate, transform, and validate resources.
 ---
 
 ## Functions Developer Guide
@@ -20,13 +20,13 @@ embedded in other systems. For example, functions could be:
 
 - manually run locally
 - automatically run locally as part of _make_, _mvn_, _go generate_, etc
-- automatically run in CICD systems
+- automatically run in CI/CD systems
 - run by controllers as reconcile implementations
 
 {{< svg src="images/fn" >}}
 
 {{% pageinfo color="primary" %}}
-Unlikely pure-templating and DSL approaches, functions must be able to both
+Unlike pure-templating and DSL approaches, functions must be able to both
 _read_ and _write_ resources, and specifically should be able to read resources
 they have previously written -- updating the inputs rather generating new
 resources.


### PR DESCRIPTION
While browsing through the nice KPT documentation, I noticed a few grammar errors and inconsistencies in the page about functions for package publishers.  Here are proposed fixes for them.