### PR TITLE
Allow test framework to better handle the main branch

### DIFF
--- a/e2e/e2eutils.go
+++ b/e2e/e2eutils.go
@@ -34,7 +34,10 @@ func SetupGitRepo(t *testing.T) (*testutil.TestGitRepo, string, func()) {
 		t.FailNow()
 	}
 
-	g, _, c := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
+	g, _, c := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}, map[string]string{})
 	upstream := g.RepoDirectory
 
 	clean := func() {

--- a/internal/cmddiff/cmddiff_test.go
+++ b/internal/cmddiff/cmddiff_test.go
@@ -45,7 +45,10 @@ func TestCmdInvalidDiffTool(t *testing.T) {
 }
 
 func TestCmdExecute(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()

--- a/internal/cmdget/cmdget_test.go
+++ b/internal/cmdget/cmdget_test.go
@@ -33,7 +33,10 @@ import (
 
 // TestCmd_execute tests that get is correctly invoked.
 func TestCmd_execute(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -77,17 +80,15 @@ func TestCmd_execute(t *testing.T) {
 // is main and master branch doesn't exist
 func TestCmdMainBranch_execute(t *testing.T) {
 	// set up git repository with master and main branches
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+		Data: testutil.Dataset1,
+	}, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
 
 	dest := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	err := g.CheckoutBranch("main", false)
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	err = g.DeleteBranch("master")
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
@@ -193,7 +194,10 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 		pathPrefix = "/private"
 	}
 
-	_, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
+	_, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()

--- a/internal/cmdinit/cmdinit_test.go
+++ b/internal/cmdinit/cmdinit_test.go
@@ -141,7 +141,10 @@ func TestCmd_failNotExists(t *testing.T) {
 
 func TestGitUtil_DefaultRef(t *testing.T) {
 	// set up git repo with both main and master branches
-	g, _, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
+	g, _, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}, map[string]string{})
 	defer clean()
 
 	// check if master is picked as default if both main and master branches exist
@@ -156,7 +159,7 @@ func TestGitUtil_DefaultRef(t *testing.T) {
 		t.FailNow()
 	}
 
-	err = g.CheckoutBranch("main", false)
+	err = g.CheckoutBranch("main", true)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/internal/cmdupdate/cmdupdate_test.go
+++ b/internal/cmdupdate/cmdupdate_test.go
@@ -34,7 +34,10 @@ import (
 
 // TestCmd_execute verifies that update is correctly invoked.
 func TestCmd_execute(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -108,7 +111,10 @@ func TestCmd_execute(t *testing.T) {
 }
 
 func TestCmd_failUnCommitted(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()

--- a/internal/testutil/setup_manager.go
+++ b/internal/testutil/setup_manager.go
@@ -77,7 +77,7 @@ type Content struct {
 // - Setup a new cache location for git repos and update the environment variable
 // - Setup fetch the upstream package to a local package
 // - Verify the local package contains the upstream content
-func (g *TestSetupManager) Init(dataset string) bool {
+func (g *TestSetupManager) Init(content Content) bool {
 	// Default optional values
 	if g.GetRef == "" {
 		g.GetRef = "master"
@@ -108,7 +108,7 @@ func (g *TestSetupManager) Init(dataset string) bool {
 	}
 
 	// Setup a "remote" source repo, and a "local" destination repo
-	g.UpstreamRepo, g.LocalWorkspace, g.cleanTestRepo = SetupDefaultRepoAndWorkspace(g.T, dataset, repoPaths)
+	g.UpstreamRepo, g.LocalWorkspace, g.cleanTestRepo = SetupDefaultRepoAndWorkspace(g.T, content, repoPaths)
 	if g.GetSubDirectory == "/" {
 		g.targetDir = filepath.Base(g.UpstreamRepo.RepoName)
 	} else {
@@ -143,7 +143,7 @@ func (g *TestSetupManager) Init(dataset string) bool {
 	}
 
 	// Verify the local package has the correct dataset
-	if same := g.AssertLocalDataEquals(filepath.Join(dataset, g.GetSubDirectory)); !same {
+	if same := g.AssertLocalDataEquals(filepath.Join(content.Data, g.GetSubDirectory)); !same {
 		return same
 	}
 

--- a/internal/util/diff/diff_test.go
+++ b/internal/util/diff/diff_test.go
@@ -44,7 +44,10 @@ import (
 // 5. Run remote diff between master and cloned
 func TestCommand_RunRemoteDiff(t *testing.T) {
 	t.SkipNow()
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}, map[string]string{})
 	defer clean()
 
 	// create a commit with dataset2 and tag it v2, then add another commit on top with dataset3
@@ -116,7 +119,10 @@ func TestCommand_RunRemoteDiff(t *testing.T) {
 // 5. add more data to the master branch, commit it
 // 5. Run combined diff between master and cloned
 func TestCommand_RunCombinedDiff(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -190,7 +196,10 @@ func TestCommand_RunCombinedDiff(t *testing.T) {
 // 5. Update cloned package with dataset3
 // 6. Run remote diff and verify the output
 func TestCommand_Run_LocalDiff(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()

--- a/internal/util/get/get_test.go
+++ b/internal/util/get/get_test.go
@@ -44,7 +44,10 @@ func TestCommand_Run_failNoRevision(t *testing.T) {
 // - destination directory should match the base name of the repo
 // - KptFile should be populated with values pointing to the origin
 func TestCommand_Run(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -94,7 +97,10 @@ func TestCommand_Run(t *testing.T) {
 // - KptFile should have the subdir listed
 func TestCommand_Run_subdir(t *testing.T) {
 	subdir := "java"
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -140,7 +146,10 @@ func TestCommand_Run_subdir(t *testing.T) {
 // than using the name of the source repo.
 func TestCommand_Run_destination(t *testing.T) {
 	dest := "my-dataset"
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -193,7 +202,10 @@ func TestCommand_Run_destination(t *testing.T) {
 func TestCommand_Run_subdirAndDestination(t *testing.T) {
 	subdir := "java"
 	dest := "new-java"
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -247,7 +259,10 @@ func TestCommand_Run_subdirAndDestination(t *testing.T) {
 // 4. clone the new branch
 // 5. verify contents match the new branch
 func TestCommand_Run_branch(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -314,7 +329,10 @@ func TestCommand_Run_branch(t *testing.T) {
 // 4. clone at the tag
 // 5. verify the clone has the data from the tagged version
 func TestCommand_Run_tag(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -385,7 +403,10 @@ func TestCommand_Run_tag(t *testing.T) {
 // 3. clone the master branch again
 // 4. verify the new master branch data is present
 func TestCommand_Run_clean(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -486,7 +507,10 @@ func TestCommand_Run_clean(t *testing.T) {
 // 2. clone a non-existing branch
 // 3. verify the master branch data is still present
 func TestCommand_Run_failClean(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -580,7 +604,10 @@ func TestCommand_Run_failClean(t *testing.T) {
 // TestCommand_Run_failExistingDir verifies that command will fail without changing anything if the
 // directory already exists
 func TestCommand_Run_failExistingDir(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}, map[string]string{})
 	defer clean()
 
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
@@ -669,7 +696,10 @@ func TestCommand_Run_failExistingDir(t *testing.T) {
 }
 
 func TestCommand_Run_failInvalidRepo(t *testing.T) {
-	_, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
+	_, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}, map[string]string{})
 	defer clean()
 
 	absPath := filepath.Join(w.WorkspaceDirectory, "foo")
@@ -690,7 +720,10 @@ func TestCommand_Run_failInvalidRepo(t *testing.T) {
 }
 
 func TestCommand_Run_failInvalidBranch(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}, map[string]string{})
 	defer clean()
 
 	absPath := filepath.Join(w.WorkspaceDirectory, g.RepoDirectory)
@@ -714,7 +747,10 @@ func TestCommand_Run_failInvalidBranch(t *testing.T) {
 }
 
 func TestCommand_Run_failInvalidTag(t *testing.T) {
-	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Dataset1, map[string]string{})
+	g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}, map[string]string{})
 	defer clean()
 
 	err := Command{
@@ -871,7 +907,10 @@ func TestCommand_Run_subpackages(t *testing.T) {
 			}
 
 			dir := pkgbuilder.ExpandPkg(t, pkgbuilder.NewRootPkg(), repoPaths)
-			g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, dir, repoPaths)
+			g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, testutil.Content{
+				Data:   dir,
+				Branch: "master",
+			}, repoPaths)
 			defer clean()
 
 			err = testutil.UpdateGitDir(t, g, []testutil.Content{test.upstream}, repoPaths)

--- a/internal/util/update/update_test.go
+++ b/internal/util/update/update_test.go
@@ -53,10 +53,17 @@ func TestCommand_Run_noRefChanges(t *testing.T) {
 			g := &testutil.TestSetupManager{
 				T: t,
 				// Update upstream to Dataset2
-				UpstreamChanges: []testutil.Content{{Data: testutil.Dataset2}},
+				UpstreamChanges: []testutil.Content{
+					{
+						Data: testutil.Dataset2,
+					},
+				},
 			}
 			defer g.Clean()
-			if !g.Init(testutil.Dataset1) {
+			if !g.Init(testutil.Content{
+				Data:   testutil.Dataset1,
+				Branch: "master",
+			}) {
 				return
 			}
 
@@ -96,7 +103,10 @@ func TestCommand_Run_subDir(t *testing.T) {
 				GetSubDirectory: "java",
 			}
 			defer g.Clean()
-			if !g.Init(testutil.Dataset1) {
+			if !g.Init(testutil.Content{
+				Data:   testutil.Dataset1,
+				Branch: "master",
+			}) {
 				return
 			}
 
@@ -143,7 +153,10 @@ func TestCommand_Run_noChanges(t *testing.T) {
 				T: t,
 			}
 			defer g.Clean()
-			if !g.Init(testutil.Dataset1) {
+			if !g.Init(testutil.Content{
+				Data:   testutil.Dataset1,
+				Branch: "master",
+			}) {
 				return
 			}
 
@@ -187,7 +200,10 @@ func TestCommand_Run_noCommit(t *testing.T) {
 				T: t,
 			}
 			defer g.Clean()
-			if !g.Init(testutil.Dataset1) {
+			if !g.Init(testutil.Content{
+				Data:   testutil.Dataset1,
+				Branch: "master",
+			}) {
 				return
 			}
 
@@ -227,7 +243,10 @@ func TestCommand_Run_noAdd(t *testing.T) {
 				T: t,
 			}
 			defer g.Clean()
-			if !g.Init(testutil.Dataset1) {
+			if !g.Init(testutil.Content{
+				Data:   testutil.Dataset1,
+				Branch: "master",
+			}) {
 				return
 			}
 
@@ -312,7 +331,10 @@ func TestCommand_Run_localPackageChanges(t *testing.T) {
 				UpstreamChanges: []testutil.Content{{Data: testutil.Dataset2}},
 			}
 			defer g.Clean()
-			if !g.Init(testutil.Dataset1) {
+			if !g.Init(testutil.Content{
+				Data:   testutil.Dataset1,
+				Branch: "master",
+			}) {
 				t.FailNow()
 			}
 
@@ -373,7 +395,10 @@ func TestCommand_Run_toBranchRef(t *testing.T) {
 				},
 			}
 			defer g.Clean()
-			if !g.Init(testutil.Dataset1) {
+			if !g.Init(testutil.Content{
+				Data:   testutil.Dataset1,
+				Branch: "master",
+			}) {
 				return
 			}
 
@@ -422,7 +447,10 @@ func TestCommand_Run_toTagRef(t *testing.T) {
 				},
 			}
 			defer g.Clean()
-			if !g.Init(testutil.Dataset1) {
+			if !g.Init(testutil.Content{
+				Data:   testutil.Dataset1,
+				Branch: "master",
+			}) {
 				return
 			}
 
@@ -470,7 +498,10 @@ func TestCommand_ResourceMerge_NonKRMUpdates(t *testing.T) {
 				},
 			}
 			defer g.Clean()
-			if !g.Init(testutil.Dataset1) {
+			if !g.Init(testutil.Content{
+				Data:   testutil.Dataset1,
+				Branch: "master",
+			}) {
 				t.FailNow()
 			}
 
@@ -519,7 +550,10 @@ func TestCommand_ResourceMerge_WithSetters_TagRef(t *testing.T) {
 				},
 			}
 			defer g.Clean()
-			if !g.Init(testutil.Dataset1) {
+			if !g.Init(testutil.Content{
+				Data:   testutil.Dataset1,
+				Branch: "master",
+			}) {
 				return
 			}
 
@@ -587,7 +621,10 @@ func TestCommand_Run_emitPatch(t *testing.T) {
 		UpstreamChanges: []testutil.Content{{Data: testutil.Dataset2}},
 	}
 	defer g.Clean()
-	if !g.Init(testutil.Dataset1) {
+	if !g.Init(testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}) {
 		return
 	}
 
@@ -647,7 +684,10 @@ func TestCommand_Run_failInvalidRef(t *testing.T) {
 				UpstreamChanges: []testutil.Content{{Data: testutil.Dataset2}},
 			}
 			defer g.Clean()
-			if !g.Init(testutil.Dataset1) {
+			if !g.Init(testutil.Content{
+				Data:   testutil.Dataset1,
+				Branch: "master",
+			}) {
 				return
 			}
 
@@ -679,7 +719,10 @@ func TestCommand_Run_badStrategy(t *testing.T) {
 		UpstreamChanges: []testutil.Content{{Data: testutil.Dataset2}},
 	}
 	defer g.Clean()
-	if !g.Init(testutil.Dataset1) {
+	if !g.Init(testutil.Content{
+		Data:   testutil.Dataset1,
+		Branch: "master",
+	}) {
 		return
 	}
 
@@ -1481,7 +1524,10 @@ func TestCommand_Run_subpackages(t *testing.T) {
 						test.updatedLocal,
 					}
 				}
-				if !g.Init(dir) {
+				if !g.Init(testutil.Content{
+					Data:   dir,
+					Branch: "master",
+				}) {
 					return
 				}
 


### PR DESCRIPTION
The existing test framework doesn't allow setting up the `main` branch properly, as it is automatically created from `master`. This leverages the existing `Content` struct to provide better support for setting up different branches.