### PR TITLE
Set `metadata.name` in Kptfile to name of directory on Get

### DIFF
--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -583,6 +583,7 @@ func replaceData(repo, data string) error {
 				return err
 			}
 			dataKptfile.Upstream = repoKptfile.Upstream
+			dataKptfile.Name = repoKptfile.Name
 			err = kptfileutil.WriteFile(repoKptfileDir, dataKptfile)
 			if err != nil {
 				return err

--- a/internal/util/git/git.go
+++ b/internal/util/git/git.go
@@ -16,6 +16,8 @@
 package git
 
 import (
+	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -69,4 +71,19 @@ func isAzureHost(host string) bool {
 // https://docs.aws.amazon.com/codecommit/latest/userguide/regions.html
 func isAWSHost(host string) bool {
 	return strings.Contains(host, "amazonaws.com")
+}
+
+// lookupCommit looks up the sha of the current commit on the repo at the
+// provided path.
+func LookupCommit(repoPath string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--verify", "HEAD")
+	cmd.Dir = repoPath
+	cmd.Env = os.Environ()
+	cmd.Stderr = os.Stderr
+	b, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	commit := strings.TrimSpace(string(b))
+	return commit, nil
 }

--- a/internal/util/update/common.go
+++ b/internal/util/update/common.go
@@ -2,7 +2,6 @@ package update
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -66,21 +65,6 @@ func subPkgFirstSorter(paths []string) func(i, j int) bool {
 	return func(i, j int) bool {
 		return !sorter(i, j)
 	}
-}
-
-// lookupCommit looks up the sha of the current commit on the repo at the
-// provided path.
-func lookupCommit(repoPath string) (string, error) {
-	cmd := exec.Command("git", "rev-parse", "--verify", "HEAD")
-	cmd.Dir = repoPath
-	cmd.Env = os.Environ()
-	cmd.Stderr = os.Stderr
-	b, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	commit := strings.TrimSpace(string(b))
-	return commit, nil
 }
 
 // exists returns true if a file or directory exists on the provided path,

--- a/internal/util/update/resource-merge.go
+++ b/internal/util/update/resource-merge.go
@@ -65,7 +65,7 @@ func (u ResourceMergeUpdater) Update(options UpdateOptions) error {
 	defer os.RemoveAll(updated.AbsPath())
 
 	// local package controls the upstream field
-	commit, err := lookupCommit(updated.AbsPath())
+	commit, err := git.LookupCommit(updated.AbsPath())
 	if err != nil {
 		return err
 	}

--- a/internal/util/update/update_test.go
+++ b/internal/util/update/update_test.go
@@ -1566,12 +1566,7 @@ func TestCommand_Run_subpackages(t *testing.T) {
 					t.FailNow()
 				}
 
-				var expectedPath string
-				if test.initialUpstream.HasKptfile() {
-					expectedPath = pkgbuilder.ExpandPkg(t, result.expectedLocal, emptyMap)
-				} else {
-					expectedPath = pkgbuilder.ExpandPkgWithName(t, result.expectedLocal, g.LocalWorkspace.PackageDir, emptyMap)
-				}
+				expectedPath := pkgbuilder.ExpandPkgWithName(t, result.expectedLocal, g.LocalWorkspace.PackageDir, emptyMap)
 
 				if !g.AssertLocalDataEquals(expectedPath) {
 					t.FailNow()
@@ -1580,6 +1575,7 @@ func TestCommand_Run_subpackages(t *testing.T) {
 				if !assert.NoError(t, err) {
 					t.FailNow()
 				}
+
 				if !g.AssertKptfileEquals(expectedPath, commit, "master") {
 					t.FailNow()
 				}


### PR DESCRIPTION
When a package is fetched with `kpt pkg get`, the name of the Kptfile should be set to the name of the directory.