### PR TITLE
Add generic function for updating the annotations only

### DIFF
--- a/commands/migratecmd.go
+++ b/commands/migratecmd.go
@@ -354,7 +354,7 @@ func updateOwningInventoryAnnotation(f cmdutil.Factory, objMetas []object.ObjMet
 			}
 			return err
 		}
-		changed, err := client.UpdateAnnotation(obj, old, new)
+		changed, err := client.ReplaceOwningInventoryID(obj, old, new)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Add a function to update the annotation of an object.  Here is how it should be used.
```
obj := client.Get()

var newAnnotations map[string]string
// get the new annotations that obj should have
// not including the last-applied-config annotation

UpdateAnnotation(obj, newAnnotations)

client.Update(obj)
```

Also add unit tests for the new function.