### PR TITLE
Get command should handle remote subpackages

### DIFF
--- a/internal/util/diff/pkgdiff_test.go
+++ b/internal/util/diff/pkgdiff_test.go
@@ -79,7 +79,7 @@ func TestPkgDiff(t *testing.T) {
 			name: "different upstream in Kptfile is not a diff",
 			pkg1: pkgbuilder.NewRootPkg().
 				WithKptfile(pkgbuilder.NewKptfile().
-					WithUpstream("github.com/GoogleContainerTools/kpt", "master").
+					WithUpstream("github.com/GoogleContainerTools/kpt", "/", "master").
 					WithSetters(
 						pkgbuilder.NewSetter("foo", "bar"),
 					),
@@ -87,7 +87,7 @@ func TestPkgDiff(t *testing.T) {
 				WithResource(pkgbuilder.DeploymentResource),
 			pkg2: pkgbuilder.NewRootPkg().
 				WithKptfile(pkgbuilder.NewKptfile().
-					WithUpstream("github.com/GoogleContainerTools/kpt", "kpt/v1").
+					WithUpstream("github.com/GoogleContainerTools/kpt", "/", "kpt/v1").
 					WithSetters(
 						pkgbuilder.NewSetter("foo", "bar"),
 					),

--- a/internal/util/update/fastforward.go
+++ b/internal/util/update/fastforward.go
@@ -15,7 +15,6 @@
 package update
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"os"
@@ -31,7 +30,6 @@ import (
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
 	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/sets"
-	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 // Updater updates a package to a new upstream version.
@@ -246,31 +244,17 @@ func hasKfDiff(localPath, orgPath string) (bool, error) {
 	orgKf.Upstream = kptfile.Upstream{}
 
 	orgKf.Name = localKf.Name
-	identical, err := isIdentical(localKf, orgKf)
+	equal, err := kptfileutil.Equal(localKf, orgKf)
 	if err != nil {
 		return false, err
 	}
 
-	return !identical, nil
+	return !equal, nil
 }
 
 func isDefaultKptfile(localKf kptfile.KptFile, name string) (bool, error) {
 	defaultKf := kptfileutil.DefaultKptfile(name)
-	return isIdentical(localKf, defaultKf)
-}
-
-func isIdentical(localKf, orgKf kptfile.KptFile) (bool, error) {
-	localKfBytes, err := yaml.Marshal(localKf)
-	if err != nil {
-		return false, err
-	}
-
-	orgKfBytes, err := yaml.Marshal(orgKf)
-	if err != nil {
-		return false, err
-	}
-
-	return bytes.Equal(localKfBytes, orgKfBytes), nil
+	return kptfileutil.Equal(localKf, defaultKf)
 }
 
 // DiffError is returned if the local package and upstream package contents do not match.

--- a/internal/util/update/update_test.go
+++ b/internal/util/update/update_test.go
@@ -1359,12 +1359,12 @@ func TestCommand_Run_subpackages(t *testing.T) {
 			name: "Merging of Kptfile in nested package",
 			initialUpstream: pkgbuilder.NewRootPkg().
 				WithKptfile(pkgbuilder.NewKptfile().
-					WithUpstream("github.com/foo/bar", "somebranch"),
+					WithUpstream("github.com/foo/bar", "/", "somebranch"),
 				).
 				WithSubPackages(
 					pkgbuilder.NewSubPkg("subpkg").
 						WithKptfile(pkgbuilder.NewKptfile().
-							WithUpstream("gitlab.com/comp/proj", "1234abcd").
+							WithUpstream("gitlab.com/comp/proj", "/", "1234abcd").
 							WithSetters(
 								pkgbuilder.NewSetter("setter1", "value1"),
 							),
@@ -1373,12 +1373,12 @@ func TestCommand_Run_subpackages(t *testing.T) {
 			updatedUpstream: testutil.Content{
 				Pkg: pkgbuilder.NewRootPkg().
 					WithKptfile(pkgbuilder.NewKptfile().
-						WithUpstream("github.com/foo/bar", "somebranch"),
+						WithUpstream("github.com/foo/bar", "/", "somebranch"),
 					).
 					WithSubPackages(
 						pkgbuilder.NewSubPkg("subpkg").
 							WithKptfile(pkgbuilder.NewKptfile().
-								WithUpstream("gitlab.com/comp/proj", "abcd1234").
+								WithUpstream("gitlab.com/comp/proj", "/", "abcd1234").
 								WithSetters(
 									pkgbuilder.NewSetter("setter1", "value1"),
 									pkgbuilder.NewSetter("setter2", "value2"),
@@ -1391,12 +1391,12 @@ func TestCommand_Run_subpackages(t *testing.T) {
 					strategies: []StrategyType{KResourceMerge, FastForward},
 					expectedLocal: pkgbuilder.NewRootPkg().
 						WithKptfile(pkgbuilder.NewKptfile().
-							WithUpstream("github.com/foo/bar", "somebranch"),
+							WithUpstream("github.com/foo/bar", "/", "somebranch"),
 						).
 						WithSubPackages(
 							pkgbuilder.NewSubPkg("subpkg").
 								WithKptfile(pkgbuilder.NewKptfile().
-									WithUpstream("gitlab.com/comp/proj", "abcd1234").
+									WithUpstream("gitlab.com/comp/proj", "/", "abcd1234").
 									WithSetters(
 										pkgbuilder.NewSetter("setter1", "value1"),
 										pkgbuilder.NewSetter("setter2", "value2"),

--- a/pkg/kptfile/kptfileutil/util.go
+++ b/pkg/kptfile/kptfileutil/util.go
@@ -15,6 +15,7 @@
 package kptfileutil
 
 import (
+	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -132,6 +133,20 @@ func ValidateInventory(inv *kptfile.Inventory) (bool, error) {
 		return false, fmt.Errorf("kptfile inventory missing inventoryID")
 	}
 	return true, nil
+}
+
+func Equal(kf1, kf2 kptfile.KptFile) (bool, error) {
+	kf1Bytes, err := yaml.Marshal(kf1)
+	if err != nil {
+		return false, err
+	}
+
+	kf2Bytes, err := yaml.Marshal(kf2)
+	if err != nil {
+		return false, err
+	}
+
+	return bytes.Equal(kf1Bytes, kf2Bytes), nil
 }
 
 // DefaultKptfile returns a new minimal Kptfile.


### PR DESCRIPTION
This updates the Get command to fetch any remote subpackages referenced in the package. It also handles situations where a remote subpackage references other remote subpackages.
