### PR TITLE
Move code for fetching and copying a package from Get command

### DIFF
--- a/internal/testutil/setup_manager.go
+++ b/internal/testutil/setup_manager.go
@@ -22,7 +22,8 @@ import (
 
 	"github.com/GoogleContainerTools/kpt/internal/gitutil"
 	"github.com/GoogleContainerTools/kpt/internal/testutil/pkgbuilder"
-	"github.com/GoogleContainerTools/kpt/internal/util/get"
+	"github.com/GoogleContainerTools/kpt/internal/util/fetch"
+	"github.com/GoogleContainerTools/kpt/internal/util/git"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
 	"github.com/stretchr/testify/assert"
@@ -120,12 +121,12 @@ func (g *TestSetupManager) Init(content Content) bool {
 		return false
 	}
 
-	if !assert.NoError(g.T, get.Command{
+	if !assert.NoError(g.T, fetch.Command{
 		Destination: filepath.Join(g.LocalWorkspace.WorkspaceDirectory, g.targetDir),
-		Git: kptfile.Git{
-			Repo:      g.UpstreamRepo.RepoDirectory,
-			Ref:       g.GetRef,
-			Directory: g.GetSubDirectory,
+		RepoSpec: &git.RepoSpec{
+			OrgRepo: g.UpstreamRepo.RepoDirectory,
+			Ref:     g.GetRef,
+			Path:    g.GetSubDirectory,
 		}}.Run()) {
 		return false
 	}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -122,10 +122,16 @@ func KptfileAwarePkgEqual(t *testing.T, pkg1, pkg2 string) bool {
 
 		// Read the Kptfiles and set the Commit field to an empty
 		// string before we compare.
-		pkg1kf, _ := kptfileutil.ReadFile(filepath.Dir(pkg1Path))
+		pkg1kf, err := kptfileutil.ReadFile(filepath.Dir(pkg1Path))
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
 		pkg1kf.Upstream.Git.Commit = ""
 
-		pkg2kf, _ := kptfileutil.ReadFile(filepath.Dir(pkg2Path))
+		pkg2kf, err := kptfileutil.ReadFile(filepath.Dir(pkg2Path))
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
 		pkg2kf.Upstream.Git.Commit = ""
 
 		equal, err := kptfileutil.Equal(pkg1kf, pkg2kf)

--- a/internal/util/diff/diff.go
+++ b/internal/util/diff/diff.go
@@ -25,7 +25,8 @@ import (
 	"strings"
 
 	"github.com/GoogleContainerTools/kpt/internal/gitutil"
-	"github.com/GoogleContainerTools/kpt/internal/util/get"
+	"github.com/GoogleContainerTools/kpt/internal/util/fetch"
+	"github.com/GoogleContainerTools/kpt/internal/util/git"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
 	"sigs.k8s.io/kustomize/kyaml/copyutil"
@@ -285,7 +286,7 @@ type PkgGetter interface {
 	GetPkg(repo, path, ref string) (dir string, err error)
 }
 
-// defaultPkgGetter uses get.Command abstraction to implement PkgGetter.
+// defaultPkgGetter uses fetch.Command abstraction to implement PkgGetter.
 type defaultPkgGetter struct{}
 
 func (pg defaultPkgGetter) GetPkg(repo, path, ref string) (string, error) {
@@ -293,8 +294,12 @@ func (pg defaultPkgGetter) GetPkg(repo, path, ref string) (string, error) {
 	if err != nil {
 		return dir, err
 	}
-	cmdGet := &get.Command{
-		Git:         kptfile.Git{Repo: repo, Directory: path, Ref: ref},
+	cmdGet := &fetch.Command{
+		RepoSpec: &git.RepoSpec{
+			OrgRepo: repo,
+			Ref:     ref,
+			Path:    path,
+		},
 		Destination: dir,
 		Clean:       true,
 	}

--- a/internal/util/diff/diff_test.go
+++ b/internal/util/diff/diff_test.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
 	. "github.com/GoogleContainerTools/kpt/internal/util/diff"
-	"github.com/GoogleContainerTools/kpt/internal/util/get"
-	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
+	"github.com/GoogleContainerTools/kpt/internal/util/fetch"
+	"github.com/GoogleContainerTools/kpt/internal/util/git"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/kyaml/copyutil"
 )
@@ -70,9 +70,14 @@ func TestCommand_RunRemoteDiff(t *testing.T) {
 	assert.NotEqual(t, commit, commit0)
 	assert.NotEqual(t, commit, commit2)
 
-	err = get.Command{Git: kptfile.Git{
-		Repo: g.RepoDirectory, Ref: "refs/tags/v2", Directory: "/"},
-		Destination: filepath.Base(g.RepoDirectory)}.Run()
+	err = fetch.Command{
+		RepoSpec: &git.RepoSpec{
+			OrgRepo: g.RepoDirectory,
+			Ref:     "refs/tags/v2",
+			Path:    "/",
+		},
+		Destination: filepath.Base(g.RepoDirectory),
+	}.Run()
 	assert.NoError(t, err)
 
 	localPkg := filepath.Join(w.WorkspaceDirectory, g.RepoName)
@@ -148,9 +153,14 @@ func TestCommand_RunCombinedDiff(t *testing.T) {
 	assert.NotEqual(t, commit, commit2)
 
 	localPkg := filepath.Join(w.WorkspaceDirectory, g.RepoName)
-	err = get.Command{Git: kptfile.Git{
-		Repo: g.RepoDirectory, Ref: "refs/tags/v2", Directory: "/"},
-		Destination: localPkg}.Run()
+	err = fetch.Command{
+		RepoSpec: &git.RepoSpec{
+			OrgRepo: g.RepoDirectory,
+			Ref:     "refs/tags/v2",
+			Path:    "/",
+		},
+		Destination: localPkg,
+	}.Run()
 	assert.NoError(t, err)
 
 	diffOutput := &bytes.Buffer{}
@@ -218,9 +228,14 @@ func TestCommand_Run_LocalDiff(t *testing.T) {
 	assert.NotEqual(t, commit, commit0)
 
 	localPkg := filepath.Join(w.WorkspaceDirectory, g.RepoName)
-	err = get.Command{Git: kptfile.Git{
-		Repo: g.RepoDirectory, Ref: "refs/tags/v2", Directory: "/"},
-		Destination: localPkg}.Run()
+	err = fetch.Command{
+		RepoSpec: &git.RepoSpec{
+			OrgRepo: g.RepoDirectory,
+			Ref:     "refs/tags/v2",
+			Path:    "/",
+		},
+		Destination: localPkg,
+	}.Run()
 	assert.NoError(t, err)
 
 	// make changes in local package

--- a/internal/util/fetch/fetch.go
+++ b/internal/util/fetch/fetch.go
@@ -1,0 +1,290 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fetch
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/GoogleContainerTools/kpt/internal/gitutil"
+	"github.com/GoogleContainerTools/kpt/internal/util/git"
+	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
+	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
+	"sigs.k8s.io/kustomize/kyaml/copyutil"
+	"sigs.k8s.io/kustomize/kyaml/errors"
+)
+
+// Command fetches a package from a git repository and copies it to a local
+// directory.
+type Command struct {
+	RepoSpec *git.RepoSpec
+
+	Destination string
+
+	Name string
+
+	Clean bool
+}
+
+// Run runs the Command.
+func (c Command) Run() error {
+	if err := (&c).DefaultValues(); err != nil {
+		return err
+	}
+
+	if _, err := os.Stat(c.Destination); !c.Clean && !os.IsNotExist(err) {
+		return errors.Errorf("destination directory %s already exists", c.Destination)
+	}
+
+	// normalize path to a filepath
+	if !strings.HasSuffix(c.RepoSpec.Dir, "file://") {
+		c.RepoSpec.Dir = filepath.Join(path.Split(c.RepoSpec.Dir))
+	}
+
+	err := cloneAndCopy(c.RepoSpec, c.Destination, c.Name, c.Clean)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// cloneAndCopy fetches the provided repo and copies the content into the
+// directory specified by dest. The provided name is set as `metadata.name`
+// of the Kptfile of the package.
+func cloneAndCopy(r *git.RepoSpec, dest, name string, clean bool) error {
+	if err := ClonerUsingGitExec(r); err != nil {
+		return errors.Errorf("failed to clone git repo: %v", err)
+	}
+	defer os.RemoveAll(r.Dir)
+
+	// delete the existing package if it exists
+	if clean {
+		if err := os.RemoveAll(dest); err != nil {
+			return errors.Wrap(err)
+		}
+	}
+
+	if err := copyutil.CopyDir(r.AbsPath(), dest); err != nil {
+		return errors.WrapPrefixf(err, "missing subdirectory %s in repo %s at ref %s\n",
+			r.Path, r.OrgRepo, r.Ref)
+	}
+
+	if err := upsertKptfile(dest, name, r); err != nil {
+		return errors.Wrap(err)
+	}
+	return nil
+}
+
+// ClonerUsingGitExec uses a local git install, as opposed
+// to say, some remote API, to obtain a local clone of
+// a remote repo. It looks for tags with the directory as a prefix to allow
+// for versioning multiple kpt packages in a single repo independently. It
+// relies on the private clonerUsingGitExec function to try fetching different
+// refs.
+func ClonerUsingGitExec(repoSpec *git.RepoSpec) error {
+	// look for a tag with the directory as a prefix for versioning
+	// subdirectories independently
+	originalRef := repoSpec.Ref
+	if repoSpec.Path != "" && !strings.Contains(repoSpec.Ref, "refs") {
+		// join the directory with the Ref (stripping the preceding '/' if it exists)
+		repoSpec.Ref = path.Join(strings.TrimLeft(repoSpec.Path, "/"), repoSpec.Ref)
+	}
+
+	defaultRef, err := gitutil.DefaultRef(repoSpec.OrgRepo)
+	if err != nil {
+		return err
+	}
+
+	// clone the repo to a tmp directory.
+	// delete the tmp directory later.
+	err = clonerUsingGitExec(repoSpec)
+	if err != nil && originalRef != repoSpec.Ref {
+		repoSpec.Ref = originalRef
+		err = clonerUsingGitExec(repoSpec)
+	}
+
+	if err != nil {
+		if strings.HasPrefix(repoSpec.Path, "blob/") {
+			return errors.Errorf("failed to clone git repo containing /blob/, "+
+				"you may need to remove /blob/%s from the url:\n%v", defaultRef, err)
+		}
+		return errors.Errorf("failed to clone git repo: %v", err)
+	}
+
+	return nil
+}
+
+// clonerUsingGitExec is the implementation for cloning a repo from git into
+// a local temp directory. This is used by the public ClonerUsingGitExec
+// function to allow trying multiple different refs.
+func clonerUsingGitExec(repoSpec *git.RepoSpec) error {
+	gitProgram, err := exec.LookPath("git")
+	if err != nil {
+		return errors.WrapPrefixf(err, "no 'git' program on path")
+	}
+
+	repoSpec.Dir, err = ioutil.TempDir("", "kpt-get-")
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(gitProgram, "init", repoSpec.Dir)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	err = cmd.Run()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error initializing empty git repo: %s", out.String())
+		return errors.WrapPrefixf(err, "trouble initializing empty git repo in %s",
+			repoSpec.Dir)
+	}
+
+	cmd = exec.Command(gitProgram, "remote", "add", "origin", repoSpec.CloneSpec())
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	cmd.Dir = repoSpec.Dir
+	err = cmd.Run()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error setting git remote: %s", out.String())
+		return errors.WrapPrefixf(
+			err,
+			"trouble adding remote %s",
+			repoSpec.CloneSpec())
+	}
+	if repoSpec.Ref == "" {
+		repoSpec.Ref, err = gitutil.DefaultRef(repoSpec.Dir)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = func() error {
+		cmd = exec.Command(gitProgram, "fetch", "origin", "--depth=1", repoSpec.Ref)
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		cmd.Dir = repoSpec.Dir
+		err = cmd.Run()
+		if err != nil {
+			return errors.WrapPrefixf(err, "trouble fetching %s, "+
+				"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials", repoSpec.Ref)
+		}
+		cmd = exec.Command(gitProgram, "reset", "--hard", "FETCH_HEAD")
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		cmd.Dir = repoSpec.Dir
+		err = cmd.Run()
+		if err != nil {
+			return errors.WrapPrefixf(
+				err, "trouble hard resetting empty repository to %s", repoSpec.Ref)
+		}
+		return nil
+	}()
+	if err != nil {
+		cmd = exec.Command(gitProgram, "fetch", "origin")
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		cmd.Dir = repoSpec.Dir
+		if err = cmd.Run(); err != nil {
+			return errors.WrapPrefixf(err, "trouble fetching origin, "+
+				"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials")
+		}
+		cmd = exec.Command(gitProgram, "reset", "--hard", repoSpec.Ref)
+		cmd.Stdout = &out
+		cmd.Stderr = &out
+		cmd.Dir = repoSpec.Dir
+		if err = cmd.Run(); err != nil {
+			return errors.WrapPrefixf(
+				err, "trouble hard resetting empty repository to %s, "+
+					"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials", repoSpec.Ref)
+		}
+	}
+
+	cmd = exec.Command(gitProgram, "submodule", "update", "--init", "--recursive")
+	cmd.Stdout = &out
+	cmd.Dir = repoSpec.Dir
+	err = cmd.Run()
+	if err != nil {
+		return errors.WrapPrefixf(err, "trouble fetching submodules for %s, "+
+			"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials", repoSpec.Ref)
+	}
+
+	return nil
+}
+
+// DefaultValues sets values to the default values if they were unspecified
+func (c *Command) DefaultValues() error {
+	if c.RepoSpec == nil {
+		return errors.Errorf("must specify a repoSpec")
+	}
+	r := c.RepoSpec
+	if len(r.OrgRepo) == 0 {
+		return errors.Errorf("must specify repo")
+	}
+	if len(r.Ref) == 0 {
+		return errors.Errorf("must specify ref")
+	}
+	if len(c.Destination) == 0 {
+		return errors.Errorf("must specify destination")
+	}
+	if len(r.Path) == 0 {
+		return errors.Errorf("must specify path")
+	}
+
+	if !filepath.IsAbs(c.Destination) {
+		return errors.Errorf("destination must be an absolute path")
+	}
+
+	// default the name to the destination name
+	if len(c.Name) == 0 {
+		c.Name = filepath.Base(c.Destination)
+	}
+
+	return nil
+}
+
+// upsertKptfile populates the KptFile values, merging any cloned KptFile and the
+// cloneFrom values.
+func upsertKptfile(path, name string, spec *git.RepoSpec) error {
+	// read KptFile cloned with the package if it exists
+	kpgfile, err := kptfileutil.ReadFile(path)
+	if err != nil {
+		// no KptFile present, create a default
+		kpgfile = kptfileutil.DefaultKptfile(name)
+	}
+	kpgfile.Name = name
+
+	// find the git commit sha that we cloned the package at so we can write it to the KptFile
+	commit, err := git.LookupCommit(spec.AbsPath())
+	if err != nil {
+		return err
+	}
+
+	// populate the cloneFrom values so we know where the package came from
+	kpgfile.Upstream = kptfile.Upstream{
+		Type: kptfile.GitOrigin,
+		Git: kptfile.Git{
+			Repo:      spec.OrgRepo,
+			Directory: spec.Path,
+			Ref:       spec.Ref,
+		},
+	}
+	kpgfile.Upstream.Git.Commit = commit
+	return kptfileutil.WriteFile(path, kpgfile)
+}

--- a/internal/util/get/get.go
+++ b/internal/util/get/get.go
@@ -16,25 +16,20 @@
 package get
 
 import (
-	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
-	"os/exec"
-	"path"
 	"path/filepath"
-	"strings"
 
-	"github.com/GoogleContainerTools/kpt/internal/gitutil"
+	"github.com/GoogleContainerTools/kpt/internal/util/fetch"
 	"github.com/GoogleContainerTools/kpt/internal/util/git"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
-	"sigs.k8s.io/kustomize/kyaml/copyutil"
 	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/pathutil"
 )
 
-// Command fetches a package from a git repository and copies it to a local directory.
+// Command fetches a package from a git repository, copies it to a local
+// directory, and expands any remote subpackages.
 type Command struct {
 	// Git contains information about the git repo to fetch
 	kptfile.Git
@@ -52,23 +47,13 @@ type Command struct {
 
 // Run runs the Command.
 func (c Command) Run() error {
-	if err := (&c).DefaultValues(); err != nil {
-		return err
-	}
-
-	if _, err := os.Stat(c.Destination); !c.Clean && !os.IsNotExist(err) {
-		return errors.Errorf("destination directory %s already exists", c.Destination)
-	}
-
-	// normalize path to a filepath
-	if !strings.HasSuffix(c.Directory, "file://") {
-		c.Directory = filepath.Join(path.Split(c.Directory))
-	}
-
-	// define where we are going to clone the package from
 	r := &git.RepoSpec{OrgRepo: c.Repo, Path: c.Directory, Ref: c.Ref}
-
-	err := cloneAndCopy(r, c.Destination, c.Name, c.Clean)
+	err := (&fetch.Command{
+		RepoSpec:    r,
+		Destination: c.Destination,
+		Name:        c.Name,
+		Clean:       c.Clean,
+	}).Run()
 	if err != nil {
 		return err
 	}
@@ -130,7 +115,12 @@ func (c Command) fetchRemoteSubpackages() error {
 			}
 
 			r := &git.RepoSpec{OrgRepo: gitInfo.Repo, Path: gitInfo.Directory, Ref: gitInfo.Ref}
-			err := cloneAndCopy(r, localPath, sp.LocalDir, false)
+			err := (&fetch.Command{
+				RepoSpec:    r,
+				Destination: localPath,
+				Name:        sp.LocalDir,
+				Clean:       false,
+			}).Run()
 			if err != nil {
 				return err
 			}
@@ -146,39 +136,6 @@ func (c Command) fetchRemoteSubpackages() error {
 				stack.push(subp)
 			}
 		}
-	}
-	return nil
-}
-
-// cloneAndCopy fetches the provided repo and copies the content into the
-// directory specified by dest. The provided name is set as `metadata.name`
-// of the Kptfile of the package.
-func cloneAndCopy(r *git.RepoSpec, dest, name string, clean bool) error {
-	defaultRef, err := gitutil.DefaultRef(r.OrgRepo)
-	if err != nil {
-		return err
-	}
-
-	if err := ClonerUsingGitExec(r, defaultRef); err != nil {
-		return errors.Errorf("failed to clone git repo: %v", err)
-	}
-	defer os.RemoveAll(r.Dir)
-
-	// delete the existing package if it exists
-	if clean {
-		err = os.RemoveAll(dest)
-		if err != nil {
-			return errors.Wrap(err)
-		}
-	}
-
-	if err := copyutil.CopyDir(r.AbsPath(), dest); err != nil {
-		return errors.WrapPrefixf(err, "missing subdirectory %s in repo %s at ref %s\n",
-			r.Path, r.OrgRepo, r.Ref)
-	}
-
-	if err := upsertKptfile(dest, name, r); err != nil {
-		return errors.Wrap(err)
 	}
 	return nil
 }
@@ -209,188 +166,4 @@ func (s *stack) pop() string {
 
 func (s *stack) len() int {
 	return len(s.slice)
-}
-
-// Cloner is a function that can clone a git repo.
-type Cloner func(repoSpec *git.RepoSpec) error
-
-// ClonerUsingGitExec uses a local git install, as opposed
-// to say, some remote API, to obtain a local clone of
-// a remote repo.
-func ClonerUsingGitExec(repoSpec *git.RepoSpec, defaultRef string) error {
-	// look for a tag with the directory as a prefix for versioning
-	// subdirectories independently
-	originalRef := repoSpec.Ref
-	if repoSpec.Path != "" && !strings.Contains(repoSpec.Ref, "refs") {
-		// join the directory with the Ref (stripping the preceding '/' if it exists)
-		repoSpec.Ref = path.Join(strings.TrimLeft(repoSpec.Path, "/"), repoSpec.Ref)
-	}
-
-	// clone the repo to a tmp directory.
-	// delete the tmp directory later.
-	err := clonerUsingGitExec(repoSpec)
-	if err != nil && originalRef != repoSpec.Ref {
-		repoSpec.Ref = originalRef
-		err = clonerUsingGitExec(repoSpec)
-	}
-
-	if err != nil {
-		if strings.HasPrefix(repoSpec.Path, "blob/") {
-			return errors.Errorf("failed to clone git repo containing /blob/, "+
-				"you may need to remove /blob/%s from the url:\n%v", defaultRef, err)
-		}
-		return errors.Errorf("failed to clone git repo: %v", err)
-	}
-
-	return nil
-}
-
-func clonerUsingGitExec(repoSpec *git.RepoSpec) error {
-	gitProgram, err := exec.LookPath("git")
-	if err != nil {
-		return errors.WrapPrefixf(err, "no 'git' program on path")
-	}
-
-	repoSpec.Dir, err = ioutil.TempDir("", "kpt-get-")
-	if err != nil {
-		return err
-	}
-	cmd := exec.Command(gitProgram, "init", repoSpec.Dir)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	err = cmd.Run()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error initializing empty git repo: %s", out.String())
-		return errors.WrapPrefixf(err, "trouble initializing empty git repo in %s",
-			repoSpec.Dir)
-	}
-
-	cmd = exec.Command(gitProgram, "remote", "add", "origin", repoSpec.CloneSpec())
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	cmd.Dir = repoSpec.Dir
-	err = cmd.Run()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error setting git remote: %s", out.String())
-		return errors.WrapPrefixf(
-			err,
-			"trouble adding remote %s",
-			repoSpec.CloneSpec())
-	}
-	if repoSpec.Ref == "" {
-		repoSpec.Ref, err = gitutil.DefaultRef(repoSpec.Dir)
-		if err != nil {
-			return err
-		}
-	}
-
-	err = func() error {
-		cmd = exec.Command(gitProgram, "fetch", "origin", "--depth=1", repoSpec.Ref)
-		cmd.Stdout = &out
-		cmd.Stderr = &out
-		cmd.Dir = repoSpec.Dir
-		err = cmd.Run()
-		if err != nil {
-			return errors.WrapPrefixf(err, "trouble fetching %s, "+
-				"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials", repoSpec.Ref)
-		}
-		cmd = exec.Command(gitProgram, "reset", "--hard", "FETCH_HEAD")
-		cmd.Stdout = &out
-		cmd.Stderr = &out
-		cmd.Dir = repoSpec.Dir
-		err = cmd.Run()
-		if err != nil {
-			return errors.WrapPrefixf(
-				err, "trouble hard resetting empty repository to %s", repoSpec.Ref)
-		}
-		return nil
-	}()
-	if err != nil {
-		cmd = exec.Command(gitProgram, "fetch", "origin")
-		cmd.Stdout = &out
-		cmd.Stderr = &out
-		cmd.Dir = repoSpec.Dir
-		if err = cmd.Run(); err != nil {
-			return errors.WrapPrefixf(err, "trouble fetching origin, "+
-				"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials")
-		}
-		cmd = exec.Command(gitProgram, "reset", "--hard", repoSpec.Ref)
-		cmd.Stdout = &out
-		cmd.Stderr = &out
-		cmd.Dir = repoSpec.Dir
-		if err = cmd.Run(); err != nil {
-			return errors.WrapPrefixf(
-				err, "trouble hard resetting empty repository to %s, "+
-					"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials", repoSpec.Ref)
-		}
-	}
-
-	cmd = exec.Command(gitProgram, "submodule", "update", "--init", "--recursive")
-	cmd.Stdout = &out
-	cmd.Dir = repoSpec.Dir
-	err = cmd.Run()
-	if err != nil {
-		return errors.WrapPrefixf(err, "trouble fetching submodules for %s, "+
-			"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials", repoSpec.Ref)
-	}
-
-	return nil
-}
-
-// DefaultValues sets values to the default values if they were unspecified
-func (c *Command) DefaultValues() error {
-	if len(c.Repo) == 0 {
-		return errors.Errorf("must specify repo")
-	}
-	if len(c.Ref) == 0 {
-		return errors.Errorf("must specify ref")
-	}
-	if len(c.Destination) == 0 {
-		return errors.Errorf("must specify destination")
-	}
-	if len(c.Directory) == 0 {
-		return errors.Errorf("must specify remote subdirectory")
-	}
-
-	if !filepath.IsAbs(c.Destination) {
-		return errors.Errorf("destination must be an absolute path")
-	}
-
-	// default the name to the destination name
-	if len(c.Name) == 0 {
-		c.Name = filepath.Base(c.Destination)
-	}
-
-	return nil
-}
-
-// upsertKptfile populates the KptFile values, merging any cloned KptFile and the
-// cloneFrom values.
-func upsertKptfile(path, name string, spec *git.RepoSpec) error {
-	// read KptFile cloned with the package if it exists
-	kpgfile, err := kptfileutil.ReadFile(path)
-	if err != nil {
-		// no KptFile present, create a default
-		kpgfile = kptfileutil.DefaultKptfile(name)
-	}
-	kpgfile.Name = name
-
-	// find the git commit sha that we cloned the package at so we can write it to the KptFile
-	commit, err := git.LookupCommit(spec.AbsPath())
-	if err != nil {
-		return err
-	}
-
-	// populate the cloneFrom values so we know where the package came from
-	kpgfile.Upstream = kptfile.Upstream{
-		Type: kptfile.GitOrigin,
-		Git: kptfile.Git{
-			Repo:      spec.OrgRepo,
-			Directory: spec.Path,
-			Ref:       spec.Ref,
-		},
-	}
-	kpgfile.Upstream.Git.Commit = commit
-	return kptfileutil.WriteFile(path, kpgfile)
 }

--- a/internal/util/sync/sync.go
+++ b/internal/util/sync/sync.go
@@ -22,7 +22,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/GoogleContainerTools/kpt/internal/util/get"
+	"github.com/GoogleContainerTools/kpt/internal/util/fetch"
+	"github.com/GoogleContainerTools/kpt/internal/util/git"
 	"github.com/GoogleContainerTools/kpt/internal/util/setters"
 	"github.com/GoogleContainerTools/kpt/internal/util/update"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
@@ -157,8 +158,12 @@ func (c Command) get(dependency kptfile.Dependency) error {
 		return nil
 	}
 
-	return get.Command{
-		Git:         dependency.Git,
+	return fetch.Command{
+		RepoSpec: &git.RepoSpec{
+			OrgRepo: dependency.Git.Repo,
+			Ref:     dependency.Git.Ref,
+			Path:    dependency.Git.Directory,
+		},
 		Destination: path,
 		Name:        dependency.Name,
 	}.Run()

--- a/internal/util/update/common.go
+++ b/internal/util/update/common.go
@@ -1,3 +1,17 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package update
 
 import (

--- a/internal/util/update/fastforward.go
+++ b/internal/util/update/fastforward.go
@@ -21,9 +21,8 @@ import (
 	"path/filepath"
 	"sort"
 
-	"github.com/GoogleContainerTools/kpt/internal/gitutil"
 	pkgdiff "github.com/GoogleContainerTools/kpt/internal/util/diff"
-	"github.com/GoogleContainerTools/kpt/internal/util/get"
+	"github.com/GoogleContainerTools/kpt/internal/util/fetch"
 	"github.com/GoogleContainerTools/kpt/internal/util/git"
 	"github.com/GoogleContainerTools/kpt/internal/util/pkgutil"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
@@ -51,21 +50,16 @@ func (u FastForwardUpdater) Update(options UpdateOptions) error {
 	g.Ref = options.ToRef
 	g.Repo = options.ToRepo
 
-	defaultRef, err := gitutil.DefaultRef(g.Repo)
-	if err != nil {
-		return err
-	}
-
 	// get the original repo
 	original := &git.RepoSpec{OrgRepo: g.Repo, Path: g.Directory, Ref: g.Commit}
-	if err := get.ClonerUsingGitExec(original, defaultRef); err != nil {
+	if err := fetch.ClonerUsingGitExec(original); err != nil {
 		return errors.Errorf("failed to clone git repo: original source: %v", err)
 	}
 	defer os.RemoveAll(original.AbsPath())
 
 	// get the updated repo
 	updated := &git.RepoSpec{OrgRepo: options.ToRepo, Path: g.Directory, Ref: options.ToRef}
-	if err := get.ClonerUsingGitExec(updated, defaultRef); err != nil {
+	if err := fetch.ClonerUsingGitExec(updated); err != nil {
 		return errors.Errorf("failed to clone git repo: updated source: %v", err)
 	}
 	defer os.RemoveAll(updated.AbsPath())

--- a/internal/util/update/replace.go
+++ b/internal/util/update/replace.go
@@ -14,7 +14,10 @@
 
 package update
 
-import "github.com/GoogleContainerTools/kpt/internal/util/get"
+import (
+	"github.com/GoogleContainerTools/kpt/internal/util/fetch"
+	"github.com/GoogleContainerTools/kpt/internal/util/git"
+)
 
 // Updater updates a package to a new upstream version.
 //
@@ -25,5 +28,13 @@ type ReplaceUpdater struct{}
 func (u ReplaceUpdater) Update(options UpdateOptions) error {
 	options.KptFile.Upstream.Git.Ref = options.ToRef
 	options.KptFile.Upstream.Git.Repo = options.ToRepo
-	return get.Command{Destination: options.PackagePath, Clean: true, Git: options.KptFile.Upstream.Git}.Run()
+	return fetch.Command{
+		RepoSpec: &git.RepoSpec{
+			OrgRepo: options.KptFile.Upstream.Git.Repo,
+			Ref:     options.KptFile.Upstream.Git.Ref,
+			Path:    options.KptFile.Upstream.Git.Directory,
+		},
+		Destination: options.PackagePath,
+		Clean:       true,
+	}.Run()
 }

--- a/internal/util/update/resource-merge.go
+++ b/internal/util/update/resource-merge.go
@@ -22,8 +22,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/GoogleContainerTools/kpt/internal/gitutil"
-	"github.com/GoogleContainerTools/kpt/internal/util/get"
+	"github.com/GoogleContainerTools/kpt/internal/util/fetch"
 	"github.com/GoogleContainerTools/kpt/internal/util/git"
 	"github.com/GoogleContainerTools/kpt/internal/util/merge"
 	"github.com/GoogleContainerTools/kpt/internal/util/pkgutil"
@@ -45,21 +44,16 @@ func (u ResourceMergeUpdater) Update(options UpdateOptions) error {
 	g.Ref = options.ToRef
 	g.Repo = options.ToRepo
 
-	defaultRef, err := gitutil.DefaultRef(g.Repo)
-	if err != nil {
-		return err
-	}
-
 	// get the original repo
 	original := &git.RepoSpec{OrgRepo: g.Repo, Path: g.Directory, Ref: g.Commit}
-	if err := get.ClonerUsingGitExec(original, defaultRef); err != nil {
+	if err := fetch.ClonerUsingGitExec(original); err != nil {
 		return errors.Errorf("failed to clone git repo: original source: %v", err)
 	}
 	defer os.RemoveAll(original.AbsPath())
 
 	// get the updated repo
 	updated := &git.RepoSpec{OrgRepo: options.ToRepo, Path: g.Directory, Ref: options.ToRef}
-	if err := get.ClonerUsingGitExec(updated, defaultRef); err != nil {
+	if err := fetch.ClonerUsingGitExec(updated); err != nil {
 		return errors.Errorf("failed to clone git repo: updated source: %v", err)
 	}
 	defer os.RemoveAll(updated.AbsPath())


### PR DESCRIPTION
Split the logic for fetching a package from git and copying to a directory from the rest of the `kpt pkg get` command. We use this functionality in several places where we only need this and doesn't want the package to be expanded with remote subpackages.

Must merge after https://github.com/GoogleContainerTools/kpt/pull/1353
