### PR TITLE
Docs: Add swagger to kptfile markdown.

### DIFF
--- a/site/content/en/api-reference/kptfile/_index.md
+++ b/site/content/en/api-reference/kptfile/_index.md
@@ -6,7 +6,4 @@ type: swagger
 description: >
    Reference for the Kptfile schema
 ---
-<link rel="stylesheet" type="text/css" href="/kpt/css/swagger-ui.css">
-<script src="/kpt/js/swagger-ui-bundle.js"></script>
-<script src="/kpt/js/swagger-ui-standalone-preset.js"></script>
 {{< swaggerui src="/kpt/openapi/kptfile.yaml" >}}

--- a/site/content/en/api-reference/kptfile/_index.md
+++ b/site/content/en/api-reference/kptfile/_index.md
@@ -6,4 +6,7 @@ type: swagger
 description: >
    Reference for the Kptfile schema
 ---
-{{< swaggerui src="/openapi/kptfile.yaml" >}}
+<link rel="stylesheet" type="text/css" href="/kpt/css/swagger-ui.css">
+<script src="/kpt/js/swagger-ui-bundle.js"></script>
+<script src="/kpt/js/swagger-ui-standalone-preset.js"></script>
+{{< swaggerui src="/kpt/openapi/kptfile.yaml" >}}

--- a/site/layouts/partials/hooks/head-end.html
+++ b/site/layouts/partials/hooks/head-end.html
@@ -15,3 +15,6 @@
 -->
 
 <link rel="stylesheet" type="text/css" href="{{ .Site.BaseURL }}/css/asciinema-player.css" />
+<script src="/kpt/js/swagger-ui-bundle.js"></script>
+<script src="/kpt/js/swagger-ui-standalone-preset.js"></script>
+<link rel="stylesheet" type="text/css" href="/kpt/css/swagger-ui.css">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31711490/104625915-20a22d00-564a-11eb-8b19-543ccc81a2b6.png)
Fixes https://github.com/GoogleContainerTools/kpt/issues/921
