### PR TITLE
Clarify Kpt Fn Run Docs

### DIFF
--- a/internal/docs/generated/fndocs/docs.go
+++ b/internal/docs/generated/fndocs/docs.go
@@ -72,7 +72,7 @@ var ExportExamples = `
 
 var RunShort = `Locally execute one or more functions in containers`
 var RunLong = `
-  kpt fn run DIR [flags]
+  kpt fn run [DIR] [flags]
 
 If the container exits with non-zero status code, run will fail and print the
 container ` + "`" + `STDERR` + "`" + `.
@@ -94,6 +94,10 @@ var RunExamples = `
   # discover functions in DIR and run them against Resource in DIR.
   # functions may be scoped to a subset of Resources -- see ` + "`" + `kpt help fn run` + "`" + `
   kpt fn run DIR/
+
+  # pipe a resource from stdin and execute a function against it.
+  # print the results to stdout
+  kpt fn source . | kpt fn run --image gcr.io/example.com/my-fn
 `
 
 var SinkShort = `Specify a directory as an output sink package`

--- a/site/content/en/reference/fn/run/_index.md
+++ b/site/content/en/reference/fn/run/_index.md
@@ -26,7 +26,7 @@ reference for advanced usecases.
 <!--mdtogo:Long-->
 
 ```sh
-kpt fn run DIR [flags]
+kpt fn run [DIR] [flags]
 ```
 
 If the container exits with non-zero status code, run will fail and print the
@@ -63,6 +63,12 @@ kpt fn run DIR/ --fn-path FUNCTIONS_DIR/
 # discover functions in DIR and run them against Resource in DIR.
 # functions may be scoped to a subset of Resources -- see `kpt help fn run`
 kpt fn run DIR/
+```
+
+```sh
+# pipe a resource from stdin and execute a function against it.
+# print the results to stdout
+kpt fn source . | kpt fn run --image gcr.io/example.com/my-fn
 ```
 
 <!--mdtogo-->


### PR DESCRIPTION
Update to documentation and cli help for `kpt fn run` that

- Includes example for printing a modification to stdout instead of performing an in-place modification
- Clarify that DIR is an optional argument

Related to Issue #981