### PR TITLE
Change MergeOpenAPI to return a merged copy rather than changing the passed-in data structures

### DIFF
--- a/internal/util/update/gitpatch.go
+++ b/internal/util/update/gitpatch.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	"github.com/GoogleContainerTools/kpt/internal/gitutil"
+	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
 	"sigs.k8s.io/kustomize/kyaml/errors"
 )
@@ -174,10 +175,11 @@ func (u *GitPatchUpdater) hardResetSourceFiles() error {
 		// since it is owned locally
 		pf.Upstream = u.UpdateOptions.KptFile.Upstream
 		// also keep the local OpenAPI which may have been modified.
-		err = pf.MergeOpenAPI(u.UpdateOptions.KptFile, u.UpdateOptions.KptFile)
+		mergedOpenAPI, err := kptfile.MergeOpenAPI(u.UpdateOptions.KptFile.OpenAPI, pf.OpenAPI, u.UpdateOptions.KptFile.OpenAPI)
 		if err != nil {
 			return err
 		}
+		pf.OpenAPI = mergedOpenAPI
 	}
 
 	// write the Kptfile so the patch sees the updates to it.  use the version we read

--- a/internal/util/update/resource-merge.go
+++ b/internal/util/update/resource-merge.go
@@ -224,8 +224,12 @@ func (u ResourceMergeUpdater) updatedKptfile(localPath, updatedPath, originalPat
 	}
 
 	// keep the local OpenAPI values
-	err = updatedKf.MergeOpenAPI(localKf, originalKf)
-	localKf.OpenAPI = updatedKf.OpenAPI
+	mergedOpenAPI, err := kptfile.MergeOpenAPI(localKf.OpenAPI, updatedKf.OpenAPI, originalKf.OpenAPI)
+	if err != nil {
+		return localKf, err
+	}
+
+	localKf.OpenAPI = mergedOpenAPI
 	localKf.Upstream = updatedKf.Upstream
 	return localKf, err
 }

--- a/pkg/kptfile/pkgfile_test.go
+++ b/pkg/kptfile/pkgfile_test.go
@@ -519,10 +519,11 @@ openAPI:
 				t.FailNow()
 			}
 
-			err := kUpdated.MergeOpenAPI(kLocal, kOriginal)
+			mergedOpenAPI, err := MergeOpenAPI(kLocal.OpenAPI, kUpdated.OpenAPI, kOriginal.OpenAPI)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
+			kUpdated.OpenAPI = mergedOpenAPI
 
 			b, err := yaml.Marshal(kUpdated)
 			if !assert.NoError(t, err) {


### PR DESCRIPTION
This updates the `MergeOpenAPI` function to return a new openapi object instead of changing the values directly in the `updated` openapi. This makes it easier to use this functionality in places where we don't necessarily want to make updates to the `updated` version of the Kptfile.