### PR TITLE
Continue on error test

### DIFF
--- a/e2e/live/end-to-end-test.sh
+++ b/e2e/live/end-to-end-test.sh
@@ -872,6 +872,15 @@ assertPodNotExists "pod-c" "test-namespace"
 assertPodNotExists "pod-d" "test-namespace"
 printResult
 
+# Test 20: kpt live apply continue-on-error
+echo "Testing continue-on-error"
+echo "kpt live apply e2e/live/testdata/continue-on-error"
+${BIN_DIR}/kpt live destroy e2e/live/testdata/continue-on-error > $OUTPUT_DIR/status
+assertCMInventory "test-namespace" "1"
+assertPodExists "pod-a" "test-namespace"
+assertPodNotExists "pod-B" "test-namespace"
+printResult
+
 # Clean-up the k8s cluster
 echo "Cleaning up cluster"
 kind delete cluster

--- a/e2e/live/end-to-end-test.sh
+++ b/e2e/live/end-to-end-test.sh
@@ -875,7 +875,7 @@ printResult
 # Test 20: kpt live apply continue-on-error
 echo "Testing continue-on-error"
 echo "kpt live apply e2e/live/testdata/continue-on-error"
-${BIN_DIR}/kpt live destroy e2e/live/testdata/continue-on-error > $OUTPUT_DIR/status
+${BIN_DIR}/kpt live apply e2e/live/testdata/continue-on-error > $OUTPUT_DIR/status
 assertCMInventory "test-namespace" "1"
 assertPodExists "pod-a" "test-namespace"
 assertPodNotExists "pod-B" "test-namespace"

--- a/e2e/live/testdata/continue-on-error/Kptfile
+++ b/e2e/live/testdata/continue-on-error/Kptfile
@@ -1,0 +1,6 @@
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: continue-on-error
+packageMetadata:
+  shortDescription: sample description

--- a/e2e/live/testdata/continue-on-error/inventory-template.yaml
+++ b/e2e/live/testdata/continue-on-error/inventory-template.yaml
@@ -1,0 +1,34 @@
+# NOTE: auto-generated. Some fields should NOT be modified.
+# Date: 2021-01-15 15:23:11 PST
+#
+# Contains the "inventory object" template ConfigMap.
+# When this object is applied, it is handled specially,
+# storing the metadata of all the other objects applied.
+# This object and its stored inventory is subsequently
+# used to calculate the set of objects to automatically
+# delete (prune), when an object is omitted from further
+# applies. When applied, this "inventory object" is also
+# used to identify the entire set of objects to delete.
+#
+# NOTE: The name of this inventory template file
+# does NOT have any impact on group-related functionality
+# such as deletion or pruning.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  # DANGER: Do not change the inventory object namespace.
+  # Changing the namespace will cause a loss of continuity
+  # with previously applied grouped objects. Set deletion
+  # and pruning functionality will be impaired.
+  namespace: test-namespace
+  # NOTE: The name of the inventory object does NOT have
+  # any impact on group-related functionality such as
+  # deletion or pruning.
+  name: inventory-10220562
+  labels:
+    # DANGER: Do not change the value of this label.
+    # Changing this value will cause a loss of continuity
+    # with previously applied grouped objects. Set deletion
+    # and pruning functionality will be impaired.
+    cli-utils.sigs.k8s.io/inventory-id: 3da10960-c1d8-46ae-988e-f330acdc8e15

--- a/e2e/live/testdata/continue-on-error/namespace.yaml
+++ b/e2e/live/testdata/continue-on-error/namespace.yaml
@@ -1,0 +1,7 @@
+# Copyright 2019 The Kubernetes Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test-namespace

--- a/e2e/live/testdata/continue-on-error/pod-a.yaml
+++ b/e2e/live/testdata/continue-on-error/pod-a.yaml
@@ -1,0 +1,13 @@
+# This pod description should be valid and is expected to successfully deploy
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-a
+  namespace: test-namespace
+  labels:
+    name: test-pod-label-foo
+spec:
+  containers:
+  - name: kubernetes-pause
+    image: k8s.gcr.io/pause:2.0

--- a/e2e/live/testdata/continue-on-error/pod-b.yaml
+++ b/e2e/live/testdata/continue-on-error/pod-b.yaml
@@ -1,0 +1,16 @@
+# This pod definition has errors and will fail to deploy
+
+apiVersion: v1
+kind: Pod
+metadata:
+  # It is invalid for a pod to be named with a capital letter
+  # Expected error:
+  #   The Pod "pod-B" is invalid: metadata.name: Invalid value: "pod-B"
+  name: pod-B
+  namespace: test-namespace
+  labels:
+    name: test-pod-label-foo
+spec:
+  containers:
+  - name: kubernetes-pause
+    image: k8s.gcr.io/pause:2.0


### PR DESCRIPTION
**WIP - please don't merge yet.**

quick test case covering #1266

This introduces one test case over `kpt live apply` where a resource is unable to be successfully applied.

It is expected that

| pod | result |
| :-- | --: |
| `pod-a` | succeeds |
| `pod-B` | fails |

Currently both `pod-a` and `pod-B` are added to the inventory object. This test expects only `pod-a` to be added to the inventory object. This means the test currently fails. Leave this PR until that behavior has been merged, some changes may need to occur after that feature has completed.

`pod-B` has an invalid pod name and should fail to create - because of this failure it should not be added to the inventory object.