### PR TITLE
Update command should handle remote subpackages

### DIFF
--- a/internal/testutil/pkgbuilder/builder.go
+++ b/internal/testutil/pkgbuilder/builder.go
@@ -455,6 +455,13 @@ func buildPkg(pkgPath string, pkg *pkg, pkgName string, repoPaths map[string]str
 	for _, ri := range pkg.resources {
 		m := ri.resourceInfo.manifest
 		r := yaml.MustParse(m)
+
+		for _, m := range ri.mutators {
+			if err := r.PipeE(m); err != nil {
+				return err
+			}
+		}
+
 		for _, setterRef := range ri.setterRefs {
 			n, err := r.Pipe(yaml.PathGetter{
 				Path: setterRef.Path,
@@ -463,12 +470,6 @@ func buildPkg(pkgPath string, pkg *pkg, pkgName string, repoPaths map[string]str
 				return err
 			}
 			n.YNode().LineComment = fmt.Sprintf(`{"$openapi":"%s"}`, setterRef.Name)
-		}
-
-		for _, m := range ri.mutators {
-			if err := r.PipeE(m); err != nil {
-				return err
-			}
 		}
 
 		filePath := filepath.Join(pkgPath, ri.resourceInfo.filename)

--- a/internal/testutil/pkgbuilder/fns.go
+++ b/internal/testutil/pkgbuilder/fns.go
@@ -37,9 +37,32 @@ func (f FieldPathSetter) Filter(rn *yaml.RNode) (*yaml.RNode, error) {
 		Path: f.Path,
 	})
 	if err != nil {
-		return n, err
+		return rn, err
 	}
 
 	n.YNode().Value = f.Value
 	return rn, nil
+}
+
+// SetAnnotation returns a new AnnotationSetters that sets an annotation
+// with the given name and value.
+func SetAnnotation(name, value string) AnnotationSetter {
+	return AnnotationSetter{
+		Name:  name,
+		Value: value,
+	}
+}
+
+type AnnotationSetter struct {
+	Name string
+
+	Value string
+}
+
+func (a AnnotationSetter) Filter(rn *yaml.RNode) (*yaml.RNode, error) {
+	err := rn.PipeE(yaml.AnnotationSetter{
+		Key:   a.Name,
+		Value: a.Value,
+	})
+	return rn, err
 }

--- a/internal/util/fetch/fetch.go
+++ b/internal/util/fetch/fetch.go
@@ -87,7 +87,7 @@ func cloneAndCopy(r *git.RepoSpec, dest, name string, clean bool) error {
 			r.Path, r.OrgRepo, r.Ref)
 	}
 
-	if err := upsertKptfile(dest, name, r); err != nil {
+	if err := UpsertKptfile(dest, name, r); err != nil {
 		return errors.Wrap(err)
 	}
 	return nil
@@ -259,9 +259,9 @@ func (c *Command) DefaultValues() error {
 	return nil
 }
 
-// upsertKptfile populates the KptFile values, merging any cloned KptFile and the
+// UpsertKptfile populates the KptFile values, merging any cloned KptFile and the
 // cloneFrom values.
-func upsertKptfile(path, name string, spec *git.RepoSpec) error {
+func UpsertKptfile(path, name string, spec *git.RepoSpec) error {
 	// read KptFile cloned with the package if it exists
 	kpgfile, err := kptfileutil.ReadFile(path)
 	if err != nil {

--- a/internal/util/get/get_test.go
+++ b/internal/util/get/get_test.go
@@ -1151,6 +1151,11 @@ func TestCommand_Run_subpackages(t *testing.T) {
 				repoPaths[name] = tgr.RepoDirectory
 			}
 
+			err = testutil.UpdateRefRepos(t, refRepos, test.refRepos, repoPaths)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
 			g, w, clean := testutil.SetupDefaultRepoAndWorkspace(t, test.upstream, repoPaths)
 			defer clean()
 

--- a/internal/util/stack/stack.go
+++ b/internal/util/stack/stack.go
@@ -1,0 +1,45 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stack
+
+import "fmt"
+
+func New() *stack {
+	return &stack{
+		slice: make([]string, 0),
+	}
+}
+
+type stack struct {
+	slice []string
+}
+
+func (s *stack) Push(str string) {
+	s.slice = append(s.slice, str)
+}
+
+func (s *stack) Pop() string {
+	l := len(s.slice)
+	if l == 0 {
+		panic(fmt.Errorf("can't pop an empty stack"))
+	}
+	str := s.slice[l-1]
+	s.slice = s.slice[:l-1]
+	return str
+}
+
+func (s *stack) Len() int {
+	return len(s.slice)
+}

--- a/internal/util/update/common.go
+++ b/internal/util/update/common.go
@@ -20,8 +20,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
-	"sigs.k8s.io/kustomize/kyaml/pathutil"
+	"github.com/GoogleContainerTools/kpt/internal/util/pkgutil"
 )
 
 // findAllSubpackages traverses the provided package paths
@@ -31,8 +30,9 @@ import (
 // relative to the root package.
 func findAllSubpackages(pkgPaths ...string) ([]string, error) {
 	uniquePaths := make(map[string]bool)
+	uniquePaths["."] = true
 	for _, path := range pkgPaths {
-		paths, err := pathutil.DirsWithFile(path, kptfile.KptFileName, true)
+		paths, err := pkgutil.FindLocalSubpackages(path)
 		if err != nil {
 			return []string{}, err
 		}

--- a/internal/util/update/fastforward.go
+++ b/internal/util/update/fastforward.go
@@ -64,11 +64,6 @@ func (u FastForwardUpdater) Update(options UpdateOptions) error {
 	}
 	defer os.RemoveAll(updated.AbsPath())
 
-	commit, err := git.LookupCommit(updated.AbsPath())
-	if err != nil {
-		return err
-	}
-
 	// Verify that there are no local changes that would prevent us from
 	// using the FastForward strategy.
 	if err := u.checkForLocalChanges(options.AbsPackagePath, original.AbsPath()); err != nil {
@@ -154,10 +149,7 @@ func (u FastForwardUpdater) Update(options UpdateOptions) error {
 		}
 	}
 
-	options.KptFile.Upstream.Git.Commit = commit
-	options.KptFile.Upstream.Git.Ref = options.ToRef
-	options.KptFile.Upstream.Git.Repo = options.ToRepo
-	return kptfileutil.WriteFile(options.AbsPackagePath, options.KptFile)
+	return fetch.UpsertKptfile(options.AbsPackagePath, filepath.Base(options.AbsPackagePath), updated)
 }
 
 func (u FastForwardUpdater) checkForLocalChanges(localPath, originalPath string) error {

--- a/internal/util/update/update_test.go
+++ b/internal/util/update/update_test.go
@@ -741,6 +741,7 @@ func TestCommand_Run_badStrategy(t *testing.T) {
 func TestCommand_Run_subpackages(t *testing.T) {
 	testCases := []struct {
 		name            string
+		refRepos        map[string][]testutil.Content
 		initialUpstream *pkgbuilder.RootPkg
 		updatedUpstream testutil.Content
 		updatedLocal    testutil.Content
@@ -772,7 +773,10 @@ func TestCommand_Run_subpackages(t *testing.T) {
 				{
 					strategies: []StrategyType{KResourceMerge, FastForward},
 					expectedLocal: pkgbuilder.NewRootPkg().
-						WithKptfile().
+						WithKptfile(
+							pkgbuilder.NewKptfile().
+								WithUpstreamRef("upstream", "/", "master"),
+						).
 						WithSubPackages(
 							pkgbuilder.NewSubPkg("bar").
 								WithKptfile().
@@ -808,7 +812,10 @@ func TestCommand_Run_subpackages(t *testing.T) {
 				{
 					strategies: []StrategyType{KResourceMerge},
 					expectedLocal: pkgbuilder.NewRootPkg().
-						WithKptfile().
+						WithKptfile(
+							pkgbuilder.NewKptfile().
+								WithUpstreamRef("upstream", "/", "master"),
+						).
 						WithSubPackages(
 							pkgbuilder.NewSubPkg("bar").
 								WithKptfile(),
@@ -854,7 +861,10 @@ func TestCommand_Run_subpackages(t *testing.T) {
 				{
 					strategies: []StrategyType{KResourceMerge},
 					expectedLocal: pkgbuilder.NewRootPkg().
-						WithKptfile().
+						WithKptfile(
+							pkgbuilder.NewKptfile().
+								WithUpstreamRef("upstream", "/", "master"),
+						).
 						WithSubPackages(
 							pkgbuilder.NewSubPkg("bar").
 								WithKptfile(),
@@ -925,7 +935,10 @@ func TestCommand_Run_subpackages(t *testing.T) {
 				{
 					strategies: []StrategyType{KResourceMerge, FastForward},
 					expectedLocal: pkgbuilder.NewRootPkg().
-						WithKptfile(),
+						WithKptfile(
+							pkgbuilder.NewKptfile().
+								WithUpstreamRef("upstream", "/", "master"),
+						),
 				},
 			},
 		},
@@ -949,7 +962,10 @@ func TestCommand_Run_subpackages(t *testing.T) {
 				{
 					strategies: []StrategyType{KResourceMerge, FastForward},
 					expectedLocal: pkgbuilder.NewRootPkg().
-						WithKptfile().
+						WithKptfile(
+							pkgbuilder.NewKptfile().
+								WithUpstreamRef("upstream", "/", "master"),
+						).
 						WithSubPackages(
 							pkgbuilder.NewSubPkg("bar").
 								WithKptfile().
@@ -1066,7 +1082,8 @@ func TestCommand_Run_subpackages(t *testing.T) {
 							WithSetters(
 								pkgbuilder.NewSetSetter("gcloud.core.project", "my-project"),
 								pkgbuilder.NewSetSetter("gcloud.project.projectNumber", "a1234"),
-							),
+							).
+							WithUpstreamRef("upstream", "/", "master"),
 						).
 						WithResourceAndSetters(pkgbuilder.DeploymentResource, []pkgbuilder.SetterRef{
 							pkgbuilder.NewSetterRef("gcloud.core.project", "metadata", "namespace"),
@@ -1133,7 +1150,10 @@ func TestCommand_Run_subpackages(t *testing.T) {
 				{
 					strategies: []StrategyType{KResourceMerge},
 					expectedLocal: pkgbuilder.NewRootPkg().
-						WithKptfile().
+						WithKptfile(
+							pkgbuilder.NewKptfile().
+								WithUpstreamRef("upstream", "/", "master"),
+						).
 						WithSubPackages(
 							pkgbuilder.NewSubPkg("bar").
 								WithKptfile(pkgbuilder.NewKptfile().
@@ -1147,7 +1167,10 @@ func TestCommand_Run_subpackages(t *testing.T) {
 				{
 					strategies: []StrategyType{FastForward},
 					expectedLocal: pkgbuilder.NewRootPkg().
-						WithKptfile().
+						WithKptfile(
+							pkgbuilder.NewKptfile().
+								WithUpstreamRef("upstream", "/", "master"),
+						).
 						WithSubPackages(
 							pkgbuilder.NewSubPkg("bar").
 								WithResource(pkgbuilder.DeploymentResource),
@@ -1156,7 +1179,7 @@ func TestCommand_Run_subpackages(t *testing.T) {
 			},
 		},
 		{
-			name: "Kptfile added only on local",
+			name: "kptfile added only on local",
 			initialUpstream: pkgbuilder.NewRootPkg().
 				WithKptfile().
 				WithSubPackages(
@@ -1189,7 +1212,10 @@ func TestCommand_Run_subpackages(t *testing.T) {
 				{
 					strategies: []StrategyType{KResourceMerge},
 					expectedLocal: pkgbuilder.NewRootPkg().
-						WithKptfile().
+						WithKptfile(
+							pkgbuilder.NewKptfile().
+								WithUpstreamRef("upstream", "/", "master"),
+						).
 						WithSubPackages(
 							pkgbuilder.NewSubPkg("bar").
 								WithKptfile(pkgbuilder.NewKptfile().
@@ -1228,7 +1254,10 @@ func TestCommand_Run_subpackages(t *testing.T) {
 				{
 					strategies: []StrategyType{KResourceMerge, FastForward},
 					expectedLocal: pkgbuilder.NewRootPkg().
-						WithKptfile(),
+						WithKptfile(
+							pkgbuilder.NewKptfile().
+								WithUpstreamRef("upstream", "/", "master"),
+						),
 				},
 			},
 		},
@@ -1267,7 +1296,10 @@ func TestCommand_Run_subpackages(t *testing.T) {
 				{
 					strategies: []StrategyType{KResourceMerge},
 					expectedLocal: pkgbuilder.NewRootPkg().
-						WithKptfile().
+						WithKptfile(
+							pkgbuilder.NewKptfile().
+								WithUpstreamRef("upstream", "/", "master"),
+						).
 						WithSubPackages(
 							pkgbuilder.NewSubPkg("bar").
 								WithKptfile(pkgbuilder.NewKptfile().
@@ -1331,7 +1363,8 @@ func TestCommand_Run_subpackages(t *testing.T) {
 						WithKptfile(pkgbuilder.NewKptfile().
 							WithSetters(
 								pkgbuilder.NewSetSetter("band", "Hüsker Dü"),
-							),
+							).
+							WithUpstreamRef("upstream", "/", "master"),
 						).WithSubPackages(
 						pkgbuilder.NewSubPkg("bar").
 							WithKptfile(pkgbuilder.NewKptfile().
@@ -1356,7 +1389,7 @@ func TestCommand_Run_subpackages(t *testing.T) {
 			},
 		},
 		{
-			name: "Merging of Kptfile in nested package",
+			name: "merging of Kptfile in nested package",
 			initialUpstream: pkgbuilder.NewRootPkg().
 				WithKptfile(pkgbuilder.NewKptfile().
 					WithUpstream("github.com/foo/bar", "/", "somebranch"),
@@ -1391,7 +1424,7 @@ func TestCommand_Run_subpackages(t *testing.T) {
 					strategies: []StrategyType{KResourceMerge, FastForward},
 					expectedLocal: pkgbuilder.NewRootPkg().
 						WithKptfile(pkgbuilder.NewKptfile().
-							WithUpstream("github.com/foo/bar", "/", "somebranch"),
+							WithUpstreamRef("upstream", "/", "master"),
 						).
 						WithSubPackages(
 							pkgbuilder.NewSubPkg("subpkg").
@@ -1407,7 +1440,7 @@ func TestCommand_Run_subpackages(t *testing.T) {
 			},
 		},
 		{
-			name: "Upstream package doesn't need to have a Kptfile in the root",
+			name: "upstream package doesn't need to have a Kptfile in the root",
 			initialUpstream: pkgbuilder.NewRootPkg().
 				WithResource(pkgbuilder.DeploymentResource).
 				WithSubPackages(
@@ -1427,7 +1460,10 @@ func TestCommand_Run_subpackages(t *testing.T) {
 				{
 					strategies: []StrategyType{KResourceMerge, FastForward},
 					expectedLocal: pkgbuilder.NewRootPkg().
-						WithKptfile().
+						WithKptfile(
+							pkgbuilder.NewKptfile().
+								WithUpstreamRef("upstream", "/", "master"),
+						).
 						WithResource(pkgbuilder.DeploymentResource).
 						WithResource(pkgbuilder.ConfigMapResource).
 						WithSubPackages(
@@ -1438,7 +1474,7 @@ func TestCommand_Run_subpackages(t *testing.T) {
 			},
 		},
 		{
-			name: "Non-krm files updated in upstream",
+			name: "non-krm files updated in upstream",
 			initialUpstream: pkgbuilder.NewRootPkg().
 				WithKptfile(pkgbuilder.NewKptfile()).
 				WithFile("data.txt", "initial content").
@@ -1461,7 +1497,10 @@ func TestCommand_Run_subpackages(t *testing.T) {
 				{
 					strategies: []StrategyType{KResourceMerge, FastForward},
 					expectedLocal: pkgbuilder.NewRootPkg().
-						WithKptfile(pkgbuilder.NewKptfile()).
+						WithKptfile(
+							pkgbuilder.NewKptfile().
+								WithUpstreamRef("upstream", "/", "master"),
+						).
 						WithFile("data.txt", "updated content").
 						WithSubPackages(
 							pkgbuilder.NewSubPkg("subpkg").
@@ -1472,7 +1511,7 @@ func TestCommand_Run_subpackages(t *testing.T) {
 			},
 		},
 		{
-			name: "Non-krm files updated in both upstream and local",
+			name: "non-krm files updated in both upstream and local",
 			initialUpstream: pkgbuilder.NewRootPkg().
 				WithKptfile(pkgbuilder.NewKptfile()).
 				WithFile("data.txt", "initial content"),
@@ -1490,12 +1529,455 @@ func TestCommand_Run_subpackages(t *testing.T) {
 				{
 					strategies: []StrategyType{KResourceMerge},
 					expectedLocal: pkgbuilder.NewRootPkg().
-						WithKptfile(pkgbuilder.NewKptfile()).
+						WithKptfile(
+							pkgbuilder.NewKptfile().
+								WithUpstreamRef("upstream", "/", "master"),
+						).
 						WithFile("data.txt", "local content"),
 				},
 				{
 					strategies:     []StrategyType{FastForward},
 					expectedErrMsg: "use a different update --strategy",
+				},
+			},
+		},
+		{
+			name: "updated setters on root package",
+			initialUpstream: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithSetters(
+							pkgbuilder.NewSetter("my-setter", "foo"),
+						),
+				),
+			updatedUpstream: testutil.Content{
+				Pkg: pkgbuilder.NewRootPkg().
+					WithKptfile(
+						pkgbuilder.NewKptfile().
+							WithSetters(
+								pkgbuilder.NewSetter("my-setter", "bar"),
+							),
+					),
+			},
+			expectedResults: []resultForStrategy{
+				{
+					strategies: []StrategyType{FastForward, KResourceMerge},
+					expectedLocal: pkgbuilder.NewRootPkg().
+						WithKptfile(
+							pkgbuilder.NewKptfile().
+								WithUpstreamRef("upstream", "/", "master").
+								WithSetters(
+									pkgbuilder.NewSetter("my-setter", "bar"),
+								),
+						),
+				},
+			},
+		},
+		{
+			name: "subpackages are updated based on the version specified in the parent Kptfile",
+			refRepos: map[string][]testutil.Content{
+				"foo": {
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithKptfile().
+							WithResource(pkgbuilder.DeploymentResource),
+						Branch: "master",
+					},
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithKptfile().
+							WithResource(pkgbuilder.ConfigMapResource),
+						Tag: "v1.0",
+					},
+				},
+			},
+			initialUpstream: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithSubpackages(
+							pkgbuilder.NewSubpackage("foo", "/", "master", "fast-forward", "foo"),
+						),
+				),
+			updatedUpstream: testutil.Content{
+				Pkg: pkgbuilder.NewRootPkg().
+					WithKptfile(
+						pkgbuilder.NewKptfile().
+							WithSubpackages( // In the new version of the parent Kptfile, v1.0 of the subpackage should be used.
+								pkgbuilder.NewSubpackage("foo", "/", "v1.0", "fast-forward", "foo"),
+							),
+					).
+					WithResource(pkgbuilder.DeploymentResource),
+			},
+			expectedResults: []resultForStrategy{
+				{
+					strategies: []StrategyType{FastForward, KResourceMerge},
+					expectedLocal: pkgbuilder.NewRootPkg().
+						WithKptfile(
+							pkgbuilder.NewKptfile().
+								WithUpstreamRef("upstream", "/", "master").
+								WithSubpackages(
+									pkgbuilder.NewSubpackage("foo", "/", "v1.0", "fast-forward", "foo"),
+								),
+						).
+						WithResource(pkgbuilder.DeploymentResource).
+						WithSubPackages(
+							pkgbuilder.NewSubPkg("foo").
+								WithKptfile(
+									pkgbuilder.NewKptfile().
+										WithUpstreamRef("foo", "/", "v1.0"),
+								).
+								WithResource(pkgbuilder.ConfigMapResource),
+						),
+				},
+			},
+		},
+		{
+			name: "subpackage with changes can not be updated with fast-forward strategy",
+			refRepos: map[string][]testutil.Content{
+				"foo": {
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithKptfile().
+							WithResource(pkgbuilder.DeploymentResource),
+						Branch: "master",
+					},
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithKptfile().
+							WithResource(pkgbuilder.ConfigMapResource),
+						Tag: "v1.0",
+					},
+				},
+			},
+			initialUpstream: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithSubpackages(
+							pkgbuilder.NewSubpackage("foo", "/", "master", "fast-forward", "foo"),
+						),
+				).
+				WithResource(pkgbuilder.ConfigMapResource),
+			updatedUpstream: testutil.Content{
+				Pkg: pkgbuilder.NewRootPkg().
+					WithKptfile(
+						pkgbuilder.NewKptfile().
+							WithSubpackages(
+								pkgbuilder.NewSubpackage("foo", "/", "v1.0", "fast-forward", "foo"),
+							),
+					).
+					WithResource(pkgbuilder.DeploymentResource),
+			},
+			updatedLocal: testutil.Content{
+				Pkg: pkgbuilder.NewRootPkg().
+					WithKptfile(
+						pkgbuilder.NewKptfile().
+							WithSubpackages(
+								pkgbuilder.NewSubpackage("foo", "/", "master", "fast-forward", "foo"),
+							),
+					).
+					WithResource(pkgbuilder.ConfigMapResource).
+					WithSubPackages(
+						pkgbuilder.NewSubPkg("foo").
+							WithKptfile().
+							WithResource(pkgbuilder.DeploymentResource,
+								pkgbuilder.SetFieldPath("34", "spec", "replicas")),
+					),
+			},
+			expectedResults: []resultForStrategy{
+				{
+					strategies:     []StrategyType{KResourceMerge, FastForward},
+					expectedErrMsg: "use a different update --strategy",
+				},
+			},
+		},
+		{
+			name: "subpackage with changes can be updated with resource-merge",
+			refRepos: map[string][]testutil.Content{
+				"foo": {
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithKptfile().
+							WithResource(pkgbuilder.DeploymentResource),
+						Branch: "master",
+					},
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithKptfile().
+							WithResource(pkgbuilder.DeploymentResource,
+								pkgbuilder.SetFieldPath("zork", "spec", "foo")),
+						Tag: "v1.0",
+					},
+				},
+			},
+			initialUpstream: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithSubpackages(
+							pkgbuilder.NewSubpackage("foo", "/", "master", "fast-forward", "foo"),
+						),
+				).
+				WithResource(pkgbuilder.ConfigMapResource),
+			updatedUpstream: testutil.Content{
+				Pkg: pkgbuilder.NewRootPkg().
+					WithKptfile(
+						pkgbuilder.NewKptfile().
+							WithSubpackages(
+								pkgbuilder.NewSubpackage("foo", "/", "v1.0", "resource-merge", "foo"),
+							),
+					).
+					WithResource(pkgbuilder.DeploymentResource),
+			},
+			updatedLocal: testutil.Content{
+				Pkg: pkgbuilder.NewRootPkg().
+					WithKptfile(
+						pkgbuilder.NewKptfile().
+							WithSubpackages(
+								pkgbuilder.NewSubpackage("foo", "/", "master", "fast-forward", "foo"),
+							),
+					).
+					WithResource(pkgbuilder.ConfigMapResource).
+					WithSubPackages(
+						pkgbuilder.NewSubPkg("foo").
+							WithKptfile().
+							WithResource(pkgbuilder.DeploymentResource,
+								pkgbuilder.SetFieldPath("34", "spec", "replicas")),
+					),
+			},
+			expectedResults: []resultForStrategy{
+				{
+					strategies: []StrategyType{KResourceMerge, FastForward},
+					expectedLocal: pkgbuilder.NewRootPkg().
+						WithKptfile(
+							pkgbuilder.NewKptfile().
+								WithUpstreamRef("upstream", "/", "master").
+								WithSubpackages(
+									pkgbuilder.NewSubpackage("foo", "/", "v1.0", "resource-merge", "foo"),
+								),
+						).
+						WithResource(pkgbuilder.DeploymentResource).
+						WithSubPackages(
+							pkgbuilder.NewSubPkg("foo").
+								WithKptfile(
+									pkgbuilder.NewKptfile().
+										WithUpstreamRef("foo", "/", "v1.0"),
+								).
+								WithResource(pkgbuilder.DeploymentResource,
+									pkgbuilder.SetFieldPath("34", "spec", "replicas"),
+									pkgbuilder.SetFieldPath("zork", "spec", "foo"),
+								),
+						),
+				},
+			},
+		},
+		{
+			name: "remote subpackages with setters",
+			refRepos: map[string][]testutil.Content{
+				"foo": {
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithKptfile(
+								pkgbuilder.NewKptfile().
+									WithSubpackages(
+										pkgbuilder.NewSubpackage("bar", "/", "master", "fast-forward", "bar"),
+									).
+									WithSetters(
+										pkgbuilder.NewSetter("my-setter", "foo-value"),
+									),
+							).
+							WithResourceAndSetters(pkgbuilder.DeploymentResource, []pkgbuilder.SetterRef{
+								pkgbuilder.NewSetterRef("my-setter", "metadata", "annotations", "my-anno"),
+							}, pkgbuilder.SetAnnotation("my-anno", "foo-value")),
+						Branch: "master",
+					},
+				},
+				"bar": {
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithKptfile(
+								pkgbuilder.NewKptfile().
+									WithSetters(
+										pkgbuilder.NewSetter("my-setter", "bar-value"),
+									),
+							).
+							WithResourceAndSetters(pkgbuilder.DeploymentResource, []pkgbuilder.SetterRef{
+								pkgbuilder.NewSetterRef("my-setter", "metadata", "annotations", "my-anno"),
+							}, pkgbuilder.SetAnnotation("my-anno", "bar-value")),
+						Branch: "master",
+					},
+				},
+			},
+			initialUpstream: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithSetters(pkgbuilder.NewSetter("my-setter", "my-value")),
+				).
+				WithResourceAndSetters(pkgbuilder.DeploymentResource, []pkgbuilder.SetterRef{
+					pkgbuilder.NewSetterRef("my-setter", "metadata", "annotations", "my-anno"),
+				}, pkgbuilder.SetAnnotation("my-anno", "my-value")),
+			updatedUpstream: testutil.Content{
+				Pkg: pkgbuilder.NewRootPkg().
+					WithKptfile(
+						pkgbuilder.NewKptfile().
+							WithSubpackages(
+								pkgbuilder.NewSubpackage("foo", "/", "master", "resource-merge", "foo"),
+							).
+							WithSetters(
+								pkgbuilder.NewSetter("my-setter", "my-value"),
+							),
+					).
+					WithResourceAndSetters(pkgbuilder.DeploymentResource, []pkgbuilder.SetterRef{
+						pkgbuilder.NewSetterRef("my-setter", "metadata", "annotations", "my-anno"),
+					}, pkgbuilder.SetAnnotation("my-anno", "my-value")),
+			},
+			updatedLocal: testutil.Content{
+				Pkg: pkgbuilder.NewRootPkg().
+					WithKptfile(
+						pkgbuilder.NewKptfile().
+							WithSetters(
+								pkgbuilder.NewSetSetter("my-setter", "Sleater-Kinney"),
+							),
+					).
+					WithResourceAndSetters(pkgbuilder.DeploymentResource, []pkgbuilder.SetterRef{
+						pkgbuilder.NewSetterRef("my-setter", "metadata", "annotations", "my-anno"),
+					}, pkgbuilder.SetAnnotation("my-anno", "Sleater-Kinney")),
+			},
+			expectedResults: []resultForStrategy{
+				{
+					strategies: []StrategyType{KResourceMerge},
+					expectedLocal: pkgbuilder.NewRootPkg().
+						WithKptfile(
+							pkgbuilder.NewKptfile().
+								WithSubpackages(
+									pkgbuilder.NewSubpackage("foo", "/", "master", "resource-merge", "foo"),
+								).
+								WithSetters(
+									pkgbuilder.NewSetSetter("my-setter", "Sleater-Kinney"),
+								).
+								WithUpstreamRef("upstream", "/", "master"),
+						).
+						WithResourceAndSetters(pkgbuilder.DeploymentResource, []pkgbuilder.SetterRef{
+							pkgbuilder.NewSetterRef("my-setter", "metadata", "annotations", "my-anno"),
+						}, pkgbuilder.SetAnnotation("my-anno", "Sleater-Kinney")).
+						WithSubPackages(
+							pkgbuilder.NewSubPkg("foo").
+								WithKptfile(
+									pkgbuilder.NewKptfile().
+										WithSubpackages(
+											pkgbuilder.NewSubpackage("bar", "/", "master", "fast-forward", "bar"),
+										).
+										WithSetters(
+											pkgbuilder.NewSetSetter("my-setter", "Sleater-Kinney"),
+										).
+										WithUpstreamRef("foo", "/", "master"),
+								).
+								WithResourceAndSetters(pkgbuilder.DeploymentResource, []pkgbuilder.SetterRef{
+									pkgbuilder.NewSetterRef("my-setter", "metadata", "annotations", "my-anno"),
+								}, pkgbuilder.SetAnnotation("my-anno", "Sleater-Kinney")).
+								WithSubPackages(
+									pkgbuilder.NewSubPkg("bar").
+										WithKptfile(
+											pkgbuilder.NewKptfile().
+												WithSetters(
+													pkgbuilder.NewSetSetter("my-setter", "Sleater-Kinney"),
+												).
+												WithUpstreamRef("bar", "/", "master"),
+										).
+										WithResourceAndSetters(pkgbuilder.DeploymentResource, []pkgbuilder.SetterRef{
+											pkgbuilder.NewSetterRef("my-setter", "metadata", "annotations", "my-anno"),
+										}, pkgbuilder.SetAnnotation("my-anno", "Sleater-Kinney")),
+								),
+						),
+				},
+			},
+		},
+		{
+			name: "multiple layers of remote packages",
+			refRepos: map[string][]testutil.Content{
+				"foo": {
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithKptfile(
+								pkgbuilder.NewKptfile().
+									WithSubpackages(
+										pkgbuilder.NewSubpackage("bar", "/", "master", "fast-forward", "bar"),
+									),
+							).
+							WithResource(pkgbuilder.DeploymentResource),
+						Branch: "master",
+					},
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithKptfile(
+								pkgbuilder.NewKptfile().
+									WithSubpackages(
+										pkgbuilder.NewSubpackage("bar", "/", "master", "fast-forward", "bar"),
+									),
+							).
+							WithResource(pkgbuilder.ConfigMapResource),
+					},
+				},
+				"bar": {
+					{
+						Pkg: pkgbuilder.NewRootPkg().
+							WithKptfile().
+							WithResource(pkgbuilder.DeploymentResource),
+						Branch: "master",
+					}, {
+						Pkg: pkgbuilder.NewRootPkg().
+							WithKptfile().
+							WithResource(pkgbuilder.ConfigMapResource),
+					},
+				},
+			},
+			initialUpstream: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithSubpackages(
+							pkgbuilder.NewSubpackage("foo", "/", "master", "resource-merge", "foo"),
+						),
+				).
+				WithResource(pkgbuilder.DeploymentResource),
+			updatedUpstream: testutil.Content{
+				Pkg: pkgbuilder.NewRootPkg().
+					WithKptfile(
+						pkgbuilder.NewKptfile().
+							WithSubpackages(
+								pkgbuilder.NewSubpackage("foo", "/", "master", "resource-merge", "foo"),
+							),
+					).
+					WithResource(pkgbuilder.ConfigMapResource),
+			},
+			expectedResults: []resultForStrategy{
+				{
+					strategies: []StrategyType{KResourceMerge},
+					expectedLocal: pkgbuilder.NewRootPkg().
+						WithKptfile(
+							pkgbuilder.NewKptfile().
+								WithSubpackages(
+									pkgbuilder.NewSubpackage("foo", "/", "master", "resource-merge", "foo"),
+								).
+								WithUpstreamRef("upstream", "/", "master"),
+						).
+						WithResource(pkgbuilder.ConfigMapResource).
+						WithSubPackages(
+							pkgbuilder.NewSubPkg("foo").
+								WithKptfile(
+									pkgbuilder.NewKptfile().
+										WithSubpackages(
+											pkgbuilder.NewSubpackage("bar", "/", "master", "fast-forward", "bar"),
+										).
+										WithUpstreamRef("foo", "/", "master"),
+								).
+								WithResource(pkgbuilder.ConfigMapResource).
+								WithSubPackages(
+									pkgbuilder.NewSubPkg("bar").
+										WithKptfile(
+											pkgbuilder.NewKptfile().
+												WithUpstreamRef("bar", "/", "master"),
+										).
+										WithResource(pkgbuilder.ConfigMapResource),
+								),
+						),
 				},
 			},
 		},
@@ -1507,9 +1989,6 @@ func TestCommand_Run_subpackages(t *testing.T) {
 		for i := range strategies {
 			strategy := strategies[i]
 			t.Run(fmt.Sprintf("%s#%s", test.name, string(strategy)), func(t *testing.T) {
-				var emptyMap map[string]string
-				dir := pkgbuilder.ExpandPkg(t, test.initialUpstream, emptyMap)
-
 				g := &testutil.TestSetupManager{
 					T: t,
 				}
@@ -1524,8 +2003,9 @@ func TestCommand_Run_subpackages(t *testing.T) {
 						test.updatedLocal,
 					}
 				}
+				g.RefReposChanges = test.refRepos
 				if !g.Init(testutil.Content{
-					Data:   dir,
+					Pkg:    test.initialUpstream,
 					Branch: "master",
 				}) {
 					return
@@ -1566,19 +2046,10 @@ func TestCommand_Run_subpackages(t *testing.T) {
 					t.FailNow()
 				}
 
-				expectedPath := pkgbuilder.ExpandPkgWithName(t, result.expectedLocal, g.LocalWorkspace.PackageDir, emptyMap)
+				expectedPath := pkgbuilder.ExpandPkgWithName(t, result.expectedLocal,
+					g.LocalWorkspace.PackageDir, g.RepoPaths)
 
-				if !g.AssertLocalDataEquals(expectedPath) {
-					t.FailNow()
-				}
-				commit, err := g.UpstreamRepo.GetCommit()
-				if !assert.NoError(t, err) {
-					t.FailNow()
-				}
-
-				if !g.AssertKptfileEquals(expectedPath, commit, "master") {
-					t.FailNow()
-				}
+				testutil.KptfileAwarePkgEqual(t, expectedPath, g.LocalWorkspace.FullPackagePath())
 			})
 		}
 	}


### PR DESCRIPTION
This adds support for updating remote subpackages and adds a number of tests to verify that it works as expected. It doesn't yet handle deletion of remote subpackages and I plan to add that in a follow-up PR.
