### PR TITLE
use preprocessing to handle the first time apply with inventorypolicy

### DIFF
--- a/commands/applycmd.go
+++ b/commands/applycmd.go
@@ -8,14 +8,21 @@ import (
 
 	"github.com/GoogleContainerTools/kpt/internal/util/setters"
 	"github.com/GoogleContainerTools/kpt/pkg/live"
+	"github.com/GoogleContainerTools/kpt/pkg/live/preprocess"
 	"github.com/spf13/cobra"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/klog"
-	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/cli-utils/cmd/apply"
+	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/manifestreader"
 	"sigs.k8s.io/cli-utils/pkg/provider"
+)
+
+const (
+	inventoryPolicyFlag = "inventory-policy"
+	strictPolicy        = "strict"
 )
 
 // Get ApplyRunner returns a wrapper around the cli-utils apply command ApplyRunner. Sets
@@ -24,7 +31,7 @@ func GetApplyRunner(provider provider.Provider, loader manifestreader.ManifestLo
 	applyRunner := apply.GetApplyRunner(provider, loader, ioStreams)
 	w := &ApplyRunnerWrapper{
 		applyRunner: applyRunner,
-		factory:     provider.Factory(),
+		provider:    provider,
 	}
 	// Set the wrapper run to be the RunE function for the wrapped command.
 	applyRunner.Command.RunE = w.RunE
@@ -36,7 +43,7 @@ func GetApplyRunner(provider provider.Provider, loader manifestreader.ManifestLo
 // as structures necessary to run.
 type ApplyRunnerWrapper struct {
 	applyRunner *apply.ApplyRunner
-	factory     cmdutil.Factory
+	provider    provider.Provider
 }
 
 // Command returns the wrapped ApplyRunner cobraCommand structure.
@@ -60,11 +67,16 @@ func (w *ApplyRunnerWrapper) PreRunE(_ *cobra.Command, args []string) error {
 func (w *ApplyRunnerWrapper) RunE(cmd *cobra.Command, args []string) error {
 	if _, exists := os.LookupEnv(resourceGroupEnv); exists {
 		klog.V(4).Infoln("wrapper applyRunner detected environment variable")
-		err := live.ApplyResourceGroupCRD(w.factory)
+		err := live.ApplyResourceGroupCRD(w.provider.Factory())
 		if err != nil && !apierrors.IsAlreadyExists(err) {
 			return err
 		}
 	}
 	klog.V(4).Infoln("wrapper applyRunner run...")
+	if w.Command().Flag(inventoryPolicyFlag).Value.String() == strictPolicy {
+		w.applyRunner.PreProcess = func(inv inventory.InventoryInfo, strategy common.DryRunStrategy) (inventory.InventoryPolicy, error) {
+			return preprocess.PreProcess(w.provider, inv, strategy)
+		}
+	}
 	return w.applyRunner.RunE(cmd, args)
 }

--- a/commands/applycmd.go
+++ b/commands/applycmd.go
@@ -14,15 +14,11 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/klog"
 	"sigs.k8s.io/cli-utils/cmd/apply"
+	"sigs.k8s.io/cli-utils/cmd/flagutils"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/manifestreader"
 	"sigs.k8s.io/cli-utils/pkg/provider"
-)
-
-const (
-	inventoryPolicyFlag = "inventory-policy"
-	strictPolicy        = "strict"
 )
 
 // Get ApplyRunner returns a wrapper around the cli-utils apply command ApplyRunner. Sets
@@ -73,7 +69,7 @@ func (w *ApplyRunnerWrapper) RunE(cmd *cobra.Command, args []string) error {
 		}
 	}
 	klog.V(4).Infoln("wrapper applyRunner run...")
-	if w.Command().Flag(inventoryPolicyFlag).Value.String() == strictPolicy {
+	if w.Command().Flag(flagutils.InventoryPolicyFlag).Value.String() == flagutils.InventoryPolicyStrict {
 		w.applyRunner.PreProcess = func(inv inventory.InventoryInfo, strategy common.DryRunStrategy) (inventory.InventoryPolicy, error) {
 			return preprocess.PreProcess(w.provider, inv, strategy)
 		}

--- a/commands/destroycmd.go
+++ b/commands/destroycmd.go
@@ -1,0 +1,50 @@
+// Copyright 2020 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"github.com/GoogleContainerTools/kpt/pkg/live/preprocess"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/cli-utils/cmd/destroy"
+	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+	"sigs.k8s.io/cli-utils/pkg/manifestreader"
+	"sigs.k8s.io/cli-utils/pkg/provider"
+)
+
+// GetDestroyRunner returns a wrapper around the cli-utils destroy command DestroyRunner. Sets
+// up the Run on this wrapped runner to be the DestroyRunnerWrapper run.
+func GetDestroyRunner(provider provider.Provider, loader manifestreader.ManifestLoader, ioStreams genericclioptions.IOStreams) *DestroyRunnerWrapper {
+	destroyRunner := destroy.GetDestroyRunner(provider, loader, ioStreams)
+	w := &DestroyRunnerWrapper{
+		destroyRunner: destroyRunner,
+		provider:      provider,
+	}
+	// Set the wrapper run to be the RunE function for the wrapped command.
+	destroyRunner.Command.RunE = w.RunE
+	return w
+}
+
+// DestroyRunnerWrapper encapsulates the cli-utils destroy command DestroyRunner as well
+// as structures necessary to run.
+type DestroyRunnerWrapper struct {
+	destroyRunner *destroy.DestroyRunner
+	provider      provider.Provider
+}
+
+// Command returns the wrapped DestroyRunner cobraCommand structure.
+func (w *DestroyRunnerWrapper) Command() *cobra.Command {
+	return w.destroyRunner.Command
+}
+
+// RunE wraps the destroyRunner.RunE with the pre-processing for inventory policy.
+func (w *DestroyRunnerWrapper) RunE(cmd *cobra.Command, args []string) error {
+	if w.Command().Flag(inventoryPolicyFlag).Value.String() == strictPolicy {
+		w.destroyRunner.PreProcess = func(inv inventory.InventoryInfo, strategy common.DryRunStrategy) (inventory.InventoryPolicy, error) {
+			return preprocess.PreProcess(w.provider, inv, strategy)
+		}
+	}
+	return w.destroyRunner.RunE(cmd, args)
+}

--- a/commands/destroycmd.go
+++ b/commands/destroycmd.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"sigs.k8s.io/cli-utils/cmd/destroy"
+	"sigs.k8s.io/cli-utils/cmd/flagutils"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/manifestreader"
@@ -41,7 +42,7 @@ func (w *DestroyRunnerWrapper) Command() *cobra.Command {
 
 // RunE wraps the destroyRunner.RunE with the pre-processing for inventory policy.
 func (w *DestroyRunnerWrapper) RunE(cmd *cobra.Command, args []string) error {
-	if w.Command().Flag(inventoryPolicyFlag).Value.String() == strictPolicy {
+	if w.Command().Flag(flagutils.InventoryPolicyFlag).Value.String() == flagutils.InventoryPolicyStrict {
 		w.destroyRunner.PreProcess = func(inv inventory.InventoryInfo, strategy common.DryRunStrategy) (inventory.InventoryPolicy, error) {
 			return preprocess.PreProcess(w.provider, inv, strategy)
 		}

--- a/commands/livecmd.go
+++ b/commands/livecmd.go
@@ -24,7 +24,6 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/klog"
 	"k8s.io/kubectl/pkg/cmd/util"
-	"sigs.k8s.io/cli-utils/cmd/destroy"
 	"sigs.k8s.io/cli-utils/cmd/diff"
 	"sigs.k8s.io/cli-utils/cmd/initcmd"
 	"sigs.k8s.io/cli-utils/cmd/status"
@@ -99,7 +98,7 @@ func GetLiveCommand(name string, f util.Factory) *cobra.Command {
 	diffCmd.Long = livedocs.DiffShort + "\n" + livedocs.DiffLong
 	diffCmd.Example = livedocs.DiffExamples
 
-	destroyCmd := destroy.GetDestroyRunner(p, l, ioStreams).Command
+	destroyCmd := GetDestroyRunner(p, l, ioStreams).Command()
 	destroyCmd.Short = livedocs.DestroyShort
 	destroyCmd.Long = livedocs.DestroyShort + "\n" + livedocs.DestroyLong
 	destroyCmd.Example = livedocs.DestroyExamples

--- a/commands/previewcmd.go
+++ b/commands/previewcmd.go
@@ -19,6 +19,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/pkg/live/preprocess"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/cli-utils/cmd/flagutils"
 	"sigs.k8s.io/cli-utils/cmd/preview"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
@@ -65,7 +66,7 @@ func (w *PreviewRunnerWrapper) PreRunE(_ *cobra.Command, args []string) error {
 // exists in the package path. Then the wrapped PreviewRunner is
 // invoked. Returns an error if one happened.
 func (w *PreviewRunnerWrapper) RunE(cmd *cobra.Command, args []string) error {
-	if w.Command().Flag(inventoryPolicyFlag).Value.String() == strictPolicy {
+	if w.Command().Flag(flagutils.InventoryPolicyFlag).Value.String() == flagutils.InventoryPolicyStrict {
 		w.previewRunner.PreProcess = func(inv inventory.InventoryInfo, strategy common.DryRunStrategy) (inventory.InventoryPolicy, error) {
 			return preprocess.PreProcess(w.provider, inv, strategy)
 		}

--- a/commands/previewcmd.go
+++ b/commands/previewcmd.go
@@ -16,10 +16,12 @@ package commands
 
 import (
 	"github.com/GoogleContainerTools/kpt/internal/util/setters"
+	"github.com/GoogleContainerTools/kpt/pkg/live/preprocess"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/cli-utils/cmd/preview"
+	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/manifestreader"
 	"sigs.k8s.io/cli-utils/pkg/provider"
 )
@@ -30,7 +32,7 @@ func GetPreviewRunner(provider provider.Provider, loader manifestreader.Manifest
 	previewRunner := preview.GetPreviewRunner(provider, loader, ioStreams)
 	w := &PreviewRunnerWrapper{
 		previewRunner: previewRunner,
-		factory:       provider.Factory(),
+		provider:      provider,
 	}
 	// Set the wrapper run to be the RunE function for the wrapped command.
 	previewRunner.Command.RunE = w.RunE
@@ -42,7 +44,7 @@ func GetPreviewRunner(provider provider.Provider, loader manifestreader.Manifest
 // as structures necessary to run.
 type PreviewRunnerWrapper struct {
 	previewRunner *preview.PreviewRunner
-	factory       cmdutil.Factory
+	provider      provider.Provider
 }
 
 // Command returns the wrapped PreviewRunner cobraCommand structure.
@@ -63,5 +65,10 @@ func (w *PreviewRunnerWrapper) PreRunE(_ *cobra.Command, args []string) error {
 // exists in the package path. Then the wrapped PreviewRunner is
 // invoked. Returns an error if one happened.
 func (w *PreviewRunnerWrapper) RunE(cmd *cobra.Command, args []string) error {
+	if w.Command().Flag(inventoryPolicyFlag).Value.String() == strictPolicy {
+		w.previewRunner.PreProcess = func(inv inventory.InventoryInfo, strategy common.DryRunStrategy) (inventory.InventoryPolicy, error) {
+			return preprocess.PreProcess(w.provider, inv, strategy)
+		}
+	}
 	return w.previewRunner.RunE(cmd, args)
 }

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	k8s.io/client-go v0.18.10
 	k8s.io/klog v1.0.0
 	k8s.io/kubectl v0.18.10
-	sigs.k8s.io/cli-utils v0.22.4-0.20210108175429-beb6f88a4384
+	sigs.k8s.io/cli-utils v0.22.5-0.20210127192708-27cfaa675296
 	sigs.k8s.io/kustomize/cmd/config v0.8.7-0.20201211170716-cc43a2d732d1
-	sigs.k8s.io/kustomize/kyaml v0.10.5
+	sigs.k8s.io/kustomize/kyaml v0.10.6
 )

--- a/go.sum
+++ b/go.sum
@@ -685,8 +685,8 @@ k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89 h1:d4vVOjXm687F1iLSP2q3lyPPuyvTU
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7/go.mod h1:PHgbrJT7lCHcxMU+mDHEm+nx46H4zuuHZkDP6icnhu0=
-sigs.k8s.io/cli-utils v0.22.4-0.20210108175429-beb6f88a4384 h1:JepLxW87TlpfpA2i7KiN86ei1cS6dbCLAebkSxz7FNw=
-sigs.k8s.io/cli-utils v0.22.4-0.20210108175429-beb6f88a4384/go.mod h1:iWbsn/CCh80/SeoecTqkAso1a+ifiHQX0x5PlZ6zjD8=
+sigs.k8s.io/cli-utils v0.22.5-0.20210127192708-27cfaa675296 h1:GcA9Uu6GfyLw7X+djhGV2h0bbcouZdVy0NIvlv7LTaU=
+sigs.k8s.io/cli-utils v0.22.5-0.20210127192708-27cfaa675296/go.mod h1:J32lRfzTB7eeQQGnXQQThd5BlhmYZuYuAAdFTQ4oSNc=
 sigs.k8s.io/controller-runtime v0.6.0 h1:Fzna3DY7c4BIP6KwfSlrfnj20DJ+SeMBK8HSFvOk9NM=
 sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2cftPHndTroo=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
@@ -695,8 +695,8 @@ sigs.k8s.io/kustomize/cmd/config v0.8.7-0.20201211170716-cc43a2d732d1 h1:hn0F38X
 sigs.k8s.io/kustomize/cmd/config v0.8.7-0.20201211170716-cc43a2d732d1/go.mod h1:e4PgdLUNnkf+Iapvjyb6gTG9DZQkDZIR6uS1Bv4YA6s=
 sigs.k8s.io/kustomize/kyaml v0.10.3 h1:ARSJUMN/c3k31DYxRfZ+vp/UepUQjg9zCwny7Oj908I=
 sigs.k8s.io/kustomize/kyaml v0.10.3/go.mod h1:RA+iCHA2wPCOfv6uG6TfXXWhYsHpgErq/AljxWKuxtg=
-sigs.k8s.io/kustomize/kyaml v0.10.5 h1:PbJcsZsEM7O3hHtUWTR+4WkHVbQRW9crSy75or1gRbI=
-sigs.k8s.io/kustomize/kyaml v0.10.5/go.mod h1:P6Oy/ah/GZMKzJMIJA2a3/bc8YrBkuL5kJji13PSIzY=
+sigs.k8s.io/kustomize/kyaml v0.10.6 h1:xUJxc/k8JoWqHUahaB8DTqY0KwEPxTbTGStvW8TOcDc=
+sigs.k8s.io/kustomize/kyaml v0.10.6/go.mod h1:K9yg1k/HB/6xNOf5VH3LhTo1DK9/5ykSZO5uIv+Y/1k=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200116222232-67a7b8c61874/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0 h1:dOmIZBMfhcHS09XZkMyUgkq5trg3/jRyJYFZUiaOp8E=
 sigs.k8s.io/structured-merge-diff/v3 v3.0.0/go.mod h1:PlARxl6Hbt/+BC80dRLi1qAmnMqwqDg62YvvVkZjemw=

--- a/pkg/live/preprocess/process.go
+++ b/pkg/live/preprocess/process.go
@@ -1,3 +1,6 @@
+// Copyright 2021 Google LLC.
+// SPDX-License-Identifier: Apache-2.0
+
 package preprocess
 
 import (

--- a/pkg/live/preprocess/process.go
+++ b/pkg/live/preprocess/process.go
@@ -1,0 +1,45 @@
+package preprocess
+
+import (
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+	"sigs.k8s.io/cli-utils/pkg/provider"
+)
+
+func PreProcess(p provider.Provider, inv inventory.InventoryInfo, strategy common.DryRunStrategy) (inventory.InventoryPolicy, error) {
+	invClient, err := p.InventoryClient()
+	if err != nil {
+		return inventory.InventoryPolicyMustMatch, err
+	}
+	obj, err := invClient.GetClusterInventoryInfo(inv)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return inventory.InventoryPolicyMustMatch, nil
+		}
+		return inventory.InventoryPolicyMustMatch, err
+	}
+
+	if obj == nil {
+		return inventory.InventoryPolicyMustMatch, nil
+	}
+
+	managedByKey := "apps.kubernetes.io/managed-by"
+	managedByVal := "kpt"
+	labels := obj.GetLabels()
+	val, found := labels[managedByKey]
+	if found {
+		if val != managedByVal {
+			return inventory.InventoryPolicyMustMatch, fmt.Errorf("can't apply the current package since it is managed by %s", val)
+		}
+		return inventory.InventoryPolicyMustMatch, nil
+	}
+	labels[managedByKey] = managedByVal
+	if strategy.ClientOrServerDryRun() {
+		return inventory.AdoptIfNoInventory, nil
+	}
+	err = invClient.UpdateLabels(inv, labels)
+	return inventory.AdoptIfNoInventory, err
+}

--- a/pkg/live/preprocess/process_test.go
+++ b/pkg/live/preprocess/process_test.go
@@ -1,0 +1,131 @@
+// Copyright 2021 Google LLC.
+// SPDX-License-Identifier: Apache-2.0
+
+package preprocess
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/cli-utils/pkg/common"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+func TestPreProcess(t *testing.T) {
+	testcases := []struct {
+		name            string
+		inventoryObject *unstructured.Unstructured
+		expected        inventory.InventoryPolicy
+	}{
+		{
+			name:            "nil cluster inventory object",
+			inventoryObject: nil,
+			expected:        inventory.InventoryPolicyMustMatch,
+		},
+		{
+			name: "existing cluster inventory object without managed-by label",
+			inventoryObject: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test",
+						"labels": map[string]interface{}{
+							common.InventoryLabel: "test",
+						},
+					},
+				},
+			},
+			expected: inventory.AdoptIfNoInventory,
+		},
+		{
+			name: "existing cluster inventory object with managed-by label",
+			inventoryObject: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "ConfigMap",
+					"metadata": map[string]interface{}{
+						"name":      "test",
+						"namespace": "test",
+						"labels": map[string]interface{}{
+							common.InventoryLabel:           "test",
+							"apps.kubernetes.io/managed-by": "kpt",
+						},
+					},
+				},
+			},
+			expected: inventory.InventoryPolicyMustMatch,
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			invClient := &fakeInventoryClient{inventory: tc.inventoryObject}
+			p := &fakeProvider{invClient: invClient}
+			actual, err := PreProcess(p, nil, common.DryRunNone)
+			if err != nil {
+				t.Fatalf("unexpected error %v", err)
+			}
+			if actual != tc.expected {
+				t.Fatalf("expected %v but got %v", tc.expected, actual)
+			}
+		})
+	}
+}
+
+type fakeProvider struct {
+	factory   util.Factory
+	invClient inventory.InventoryClient
+}
+
+func (p *fakeProvider) Factory() util.Factory {
+	return p.factory
+}
+
+func (p *fakeProvider) InventoryClient() (inventory.InventoryClient, error) {
+	return p.invClient, nil
+}
+
+type fakeInventoryClient struct {
+	inventory *unstructured.Unstructured
+}
+
+func (f *fakeInventoryClient) GetClusterObjs(inv inventory.InventoryInfo) ([]object.ObjMetadata, error) {
+	return nil, nil
+}
+
+func (f *fakeInventoryClient) Merge(inv inventory.InventoryInfo, objs []object.ObjMetadata) ([]object.ObjMetadata, error) {
+	return nil, nil
+}
+
+// Replace replaces the set of objects stored in the inventory
+// object with the passed set of objects, or an error if one occurs.
+func (f *fakeInventoryClient) Replace(inv inventory.InventoryInfo, objs []object.ObjMetadata) error {
+	return nil
+}
+
+// DeleteInventoryObj deletes the passed inventory object from the APIServer.
+func (f *fakeInventoryClient) DeleteInventoryObj(inv inventory.InventoryInfo) error {
+	return nil
+}
+
+// SetDryRunStrategy sets the dry run strategy on whether this we actually mutate.
+func (f *fakeInventoryClient) SetDryRunStrategy(drs common.DryRunStrategy) {}
+
+// ApplyInventoryNamespace applies the Namespace that the inventory object should be in.
+func (f *fakeInventoryClient) ApplyInventoryNamespace(invNamespace *unstructured.Unstructured) error {
+	return nil
+}
+
+// GetClusterInventoryInfo returns the cluster inventory object.
+func (f *fakeInventoryClient) GetClusterInventoryInfo(inv inventory.InventoryInfo) (*unstructured.Unstructured, error) {
+	return f.inventory, nil
+}
+
+// UpdateLabels updates the labels of the cluster inventory object if it exists.
+func (f *fakeInventoryClient) UpdateLabels(inv inventory.InventoryInfo, labels map[string]string) error {
+	f.inventory.SetLabels(labels)
+	return nil
+}


### PR DESCRIPTION
With `inventory-policy` flags added, users have two options: `strict` and `adopt`. `strict` means an object can be updated/pruned only when the `owning-inventory` annotation matches with the current inventory object. `adopt` means that an object can be updated/pruned when the `owning-inventory` annotation matches or this annotation is not present. The default option is `strict`. 

When package was applied by previous version of `kpt`, which doesn't have the `inventory-policy` flag. We need to handle the first time apply when user switches to the new version of `kpt`. In the first time apply, the inventory-policy should be `adopt` so that the resources will be added the `owning-inventory` annotation. 

In this change, the first time apply is detected by checking the label "apps.kubernetes.io./managed-by". If this label is missing, we treat it as the first time apply and add this label to the inventory object.

This PR depends on https://github.com/kubernetes-sigs/cli-utils/pull/316