### PR TITLE
Binary only release artifacts

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -34,3 +34,17 @@ also updated with the `latest` tag for tagged releases.
 - `kpt-dev` release buckets
   - `gs://kpt-dev/latest`
   - `gs://kpt-dev/releases`
+
+# Dry-Run Goreleaser
+
+To test local changes to the [`goreleaser.yaml`](./tag/goreleaser.yaml) config. You may
+[install goreleaser](https://goreleaser.com/install/) locally and provide the
+`--skip-verify --skip-publish` flags.
+
+From the kpt directory you would run:
+
+```sh
+goreleaser release --skip-validate --skip-publish -f release/tag/goreleaser.yaml
+```
+
+The resulting release artifacts will be stored in the `./dist` directory.

--- a/release/tag/goreleaser.yaml
+++ b/release/tag/goreleaser.yaml
@@ -25,10 +25,15 @@ builds:
       - arm64
     ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}}
 archives:
-  - files:
+  - id: archived
+    files:
       - LICENSES*
       - lib.zip*
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}-{{ .Version }}"
+  - id: bin-only
+    format: binary
+    name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+
 checksum:
   name_template: 'checksums.txt'
 snapshot:


### PR DESCRIPTION
- GitHub tagged releases now include direct binary downloads. More info: https://goreleaser.com/customization/archive/
  - New binary only releases should be available at `kpt_darwin_amd64/kpt` (exact name varies by platform).
- kpt release/README includes documentation for dry-running goreleaser. This can be used for locally testing changes to goreleaser configs.

Fixes #1349 
