### PR TITLE
update functions for wrapping an inventory ResourceGroup

### DIFF
--- a/commands/migratecmd.go
+++ b/commands/migratecmd.go
@@ -262,7 +262,7 @@ func (mr *MigrateRunner) migrateObjs(cmObjs []object.ObjMetadata, oldID string, 
 	if err != nil {
 		return err
 	}
-	inv := live.WrapInventoryInfoObj(rgInv)
+	inv := live.WrapInventoryResourceGroup(rgInv)
 	err = updateOwningInventoryAnnotation(mr.rgProvider.Factory(), cmObjs, oldID, inv.ID())
 	if err != nil {
 		return err

--- a/pkg/live/inventoryrg.go
+++ b/pkg/live/inventoryrg.go
@@ -49,17 +49,16 @@ type InventoryResourceGroup struct {
 var _ inventory.Inventory = &InventoryResourceGroup{}
 var _ inventory.InventoryInfo = &InventoryResourceGroup{}
 
-// WrapInventoryObj takes a passed ResourceGroup (as a resource.Info),
+// WrapInventoryObj takes a passed ResourceGroup (as an unstructured),
 // wraps it with the InventoryResourceGroup and upcasts the wrapper as
 // an the Inventory interface.
 func WrapInventoryObj(obj *unstructured.Unstructured) inventory.Inventory {
-	if obj != nil {
-		klog.V(4).Infof("wrapping Inventory obj: %s/%s\n", obj.GetNamespace(), obj.GetName())
-	}
-	return &InventoryResourceGroup{inv: obj}
+	return WrapInventoryResourceGroup(obj)
 }
 
-func WrapInventoryInfoObj(obj *unstructured.Unstructured) inventory.InventoryInfo {
+// WrapInventoryResourceGroup takes a passed ResourceGroup (as an unstructured),
+// wraps it with the InventoryResourceGroup.
+func WrapInventoryResourceGroup(obj *unstructured.Unstructured) *InventoryResourceGroup {
 	if obj != nil {
 		klog.V(4).Infof("wrapping InventoryInfo obj: %s/%s\n", obj.GetNamespace(), obj.GetName())
 	}


### PR DESCRIPTION
Replace the existing function
```
func WrapInventoryInfoObj(obj *unstructured.Unstructured) inventory.InventoryInfo
```
by
```
func WrapInventoryResourceGroup(obj *unstructured.Unstructured) *InventoryResourceGroup 
```

The latter one can cover the use case of the former one. The latter one also helps simplify the integration with ConfigSync.