### PR TITLE
Update kpt live init documentation.

### DIFF
--- a/internal/docs/generated/livedocs/docs.go
+++ b/internal/docs/generated/livedocs/docs.go
@@ -137,22 +137,12 @@ var FetchK8sSchemaExamples = `
 
 var InitShort = `Initialize a package with a object to track previously applied resources`
 var InitLong = `
-  kpt live init DIRECTORY [flags]
+The init command initializes a package with a template resource which will
+be used to track previously applied resources so that they can be pruned
+when they are deleted.
 
-Args:
-
-  DIR:
-    Path to a package directory.  The directory must contain exactly
-    one ConfigMap with the grouping object annotation.
-
-Flags:
-
-  --inventory-id:
-    Identifier for group of applied resources. Must be composed of valid label characters.
-  --namespace:
-    namespace for the inventory object. If not provided, kpt will check if all the resources
-    in the package belong in the same namespace. If they are, that namespace will be used. If
-    they are not, the namespace in the user's context will be chosen.
+The template resource is required by other live commands
+such as apply, preview and destroy.
 `
 var InitExamples = `
   # initialize a package

--- a/site/content/en/reference/live/init/_index.md
+++ b/site/content/en/reference/live/init/_index.md
@@ -11,12 +11,14 @@ description: >
 
 {{< asciinema key="live-init" rows="10" preload="1" >}}
 
+<!--mdtogo:Long-->
 The init command initializes a package with a template resource which will
 be used to track previously applied resources so that they can be pruned
 when they are deleted.
 
 The template resource is required by other live commands
 such as apply, preview and destroy.
+<!--mdtogo-->
 
 ### Examples
 <!--mdtogo:Examples-->
@@ -32,7 +34,7 @@ kpt live init --namespace=test my-dir/
 <!--mdtogo-->
 
 ### Synopsis
-<!--mdtogo:Long-->
+
 ```
 kpt live init DIRECTORY [flags]
 ```
@@ -55,4 +57,3 @@ DIR:
   in the package belong in the same namespace. If they are, that namespace will be used. If
   they are not, the namespace in the user's context will be chosen.
 ```
-<!--mdtogo-->


### PR DESCRIPTION
This updates the `kpt live init` cli help. This changes the text that is selected from online documentation via `mdtogo`. Flags are documented via the Cobra command config:

```txt
Initialize a package with a object to track previously applied resources

The init command initializes a package with a template resource which will
be used to track previously applied resources so that they can be pruned
when they are deleted.

The template resource is required by other live commands
such as apply, preview and destroy.

Usage:
  kpt live init DIRECTORY

Examples:

  # initialize a package
  kpt live init my-dir/

  # initialize a package with a specific name for the group of resources
  kpt live init --namespace=test my-dir/


Flags:
  -h, --help                  help for init
  -i, --inventory-id string   Identifier for group of applied resources. Must be composed of valid label characters.
```

This removes the duplicated Flag values and provides additional context for the command.

> Note: other commands which have similar behavior to the original `kpt live init --help` have not been updated (for example `kpt pkg init --help`).

Fixes #1362 