### PR TITLE
Fix parsing of repos with .git

### DIFF
--- a/internal/cmdget/cmdget_test.go
+++ b/internal/cmdget/cmdget_test.go
@@ -165,6 +165,15 @@ func TestCmd_fail(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to lookup master(or main) branch")
 }
 
+// TestCmd_git tests that if a package path contains .git, it is still parsed correctly
+func TestCmd_git(t *testing.T) {
+	r := cmdget.NewRunner("kpt")
+	r.Command.SetArgs([]string{"https://github.com/GoogleContainerTools/kpt/.github/workflows", "./"})
+	err := r.Command.Execute()
+	assert.NoError(t, err)
+	assert.NoError(t, os.RemoveAll("workflows"))
+}
+
 // NoOpRunE is a noop function to replace the run function of a command.  Useful for testing argument parsing.
 var NoOpRunE = func(cmd *cobra.Command, args []string) error { return nil }
 

--- a/internal/util/parse/parse.go
+++ b/internal/util/parse/parse.go
@@ -36,11 +36,14 @@ func GitParseArgs(args []string) (Target, error) {
 		return g, nil
 	}
 
-	// Simple parsing if contains .git
-	if strings.Contains(args[0], ".git") {
+	// Simple parsing if repo name ends in .git
+	if strings.Contains(args[0], ".git/") ||
+		strings.HasSuffix(args[0], ".git") {
+
 		var repo, dir, version string
 		parts := strings.Split(args[0], ".git")
 		repo = strings.TrimSuffix(parts[0], "/")
+
 		switch {
 		case len(parts) == 1:
 			// do nothing


### PR DESCRIPTION
Close #1323 

Parsing should check that a repository name ends in .git, rather than blindly checking if the package name contains .git anywhere.

E.g. `kpt pkg get https://github.com/GoogleContainerTools/kpt/.github/workflows ./`