### PR TITLE
Add ability to name doc variables directly with mdtogo

### DIFF
--- a/mdtogo/cmddocs/cmddocs.go
+++ b/mdtogo/cmddocs/cmddocs.go
@@ -33,9 +33,9 @@ func ParseCmdDocs(files []string) []doc {
 			fmt.Fprintf(os.Stderr, "%v\n", err)
 			os.Exit(1)
 		}
-		parsedDoc := parse(path, string(b))
+		parsedDocs := parse(path, string(b))
 
-		docs = append(docs, parsedDoc)
+		docs = append(docs, parsedDocs...)
 	}
 	return docs
 }
@@ -45,7 +45,7 @@ var (
 	mdtogoInternalTag = regexp.MustCompile(`<!--mdtogo:(Short|Long|Examples)\s+?([\s\S]*?)-->`)
 )
 
-func parse(path, value string) doc {
+func parse(path, value string) []doc {
 	pathDir := filepath.Dir(path)
 	_, name := filepath.Split(pathDir)
 
@@ -55,6 +55,7 @@ func parse(path, value string) doc {
 	matches := mdtogoTag.FindAllStringSubmatch(value, -1)
 	matches = append(matches, mdtogoInternalTag.FindAllStringSubmatch(value, -1)...)
 
+	var docs []doc
 	var doc doc
 	for _, match := range matches {
 		switch match[1] {
@@ -70,7 +71,9 @@ func parse(path, value string) doc {
 		}
 	}
 	doc.Name = name
-	return doc
+
+	docs = append(docs, doc)
+	return docs
 }
 
 func cleanUpContent(text string) string {

--- a/mdtogo/cmddocs/cmddocs.go
+++ b/mdtogo/cmddocs/cmddocs.go
@@ -41,7 +41,9 @@ func ParseCmdDocs(files []string) []doc {
 }
 
 var (
-	mdtogoTag         = regexp.MustCompile(`<!--mdtogo:(\S*)(Short|Long|Examples)-->([\s\S]*?)<!--mdtogo-->`)
+	// Capture content between opening and closing tags like <!--mdtogo:(Variable)(Short)>(Content)<!--mdtogo-->
+	mdtogoTag = regexp.MustCompile(`<!--mdtogo:(\S*)(Short|Long|Examples)-->([\s\S]*?)<!--mdtogo-->`)
+	// Capture content within a tag like <!--mdtogo:(Variable)(Short) (Content)-->
 	mdtogoInternalTag = regexp.MustCompile(`<!--mdtogo:(\S*)(Short|Long|Examples)\s+?([\s\S]*?)-->`)
 )
 

--- a/mdtogo/cmddocs/cmddocs_test.go
+++ b/mdtogo/cmddocs/cmddocs_test.go
@@ -1,0 +1,69 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmddocs_test
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/GoogleContainerTools/kpt/mdtogo/cmddocs"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParsingDocWithNameFromFolder(t *testing.T) {
+	testDir := path.Join(t.TempDir(), "example")
+	dirErr := os.Mkdir(testDir, os.ModePerm)
+	assert.NoError(t, dirErr)
+	exampleMd, err := ioutil.TempFile(testDir, "_index.md")
+	assert.NoError(t, err)
+
+	testData := []byte(`
+<!--mdtogo:Short
+Short documentation.
+-->
+Test document.
+
+# Documentation
+<!--mdtogo:Long-->
+With
+long
+documentation.
+<!--mdtogo-->
+
+# Examples
+<!--mdtogo:Examples-->` +
+		"```sh\n" +
+		`
+# An example invocation
+example_bin arg1
+` +
+		"```\n" +
+		`
+
+<!--mdtogo-->
+	`)
+
+	err = os.WriteFile(exampleMd.Name(), testData, os.WritePermission)
+	assert.NoError(t, err)
+
+	docs := cmddocs.ParseCmdDocs([]string{exampleMd.Name()})
+	assert.Equal(t, 1, len(docs))
+	assert.Equal(t, "Example", docs[0].Name)
+	assert.Equal(t, "Short documentation.", docs[0].Short)
+	assert.Equal(t, "\nWith\nlong\ndocumentation.\n", docs[0].Long)
+	assert.Equal(t, "\n  \n  # An example invocation\n  example_bin arg1\n", docs[0].Examples)
+}

--- a/mdtogo/cmddocs/cmddocs_test.go
+++ b/mdtogo/cmddocs/cmddocs_test.go
@@ -78,11 +78,14 @@ func TestParsingDocWithNameFromComment(t *testing.T) {
 
 	testData := []byte(`
 <!--mdtogo:FirstShort
-Short documentation.
+First short documentation.
 -->
 Test document.
 
 # Documentation
+<!--mdtogo:SecondShort
+Second short documentation.
+-->
 <!--mdtogo:SecondLong-->
 With
 long
@@ -110,9 +113,10 @@ example_bin arg1
 	assert.Equal(t, 2, len(docs))
 
 	assert.Equal(t, "First", docs[0].Name)
-	assert.Equal(t, "Short documentation.", docs[0].Short)
+	assert.Equal(t, "First short documentation.", docs[0].Short)
 	assert.Equal(t, "\n  \n  # An example invocation\n  example_bin arg1\n", docs[0].Examples)
 
 	assert.Equal(t, "Second", docs[1].Name)
+	assert.Equal(t, "Second short documentation.", docs[1].Short)
 	assert.Equal(t, "\nWith\nlong\ndocumentation.\n", docs[1].Long)
 }

--- a/mdtogo/cmddocs/cmddocs_test.go
+++ b/mdtogo/cmddocs/cmddocs_test.go
@@ -164,6 +164,7 @@ documentation.
 	`)
 
 	err = ioutil.WriteFile(firstExampleMd.Name(), firstTestData, os.ModePerm)
+	assert.NoError(t, err)
 	err = ioutil.WriteFile(secondExampleMd.Name(), secondTestData, os.ModePerm)
 	assert.NoError(t, err)
 

--- a/mdtogo/cmddocs/cmddocs_test.go
+++ b/mdtogo/cmddocs/cmddocs_test.go
@@ -58,7 +58,7 @@ example_bin arg1
 <!--mdtogo-->
 	`)
 
-	err = ioutil.WriteFile(exampleMd.Name(), testData, os.WritePermission)
+	err = ioutil.WriteFile(exampleMd.Name(), testData, os.ModePerm)
 	assert.NoError(t, err)
 
 	docs := cmddocs.ParseCmdDocs([]string{exampleMd.Name()})
@@ -102,7 +102,7 @@ example_bin arg1
 <!--mdtogo-->
 	`)
 
-	err = ioutil.WriteFile(exampleMd.Name(), testData, os.WritePermission)
+	err = ioutil.WriteFile(exampleMd.Name(), testData, os.ModePerm)
 	assert.NoError(t, err)
 
 	docs := cmddocs.ParseCmdDocs([]string{exampleMd.Name()})

--- a/mdtogo/cmddocs/cmddocs_test.go
+++ b/mdtogo/cmddocs/cmddocs_test.go
@@ -18,6 +18,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"sort"
 	"testing"
 
 	"github.com/GoogleContainerTools/kpt/mdtogo/cmddocs"
@@ -105,11 +106,13 @@ example_bin arg1
 	assert.NoError(t, err)
 
 	docs := cmddocs.ParseCmdDocs([]string{exampleMd.Name()})
+	sort.Slice(docs, func(i, j int) bool { return docs[i].Name < docs[j].Name })
 	assert.Equal(t, 2, len(docs))
-	assert.Equal(t, "Second", docs[0].Name)
-	assert.Equal(t, "\nWith\nlong\ndocumentation.\n", docs[0].Long)
 
-	assert.Equal(t, "First", docs[1].Name)
-	assert.Equal(t, "Short documentation.", docs[1].Short)
-	assert.Equal(t, "\n  \n  # An example invocation\n  example_bin arg1\n", docs[1].Examples)
+	assert.Equal(t, "First", docs[0].Name)
+	assert.Equal(t, "Short documentation.", docs[0].Short)
+	assert.Equal(t, "\n  \n  # An example invocation\n  example_bin arg1\n", docs[0].Examples)
+
+	assert.Equal(t, "Second", docs[1].Name)
+	assert.Equal(t, "\nWith\nlong\ndocumentation.\n", docs[1].Long)
 }

--- a/mdtogo/cmddocs/cmddocs_test.go
+++ b/mdtogo/cmddocs/cmddocs_test.go
@@ -58,7 +58,7 @@ example_bin arg1
 <!--mdtogo-->
 	`)
 
-	err = os.WriteFile(exampleMd.Name(), testData, os.WritePermission)
+	err = ioutil.WriteFile(exampleMd.Name(), testData, os.WritePermission)
 	assert.NoError(t, err)
 
 	docs := cmddocs.ParseCmdDocs([]string{exampleMd.Name()})
@@ -102,7 +102,7 @@ example_bin arg1
 <!--mdtogo-->
 	`)
 
-	err = os.WriteFile(exampleMd.Name(), testData, os.WritePermission)
+	err = ioutil.WriteFile(exampleMd.Name(), testData, os.WritePermission)
 	assert.NoError(t, err)
 
 	docs := cmddocs.ParseCmdDocs([]string{exampleMd.Name()})

--- a/mdtogo/common/common.go
+++ b/mdtogo/common/common.go
@@ -36,14 +36,19 @@ func ReadFiles(source string, recursive bool) ([]string, error) {
 			return filePaths, err
 		}
 	} else {
-		files, err := ioutil.ReadDir(source)
-		if err != nil {
-			return filePaths, err
-		}
-		for _, info := range files {
-			if filepath.Ext(info.Name()) == ".md" {
-				path := filepath.Join(source, info.Name())
-				filePaths = append(filePaths, path)
+		if filepath.Ext(source) == ".md" {
+			filePaths = append(filePaths, source)
+
+		} else {
+			files, err := ioutil.ReadDir(source)
+			if err != nil {
+				return filePaths, err
+			}
+			for _, info := range files {
+				if filepath.Ext(info.Name()) == ".md" {
+					path := filepath.Join(source, info.Name())
+					filePaths = append(filePaths, path)
+				}
 			}
 		}
 	}

--- a/mdtogo/common/common.go
+++ b/mdtogo/common/common.go
@@ -20,6 +20,8 @@ import (
 	"path/filepath"
 )
 
+const markdownExtension = ".md"
+
 func ReadFiles(source string, recursive bool) ([]string, error) {
 	filePaths := make([]string, 0)
 	if recursive {
@@ -27,7 +29,7 @@ func ReadFiles(source string, recursive bool) ([]string, error) {
 			if err != nil {
 				return err
 			}
-			if filepath.Ext(info.Name()) == ".md" {
+			if filepath.Ext(info.Name()) == markdownExtension {
 				filePaths = append(filePaths, path)
 			}
 			return nil
@@ -36,7 +38,7 @@ func ReadFiles(source string, recursive bool) ([]string, error) {
 			return filePaths, err
 		}
 	} else {
-		if filepath.Ext(source) == ".md" {
+		if filepath.Ext(source) == markdownExtension {
 			filePaths = append(filePaths, source)
 
 		} else {
@@ -45,7 +47,7 @@ func ReadFiles(source string, recursive bool) ([]string, error) {
 				return filePaths, err
 			}
 			for _, info := range files {
-				if filepath.Ext(info.Name()) == ".md" {
+				if filepath.Ext(info.Name()) == markdownExtension {
 					path := filepath.Join(source, info.Name())
 					filePaths = append(filePaths, path)
 				}

--- a/mdtogo/common/common_test.go
+++ b/mdtogo/common/common_test.go
@@ -55,3 +55,12 @@ func TestReadingMarkdownFileNonrecursively(t *testing.T) {
 	assert.Equal(t, len(files), 1)
 	assert.Contains(t, files, testFile.Name())
 }
+
+func TestReadingMarkdownFileRecursively(t *testing.T) {
+	testDir := t.TempDir()
+	testFile, _ := os.Create(path.Join(testDir, "examples.md"))
+	files, err := common.ReadFiles(testFile.Name(), true)
+	assert.NoError(t, err)
+	assert.Equal(t, len(files), 1)
+	assert.Contains(t, files, testFile.Name())
+}

--- a/mdtogo/common/common_test.go
+++ b/mdtogo/common/common_test.go
@@ -15,6 +15,7 @@
 package common_test
 
 import (
+	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -23,7 +24,30 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestReadingDirectMarkdownNonRecursively(t *testing.T) {
+func TestReadingMarkdownDirectoryRecursively(t *testing.T) {
+	parentTestDir := t.TempDir()
+	childTestDir, dirErr := ioutil.TempDir(parentTestDir, "test") // os.Mkdir(childTestDir, os.ReadPermission|os.WritePermission)
+	assert.NoError(t, dirErr)
+
+	firstTestFile, _ := os.Create(path.Join(parentTestDir, "example1.md"))
+	secondTestFile, _ := os.Create(path.Join(childTestDir, "example2.md"))
+	files, err := common.ReadFiles(parentTestDir, true)
+	assert.NoError(t, err)
+	assert.Equal(t, len(files), 2)
+	assert.Contains(t, files, firstTestFile.Name(), secondTestFile.Name())
+}
+
+func TestReadingMarkdownDirectoryNonrecursively(t *testing.T) {
+	testDir := t.TempDir()
+	firstTestFile, _ := os.Create(path.Join(testDir, "example1.md"))
+	secondTestFile, _ := os.Create(path.Join(testDir, "example2.md"))
+	files, err := common.ReadFiles(testDir, false)
+	assert.NoError(t, err)
+	assert.Equal(t, len(files), 2)
+	assert.Contains(t, files, firstTestFile.Name(), secondTestFile.Name())
+}
+
+func TestReadingMarkdownFileNonrecursively(t *testing.T) {
 	testDir := t.TempDir()
 	testFile, _ := os.Create(path.Join(testDir, "examples.md"))
 	files, err := common.ReadFiles(testFile.Name(), false)

--- a/mdtogo/common/common_test.go
+++ b/mdtogo/common/common_test.go
@@ -26,15 +26,16 @@ import (
 
 func TestReadingMarkdownDirectoryRecursively(t *testing.T) {
 	parentTestDir := t.TempDir()
-	childTestDir, dirErr := ioutil.TempDir(parentTestDir, "test") // os.Mkdir(childTestDir, os.ReadPermission|os.WritePermission)
+	childTestDir, dirErr := ioutil.TempDir(parentTestDir, "test")
 	assert.NoError(t, dirErr)
 
 	firstTestFile, _ := os.Create(path.Join(parentTestDir, "example1.md"))
 	secondTestFile, _ := os.Create(path.Join(childTestDir, "example2.md"))
 	files, err := common.ReadFiles(parentTestDir, true)
 	assert.NoError(t, err)
-	assert.Equal(t, len(files), 2)
-	assert.Contains(t, files, firstTestFile.Name(), secondTestFile.Name())
+	assert.Equal(t, 2, len(files))
+	assert.Contains(t, files, firstTestFile.Name())
+	assert.Contains(t, files, secondTestFile.Name())
 }
 
 func TestReadingMarkdownDirectoryNonrecursively(t *testing.T) {
@@ -43,8 +44,9 @@ func TestReadingMarkdownDirectoryNonrecursively(t *testing.T) {
 	secondTestFile, _ := os.Create(path.Join(testDir, "example2.md"))
 	files, err := common.ReadFiles(testDir, false)
 	assert.NoError(t, err)
-	assert.Equal(t, len(files), 2)
-	assert.Contains(t, files, firstTestFile.Name(), secondTestFile.Name())
+	assert.Equal(t, 2, len(files))
+	assert.Contains(t, files, firstTestFile.Name())
+	assert.Contains(t, files, secondTestFile.Name())
 }
 
 func TestReadingMarkdownFileNonrecursively(t *testing.T) {
@@ -52,7 +54,7 @@ func TestReadingMarkdownFileNonrecursively(t *testing.T) {
 	testFile, _ := os.Create(path.Join(testDir, "examples.md"))
 	files, err := common.ReadFiles(testFile.Name(), false)
 	assert.NoError(t, err)
-	assert.Equal(t, len(files), 1)
+	assert.Equal(t, 1, len(files))
 	assert.Contains(t, files, testFile.Name())
 }
 
@@ -61,6 +63,6 @@ func TestReadingMarkdownFileRecursively(t *testing.T) {
 	testFile, _ := os.Create(path.Join(testDir, "examples.md"))
 	files, err := common.ReadFiles(testFile.Name(), true)
 	assert.NoError(t, err)
-	assert.Equal(t, len(files), 1)
+	assert.Equal(t, 1, len(files))
 	assert.Contains(t, files, testFile.Name())
 }

--- a/mdtogo/common/common_test.go
+++ b/mdtogo/common/common_test.go
@@ -1,0 +1,33 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common_test
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/GoogleContainerTools/kpt/mdtogo/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReadingDirectMarkdownNonRecursively(t *testing.T) {
+	testDir := t.TempDir()
+	testFile, _ := os.Create(path.Join(testDir, "examples.md"))
+	files, err := common.ReadFiles(testFile.Name(), false)
+	assert.NoError(t, err)
+	assert.Equal(t, len(files), 1)
+	assert.Contains(t, files, testFile.Name())
+}

--- a/mdtogo/main.go
+++ b/mdtogo/main.go
@@ -26,7 +26,8 @@
 // The first are for content that should show up in the rendered HTML, while
 // the second is for content that should be hidden in the rendered HTML.
 //
-// <VARIABLE_NAME> must be one of Short, Long or Examples.
+// <VARIABLE_NAME> must be suffixed with Short, Long or Examples; <VARIABLE_NAME>s without
+// a prefix will have an assumed prefix of the parent directory of the markdown file.
 //
 // Flags:
 //   --recursive=true


### PR DESCRIPTION
to support multiple documentation tags in a single markdown file, which is the case in the next-gen documentation site.

`mdtogo /tmp/testDir /tmp/testDir --license=none --recursive=false --strategy=cmdDocs`
and
`mdtogo /tmp/foo/some.md /tmp/testDir --license=none --recursive=false --strategy=cmdDocs`
both produce the same output with the below data.

`/tmp/testDir/_index.md`:
```
<!--mdtogo:Short
    Example documentation.
-->
Test markdown.
```

`/tmp/foo/some.md`:
```
<!--mdtogo:TestDirShort
    Example documentation.
-->
foo
```

`/tmp/testDir/docs.go`:
```
// Code generated by "mdtogo"; DO NOT EDIT.
package testDir

var TestDirShort = `Example documentation.`
```

Explicitly adds support for specifying a single file to be parsed.
Also adds tests for functionality of existing and new code.

