### PR TITLE
Read and write Kptfile As Rnode for get and init commands

### DIFF
--- a/internal/cmdget/cmdget_test.go
+++ b/internal/cmdget/cmdget_test.go
@@ -16,6 +16,7 @@ package cmdget_test
 
 import (
 	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -27,7 +28,6 @@ import (
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 // TestCmd_execute tests that get is correctly invoked.
@@ -45,28 +45,21 @@ func TestCmd_execute(t *testing.T) {
 
 	commit, err := g.GetCommit()
 	assert.NoError(t, err)
-	g.AssertKptfile(t, dest, kptfile.KptFile{
-		ResourceMeta: yaml.ResourceMeta{
-			ObjectMeta: yaml.ObjectMeta{
-				NameMeta: yaml.NameMeta{
-					Name: g.RepoName,
-				},
-			},
-			TypeMeta: yaml.TypeMeta{
-				APIVersion: kptfile.TypeMeta.APIVersion,
-				Kind:       kptfile.TypeMeta.Kind},
-		},
-		PackageMeta: kptfile.PackageMeta{},
-		Upstream: kptfile.Upstream{
-			Type: "git",
-			Git: kptfile.Git{
-				Directory: "/",
-				Repo:      "file://" + g.RepoDirectory,
-				Ref:       "master",
-				Commit:    commit, // verify the commit matches the repo
-			},
-		},
-	})
+
+	contents, err := ioutil.ReadFile(filepath.Join(dest, kptfile.KptFileName))
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf(`apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: %s
+upstream:
+  type: git
+  git:
+    commit: %s
+    repo: file://%s
+    directory: /
+    ref: master
+`, g.RepoName, commit, g.RepoDirectory), string(contents))
 }
 
 // TestCmdMainBranch_execute tests that get is correctly invoked if default branch
@@ -94,28 +87,21 @@ func TestCmdMainBranch_execute(t *testing.T) {
 
 	commit, err := g.GetCommit()
 	assert.NoError(t, err)
-	g.AssertKptfile(t, dest, kptfile.KptFile{
-		ResourceMeta: yaml.ResourceMeta{
-			ObjectMeta: yaml.ObjectMeta{
-				NameMeta: yaml.NameMeta{
-					Name: g.RepoName,
-				},
-			},
-			TypeMeta: yaml.TypeMeta{
-				APIVersion: kptfile.TypeMeta.APIVersion,
-				Kind:       kptfile.TypeMeta.Kind},
-		},
-		PackageMeta: kptfile.PackageMeta{},
-		Upstream: kptfile.Upstream{
-			Type: "git",
-			Git: kptfile.Git{
-				Directory: "/",
-				Repo:      "file://" + g.RepoDirectory,
-				Ref:       "main",
-				Commit:    commit, // verify the commit matches the repo
-			},
-		},
-	})
+
+	contents, err := ioutil.ReadFile(filepath.Join(dest, kptfile.KptFileName))
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf(`apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: %s
+upstream:
+  type: git
+  git:
+    commit: %s
+    repo: file://%s
+    directory: /
+    ref: main
+`, g.RepoName, commit, g.RepoDirectory), string(contents))
 
 }
 

--- a/internal/cmdinit/cmdinit_test.go
+++ b/internal/cmdinit/cmdinit_test.go
@@ -35,7 +35,7 @@ func TestCmd(t *testing.T) {
 	assert.NoError(t, os.Mkdir(filepath.Join(d, "my-pkg"), 0700))
 
 	r := cmdinit.NewRunner("kpt")
-	r.Command.SetArgs([]string{filepath.Join(d, "my-pkg"), "--description", "my description", "--tag", "app.kpt.dev/cockroachdb"})
+	r.Command.SetArgs([]string{filepath.Join(d, "my-pkg"), "--description", "my description"})
 	err = r.Command.Execute()
 	assert.NoError(t, err)
 
@@ -47,8 +47,6 @@ kind: Kptfile
 metadata:
   name: my-pkg
 packageMetadata:
-  tags:
-  - app.kpt.dev/cockroachdb
   shortDescription: my description
 `, string(b))
 
@@ -107,7 +105,7 @@ func TestCmd_currentDir(t *testing.T) {
 		}()
 
 		r := cmdinit.NewRunner("kpt")
-		r.Command.SetArgs([]string{".", "--description", "my description", "--tag", "app.kpt.dev/cockroachdb"})
+		r.Command.SetArgs([]string{".", "--description", "my description"})
 		return r.Command.Execute()
 	}()
 	assert.NoError(t, err)
@@ -120,8 +118,6 @@ kind: Kptfile
 metadata:
   name: my-pkg
 packageMetadata:
-  tags:
-  - app.kpt.dev/cockroachdb
   shortDescription: my description
 `, string(b))
 }
@@ -132,7 +128,7 @@ func TestCmd_failNotExists(t *testing.T) {
 	assert.NoError(t, err)
 
 	r := cmdinit.NewRunner("kpt")
-	r.Command.SetArgs([]string{filepath.Join(d, "my-pkg"), "--description", "my description", "--tag", "app.kpt.dev/cockroachdb"})
+	r.Command.SetArgs([]string{filepath.Join(d, "my-pkg"), "--description", "my description"})
 	err = r.Command.Execute()
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "does not exist")

--- a/internal/util/get/get_test.go
+++ b/internal/util/get/get_test.go
@@ -16,6 +16,7 @@ package get_test
 
 import (
 	"fmt"
+	"io/ioutil"
 	"path/filepath"
 	"testing"
 
@@ -23,7 +24,6 @@ import (
 	. "github.com/GoogleContainerTools/kpt/internal/util/get"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
 	"github.com/stretchr/testify/assert"
-	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 // TestCommand_Run_failEmptyRepo verifies that Command fail if not repo is provided.
@@ -57,32 +57,25 @@ func TestCommand_Run(t *testing.T) {
 	// verify the cloned contents matches the repository
 	r := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset1), r)
-
-	// verify the KptFile contains the expected values
 	commit, err := g.GetCommit()
 	assert.NoError(t, err)
-	g.AssertKptfile(t, r, kptfile.KptFile{
-		ResourceMeta: yaml.ResourceMeta{
-			ObjectMeta: yaml.ObjectMeta{
-				NameMeta: yaml.NameMeta{
-					Name: g.RepoName,
-				},
-			},
-			TypeMeta: yaml.TypeMeta{
-				APIVersion: kptfile.TypeMeta.APIVersion,
-				Kind:       kptfile.TypeMeta.Kind},
-		},
-		PackageMeta: kptfile.PackageMeta{},
-		Upstream: kptfile.Upstream{
-			Type: "git",
-			Git: kptfile.Git{
-				Directory: "/",
-				Repo:      "file://" + g.RepoDirectory,
-				Ref:       "master",
-				Commit:    commit, // verify the commit matches the repo
-			},
-		},
-	})
+
+	// verify the KptFile contains the expected values
+	assert.NoError(t, err)
+	contents, err := ioutil.ReadFile(filepath.Join(r, kptfile.KptFileName))
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf(`apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: %s
+upstream:
+  type: git
+  git:
+    commit: %s
+    repo: file://%s
+    directory: /
+    ref: master
+`, g.RepoName, commit, g.RepoDirectory), string(contents))
 }
 
 // TestCommand_Run_subdir verifies that Command will clone a subdirectory of a repo.
@@ -107,28 +100,21 @@ func TestCommand_Run_subdir(t *testing.T) {
 	// verify the KptFile contains the expected values
 	commit, err := g.GetCommit()
 	assert.NoError(t, err)
-	g.AssertKptfile(t, r, kptfile.KptFile{
-		ResourceMeta: yaml.ResourceMeta{
-			ObjectMeta: yaml.ObjectMeta{
-				NameMeta: yaml.NameMeta{
-					Name: subdir,
-				},
-			},
-			TypeMeta: yaml.TypeMeta{
-				APIVersion: kptfile.TypeMeta.APIVersion,
-				Kind:       kptfile.TypeMeta.Kind},
-		},
-		PackageMeta: kptfile.PackageMeta{},
-		Upstream: kptfile.Upstream{
-			Type: "git",
-			Git: kptfile.Git{
-				Commit:    commit,
-				Directory: subdir,
-				Ref:       "refs/heads/master",
-				Repo:      g.RepoDirectory,
-			},
-		},
-	})
+
+	contents, err := ioutil.ReadFile(filepath.Join(r, kptfile.KptFileName))
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf(`apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: %s
+upstream:
+  type: git
+  git:
+    commit: %s
+    repo: %s
+    directory: %s
+    ref: refs/heads/master
+`, subdir, commit, g.RepoDirectory, subdir), string(contents))
 }
 
 // TestCommand_Run_destination verifies Command clones the repo to a destination with a specific name rather
@@ -148,28 +134,21 @@ func TestCommand_Run_destination(t *testing.T) {
 	// verify the KptFile contains the expected values
 	commit, err := g.GetCommit()
 	assert.NoError(t, err)
-	g.AssertKptfile(t, r, kptfile.KptFile{
-		ResourceMeta: yaml.ResourceMeta{
-			ObjectMeta: yaml.ObjectMeta{
-				NameMeta: yaml.NameMeta{
-					Name: dest,
-				},
-			},
-			TypeMeta: yaml.TypeMeta{
-				APIVersion: kptfile.TypeMeta.APIVersion,
-				Kind:       kptfile.TypeMeta.Kind},
-		},
-		PackageMeta: kptfile.PackageMeta{},
-		Upstream: kptfile.Upstream{
-			Type: "git",
-			Git: kptfile.Git{
-				Directory: "/",
-				Repo:      g.RepoDirectory,
-				Ref:       "master",
-				Commit:    commit,
-			},
-		},
-	})
+
+	contents, err := ioutil.ReadFile(filepath.Join(r, kptfile.KptFileName))
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf(`apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: %s
+upstream:
+  type: git
+  git:
+    commit: %s
+    repo: %s
+    directory: /
+    ref: master
+`, dest, commit, g.RepoDirectory), string(contents))
 }
 
 // TestCommand_Run_subdirAndDestination verifies that Command will copy a subdirectory of a repo to a
@@ -195,28 +174,21 @@ func TestCommand_Run_subdirAndDestination(t *testing.T) {
 	// verify the KptFile contains the expected values
 	commit, err := g.GetCommit()
 	assert.NoError(t, err)
-	g.AssertKptfile(t, r, kptfile.KptFile{
-		ResourceMeta: yaml.ResourceMeta{
-			ObjectMeta: yaml.ObjectMeta{
-				NameMeta: yaml.NameMeta{
-					Name: dest,
-				},
-			},
-			TypeMeta: yaml.TypeMeta{
-				APIVersion: kptfile.TypeMeta.APIVersion,
-				Kind:       kptfile.TypeMeta.Kind},
-		},
-		PackageMeta: kptfile.PackageMeta{},
-		Upstream: kptfile.Upstream{
-			Type: "git",
-			Git: kptfile.Git{
-				Commit:    commit,
-				Directory: subdir,
-				Ref:       "master",
-				Repo:      g.RepoDirectory,
-			},
-		},
-	})
+
+	contents, err := ioutil.ReadFile(filepath.Join(r, kptfile.KptFileName))
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf(`apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: %s
+upstream:
+  type: git
+  git:
+    commit: %s
+    repo: %s
+    directory: %s
+    ref: master
+`, dest, commit, g.RepoDirectory, subdir), string(contents))
 }
 
 // TestCommand_Run_branch verifies Command can clone a git branch
@@ -254,29 +226,20 @@ func TestCommand_Run_branch(t *testing.T) {
 	r := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset2), r)
 
-	// verify the KptFile contains the expected values
-	g.AssertKptfile(t, r, kptfile.KptFile{
-		ResourceMeta: yaml.ResourceMeta{
-			ObjectMeta: yaml.ObjectMeta{
-				NameMeta: yaml.NameMeta{
-					Name: g.RepoName,
-				},
-			},
-			TypeMeta: yaml.TypeMeta{
-				APIVersion: kptfile.TypeMeta.APIVersion,
-				Kind:       kptfile.TypeMeta.Kind},
-		},
-		PackageMeta: kptfile.PackageMeta{},
-		Upstream: kptfile.Upstream{
-			Type: "git",
-			Git: kptfile.Git{
-				Directory: "/",
-				Repo:      g.RepoDirectory,
-				Ref:       "refs/heads/exp",
-				Commit:    commit,
-			},
-		},
-	})
+	contents, err := ioutil.ReadFile(filepath.Join(r, kptfile.KptFileName))
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf(`apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: %s
+upstream:
+  type: git
+  git:
+    commit: %s
+    repo: %s
+    directory: /
+    ref: refs/heads/exp
+`, g.RepoName, commit, g.RepoDirectory), string(contents))
 }
 
 // TestCommand_Run_tag verifies Command can clone from a git tag
@@ -320,28 +283,22 @@ func TestCommand_Run_tag(t *testing.T) {
 	g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset2), r)
 
 	// verify the KptFile contains the expected values
-	g.AssertKptfile(t, r, kptfile.KptFile{
-		ResourceMeta: yaml.ResourceMeta{
-			ObjectMeta: yaml.ObjectMeta{
-				NameMeta: yaml.NameMeta{
-					Name: g.RepoName,
-				},
-			},
-			TypeMeta: yaml.TypeMeta{
-				APIVersion: kptfile.TypeMeta.APIVersion,
-				Kind:       kptfile.TypeMeta.Kind},
-		},
-		PackageMeta: kptfile.PackageMeta{},
-		Upstream: kptfile.Upstream{
-			Type: "git",
-			Git: kptfile.Git{
-				Directory: "/",
-				Repo:      g.RepoDirectory,
-				Ref:       "refs/tags/v2",
-				Commit:    commit,
-			},
-		},
-	})
+
+	contents, err := ioutil.ReadFile(filepath.Join(r, kptfile.KptFileName))
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf(`apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: %s
+upstream:
+  type: git
+  git:
+    commit: %s
+    repo: %s
+    directory: /
+    ref: refs/tags/v2
+`, g.RepoName, commit, g.RepoDirectory), string(contents))
+
 }
 
 // TestCommand_Run_clean verifies that the Command delete the existing directory if Clean is set.
@@ -367,28 +324,20 @@ func TestCommand_Run_clean(t *testing.T) {
 	r := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset1), r)
 
-	g.AssertKptfile(t, r, kptfile.KptFile{
-		ResourceMeta: yaml.ResourceMeta{
-			ObjectMeta: yaml.ObjectMeta{
-				NameMeta: yaml.NameMeta{
-					Name: g.RepoName,
-				},
-			},
-			TypeMeta: yaml.TypeMeta{
-				APIVersion: kptfile.TypeMeta.APIVersion,
-				Kind:       kptfile.TypeMeta.Kind},
-		},
-		PackageMeta: kptfile.PackageMeta{},
-		Upstream: kptfile.Upstream{
-			Type: "git",
-			Git: kptfile.Git{
-				Directory: "/",
-				Repo:      g.RepoDirectory,
-				Ref:       "master",
-				Commit:    commit, // verify the commit matches the repo
-			},
-		},
-	})
+	contents, err := ioutil.ReadFile(filepath.Join(r, kptfile.KptFileName))
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf(`apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: %s
+upstream:
+  type: git
+  git:
+    commit: %s
+    repo: %s
+    directory: /
+    ref: master
+`, g.RepoName, commit, g.RepoDirectory), string(contents))
 
 	// update the data that would be cloned
 	err = g.ReplaceData(testutil.Dataset2)
@@ -408,28 +357,21 @@ func TestCommand_Run_clean(t *testing.T) {
 
 	// verify files are updated
 	g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset2), r)
-	g.AssertKptfile(t, r, kptfile.KptFile{
-		ResourceMeta: yaml.ResourceMeta{
-			ObjectMeta: yaml.ObjectMeta{
-				NameMeta: yaml.NameMeta{
-					Name: g.RepoName,
-				},
-			},
-			TypeMeta: yaml.TypeMeta{
-				APIVersion: kptfile.TypeMeta.APIVersion,
-				Kind:       kptfile.TypeMeta.Kind},
-		},
-		PackageMeta: kptfile.PackageMeta{},
-		Upstream: kptfile.Upstream{
-			Type: "git",
-			Git: kptfile.Git{
-				Directory: "/",
-				Repo:      g.RepoDirectory,
-				Ref:       "master",
-				Commit:    commit, // verify the commit matches the repo
-			},
-		},
-	})
+	contents, err = ioutil.ReadFile(filepath.Join(r, kptfile.KptFileName))
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf(`apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: %s
+upstream:
+  type: git
+  git:
+    commit: %s
+    repo: %s
+    directory: /
+    ref: master
+`, g.RepoName, commit, g.RepoDirectory), string(contents))
+
 }
 
 // TestCommand_Run_failClean verifies that the Command will not clean the existing directory if it
@@ -455,28 +397,21 @@ func TestCommand_Run_failClean(t *testing.T) {
 	// verify the cloned contents matches the repository
 	r := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset1), r)
-	g.AssertKptfile(t, r, kptfile.KptFile{
-		ResourceMeta: yaml.ResourceMeta{
-			ObjectMeta: yaml.ObjectMeta{
-				NameMeta: yaml.NameMeta{
-					Name: g.RepoName,
-				},
-			},
-			TypeMeta: yaml.TypeMeta{
-				APIVersion: kptfile.TypeMeta.APIVersion,
-				Kind:       kptfile.TypeMeta.Kind},
-		},
-		PackageMeta: kptfile.PackageMeta{},
-		Upstream: kptfile.Upstream{
-			Type: "git",
-			Git: kptfile.Git{
-				Directory: "/",
-				Repo:      g.RepoDirectory,
-				Ref:       "master",
-				Commit:    commit, // verify the commit matches the repo
-			},
-		},
-	})
+
+	contents, err := ioutil.ReadFile(filepath.Join(r, kptfile.KptFileName))
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf(`apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: %s
+upstream:
+  type: git
+  git:
+    commit: %s
+    repo: %s
+    directory: /
+    ref: master
+`, g.RepoName, commit, g.RepoDirectory), string(contents))
 
 	// configure clone to clean the existing dir, but fail
 	err = Command{
@@ -496,28 +431,20 @@ func TestCommand_Run_failClean(t *testing.T) {
 
 	// verify files weren't deleted
 	g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset1), r)
-	g.AssertKptfile(t, r, kptfile.KptFile{
-		ResourceMeta: yaml.ResourceMeta{
-			ObjectMeta: yaml.ObjectMeta{
-				NameMeta: yaml.NameMeta{
-					Name: g.RepoName,
-				},
-			},
-			TypeMeta: yaml.TypeMeta{
-				APIVersion: kptfile.TypeMeta.APIVersion,
-				Kind:       kptfile.TypeMeta.Kind},
-		},
-		PackageMeta: kptfile.PackageMeta{},
-		Upstream: kptfile.Upstream{
-			Type: "git",
-			Git: kptfile.Git{
-				Directory: "/",
-				Repo:      g.RepoDirectory,
-				Ref:       "master",
-				Commit:    commit, // verify the commit matches the repo
-			},
-		},
-	})
+	contents, err = ioutil.ReadFile(filepath.Join(r, kptfile.KptFileName))
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf(`apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: %s
+upstream:
+  type: git
+  git:
+    commit: %s
+    repo: %s
+    directory: /
+    ref: master
+`, g.RepoName, commit, g.RepoDirectory), string(contents))
 }
 
 // TestCommand_Run_failExistingDir verifies that command will fail without changing anything if the
@@ -538,28 +465,20 @@ func TestCommand_Run_failExistingDir(t *testing.T) {
 	// verify the cloned contents matches the repository
 	r := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset1), r)
-	g.AssertKptfile(t, r, kptfile.KptFile{
-		ResourceMeta: yaml.ResourceMeta{
-			ObjectMeta: yaml.ObjectMeta{
-				NameMeta: yaml.NameMeta{
-					Name: g.RepoName,
-				},
-			},
-			TypeMeta: yaml.TypeMeta{
-				APIVersion: kptfile.TypeMeta.APIVersion,
-				Kind:       kptfile.TypeMeta.Kind},
-		},
-		PackageMeta: kptfile.PackageMeta{},
-		Upstream: kptfile.Upstream{
-			Type: "git",
-			Git: kptfile.Git{
-				Directory: "/",
-				Repo:      g.RepoDirectory,
-				Ref:       "master",
-				Commit:    commit, // verify the commit matches the repo
-			},
-		},
-	})
+	contents, err := ioutil.ReadFile(filepath.Join(r, kptfile.KptFileName))
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf(`apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: %s
+upstream:
+  type: git
+  git:
+    commit: %s
+    repo: %s
+    directory: /
+    ref: master
+`, g.RepoName, commit, g.RepoDirectory), string(contents))
 
 	// update the data that would be cloned
 	err = g.ReplaceData(testutil.Dataset2)
@@ -575,28 +494,20 @@ func TestCommand_Run_failExistingDir(t *testing.T) {
 
 	// verify files are unchanged
 	g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset1), r)
-	g.AssertKptfile(t, r, kptfile.KptFile{
-		ResourceMeta: yaml.ResourceMeta{
-			ObjectMeta: yaml.ObjectMeta{
-				NameMeta: yaml.NameMeta{
-					Name: g.RepoName,
-				},
-			},
-			TypeMeta: yaml.TypeMeta{
-				APIVersion: kptfile.TypeMeta.APIVersion,
-				Kind:       kptfile.TypeMeta.Kind},
-		},
-		PackageMeta: kptfile.PackageMeta{},
-		Upstream: kptfile.Upstream{
-			Type: "git",
-			Git: kptfile.Git{
-				Directory: "/",
-				Repo:      g.RepoDirectory,
-				Ref:       "master",
-				Commit:    commit, // verify the commit matches the repo
-			},
-		},
-	})
+	contents, err = ioutil.ReadFile(filepath.Join(r, kptfile.KptFileName))
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf(`apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: %s
+upstream:
+  type: git
+  git:
+    commit: %s
+    repo: %s
+    directory: /
+    ref: master
+`, g.RepoName, commit, g.RepoDirectory), string(contents))
 }
 
 func TestCommand_Run_failInvalidRepo(t *testing.T) {

--- a/pkg/kptfile/pkgfile.go
+++ b/pkg/kptfile/pkgfile.go
@@ -306,6 +306,12 @@ const (
 	// GitOrigin specifies a package as having been cloned from a git repository
 	GitOrigin   OriginType = "git"
 	StdinOrigin OriginType = "stdin"
+	UpstreamKey            = "upstream"
+	Directory              = "directory"
+	Type                   = "type"
+	Ref                    = "ref"
+	Commit                 = "commit"
+	Repo                   = "repo"
 )
 
 // Upstream defines where a package was cloned from


### PR DESCRIPTION
@mortent 

This PR is to make Kptfile to be treated as general RNode for get and init commands. The aim is to treat Kptfile as any other configuration file, read and edit it in similar manner. 