### PR TITLE
Define schema for Kptfile v1alpha2

### DIFF
--- a/pkg/api/kptfile/v1alpha2/types.go
+++ b/pkg/api/kptfile/v1alpha2/types.go
@@ -30,7 +30,7 @@ const (
 type KptFile struct {
 	yaml.ResourceMeta `yaml:",inline"`
 
-	// UpstreamLock is a resolved locator for the last fetch of the packgae.
+	// UpstreamLock is a resolved locator for the last fetch of the package.
 	UpstreamLock *UpstreamLock `yaml:"upstreamLock,omitempty"`
 
 	// Info contains metadata such as license, documentation, etc.
@@ -126,7 +126,7 @@ type PackageInfo struct {
 	Man string `yaml:"man,omitempty"`
 
 	// Description contains a short description of the package.
-	description string `yaml:"description,omitempty"`
+	Description string `yaml:"description,omitempty"`
 }
 
 // Subpackages declares a local or remote subpackage.

--- a/pkg/api/kptfile/v1alpha2/types.go
+++ b/pkg/api/kptfile/v1alpha2/types.go
@@ -80,53 +80,73 @@ type Upstream struct {
 	UpdateStrategy UpdateStrategyType `yaml:"updateStrategy,omitempty"`
 }
 
+// Git is the user-specified locator for a package on Git.
+type Git struct {
+	// Repo is the git repository the package.
+	// e.g. 'https://github.com/kubernetes/examples.git'
+	Repo string `yaml:"repo,omitempty"`
+
+	// Directory is the sub directory of the git repository.
+	// e.g. 'staging/cockroachdb'
+	Directory string `yaml:"directory,omitempty"`
+
+	// Ref can be a Git branch, tag, or a commit SHA-1.
+	Ref string `yaml:"ref,omitempty"`
+}
+
 // UpstreamLock is a resolved locator for the last fetch of the package.
 type UpstreamLock struct {
 	// Type is the type of origin.
 	Type OriginType `yaml:"type,omitempty"`
 
-	// Git is the locator for a package stored on Git.
-	Git *Git `yaml:"git,omitempty"`
+	// GitLock is the resolved locator for a package on Git.
+	GitLock *GitLock `yaml:"git,omitempty"`
 }
 
-// Git contains information on the origin of packages fetched from a git repository.
-type Git struct {
-	// Repo is the git repository the package was cloned from.  e.g. https://
+// GitLock is the resolved locator for a package on Git.
+type GitLock struct {
+	// Repo is the git repository that was fetched.
+	// e.g. 'https://github.com/kubernetes/examples.git'
 	Repo string `yaml:"repo,omitempty"`
 
-	// Directory is the sub directory of the git repository that the package was cloned from
+	// Directory is the sub directory of the git repository that was fetched.
+	// e.g. 'staging/cockroachdb'
 	Directory string `yaml:"directory,omitempty"`
 
-	// Ref can be a Git branch, tag, or commit ID.
+	// Ref can be a Git branch, tag, or a commit SHA-1 that was fetched.
+	// e.g. 'master'
 	Ref string `yaml:"ref,omitempty"`
 
-	// Commit is the git commit that the package was fetched at
+	// Commit is the SHA-1 for the last fetch of the package.
+	// This is set by kpt for bookkeeping purposes.
 	Commit string `yaml:"commit,omitempty"`
 }
 
-// PackageInfo contains information such as license, documentation, etc.
+// PackageInfo contains optional information about the package such as license, documentation, etc.
 // These fields are not consumed by any functionality in kpt and are simply passed through.
+// Note that like any other KRM resource, humans and automation can also use `metadata.labels` and
+// `metadata.annotations` as the extrension mechanism.
 type PackageInfo struct {
-	// URL is the location of the package.  e.g. https://github.com/example/com
-	URL string `yaml:"url,omitempty"`
+	// Site is the URL for package web page.
+	Site string `yaml:"site,omitempty"`
 
-	// Email is the email of the package maintainer
-	Email string `yaml:"email,omitempty"`
+	// Email is the list of emails for the package authors.
+	Emails []string `yaml:"emails,omitempty"`
 
-	// License is the package license
+	// SPDX license identifier (e.g. "Apache-2.0"). See: https://spdx.org/licenses/
 	License string `yaml:"license,omitempty"`
 
-	// Version is a logical package version
-	Version string `yaml:"version,omitempty"`
+	// Relative slash-delimited path to the license file (e.g. LICENSE.txt)
+	LicenseFile string `yaml:"licenseFile,omitempty"`
 
-	// Tags enables humans and tools to attach arbitrary package metadata.
-	Tags []string `yaml:"tags,omitempty"`
-
-	// Man is the path to documentation about the package.
-	Man string `yaml:"man,omitempty"`
+	// Doc is the path to documentation about the package.
+	Doc string `yaml:"doc,omitempty"`
 
 	// Description contains a short description of the package.
 	Description string `yaml:"description,omitempty"`
+
+	// Keywrods is a list of keywords for this package.
+	Keywords []string `yaml:"keywords,omitempty"`
 }
 
 // Subpackages declares a local or remote subpackage.
@@ -185,12 +205,12 @@ type Function struct {
 	//	image: set-label
 	Image string `yaml:"image,omitempty"`
 
-	// `Config` specifies an inline k8s resource used as the function config.
+	// `Config` specifies an inline KRM resource used as the function config.
 	// Config, ConfigPath, and ConfigMap fields are mutually exclusive.
 	Config *yaml.Node `yaml:"config,omitempty"`
 
 	// `ConfigPath` specifies a slash-delimited relative path to a file in the current directory
-	// containing a K8S resource used as the function config. This resource is
+	// containing a KRM resource used as the function config. This resource is
 	// excluded when resolving 'sources', and as a result cannot be operated on
 	// by the pipeline.
 	ConfigPath string `yaml:"configPath,omitempty"`

--- a/pkg/api/kptfile/v1alpha2/types.go
+++ b/pkg/api/kptfile/v1alpha2/types.go
@@ -30,11 +30,11 @@ const (
 type KptFile struct {
 	yaml.ResourceMeta `yaml:",inline"`
 
-	// Upstream is a reference to where the package is fetched from.
-	Upstream Upstream `yaml:"upstream,omitempty"`
+	// UpstreamLock is a resolved locator for the last fetch of the packgae.
+	UpstreamLock *UpstreamLock `yaml:"upstreamLock,omitempty"`
 
-	// PackageMeta contains metadata such as license, documentation, etc.
-	PackageMeta PackageMeta `yaml:"packageMeta,omitempty"`
+	// Info contains metadata such as license, documentation, etc.
+	Info *PackageInfo `yaml:"info,omitempty"`
 
 	// Subpackages declares the list of subpackages.
 	Subpackages []Subpackage `yaml:"subpackages,omitempty"`
@@ -46,7 +46,7 @@ type KptFile struct {
 	Inventory *Inventory `yaml:"inventory,omitempty"`
 }
 
-// OriginType defines the type of origin for a package
+// OriginType defines the type of origin for a package.
 type OriginType string
 
 const (
@@ -68,21 +68,45 @@ const (
 	ForceDeleteReplace UpdateStrategyType = "force-delete-replace"
 )
 
-// Upstream is a reference to where the package is fetched from.
+// Upstream is a user-specified upstream locator for a package.
 type Upstream struct {
 	// Type is the type of origin.
 	Type OriginType `yaml:"type,omitempty"`
 
-	// Git contains information on the origin of packages fetched from a git repository.
+	// Git is the locator for a package stored on Git.
 	Git Git `yaml:"git,omitempty"`
 
-	// UpdateStrategy defines how a package is updated from upstream.
+	// UpdateStrategy declares how a package will be updated from upstream.
 	UpdateStrategy UpdateStrategyType `yaml:"updateStrategy,omitempty"`
 }
 
-// PackageMeta contains metadata such as license, documentation, etc.
+// UpstreamLock is a resolved locator for the last fetch of the packgae.
+type UpstreamLock struct {
+	// Type is the type of origin.
+	Type OriginType `yaml:"type,omitempty"`
+
+	// Git is the locator for a package stored on Git.
+	Git Git `yaml:"git,omitempty"`
+}
+
+// Git contains information on the origin of packages fetched from a git repository.
+type Git struct {
+	// Repo is the git repository the package was cloned from.  e.g. https://
+	Repo string `yaml:"repo,omitempty"`
+
+	// Directory is the sub directory of the git repository that the package was cloned from
+	Directory string `yaml:"directory,omitempty"`
+
+	// Ref can be a Git branch, tag, or commit ID.
+	Ref string `yaml:"ref,omitempty"`
+
+	// Commit is the git commit that the package was fetched at
+	Commit string `yaml:"commit,omitempty"`
+}
+
+// PackageInfo contains metadata such as license, documentation, etc.
 // These fields are not used for any functionality in kpt and are simply passed through.
-type PackageMeta struct {
+type PackageInfo struct {
 	// URL is the location of the package.  e.g. https://github.com/example/com
 	URL string `yaml:"url,omitempty"`
 
@@ -101,8 +125,8 @@ type PackageMeta struct {
 	// Man is the path to documentation about the package
 	Man string `yaml:"man,omitempty"`
 
-	// ShortDescription contains a short description of the package.
-	ShortDescription string `yaml:"shortDescription,omitempty"`
+	// Description contains a short description of the package.
+	description string `yaml:"description,omitempty"`
 }
 
 // Subpackages declares a local or remote subpackage.
@@ -111,24 +135,10 @@ type Subpackage struct {
 	// either exists (local subpackages) or will be fetched to (remote subpckages).
 	// This must be unique across all subpckages of a package.
 	LocalDir string `yaml:"localDir,omitempty"`
+
+	// Upstream is a reference to where the subpackage should be fetched from.
 	// Whether a subpackage is local or remote is determined by whether Upstream is specified.
-	// Upstream is a reference to where the package is fetched from.
-	Upstream Upstream `yaml:"upstream,omitempty"`
-}
-
-// Git contains information on the origin of packages fetched from a git repository.
-type Git struct {
-	// Commit is the git commit that the package was fetched at
-	Commit string `yaml:"commit,omitempty"`
-
-	// Repo is the git repository the package was cloned from.  e.g. https://
-	Repo string `yaml:"repo,omitempty"`
-
-	// Directory is the sub directory of the git repository that the package was cloned from
-	Directory string `yaml:"directory,omitempty"`
-
-	// Ref is the git ref the package was cloned from
-	Ref string `yaml:"ref,omitempty"`
+	Upstream *Upstream `yaml:"upstream,omitempty"`
 }
 
 // Pipeline declares a pipeline of functions used to mutate or validate resources.
@@ -177,7 +187,7 @@ type Function struct {
 
 	// `Config` specifies an inline k8s resource used as the function config.
 	// Config, ConfigPath, and ConfigMap fields are mutually exclusive.
-	Config yaml.Node `yaml:"config,omitempty"`
+	Config *yaml.Node `yaml:"config,omitempty"`
 
 	// `ConfigPath` specifies a relative path to a file in the current directory
 	// containing a K8S resource used as the function config. This resource is

--- a/pkg/api/kptfile/v1alpha2/types.go
+++ b/pkg/api/kptfile/v1alpha2/types.go
@@ -74,7 +74,7 @@ type Upstream struct {
 	Type OriginType `yaml:"type,omitempty"`
 
 	// Git is the locator for a package stored on Git.
-	Git Git `yaml:"git,omitempty"`
+	Git *Git `yaml:"git,omitempty"`
 
 	// UpdateStrategy declares how a package will be updated from upstream.
 	UpdateStrategy UpdateStrategyType `yaml:"updateStrategy,omitempty"`
@@ -86,7 +86,7 @@ type UpstreamLock struct {
 	Type OriginType `yaml:"type,omitempty"`
 
 	// Git is the locator for a package stored on Git.
-	Git Git `yaml:"git,omitempty"`
+	Git *Git `yaml:"git,omitempty"`
 }
 
 // Git contains information on the origin of packages fetched from a git repository.
@@ -104,8 +104,8 @@ type Git struct {
 	Commit string `yaml:"commit,omitempty"`
 }
 
-// PackageInfo contains metadata such as license, documentation, etc.
-// These fields are not used for any functionality in kpt and are simply passed through.
+// PackageInfo contains information such as license, documentation, etc.
+// These fields are not consumed by any functionality in kpt and are simply passed through.
 type PackageInfo struct {
 	// URL is the location of the package.  e.g. https://github.com/example/com
 	URL string `yaml:"url,omitempty"`
@@ -116,7 +116,7 @@ type PackageInfo struct {
 	// License is the package license
 	License string `yaml:"license,omitempty"`
 
-	// Version is a logical package version (ignored by kpt)
+	// Version is a logical package version
 	Version string `yaml:"version,omitempty"`
 
 	// Tags enables humans and tools to attach arbitrary package metadata.
@@ -189,7 +189,7 @@ type Function struct {
 	// Config, ConfigPath, and ConfigMap fields are mutually exclusive.
 	Config *yaml.Node `yaml:"config,omitempty"`
 
-	// `ConfigPath` specifies a relative path to a file in the current directory
+	// `ConfigPath` specifies a slash-delimited relative path to a file in the current directory
 	// containing a K8S resource used as the function config. This resource is
 	// excluded when resolving 'sources', and as a result cannot be operated on
 	// by the pipeline.

--- a/pkg/api/kptfile/v1alpha2/types.go
+++ b/pkg/api/kptfile/v1alpha2/types.go
@@ -50,7 +50,7 @@ type KptFile struct {
 type OriginType string
 
 const (
-	// GitOrigin specifies a package as having been cloned from a git repository
+	// GitOrigin specifies a package as having been cloned from a git repository.
 	GitOrigin OriginType = "git"
 )
 
@@ -80,7 +80,7 @@ type Upstream struct {
 	UpdateStrategy UpdateStrategyType `yaml:"updateStrategy,omitempty"`
 }
 
-// UpstreamLock is a resolved locator for the last fetch of the packgae.
+// UpstreamLock is a resolved locator for the last fetch of the package.
 type UpstreamLock struct {
 	// Type is the type of origin.
 	Type OriginType `yaml:"type,omitempty"`
@@ -122,7 +122,7 @@ type PackageInfo struct {
 	// Tags enables humans and tools to attach arbitrary package metadata.
 	Tags []string `yaml:"tags,omitempty"`
 
-	// Man is the path to documentation about the package
+	// Man is the path to documentation about the package.
 	Man string `yaml:"man,omitempty"`
 
 	// Description contains a short description of the package.
@@ -199,12 +199,14 @@ type Function struct {
 	ConfigMap map[string]string `yaml:"configMap,omitempty"`
 }
 
-// Inventory encapsulates the parameters for the inventory object. All of the
-// the parameters are required if any are set.
+// Inventory encapsulates the parameters for the inventory resource applied to a cluster.
+// All of the the parameters are required if any are set.
 type Inventory struct {
+	// Namespace for the inventory resource.
 	Namespace string `yaml:"namespace,omitempty"`
-	Name      string `yaml:"name,omitempty"`
-	// Unique label to identify inventory object in cluster.
+	// Name of the inventory resource.
+	Name string `yaml:"name,omitempty"`
+	// Unique label to identify inventory resource in cluster.
 	InventoryID string            `yaml:"inventoryID,omitempty"`
 	Labels      map[string]string `yaml:"labels,omitempty"`
 	Annotations map[string]string `yaml:"annotations,omitempty"`

--- a/pkg/api/kptfile/v1alpha2/types.go
+++ b/pkg/api/kptfile/v1alpha2/types.go
@@ -1,0 +1,201 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package defines the schema for Kptfile version v1alpha2.
+package v1alpha2
+
+import (
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+const (
+	KptFileName       = "Kptfile"
+	KptFileGroup      = "kpt.dev"
+	KptFileVersion    = "v1alpha2"
+	KptFileAPIVersion = KptFileGroup + "/" + KptFileVersion
+)
+
+// KptFile contains information about a package managed with kpt.
+type KptFile struct {
+	yaml.ResourceMeta `yaml:",inline"`
+
+	// Upstream is a reference to where the package is fetched from.
+	Upstream Upstream `yaml:"upstream,omitempty"`
+
+	// PackageMeta contains metadata such as license, documentation, etc.
+	PackageMeta PackageMeta `yaml:"packageMeta,omitempty"`
+
+	// Subpackages declares the list of subpackages.
+	Subpackages []Subpackage `yaml:"subpackages,omitempty"`
+
+	// Pipeline declares the pipeline of functions.
+	Pipeline *Pipeline `yaml:"pipeline,omitempty"`
+
+	// Inventory contains parameters for the inventory object used in apply.
+	Inventory *Inventory `yaml:"inventory,omitempty"`
+}
+
+// OriginType defines the type of origin for a package
+type OriginType string
+
+const (
+	// GitOrigin specifies a package as having been cloned from a git repository
+	GitOrigin OriginType = "git"
+)
+
+// UpdateStrategyType defines the strategy for updating a package from upstream.
+type UpdateStrategyType string
+
+const (
+	// ResourceMerge performs a structural schema-aware comparison and
+	// merges the changes into the local package.
+	ResourceMerge UpdateStrategyType = "resource-merge"
+	// FastForward fails without updating if the local package was modified
+	// since it was fetched.
+	FastForward UpdateStrategyType = "fast-forward"
+	// ForceDeleteReplace wipes all local changes to the package.
+	ForceDeleteReplace UpdateStrategyType = "force-delete-replace"
+)
+
+// Upstream is a reference to where the package is fetched from.
+type Upstream struct {
+	// Type is the type of origin.
+	Type OriginType `yaml:"type,omitempty"`
+
+	// Git contains information on the origin of packages fetched from a git repository.
+	Git Git `yaml:"git,omitempty"`
+
+	// UpdateStrategy defines how a package is updated from upstream.
+	UpdateStrategy UpdateStrategyType `yaml:"updateStrategy,omitempty"`
+}
+
+// PackageMeta contains metadata such as license, documentation, etc.
+// These fields are not used for any functionality in kpt and are simply passed through.
+type PackageMeta struct {
+	// URL is the location of the package.  e.g. https://github.com/example/com
+	URL string `yaml:"url,omitempty"`
+
+	// Email is the email of the package maintainer
+	Email string `yaml:"email,omitempty"`
+
+	// License is the package license
+	License string `yaml:"license,omitempty"`
+
+	// Version is a logical package version (ignored by kpt)
+	Version string `yaml:"version,omitempty"`
+
+	// Tags enables humans and tools to attach arbitrary package metadata.
+	Tags []string `yaml:"tags,omitempty"`
+
+	// Man is the path to documentation about the package
+	Man string `yaml:"man,omitempty"`
+
+	// ShortDescription contains a short description of the package.
+	ShortDescription string `yaml:"shortDescription,omitempty"`
+}
+
+// Subpackages declares a local or remote subpackage.
+type Subpackage struct {
+	// Name of the immediate subdirectory relative to this Kptfile where the suppackage
+	// either exists (local subpackages) or will be fetched to (remote subpckages).
+	// This must be unique across all subpckages of a package.
+	LocalDir string `yaml:"localDir,omitempty"`
+	// Whether a subpackage is local or remote is determined by whether Upstream is specified.
+	// Upstream is a reference to where the package is fetched from.
+	Upstream Upstream `yaml:"upstream,omitempty"`
+}
+
+// Git contains information on the origin of packages fetched from a git repository.
+type Git struct {
+	// Commit is the git commit that the package was fetched at
+	Commit string `yaml:"commit,omitempty"`
+
+	// Repo is the git repository the package was cloned from.  e.g. https://
+	Repo string `yaml:"repo,omitempty"`
+
+	// Directory is the sub directory of the git repository that the package was cloned from
+	Directory string `yaml:"directory,omitempty"`
+
+	// Ref is the git ref the package was cloned from
+	Ref string `yaml:"ref,omitempty"`
+}
+
+// Pipeline declares a pipeline of functions used to mutate or validate resources.
+type Pipeline struct {
+	//  Sources defines the source packages to resolve as input to the pipeline. Possible values:
+	//  a) A slash-separated, OS-agnostic relative package path which may include '.' and '..' e.g. './base', '../foo'
+	//     The source package is resolved recursively.
+	//  b) Resources in this package using '.'. Meta resources such as the Kptfile, Pipeline, and function configs
+	//     are excluded.
+	//  c) Resources in this package AND all resolved subpackages using './*'
+	//
+	// Resultant list of resources are ordered:
+	// - According to the order of sources specified in this array.
+	// - When using './*': Subpackages are resolved in alphanumerical order before package resources.
+	//
+	// When omitted, defaults to './*'.
+	// Sources []string `yaml:"sources,omitempty"`
+
+	// Following fields define the sequence of functions in the pipeline.
+	// Input of the first function is the resolved sources.
+	// Input of the second function is the output of the first function, and so on.
+	// Order of operation: mutators, validators
+
+	// Mutators defines a list of of KRM functions that mutate resources.
+	Mutators []Function `yaml:"mutators,omitempty"`
+
+	// Validators defines a list of KRM functions that validate resources.
+	// Validators are not permitted to mutate resources.
+	Validators []Function `yaml:"validators,omitempty"`
+}
+
+// Function specifies a KRM function.
+type Function struct {
+	// `Image` specifies the function container image.
+	// It can either be fully qualified, e.g.:
+	//
+	//	image: gcr.io/kpt-fn/set-label
+	//
+	// Optionally, kpt can be configured to use a image
+	// registry host-path that will be used to resolve the image path in case
+	// the image path is missing (Defaults to gcr.io/kpt-fn).
+	// e.g. The following resolves to gcr.io/kpt-fn/set-label:
+	//
+	//	image: set-label
+	Image string `yaml:"image,omitempty"`
+
+	// `Config` specifies an inline k8s resource used as the function config.
+	// Config, ConfigPath, and ConfigMap fields are mutually exclusive.
+	Config yaml.Node `yaml:"config,omitempty"`
+
+	// `ConfigPath` specifies a relative path to a file in the current directory
+	// containing a K8S resource used as the function config. This resource is
+	// excluded when resolving 'sources', and as a result cannot be operated on
+	// by the pipeline.
+	ConfigPath string `yaml:"configPath,omitempty"`
+
+	// `ConfigMap` is a convenient way to specify a function config of kind ConfigMap.
+	ConfigMap map[string]string `yaml:"configMap,omitempty"`
+}
+
+// Inventory encapsulates the parameters for the inventory object. All of the
+// the parameters are required if any are set.
+type Inventory struct {
+	Namespace string `yaml:"namespace,omitempty"`
+	Name      string `yaml:"name,omitempty"`
+	// Unique label to identify inventory object in cluster.
+	InventoryID string            `yaml:"inventoryID,omitempty"`
+	Labels      map[string]string `yaml:"labels,omitempty"`
+	Annotations map[string]string `yaml:"annotations,omitempty"`
+}


### PR DESCRIPTION
Defines the core schema.

Some additive changes not included for now as they're being finalized (will be additive change in separate PRs):

- Setters as a top-level field in `pipeline`.
- Filters in `pipeline`.
