### PR TITLE
Update Diffing Display

### DIFF
--- a/internal/util/diff/diff.go
+++ b/internal/util/diff/diff.go
@@ -104,7 +104,7 @@ func (c *Command) Run() error {
 
 	// Stage current package
 	// This prevents prepareForDiff from modifying the local package
-	currPkg, err := ioutil.TempDir("", "kpt-")
+	currPkg, err := ioutil.TempDir("", "kpt-local-")
 	if err != nil {
 		return errors.Errorf("failed to create stage dir for current package: %v", err)
 	}
@@ -308,7 +308,7 @@ type defaultPkgGetter struct{}
 func (pg defaultPkgGetter) GetPkg(repo, path, ref string) (string, error) {
 	repoSrc := strings.Split(repo, "/") // For github repo's this will be the project name
 	pkgSrc := strings.Split(path, "/")  // This will be the directory the package is contained in
-	tmpPath := fmt.Sprintf("kpt-%s-%s-",
+	tmpPath := fmt.Sprintf("kpt-upstream-%s-%s-",
 		repoSrc[len(repoSrc)-1],
 		pkgSrc[len(pkgSrc)-1])
 	dir, err := ioutil.TempDir("", tmpPath)

--- a/internal/util/diff/diff.go
+++ b/internal/util/diff/diff.go
@@ -139,7 +139,6 @@ func (c *Command) Run() error {
 	if err != nil {
 		return errors.Errorf("failed to stage current package: %v", err)
 	}
-	fmt.Printf("Staging %s at %s\n", c.Path, currPkg)
 
 	// get the upstreamPkg at current version
 	upstreamPkgName := NameStagingDirectory(remotePackageSource,
@@ -150,11 +149,6 @@ func (c *Command) Run() error {
 		kptFile.Upstream.Git.Repo,
 		kptFile.Upstream.Git.Directory,
 		kptFile.Upstream.Git.Commit)
-	fmt.Printf("Staging %s/%s@%s at %s\n",
-		kptFile.Upstream.Git.Repo,
-		kptFile.Upstream.Git.Directory,
-		kptFile.Upstream.Git.Commit,
-		upstreamPkg)
 	if err != nil {
 		return err
 	}
@@ -183,11 +177,6 @@ func (c *Command) Run() error {
 		if err != nil {
 			return err
 		}
-		fmt.Printf("Staging %s/%s@%s at %s\n",
-			kptFile.Upstream.Git.Repo,
-			kptFile.Upstream.Git.Directory,
-			c.Ref,
-			upstreamTargetPkg)
 	}
 
 	if c.Debug {

--- a/internal/util/diff/diff.go
+++ b/internal/util/diff/diff.go
@@ -105,7 +105,7 @@ func (c *Command) Run() error {
 
 	// Stage current package
 	// This prevents prepareForDiff from modifying the local package
-	currPkg, err := ioutil.TempDir("", "kpt-")
+	currPkg, err := ioutil.TempDir("", "kpt-local-")
 	if err != nil {
 		return errors.Errorf("failed to create stage dir for current package: %v", err)
 	}

--- a/internal/util/diff/diff.go
+++ b/internal/util/diff/diff.go
@@ -105,6 +105,9 @@ func (c *Command) Run() error {
 
 	// Create a staging directory to store all compared packages
 	stagingDirectory, err := ioutil.TempDir("", "kpt-")
+	if err != nil {
+		return errors.Errorf("failed to create stage dir: %v", err)
+	}
 	defer func() {
 		// Cleanup staged content after diff. Ignore cleanup if debugging.
 		if !c.Debug {

--- a/internal/util/diff/diff.go
+++ b/internal/util/diff/diff.go
@@ -47,6 +47,16 @@ const (
 	DiffType3Way DiffType = "3way"
 )
 
+// A collection of user-readable "source" definitions for diffed packages.
+const (
+	// localPackageSource represents the local package
+	localPackageSource string = "local"
+	// remotePackageSource represents the remote version of the package
+	remotePackageSource string = "remote"
+	// targetRemotePackageSource represents the targeted remote version of a package
+	targetRemotePackageSource string = "target"
+)
+
 // String implements Stringer.
 func (dt DiffType) String() string {
 	return string(dt)
@@ -117,7 +127,10 @@ func (c *Command) Run() error {
 
 	// Stage current package
 	// This prevents prepareForDiff from modifying the local package
-	currPkg, err := stageDirectory(stagingDirectory, "local-package")
+	localPkgName := nameStagingDirectory(localPackageSource,
+		kptFile.Upstream.Git.Ref,
+		kptFile.Upstream.Git.Commit)
+	currPkg, err := stageDirectory(stagingDirectory, localPkgName)
 	if err != nil {
 		return errors.Errorf("failed to create stage dir for current package: %v", err)
 	}
@@ -129,7 +142,11 @@ func (c *Command) Run() error {
 	fmt.Printf("Staging %s at %s\n", c.Path, currPkg)
 
 	// get the upstreamPkg at current version
+	upstreamPkgName := nameStagingDirectory(remotePackageSource,
+		kptFile.Upstream.Git.Ref,
+		kptFile.Upstream.Git.Commit)
 	upstreamPkg, err := c.PkgGetter.GetPkg(stagingDirectory,
+		upstreamPkgName,
 		kptFile.Upstream.Git.Repo,
 		kptFile.Upstream.Git.Directory,
 		kptFile.Upstream.Git.Commit)
@@ -155,7 +172,11 @@ func (c *Command) Run() error {
 		c.DiffType == DiffTypeCombined ||
 		c.DiffType == DiffType3Way {
 		// get the upstream pkg at the target version
+		upstreamTargetPkgName := nameStagingDirectory(targetRemotePackageSource,
+			c.Ref,
+			c.Ref)
 		upstreamTargetPkg, err = c.PkgGetter.GetPkg(stagingDirectory,
+			upstreamTargetPkgName,
 			kptFile.Upstream.Git.Repo,
 			kptFile.Upstream.Git.Directory,
 			c.Ref)
@@ -294,7 +315,7 @@ func (d *defaultPkgDiffer) prepareForDiff(dir string) error {
 
 // PkgGetter knows how to fetch a package given a git repo, path and ref.
 type PkgGetter interface {
-	GetPkg(stagingDir, repo, path, ref string) (dir string, err error)
+	GetPkg(stagingDir, targetDir, repo, path, ref string) (dir string, err error)
 }
 
 // defaultPkgGetter uses get.Command abstraction to implement PkgGetter.
@@ -306,9 +327,8 @@ type defaultPkgGetter struct{}
 // path is the sub directory of the git repository that the package was cloned from
 // ref is the git ref the package was cloned from
 // refDesc is a human readable name of the reference
-func (pg defaultPkgGetter) GetPkg(stagingDir, repo, path, ref string) (string, error) {
-	tmpPath := fmt.Sprintf("upstream-%s", shortSha(ref))
-	dir, err := stageDirectory(stagingDir, tmpPath)
+func (pg defaultPkgGetter) GetPkg(stagingDir, targetDir, repo, path, ref string) (string, error) {
+	dir, err := stageDirectory(stagingDir, targetDir)
 	if err != nil {
 		return dir, err
 	}
@@ -333,4 +353,21 @@ func stageDirectory(path, subpath string) (string, error) {
 	targetPath := filepath.Join(path, subpath)
 	err := os.Mkdir(targetPath, os.ModePerm)
 	return targetPath, err
+}
+
+// nameStagingDirectory assigns a name that matches the package source information
+func nameStagingDirectory(source, branch, sha string) string {
+	// The branch and sha may not always be known simultaneously
+	// In these cases the values will be the same. Collapse these references
+	// when this occurs to avoid confusion/duplicate info.
+	// This occurs during a remote target operation for example.
+	if branch == sha {
+		return fmt.Sprintf("%s-%s",
+			source,
+			branch)
+	}
+	return fmt.Sprintf("%s-%s-%s",
+		source,
+		branch,
+		shortSha(sha))
 }

--- a/internal/util/diff/diff_test.go
+++ b/internal/util/diff/diff_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
+	"github.com/GoogleContainerTools/kpt/internal/util/diff"
 	. "github.com/GoogleContainerTools/kpt/internal/util/diff"
 	"github.com/GoogleContainerTools/kpt/internal/util/get"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
@@ -264,4 +265,29 @@ func filterDiffMetadata(r io.Reader) string {
 		b.WriteString("\n")
 	}
 	return b.String()
+}
+
+func TestStagingDirectoryNames(t *testing.T) {
+	var tests = []struct {
+		source   string
+		branch   string
+		sha      string
+		expected string
+	}{
+		{"source", "branch", "sha", "source-branch-sha"},
+		{"source", "branch", "shortenedSha", "source-branch-shorten"},
+		{"source", "duplicate", "duplicate", "source-duplicate"},
+		{"source", "refs/tags/version", "sha", "source-version-sha"},
+		{"source", "refs/tags/version", "shortenedSha", "source-version-shorten"},
+		{"source", "refs/tags/version", "refs/tags/version", "source-version"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			result := diff.NameStagingDirectory(tt.source, tt.branch, tt.sha)
+			if result != tt.expected {
+				t.Errorf("got %s, want %s", result, tt.expected)
+			}
+		})
+	}
 }

--- a/internal/util/diff/diff_test.go
+++ b/internal/util/diff/diff_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
-	"github.com/GoogleContainerTools/kpt/internal/util/diff"
 	. "github.com/GoogleContainerTools/kpt/internal/util/diff"
 	"github.com/GoogleContainerTools/kpt/internal/util/get"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile"
@@ -284,7 +283,7 @@ func TestStagingDirectoryNames(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.expected, func(t *testing.T) {
-			result := diff.NameStagingDirectory(tt.source, tt.branch, tt.sha)
+			result := NameStagingDirectory(tt.source, tt.branch, tt.sha)
 			if result != tt.expected {
 				t.Errorf("got %s, want %s", result, tt.expected)
 			}

--- a/internal/util/diff/diff_test.go
+++ b/internal/util/diff/diff_test.go
@@ -282,6 +282,7 @@ func TestStagingDirectoryNames(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt // Account for scopelint checks
 		t.Run(tt.expected, func(t *testing.T) {
 			result := NameStagingDirectory(tt.source, tt.branch, tt.sha)
 			if result != tt.expected {


### PR DESCRIPTION
Attempts to improve the UX of kpt package diffs like experienced in #1377

#### update upstream directory names

`kpt-12348765` might now appear as `kpt-upstream-examples-cockroachdb-ProjectVersion-12348765` where:
  - `upstream` references that the package was fetched from the source package. The local copy will appear as `local` instead.
  - `examples` references the Git project name. In this case taken from: https://github.com/kubernetes/examples
  - `cockroachdb` references the directory containing the upstream package. In this case taken from: staging/cockroachdb
  - `ProjectVersion` is a string constant that represents a version stored in the projects Kptfile. During remote or 3way diffs this may also appear as the provided reference (`main`, `master` etc).

#### add output of staged directories to stdout, this information looks like this:

```txt
Staging cockroachdb at /tmp/kpt-local-943465024
Staging https://github.com/kubernetes/examples/staging/cockroachdb:PackageVersion at /tmp/kpt-upstream-examples-cockroachdb-ProjectVersion-535434399
Staging https://github.com/kubernetes/examples/staging/cockroachdb:master at /tmp/kpt-upstream-examples-cockroachdb-master-555934580
```

  - `PackageVersion` represents a package which matches the package version stored in the projects Kptfile
  - `master` will represent the remote reference used during a 3way diff.

> The `/tmp` directory will appear differently depending on the system (MacOS, Linux or Windows OS).

#### There are some known issues with this approach:

1. When a diffing UI is used the "Staging..." text may not be obvious (hidden by the UI window) and the directories do not capture the complete information yet.
2. Performing diffs against a series of temporary directories is still confusing. Note here: Kpt's diff is not atomic and will change the directory it is run against - this is the motivation for tmp directories - this prevents expected differences from being diffed like in the Kptfile but also means that a diff should not be run directly against the local package.