### PR TITLE
Updates kpt to use cli-utils version 0.23.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	k8s.io/client-go v0.18.10
 	k8s.io/klog v1.0.0
 	k8s.io/kubectl v0.18.10
-	sigs.k8s.io/cli-utils v0.22.5-0.20210127192708-27cfaa675296
+	sigs.k8s.io/cli-utils v0.23.0
 	sigs.k8s.io/kustomize/cmd/config v0.8.7-0.20201211170716-cc43a2d732d1
 	sigs.k8s.io/kustomize/kyaml v0.10.6
 )

--- a/go.sum
+++ b/go.sum
@@ -685,8 +685,8 @@ k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89 h1:d4vVOjXm687F1iLSP2q3lyPPuyvTU
 k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.7/go.mod h1:PHgbrJT7lCHcxMU+mDHEm+nx46H4zuuHZkDP6icnhu0=
-sigs.k8s.io/cli-utils v0.22.5-0.20210127192708-27cfaa675296 h1:GcA9Uu6GfyLw7X+djhGV2h0bbcouZdVy0NIvlv7LTaU=
-sigs.k8s.io/cli-utils v0.22.5-0.20210127192708-27cfaa675296/go.mod h1:J32lRfzTB7eeQQGnXQQThd5BlhmYZuYuAAdFTQ4oSNc=
+sigs.k8s.io/cli-utils v0.23.0 h1:nhfLzj1QEephCKHt4hKeCwUE2lVE4jHOgrG3+j0+LKU=
+sigs.k8s.io/cli-utils v0.23.0/go.mod h1:J32lRfzTB7eeQQGnXQQThd5BlhmYZuYuAAdFTQ4oSNc=
 sigs.k8s.io/controller-runtime v0.6.0 h1:Fzna3DY7c4BIP6KwfSlrfnj20DJ+SeMBK8HSFvOk9NM=
 sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2cftPHndTroo=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=


### PR DESCRIPTION
* Very small change to update imported `cli-utils` version from `v0.22.5` to `v0.23.0`
* Necessary for release of kpt