### PR TITLE
Setter Inheritance: Handle no definitions in parent

### DIFF
--- a/internal/util/setters/setters.go
+++ b/internal/util/setters/setters.go
@@ -262,6 +262,9 @@ func (a AutoSet) setInheritedSettersForPkg(pkgPath, parentKptfilePath, setterRef
 	if err != nil {
 		return err
 	}
+	if sc == nil {
+		return nil
+	}
 	sch := sc.Definitions[setterRef]
 	cliExt, err := setters2.GetExtFromSchema(&sch)
 	if cliExt == nil || cliExt.Setter == nil || err != nil {

--- a/internal/util/setters/setters_test.go
+++ b/internal/util/setters/setters_test.go
@@ -496,6 +496,51 @@ kind: Deployment
 metadata:
   namespace: child_namespace # {"$kpt-set":"namespace"}`,
 		},
+
+		{
+			name:       "no setter definitions in parent",
+			parentPath: "${baseDir}/parentPath",
+			childPath:  "${baseDir}/parentPath/somedir/childPath",
+			parentKptfile: `apiVersion: krm.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: parent`,
+			childConfigFile: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: child_namespace # {"$kpt-set":"namespace"}`,
+			childKptfile: `apiVersion: krm.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: child
+openAPI:
+  definitions:
+    io.k8s.cli.setters.namespace:
+      x-k8s-cli:
+        setter:
+          name: namespace
+          value: child_namespace
+          isSet: true
+`,
+			expectedChildKptfile: `apiVersion: krm.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: child
+openAPI:
+  definitions:
+    io.k8s.cli.setters.namespace:
+      x-k8s-cli:
+        setter:
+          name: namespace
+          value: child_namespace
+          isSet: true
+`,
+			expectedChildConfigFile: `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: child_namespace # {"$kpt-set":"namespace"}`,
+		},
+
 		{
 			name:       "inherit-defalut-values-from-parent",
 			parentPath: "${baseDir}/parentPath",


### PR DESCRIPTION
This PR is to make sure that Setter Inheritance handles the case where there are no Setter Definitions in parent Kptfile.