### PR TITLE
Updates continue-on-error e2e test case

### DIFF
--- a/e2e/live/end-to-end-test.sh
+++ b/e2e/live/end-to-end-test.sh
@@ -853,7 +853,18 @@ assertPodExists "pod-c" "test-namespace"
 assertPodExists "pod-d" "test-namespace"
 printResult
 
-# Test 19: Basic kpt live destroy
+# Test 19: kpt live apply continue-on-error
+echo "Testing continue-on-error"
+echo "kpt live apply e2e/live/testdata/continue-on-error"
+${BIN_DIR}/kpt live apply e2e/live/testdata/continue-on-error > $OUTPUT_DIR/status
+assertCMInventory "test-namespace" "2"
+assertContains "pod/pod-a created"
+assertContains "pod/pod-B failed"
+assertPodExists "pod-a" "test-namespace"
+assertPodNotExists "pod-B" "test-namespace"
+printResult
+
+# Test 20: Basic kpt live destroy
 # "test-case-1b" directory is "test-case-1a" directory with "pod-a" removed and "pod-d" added.
 echo "Testing basic destroy"
 echo "kpt live destroy e2e/live/testdata/test-case-1b"
@@ -869,15 +880,6 @@ assertContains "4 resource(s) deleted, 0 skipped"
 assertPodNotExists "pod-b" "test-namespace"
 assertPodNotExists "pod-c" "test-namespace"
 assertPodNotExists "pod-d" "test-namespace"
-printResult
-
-# Test 20: kpt live apply continue-on-error
-echo "Testing continue-on-error"
-echo "kpt live apply e2e/live/testdata/continue-on-error"
-${BIN_DIR}/kpt live apply e2e/live/testdata/continue-on-error > $OUTPUT_DIR/status
-assertCMInventory "test-namespace" "1"
-assertPodExists "pod-a" "test-namespace"
-assertPodNotExists "pod-B" "test-namespace"
 printResult
 
 # Clean-up the k8s cluster

--- a/e2e/live/testdata/continue-on-error/inventory-template.yaml
+++ b/e2e/live/testdata/continue-on-error/inventory-template.yaml
@@ -1,3 +1,17 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # NOTE: auto-generated. Some fields should NOT be modified.
 # Date: 2021-01-15 15:23:11 PST
 #

--- a/e2e/live/testdata/continue-on-error/pod-a.yaml
+++ b/e2e/live/testdata/continue-on-error/pod-a.yaml
@@ -1,3 +1,17 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This pod description should be valid and is expected to successfully deploy
 
 apiVersion: v1

--- a/e2e/live/testdata/continue-on-error/pod-b.yaml
+++ b/e2e/live/testdata/continue-on-error/pod-b.yaml
@@ -1,3 +1,17 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # This pod definition has errors and will fail to deploy
 
 apiVersion: v1


### PR DESCRIPTION
* Fixes flaky "continue-on-error" end-to-end test case. Flakiness caused by re-using namespace from previous test which is deleted before being re-created, causing a race condition. Moves test to position before deletion.
* Updates number of inventory items from 1 to 2, since the namespace is also stored in the inventory if it applied with other items.
* Adds a couple more assert statements.
* Adds missing licenses to resource yamls.

Current output:
```
Testing continue-on-error
kpt live apply e2e/live/testdata/continue-on-error
......SUCCESS
```