### PR TITLE
Simplify setter creation experience, avoid kptfile dependency

### DIFF
--- a/internal/cmdsearch/cmdsearch.go
+++ b/internal/cmdsearch/cmdsearch.go
@@ -100,7 +100,6 @@ func (r *SearchRunner) runE(c *cobra.Command, args []string) error {
 		RecurseSubPackages: r.RecurseSubPackages,
 		CmdRunner:          r,
 		RootPkgPath:        args[0],
-		NeedOpenAPI:        true,
 		SkipPkgPathPrint:   true,
 	}
 	err := e.Execute()

--- a/internal/cmdsearch/cmdsearch_test.go
+++ b/internal/cmdsearch/cmdsearch_test.go
@@ -32,7 +32,6 @@ import (
 type test struct {
 	name              string
 	input             string
-	inputKptfile      string
 	args              []string
 	out               string
 	expectedResources string
@@ -61,19 +60,6 @@ func TestSearchCommand(t *testing.T) {
 				err = ioutil.WriteFile(r.Name(), []byte(test.input), 0600)
 				if !assert.NoError(t, err) {
 					t.FailNow()
-				}
-
-				if test.inputKptfile != "" {
-					err = ioutil.WriteFile(filepath.Join(baseDir, kptfile.KptFileName), []byte(test.inputKptfile), 0600)
-					if !assert.NoError(t, err) {
-						t.FailNow()
-					}
-				} else {
-					err = ioutil.WriteFile(filepath.Join(baseDir, kptfile.KptFileName), []byte(`apiVersion: v1alpha1
-kind: Kptfile`), 0600)
-					if !assert.NoError(t, err) {
-						t.FailNow()
-					}
 				}
 
 				runner := NewSearchRunner("")

--- a/internal/cmdsearch/putpattern_test.go
+++ b/internal/cmdsearch/putpattern_test.go
@@ -26,15 +26,6 @@ metadata:
 spec:
   replicas: 3
  `,
-		inputKptfile: `apiVersion: v1alpha1
-kind: Kptfile
-openAPI:
-  definitions:
-    io.k8s.cli.setters.replicas:
-      x-k8s-cli:
-        setter:
-          name: replicas
-          value: "3"`,
 		out: `${baseDir}/${filePath}
 fieldPath: spec.replicas
 value: 3 # kpt-set: ${replicas}
@@ -61,20 +52,6 @@ metadata:
 spec:
   replicas: 3
  `,
-		inputKptfile: `apiVersion: v1alpha1
-kind: Kptfile
-openAPI:
-  definitions:
-    io.k8s.cli.setters.image:
-      x-k8s-cli:
-        setter:
-          name: image
-          value: "nginx"
-    io.k8s.cli.setters.kind:
-      x-k8s-cli:
-        setter:
-          name: kind
-          value: "deployment"`,
 		out: `${baseDir}/${filePath}
 fieldPath: metadata.name
 value: nginx-deployment # kpt-set: ${image}-${kind}
@@ -91,47 +68,6 @@ spec:
  `,
 	},
 	{
-		name: "put pattern by regex",
-		args: []string{"--by-value-regex", "my-project-*", "--put-pattern", "${project}-*"},
-		input: `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: my-project-deployment
-  namespace: my-project-namespace
-spec:
-  replicas: 3
- `,
-		inputKptfile: `apiVersion: v1alpha1
-kind: Kptfile
-openAPI:
-  definitions:
-    io.k8s.cli.setters.project:
-      x-k8s-cli:
-        setter:
-          name: project
-          value: "my-project"`,
-		out: `${baseDir}/${filePath}
-fieldPath: metadata.name
-value: my-project-deployment # kpt-set: ${project}-deployment
-
-${baseDir}/${filePath}
-fieldPath: metadata.namespace
-value: my-project-namespace # kpt-set: ${project}-namespace
-
-Mutated 2 field(s)
-`,
-		expectedResources: `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: my-project-deployment # kpt-set: ${project}-deployment
-  namespace: my-project-namespace # kpt-set: ${project}-namespace
-spec:
-  replicas: 3
- `,
-	},
-	{
 		name: "put pattern by value",
 		args: []string{"--by-value", "dev/my-project/nginx", "--put-pattern", "${env}/${project}/${name}"},
 		input: `
@@ -142,30 +78,6 @@ metadata:
 spec:
   replicas: 3
  `,
-		inputKptfile: `apiVersion: v1alpha1
-kind: Kptfile
-openAPI:
-  definitions:
-    io.k8s.cli.setters.project:
-      x-k8s-cli:
-        setter:
-          name: project
-          value: "my-project"
-    io.k8s.cli.setters.env:
-      x-k8s-cli:
-        setter:
-          name: env
-          value: "dev"
-    io.k8s.cli.setters.name:
-      x-k8s-cli:
-        setter:
-          name: name
-          value: "nginx"
-    io.k8s.cli.setters.namespace:
-      x-k8s-cli:
-        setter:
-          name: namespace
-          value: "my-space"`,
 		out: `${baseDir}/${filePath}
 fieldPath: metadata.name
 value: dev/my-project/nginx # kpt-set: ${env}/${project}/${name}
@@ -180,73 +92,5 @@ metadata:
 spec:
   replicas: 3
  `,
-	},
-	{
-		name: "put pattern error",
-		args: []string{"--by-value", "nginx-deployment", "--put-pattern", "${image}-${tag}"},
-		input: `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: nginx-deployment
-spec:
-  replicas: 3
- `,
-		inputKptfile: `apiVersion: v1alpha1
-kind: Kptfile
-openAPI:
-  definitions:
-    io.k8s.cli.setters.image:
-      x-k8s-cli:
-        setter:
-          name: image
-          value: "nginx"
-    io.k8s.cli.setters.kind:
-      x-k8s-cli:
-        setter:
-          name: kind
-          value: "deployment"`,
-		expectedResources: `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: nginx-deployment
-spec:
-  replicas: 3
- `,
-		errMsg: `setter "tag" doesn't exist, please create setter definition and try again`,
-	},
-	{
-		name: "put pattern list-values error",
-		args: []string{"--by-value", "3", "--put-pattern", "${replicas-list}"},
-		input: `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: nginx-deployment
-spec:
-  replicas: 3
- `,
-		inputKptfile: `apiVersion: v1alpha1
-kind: Kptfile
-openAPI:
-  definitions:
-    io.k8s.cli.setters.replicas-list:
-      x-k8s-cli:
-        setter:
-          name: replicas-list
-          value: ""
-          listValues: 
-           - "1"
-           - "2"`,
-		expectedResources: `
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: nginx-deployment
-spec:
-  replicas: 3
- `,
-		errMsg: `setter pattern should not refer to array type setters: "replicas-list"`,
 	},
 }


### PR DESCRIPTION
@mortent

This PR simplifies the setter creation experience to the package publishers, avoiding the dependency on Setter Definitions and Kptfile. It would just add the setter pattern comment to the target fields.