### PR TITLE
[WIP] Include gcloud in kpt image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,9 @@ RUN go mod download
 COPY . .
 RUN go build -v -o /usr/local/bin/kpt -ldflags="-s -w -X github.com/GoogleContainerTools/kpt/run.version=$KPT_VERSION" ./
 
-FROM alpine:3.11
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine
 RUN apk update && apk upgrade && \
-    apk add --no-cache git less man diffutils bash openssh docker-cli && \
+    apk add --no-cache git less diffutils bash openssh docker-cli && \
     rm -rf /var/lib/apt/lists/* && \
     rm /var/cache/apk/*
 COPY --from=0 /usr/local/bin/kpt /usr/local/bin/kpt


### PR DESCRIPTION
Using `kpt live` from the kpt docker image requires gcloud for auth. This changes the source image we use for the kpt to use the cloud-sdk:alpine image.
