### PR TITLE
get and update commands update parent package Kptfile if it exists

### DIFF
--- a/internal/cmdget/cmdget.go
+++ b/internal/cmdget/cmdget.go
@@ -61,7 +61,7 @@ type Runner struct {
 	FilenamePattern string
 }
 
-func (r *Runner) preRunE(c *cobra.Command, args []string) error {
+func (r *Runner) preRunE(_ *cobra.Command, args []string) error {
 	t, err := parse.GitParseArgs(args)
 	if err != nil {
 		return err

--- a/internal/testutil/pkgbuilder/builder.go
+++ b/internal/testutil/pkgbuilder/builder.go
@@ -558,6 +558,7 @@ upstream:
     directory: {{.Pkg.Kptfile.Upstream.Dir}}
     ref: {{.Pkg.Kptfile.Upstream.Ref}}
     repo: {{.Pkg.Kptfile.Upstream.Repo}}
+    commit: abc123
 {{- end }}
 `
 

--- a/pkg/kptfile/kptfileutil/util.go
+++ b/pkg/kptfile/kptfileutil/util.go
@@ -165,3 +165,20 @@ func DefaultKptfile(name string) kptfile.KptFile {
 		},
 	}
 }
+
+// HasKptfile checks if there exists a Kptfile on the provided path.
+func HasKptfile(path string) (bool, error) {
+	_, err := os.Stat(filepath.Join(path, kptfile.KptFileName))
+
+	// If we got an error that wasn't IsNotExist, something went wrong and
+	// we don't really know if the file exists or not.
+	if err != nil && !os.IsNotExist(err) {
+		return false, err
+	}
+
+	// If the error is IsNotExist, we know the file doesn't exist.
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return true, nil
+}


### PR DESCRIPTION
Updates the `kpt pkg get` and `kpt pkg update` commands to update the Kptfile of the parent package if one exists. This makes sure that remote subpackages will always be listed in the parent Kptfile.

Fixes: https://github.com/GoogleContainerTools/kpt/issues/1443
