### PR TITLE
Add help message when diff fails

### DIFF
--- a/internal/util/diff/diff.go
+++ b/internal/util/diff/diff.go
@@ -58,7 +58,11 @@ const (
 )
 
 const (
-	exitCodeDiffWarning string = "\nThe selected diff tool (%s) exited with an error. It may not support the chosen diff type (%s). To use a different diff tool please provide the tool using the --diff-tool flag. \n\nFor more information about using kpt's diff command please see the commands --help.\n"
+	exitCodeDiffWarning string = "\nThe selected diff tool (%s) exited with an " +
+		"error. It may not support the chosen diff type (%s). To use a different " +
+		"diff tool please provide the tool using the --diff-tool flag. \n\nFor " +
+		"more information about using kpt's diff command please see the commands " +
+		"--help.\n"
 )
 
 // String implements Stringer.

--- a/internal/util/diff/diff.go
+++ b/internal/util/diff/diff.go
@@ -57,6 +57,10 @@ const (
 	targetRemotePackageSource string = "target"
 )
 
+const (
+	exitCodeDiffWarning string = "\nThe selected diff tool (%s) exited with an error. It may not support the chosen diff type (%s). To use a different diff tool please provide the tool using the --diff-tool flag. \n\nFor more information about using kpt's diff command please see the commands --help.\n"
+)
+
 // String implements Stringer.
 func (dt DiffType) String() string {
 	return string(dt)
@@ -279,11 +283,15 @@ func (d *defaultPkgDiffer) Diff(pkgs ...string) error {
 	}
 	err := cmd.Run()
 	if err != nil {
-		if exitErr, ok := err.(*exec.ExitError); ok &&
-			exitErr.ExitCode() == 1 {
+		exitErr, ok := err.(*exec.ExitError)
+		if ok && exitErr.ExitCode() == 1 {
 			// diff tool will exit with return code 1 if there are differences
 			// between two dirs. This suppresses those errors.
 			err = nil
+		} else if ok {
+			// An error occurred but was not one of the excluded ones
+			// Attempt to display help information to assist with resolving
+			fmt.Printf(exitCodeDiffWarning, d.DiffTool, d.DiffType)
 		}
 	}
 	return err


### PR DESCRIPTION
Related to #1378

This introduces an additional error message when a potential error is detected during a `pkg diff` (error codes non-0 or 1 - diff returning error code 1 indicates a difference was detected).

Kpt uses an external diff tool to compare packages using the provided diff strategy. Some of these tools may not support 3 way diffs, others may not support diffing over directories. In order to attempt to improve the experience of working with `kpt pkg diff` these new errors are added to attempt to help provide guidance around resolving the error.

For example this changes the behavior of a `3way` diff on clients where `diff` does not support 3 directories from

```txt
➜  kpt pkg diff package@main --diff-type=3way
/usr/bin/diff: extra operand `/tmp/kpt-234176370/target-main'
/usr/bin/diff: Try `/usr/bin/diff --help' for more information.

error: exit status 2
exit status 1
```

to

```txt
➜  kpt pkg diff package@main --diff-type=3way
/usr/bin/diff: extra operand `/tmp/kpt-234176370/target-main'
/usr/bin/diff: Try `/usr/bin/diff --help' for more information.

The selected diff tool (/usr/bin/diff) exited with an error. It may not support the chosen diff type (3way). To use a different diff tool please provide the tool using the --diff-tool flag. 

For more information about using kpt's diff command please see the commands --help.
error: exit status 2
exit status 1
```