### PR TITLE
Update diff-tool-opts docs for correctness.

### DIFF
--- a/internal/docs/generated/pkgdocs/docs.go
+++ b/internal/docs/generated/pkgdocs/docs.go
@@ -93,11 +93,11 @@ Flags:
     # Show changes using 'meld' commandline tool
     kpt pkg diff @master --diff-tool meld
   
-  --diff-opts:
+  --diff-tool-opts:
     Commandline options to use with the diffing tool.
     Note that it overrides the KPT_EXTERNAL_DIFF_OPTS environment variable.
     # Show changes using "diff" with recurive options
-    kpt pkg diff @master --diff-tool meld --diff-opts "-r"
+    kpt pkg diff @master --diff-tool meld --diff-tool-opts "-r"
 
 Environment Variables:
 

--- a/site/content/en/reference/pkg/diff/_index.md
+++ b/site/content/en/reference/pkg/diff/_index.md
@@ -91,11 +91,11 @@ VERSION:
   # Show changes using 'meld' commandline tool
   kpt pkg diff @master --diff-tool meld
 
---diff-opts:
+--diff-tool-opts:
   Commandline options to use with the diffing tool.
   Note that it overrides the KPT_EXTERNAL_DIFF_OPTS environment variable.
   # Show changes using "diff" with recurive options
-  kpt pkg diff @master --diff-tool meld --diff-opts "-r"
+  kpt pkg diff @master --diff-tool meld --diff-tool-opts "-r"
 ```
 
 #### Environment Variables


### PR DESCRIPTION
Fix for incorrect `kpt pkg diff` documentation that suggests using `--diff-opts`. This replaces that with the `--diff-tool-opts` flag instead.

Fixes: #1468