### PR TITLE
Fix doc link 404's

### DIFF
--- a/site/content/en/reference/live/init-alpha.md
+++ b/site/content/en/reference/live/init-alpha.md
@@ -16,8 +16,8 @@ inventory object functionality. The alpha version of this command is not
 available unless the `RESOURCE_GROUP_INVENTORY` environment variable is set.
 
 The init command will initialize a package using the next generation inventory
-object (**ResourceGroup** custom resource). See commands [`migrate`](./migrate) and
-[`install-resource-group`](./install-resource-group) for more information. A Kptfile
+object (**ResourceGroup** custom resource). See commands [`migrate`](../migrate) and
+[`install-resource-group`](../install-resource-group) for more information. A Kptfile
 is required in the package directory.
 
 The inventory object is required by other live commands


### PR DESCRIPTION
Fix for live alpha links 404ing causing `sitecheck` CI job to fail.

Should resolve CI errors seen in #1467