### PR TITLE
updating go-version to 1.15 across the board.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,10 +28,10 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.13
+    - name: Set up Go 1.15
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.15
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v1

--- a/.github/workflows/verifyGuides.yml
+++ b/.github/workflows/verifyGuides.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.15
       - uses: actions/checkout@v2
       - run: |
           make build


### PR DESCRIPTION
Looks like the go version on master branch is a little bit behind.  This is an update from 1.13 to 1.15.  Thank you @runewake2 for pointing this out.  

## Testing
this should be tested well enough by running the CI on the PR.