### PR TITLE
use starlark based generator function for e2e test

### DIFF
--- a/internal/pipeline/testdata/pkg-with-generator/configs/db/Kptfile
+++ b/internal/pipeline/testdata/pkg-with-generator/configs/db/Kptfile
@@ -4,7 +4,8 @@ metadata:
   name: db
 pipeline:
   mutators:
-  - image: gcr.io/sunilarora-sandbox/httpbin-fn:latest
+  - image: gcr.io/kpt-fn/starlark:unstable
+    configPath: starlark-httpbin.yaml
   - image: gcr.io/kpt-fn/set-namespace:unstable
     configMap:
       namespace: db

--- a/internal/pipeline/testdata/pkg-with-generator/configs/db/starlark-httpbin.yaml
+++ b/internal/pipeline/testdata/pkg-with-generator/configs/db/starlark-httpbin.yaml
@@ -1,0 +1,42 @@
+apiVersion: fn.kpt.dev/v1alpha1
+kind: StarlarkRun
+metadata:
+  name: httpbin-gen
+source: |
+  httpbin_deployment = {
+     "apiVersion": "apps/v1",
+     "kind": "Deployment",
+     "metadata": {
+        "name": "httpbin",
+     },
+     "spec": {
+        "replicas": 4,
+        "template": {
+           "spec": {
+              "containers": [
+                {
+                  "name": "httpbin",
+                  "image": "kennethreitz/httpbin",
+                  "ports": [
+                    {
+                       "containerPort": 9876
+                    }
+                  ]
+                }
+              ]
+           }
+        }
+    }
+  }
+  # filter to return if resource is HTTPBin resource
+  def is_httpbin(r):
+    return r["apiVersion"] == "apps/v1" and r["kind"] == "Deployment" and r["metadata"]["name"] == "httpbin"
+
+  def ensure_httpbin(resources):
+    for r in resources:
+      if is_httpbin(r):
+        return
+
+    resources.append(httpbin_deployment)
+
+  ensure_httpbin(ctx.resource_list["items"])


### PR DESCRIPTION
This PR modifies an e2e test `pkg-with-generator` for `fn render` to use starlark based function instead of `Go` function (implemented in PR https://github.com/GoogleContainerTools/kpt-functions-catalog/pull/182)

