### PR TITLE
Implement kpt fn doc command

### DIFF
--- a/commands/fncmd.go
+++ b/commands/fncmd.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/kustomize/cmd/config/configcobra"
 
 	"github.com/GoogleContainerTools/kpt/internal/cmdexport"
+	"github.com/GoogleContainerTools/kpt/internal/cmdfndoc"
 	"github.com/GoogleContainerTools/kpt/internal/docs/generated/fndocs"
 	"github.com/GoogleContainerTools/kpt/internal/pipeline"
 	"github.com/GoogleContainerTools/kpt/thirdparty/cmdconfig/commands"
@@ -50,6 +51,11 @@ func GetFnCommand(name string) *cobra.Command {
 
 	render := pipeline.NewCommand(name)
 
+	doc := cmdfndoc.NewCommand(name)
+	doc.Short = fndocs.DocShort
+	doc.Long = fndocs.DocShort + "\n" + fndocs.DocLong
+	doc.Example = fndocs.DocExamples
+
 	source := configcobra.Source(name)
 	source.Short = fndocs.SourceShort
 	source.Long = fndocs.SourceShort + "\n" + fndocs.SourceLong
@@ -60,6 +66,6 @@ func GetFnCommand(name string) *cobra.Command {
 	sink.Long = fndocs.SinkShort + "\n" + fndocs.SinkLong
 	sink.Example = fndocs.SinkExamples
 
-	functions.AddCommand(eval, render, source, sink, cmdexport.ExportCommand())
+	functions.AddCommand(eval, render, doc, source, sink, cmdexport.ExportCommand())
 	return functions
 }

--- a/internal/cmdfndoc/cmdfndoc.go
+++ b/internal/cmdfndoc/cmdfndoc.go
@@ -1,0 +1,73 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cmddesc contains the desc command
+package cmdfndoc
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/GoogleContainerTools/kpt/internal/docs/generated/fndocs"
+	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
+	"github.com/spf13/cobra"
+)
+
+func NewRunner(parent string) *Runner {
+	r := &Runner{}
+	c := &cobra.Command{
+		Use:     "doc [PKG_PATH] [flags]",
+		Args:    cobra.MaximumNArgs(1),
+		Short:   fndocs.DocShort,
+		Long:    fndocs.DocShort + "\n" + fndocs.DocLong,
+		Example: fndocs.DocExamples,
+		RunE:    r.runE,
+	}
+	r.Command = c
+	c.Flags().StringVar(&r.Image, "image", "", "kpt function image name")
+	cmdutil.FixDocs("kpt", parent, c)
+	return r
+}
+
+func NewCommand(parent string) *cobra.Command {
+	return NewRunner(parent).Command
+}
+
+type Runner struct {
+	Image   string
+	Command *cobra.Command
+}
+
+func (r *Runner) runE(c *cobra.Command, args []string) error {
+	var out, errout bytes.Buffer
+	dockerRunArgs := []string{
+		"run",
+		"--rm",                         // delete the container afterward
+		"-a", "STDOUT", "-a", "STDERR", // attach stdin, stdout, stderr
+		r.Image,
+		"--help",
+	}
+	cmd := exec.Command("docker", dockerRunArgs...)
+	cmd.Stdout = &out
+	cmd.Stderr = &errout
+	err := cmd.Run()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, errout.String())
+		return fmt.Errorf("please ensure the container has an entrypoint and it supports --help flag: %w", err)
+	}
+	fmt.Fprintln(os.Stdout, out.String())
+	return nil
+}

--- a/internal/cmdfndoc/cmdfndoc_test.go
+++ b/internal/cmdfndoc/cmdfndoc_test.go
@@ -1,0 +1,53 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdfndoc_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/GoogleContainerTools/kpt/internal/cmdfndoc"
+	"sigs.k8s.io/kustomize/kyaml/testutil"
+)
+
+// TestDesc_Execute tests happy path for Describe command.
+func TestFnDoc(t *testing.T) {
+	type testcase struct {
+		image     string
+		expectErr string
+	}
+	testcases := []testcase{
+		{
+			image: "gcr.io/kpt-fn/set-namespace:unstable",
+		},
+		{
+			image:     "gcr.io/kpt-fn/set-namespace:v0.1.0",
+			expectErr: "please ensure the container has an entrypoint and it supports --help flag",
+		},
+	}
+
+	for _, tc := range testcases {
+		b := &bytes.Buffer{}
+		runner := cmdfndoc.NewRunner("kpt")
+		runner.Image = tc.image
+		runner.Command.SetOut(b)
+		err := runner.Command.Execute()
+		if tc.expectErr == "" {
+			testutil.AssertNoError(t, err)
+		} else {
+			testutil.AssertErrorContains(t, err, tc.expectErr)
+		}
+	}
+}

--- a/internal/docs/generated/fndocs/docs.go
+++ b/internal/docs/generated/fndocs/docs.go
@@ -96,6 +96,18 @@ var RunExamples = `
   kpt fn run DIR/
 `
 
+var DocShort = `Locally execuate a function to get the help text`
+var DocLong = `
+  kpt fn doc --image=IMAGE
+
+If the function supports --help, it will print the help text to STDOUT.
+Otherwise, it will exit with non-zero exit code and print the error message to
+STDERR.
+`
+var DocExamples = `
+  kpt fn doc --image gcr.io/kpt-fn/set-namespace:unstable
+`
+
 var SinkShort = `Specify a directory as an output sink package`
 var SinkLong = `
   kpt fn sink [DIR]


### PR DESCRIPTION
`kpt fn doc --image=IMAGE` will return the help text.

fixes: https://github.com/GoogleContainerTools/kpt/issues/1516