### PR TITLE
Normalize shell block naming and styling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,20 +30,20 @@ Conduct].
 
 1. Clone the project
 
-   ```sh
+   ```shell
    git clone https://github.com/GoogleContainerTools/kpt
    cd kpt
    ```
 
 2. Build `kpt` to `$(go env GOPATH)/bin/kpt`
 
-   ```sh
+   ```shell
    make
    ```
 
 3. Run test
 
-   ```sh
+   ```shell
    make all
    ```
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ kpt is a toolkit to help you manage, manipulate, customize, and apply Kubernetes
 
 The version of kpt installed using `gcloud` may not be the latest released version.
 
-```Shell
+```shell
 gcloud components install kpt
 ```
 
 ### Install with Homebrew
 
-```Shell
+```shell
 brew tap GoogleContainerTools/kpt https://github.com/GoogleContainerTools/kpt.git
 brew install kpt
 ```
@@ -32,7 +32,7 @@ brew install kpt
 
 ### Install from source
 
-```sh
+```shell
 GO111MODULE=on go get -v github.com/GoogleContainerTools/kpt
 ```
 
@@ -40,7 +40,7 @@ GO111MODULE=on go get -v github.com/GoogleContainerTools/kpt
 
 [gcr.io/kpt-dev/kpt]
 
-```sh
+```shell
 docker run gcr.io/kpt-dev/kpt version
 ```
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,7 +11,7 @@ Helper scripts for kpt repository.
 
 From top-level kpt directory:
 
-```Shell
+```shell
 ./scripts/create-licenses.sh
 ```
 

--- a/site/concepts/packaging/README.md
+++ b/site/concepts/packaging/README.md
@@ -32,7 +32,7 @@ another `kpt` package.
 
 Here is an example directory structure of a `kpt` package with subpackages
 
-```sh
+```shell
 foo
 ├── Kptfile
 ├── bar # subpackage

--- a/site/guides/consumer/apply/README.md
+++ b/site/guides/consumer/apply/README.md
@@ -60,7 +60,7 @@ resources for deleted configuration.
 ### Command
 
 <!-- @fetchPackage @verifyGuides-->
-```sh
+```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
 kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.5.0 helloworld
 ```
@@ -69,7 +69,7 @@ Grab a remote package to apply to a cluster.
 
 ### Output
 
-```sh
+```shell
 fetching package /package-examples/helloworld-set from https://github.com/GoogleContainerTools/kpt to helloworld
 ```
 
@@ -90,13 +90,13 @@ The inventory template must be created for a package to be applied using
 ### Init Command
 
 <!-- @liveInit @verifyGuides-->
-```sh
+```shell
 kpt live init helloworld
 ```
 
 ### Init Output
 
-```sh
+```shell
 namespace: default is used for inventory object
 Initialized: helloworld/inventory-template.yaml
 ```
@@ -136,7 +136,7 @@ kind delete cluster && kind create cluster
 ### Apply Command
 
 <!-- @liveApply @verifyGuides-->
-```sh
+```shell
 kpt live apply helloworld --reconcile-timeout=2m
 ```
 
@@ -145,7 +145,7 @@ been fully rolled out -- e.g. until the Pods are running.
 
 ### Apply Output
 
-```sh
+```shell
 configmap/inventory-17c4dd3c created
 service/helloworld-gke created
 deployment.apps/helloworld-gke created
@@ -168,13 +168,13 @@ Display the resources in the cluster using kubectl.
 
 ### Print Command
 
-```sh
+```shell
 kubectl get configmaps,deploy,services
 ```
 
 ### Print Output
 
-```sh
+```shell
 NAME                                 DATA   AGE
 configmap/inventory-28c4kc3c         2      2m47s
 
@@ -198,7 +198,7 @@ kubectl get deployments | tr -s ' ' | grep "deployment.apps/helloworld-gke 5/5"
 
 ### Command: `tree`
 
-```sh
+```shell
 kubectl get all -o yaml | kpt pkg tree
 ```
 
@@ -207,7 +207,7 @@ the resources.
 
 ### Output: `tree`
 
-```sh
+```shell
 .
 ├── [Resource]  Deployment default/helloworld-gke
 │   └── [Resource]  ReplicaSet default/helloworld-gke-5bf95f8869
@@ -227,7 +227,7 @@ resource configuration.
 
 ### Prune Command
 
-```sh
+```shell
 rm helloworld/deploy.yaml
 kpt live apply helloworld/ --reconcile-timeout=2m
 ```
@@ -238,7 +238,7 @@ Deployment.
 
 ### Prune Output
 
-```sh
+```shell
 service/helloworld-gke is Current: Service is ready
 resources failed to the reached Current status
 deployment.apps/helloworld-gke pruned
@@ -248,11 +248,11 @@ configmap/inventory-2911da3b pruned
 
 ### Print the live resources after pruning
 
-```sh
+```shell
 kubectl get deploy
 ```
 
-```sh
+```shell
 No resources found in default namespace.
 ```
 

--- a/site/guides/consumer/function/README.md
+++ b/site/guides/consumer/function/README.md
@@ -72,7 +72,7 @@ label to all Namespace resources provided to it.
 
 Run the function:
 
-```sh
+```shell
 kpt fn run . --image gcr.io/kpt-functions/label-namespace -- label_name=color label_value=orange
 ```
 
@@ -85,7 +85,7 @@ and sink will default to STDOUT.
 
 **Example:** This is equivalent to the preceding example
 
-```sh
+```shell
 kpt fn source . |
   kpt fn run --image gcr.io/kpt-functions/label-namespace -- label_name=color label_value=orange |
   kpt fn sink .
@@ -139,7 +139,7 @@ like a list of strings.
 
 Run the function:
 
-```sh
+```shell
 kpt fn run .
 ```
 

--- a/site/guides/consumer/function/export/circleci/README.md
+++ b/site/guides/consumer/function/export/circleci/README.md
@@ -21,7 +21,7 @@ Before diving into the following tutorial, you need to create a public repo on G
 
 On your local machine, create an empty directory:
 
-```shell script
+```shell
 mkdir function-export-example
 cd function-export-example
 ```
@@ -32,7 +32,7 @@ All commands must be run at the root of this directory.
 
 Use `kpt pkg get` to fetch source files of this tutorial:
 
-```shell script
+```shell
 # Init git
 git init
 git remote add origin https://github.com/<USER>/<REPO>.git
@@ -50,7 +50,7 @@ Then you will get an `example-package` directory:
 
 ## Exporting a pipeline
 
-```shell script
+```shell
 kpt fn export example-package --workflow circleci --output config.yml
 ```
 
@@ -132,7 +132,7 @@ Once all changes are pushed into GitHub, you can do the following steps to setti
 
 ## Viewing the result on CircleCI
 
-```shell script
+```shell
 git add .
 git commit -am 'Init pipeline'
 git push --set-upstream origin master

--- a/site/guides/consumer/function/export/cloud-build/README.md
+++ b/site/guides/consumer/function/export/cloud-build/README.md
@@ -19,7 +19,7 @@ A kpt version `v0.32.0` or higher is required.
 
 On your local machine, create an empty directory:
 
-```shell script
+```shell
 mkdir function-export-example
 cd function-export-example
 ```
@@ -30,7 +30,7 @@ All commands must be run at the root of this directory.
 
 Use `kpt pkg get` to fetch source files of this tutorial:
 
-```shell script
+```shell
 # Fetch source files
 kpt pkg get https://github.com/GoogleContainerTools/kpt/package-examples/function-export example-package
 ```
@@ -45,7 +45,7 @@ Then you will get an `example-package` directory:
 
 ## Exporting a pipeline
 
-```shell script
+```shell
 kpt fn export example-package --workflow cloud-build --output cloudbuild.yaml
 ```
 

--- a/site/guides/consumer/function/export/github-actions/README.md
+++ b/site/guides/consumer/function/export/github-actions/README.md
@@ -21,7 +21,7 @@ Before diving into the following tutorial, you need to create a public repo on G
 
 On your local machine, create an empty directory:
 
-```shell script
+```shell
 mkdir function-export-example
 cd function-export-example
 ```
@@ -32,7 +32,7 @@ All commands must be run at the root of this directory.
 
 Use `kpt pkg get` to fetch source files of this tutorial:
 
-```shell script
+```shell
 # Init git
 git init
 git remote add origin https://github.com/<USER>/<REPO>.git
@@ -50,7 +50,7 @@ Then you will get an `example-package` directory:
 
 ## Exporting a workflow
 
-```shell script
+```shell
 kpt fn export example-package --workflow github-actions --output main.yaml
 ```
 
@@ -109,7 +109,7 @@ jobs:
 
 ## Viewing the result on GitHub Actions
 
-```shell script
+```shell
 git add .
 git commit -am 'Init pipeline'
 git push --set-upstream origin master

--- a/site/guides/consumer/function/export/gitlab-ci/README.md
+++ b/site/guides/consumer/function/export/gitlab-ci/README.md
@@ -21,7 +21,7 @@ Before diving into the following tutorial, you need to create a public repo on G
 
 On your local machine, create an empty directory:
 
-```shell script
+```shell
 mkdir function-export-example
 cd function-export-example
 ```
@@ -32,7 +32,7 @@ All commands must be run at the root of this directory.
 
 Use `kpt pkg get` to fetch source files of this tutorial:
 
-```shell script
+```shell
 # Init git
 git init
 git remote add origin https://github.com/<USER>/<REPO>.git
@@ -50,7 +50,7 @@ Then you will get an `example-package` directory:
 
 ## Exporting a pipeline
 
-```shell script
+```shell
 kpt fn export example-package --workflow gitlab-ci --output .gitlab-ci.yml
 ```
 
@@ -94,7 +94,7 @@ kpt:
 
 ## Viewing the result on GitLab
 
-```shell script
+```shell
 git add .
 git commit -am 'Init pipeline'
 git push --set-upstream origin master

--- a/site/guides/consumer/function/export/jenkins/README.md
+++ b/site/guides/consumer/function/export/jenkins/README.md
@@ -22,7 +22,7 @@ Before diving into the following tutorial, you need to create a public repo on G
 
 On your local machine, create an empty directory:
 
-```shell script
+```shell
 mkdir function-export-example
 cd function-export-example
 ```
@@ -33,7 +33,7 @@ All commands must be run at the root of this directory.
 
 Use `kpt pkg get` to fetch source files of this tutorial:
 
-```shell script
+```shell
 # Init git
 git init
 git remote add origin https://github.com/<USER>/<REPO>.git
@@ -59,14 +59,14 @@ The exported pipeline leverages docker to run the kpt container, so you also nee
 
 1. Install docker using the convenience script.
 
-    ```shell script
+    ```shell
     curl -fsSL https://get.docker.com -o get-docker.sh
     sudo sh get-docker.sh
     ```
 
 1. Add the `jenkins` user to the `docker` group so that docker commands can be run in Jenkins pipelines.
 
-    ```shell script
+    ```shell
     sudo usermod -aG docker jenkins
     ```
 
@@ -82,7 +82,7 @@ The exported pipeline leverages docker to run the kpt container, so you also nee
 
 ## Exporting a pipeline
 
-```shell script
+```shell
 kpt fn export example-package --workflow jenkins --output Jenkinsfile
 ```
 
@@ -146,7 +146,7 @@ pipeline {
 
 ## Viewing the result on Jenkins
 
-```shell script
+```shell
 git add .
 git commit -am 'Init pipeline'
 git push --set-upstream origin master

--- a/site/guides/consumer/function/export/jenkins/creating_a_jenkins_instance_on_gcp.md
+++ b/site/guides/consumer/function/export/jenkins/creating_a_jenkins_instance_on_gcp.md
@@ -23,14 +23,14 @@ type: docs
 
     1. Install JDK first.
 
-        ```shell script
+        ```shell
         sudo apt update
         sudo apt install openjdk-8-jdk
         ```
 
     1. Then install Jenkins.
 
-        ```shell script
+        ```shell
         wget -q -O - https://pkg.jenkins.io/debian-stable/jenkins.io.key | sudo apt-key add -
         sudo sh -c 'echo deb https://pkg.jenkins.io/debian-stable binary/ > \
             /etc/apt/sources.list.d/jenkins.list'

--- a/site/guides/consumer/function/export/tekton/README.md
+++ b/site/guides/consumer/function/export/tekton/README.md
@@ -21,7 +21,7 @@ Before diving into the following tutorial, you need to create a public repo on G
 
 On your local machine, create an empty directory:
 
-```shell script
+```shell
 mkdir function-export-example
 cd function-export-example
 ```
@@ -32,7 +32,7 @@ All commands must be run at the root of this directory.
 
 Use `kpt pkg get` to fetch source files of this tutorial:
 
-```shell script
+```shell
 # Init git
 git init
 git remote add origin https://github.com/<USER>/<REPO>.git
@@ -55,19 +55,19 @@ Follow the instructions in the [Getting Started] guide of Tekton.
 1. Check the [prerequisites].
 1. [Create a Kubernetes cluster] of version 1.15 or higher on Google Cloud.
 
-    ```shell script
+    ```shell
     gcloud container clusters create tekton-cluster --cluster-version=1.15
     ```
 
 1. Install Tekton to the cluster.
 
-    ```shell script
+    ```shell
     kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
     ```
 
 1. Verify every component listed in the following command has the status `Running`.
 
-    ```shell script
+    ```shell
     kubectl get pods --namespace tekton-pipelines
     ```
 
@@ -75,14 +75,14 @@ To make the exported pipeline fully functional, you probably need to do the foll
 
 1. Install [Git Tasks] from Tekton Catalog.
 
-    ```shell script
+    ```shell
     kpt pkg get https://github.com/tektoncd/catalog/git@v1beta1 git
     kubectl apply -f git/git-clone.yaml
     ```
 
 1. Provide a Persistent Volume for storage purposes.
 
-    ```shell script
+    ```shell
     cat <<EOF | kubectl apply -f -
     kind: PersistentVolumeClaim
     apiVersion: v1
@@ -99,7 +99,7 @@ To make the exported pipeline fully functional, you probably need to do the foll
 
 ## Exporting a pipeline
 
-```shell script
+```shell
 kpt fn export example-package --workflow tekton --output pipeline.yaml
 ```
 
@@ -220,7 +220,7 @@ spec:
 
 ## Run the pipeline via Tekton CLI
 
-```shell script
+```shell
 git add .
 git commit -am 'Init pipeline'
 git push --set-upstream origin master
@@ -228,7 +228,7 @@ git push --set-upstream origin master
 
 Once local changes are committed and pushed. Start the pipeline:
 
-```shell script
+```shell
 kubectl apply -f pipeline.yaml
 tkn pipeline start run-kpt-functions
 ```
@@ -239,7 +239,7 @@ In the prompt, enter `shared-workspace` as workspace name, leave `Value of the S
 
 To view the output, run
 
-```shell script
+```shell
 tkn pipeline logs
 ```
 

--- a/site/guides/consumer/get/README.md
+++ b/site/guides/consumer/get/README.md
@@ -59,13 +59,13 @@ as a public package catalogue.
 ### Fetch Command
 
 <!-- @fetchPackage @verifyGuides-->
-```sh
+```shell
 kpt pkg get https://github.com/kubernetes/examples/staging/cockroachdb cockroachdb
 ```
 
 ### Fetch Output
 
-```sh
+```shell
 fetching package staging/cockroachdb from https://github.com/kubernetes/examples to cockroachdb
 ```
 
@@ -105,7 +105,7 @@ The upstream commit and branch / tag reference are stored in the package's
 [Kptfile].  These are used by `kpt pkg update`.
 
 <!-- @catPackage @verifyGuides-->
-```sh
+```shell
 cat cockroachdb/Kptfile
 ```
 
@@ -146,13 +146,13 @@ artifacts such as documentation.
 ### Package Contents Command
 
 <!-- @treePackage @verifyGuides-->
-```sh
+```shell
 kpt pkg tree cockroachdb/
 ```
 
 ### Package Contents Output
 
-```sh
+```shell
 cockroachdb
 ├── [cockroachdb-statefulset.yaml]  Service cockroachdb
 ├── [cockroachdb-statefulset.yaml]  StatefulSet cockroachdb
@@ -173,7 +173,7 @@ upstream rather than replacing it.
 
 ### Command
 
-```sh
+```shell
 head cockroachdb/cockroachdb-statefulset.yaml
 ```
 
@@ -214,13 +214,13 @@ kind delete cluster && kind create cluster
 {{% /hide %}}
 
 <!-- @applyPackage @verifyGuides-->
-```sh
+```shell
 kubectl apply -R -f cockroachdb
 ```
 
 ### Apply Output
 
-```sh
+```shell
 service/cockroachdb-public created
 service/cockroachdb created
 poddisruptionbudget.policy/cockroachdb-budget unchanged
@@ -262,13 +262,13 @@ tools such as `kubectl get`.
 
 ### Applied Package Command
 
-```sh
+```shell
 kubectl get all
 ```
 
 ### Applied Package Output
 
-```sh
+```shell
 NAME                READY   STATUS    RESTARTS   AGE
 pod/cockroachdb-0   1/1     Running   0          54s
 pod/cockroachdb-1   1/1     Running   0          41s

--- a/site/guides/consumer/update/README.md
+++ b/site/guides/consumer/update/README.md
@@ -78,7 +78,7 @@ updated to later versions by merging in upstream changes.
 ### Initialize local Repository
 
 <!-- @InitRepo @verifyStaleGuides-->
-```sh
+```shell
 mkdir workspace
 cd workspace
 git init
@@ -87,7 +87,7 @@ git init
 ### Fetch Command
 
 <!-- @fetchPackage @verifyStaleGuides-->
-```sh
+```shell
 export REPO=https://github.com/GoogleContainerTools/kpt.git
 kpt pkg get $REPO/package-examples/helloworld-set@v0.3.0 helloworld
 ```
@@ -96,7 +96,7 @@ Fetch the `helloworld-set` package at version `v0.3.0`.
 
 ### Fetch Output
 
-```sh
+```shell
 fetching package /package-examples/helloworld-set from https://github.com/GoogleContainerTools/kpt to helloworld
 ```
 
@@ -113,7 +113,7 @@ resolved to the tag `v0.3.0`.
 ### Commit Local Repository 1st Version
 
 <!-- @commitLocalRepository @verifyStaleGuides-->
-```sh
+```shell
 git add .
 git commit -m "init"
 ```
@@ -137,7 +137,7 @@ Edit the contents of the package by making changes to it.
 
 The old package contents without local modifications.
 
-```sh
+```shell
 vi helloworld/deploy.yaml
 ```
 
@@ -182,7 +182,7 @@ has uncommitted changes.
 {{% /pageinfo %}}
 
 <!-- @commitLocalChanges @verifyStaleGuides-->
-```sh
+```shell
 git add .
 git commit -m "local package edits"
 ```
@@ -195,7 +195,7 @@ specified version and applying the upstream changes to the local package.
 ### Merge Command
 
 <!-- @mergeUpdates @verifyStaleGuides-->
-```sh
+```shell
 kpt pkg update helloworld@v0.5.0 --strategy=resource-merge
 ```
 
@@ -205,13 +205,13 @@ package, 3) the new upstream reference.
 
 ### Merge Output
 
-```sh
+```shell
 updating package helloworld to v0.5.0
 ```
 
 ### Merge Changes
 
-```sh
+```shell
 --- a/helloworld/deploy.yaml
 +++ b/helloworld/deploy.yaml
 @@ -31,7 +31,7 @@ spec:
@@ -233,7 +233,7 @@ index 0853ee1..c938fde 100644
 
 The Deployment was updated with a new image tag.
 
-```sh
+```shell
 --- a/helloworld/service.yaml
 +++ b/helloworld/service.yaml
 @@ -22,7 +22,7 @@ metadata:
@@ -249,7 +249,7 @@ The Deployment was updated with a new image tag.
 
 The Service was updated with a new `type`.
 
-```sh
+```shell
 --- a/helloworld/Kptfile
 +++ b/helloworld/Kptfile
 @@ -5,10 +5,10 @@ metadata:

--- a/site/guides/ecosystem/helm/README.md
+++ b/site/guides/ecosystem/helm/README.md
@@ -23,7 +23,7 @@ customized directly.
 
 ##### Command
 
-```sh
+```shell
 helm fetch stable/mysql
 ```
 
@@ -34,7 +34,7 @@ git so it can be expanded again in the future.
 
 ##### Command
 
-```sh
+```shell
 helm template mysql-1.3.1.tgz --output-dir .
 ```
 
@@ -43,7 +43,7 @@ provided on the commandline or through a `value.yaml`
 
 ##### Output
 
-```sh
+```shell
 wrote ./mysql/templates/secrets.yaml
 wrote ./mysql/templates/tests/test-configmap.yaml
 wrote ./mysql/templates/pvc.yaml
@@ -54,7 +54,7 @@ wrote ./mysql/templates/deployment.yaml
 
 ##### Command
 
-```sh
+```shell
 tree mysql/
 ```
 
@@ -77,7 +77,7 @@ mysql
 The expanded chart will function as a kpt package once checked into a git
 repository.  It may optionally be tagged with a package version.
 
-```sh
+```shell
 git add .
 git commit -m “add mysql package”
 git tag package-examples/mysql/mysql/templates/v0.1.0
@@ -86,7 +86,7 @@ git push package-examples/mysql/mysql/templates/v0.1.0
 
 Once stored in git, kpt can be used to fetch the package and customize it directly.
 
-```sh
+```shell
 export REPO=https://github.com/GoogleContainerTools/kpt.git
 kpt pkg get $REPO/package-examples/mysql/mysql/templates@v0.16.0 mysql/
 ```

--- a/site/guides/producer/bootstrap/README.md
+++ b/site/guides/producer/bootstrap/README.md
@@ -12,7 +12,7 @@ description: >
 Fetch another package and use it as your starting point (e.g.
 [kubernetes-examples](https://github.com/kubernetes/examples))
 
-```sh
+```shell
 kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/helloworld-set@v0.3.0 helloworld
 ```
 
@@ -21,7 +21,7 @@ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/hel
 Generate configuration from commandline tools (e.g.
 [kubectl](https://kubectl.docs.kubernetes.io/pages/imperative_porcelain/creating_resources.html))
 
-```sh
+```shell
 kubectl create deployment nginx --image nginx -o yaml --dry-run > deploy.yaml
 ```
 
@@ -30,7 +30,7 @@ kubectl create deployment nginx --image nginx -o yaml --dry-run > deploy.yaml
 Some examples may be published as blog posts without being published
 as a package in git.  These can be copied directly from their source.
 
-```sh
+```shell
 curl https://raw.githubusercontent.com/kubernetes/website/master/content/en/examples/controllers/nginx-deployment.yaml --output nginx/nginx-deployment.yaml
 ```
 
@@ -38,7 +38,7 @@ curl https://raw.githubusercontent.com/kubernetes/website/master/content/en/exam
 
 Generate configuration from templates (e.g. [helm](https://helm.sh/))
 
-```sh
+```shell
 helm fetch stable/mysql
 helm template mysql-1.3.1.tgz --output-dir .
 ```
@@ -48,6 +48,6 @@ helm template mysql-1.3.1.tgz --output-dir .
 Generate configuration from application source code
 (e.g. [dekorate](https://github.com/dekorateio/dekorate))
 
-```sh
+```shell
 mvn clean package
 ```

--- a/site/guides/producer/functions/container/README.md
+++ b/site/guides/producer/functions/container/README.md
@@ -33,7 +33,7 @@ STDIN a ResourceList created from the contents of the package directory, and
 finally read from it's STDOUT a ResourceList used to write resource back to
 the package directory.
 
-```sh
+```shell
 kpt fn run DIR/ --image gcr.io/a/b:v1
 ```
 

--- a/site/guides/producer/functions/exec/README.md
+++ b/site/guides/producer/functions/exec/README.md
@@ -30,7 +30,7 @@ executable into a container and invoking it as the container's `CMD` or
 Exec functions may be run imperatively using the `--exec-path` flag with
 `kpt fn run`.
 
-```sh
+```shell
 kpt fn run DIR/ --enable-exec --exec-path /path/to/executable
 ```
 
@@ -38,14 +38,14 @@ This is similar to building `/path/to/executable` into the container image
 `gcr.io/project/image:tag` and running -- except that the executable has access
 to the local machine.
 
-```sh
+```shell
 kpt fn run DIR/ --image gcr.io/project/image:tag
 ```
 
 Just like container functions, exec functions accept input as arguments after
 `--`.
 
-```sh
+```shell
 kpt fn run DIR/ --enable-exec --exec-path /path/to/executable -- foo=bar
 ```
 

--- a/site/guides/producer/functions/golang/README.md
+++ b/site/guides/producer/functions/golang/README.md
@@ -22,7 +22,7 @@ kyaml libraries' reference below.
 
 ### Create the go module
 
-```sh
+```shell
 go mod init github.com/user/repo
 go get sigs.k8s.io/kustomize/kyaml
 ```
@@ -67,13 +67,13 @@ func main() {
 
 Build the go binary:
 
-```sh
+```shell
 go build -o my-fn .
 ```
 
 Test it by running imperatively as an executable function:
 
-```sh
+```shell
 # run the my-fn function against the configuration in PACKAGE_DIR/
 kpt fn run PACKAGE_DIR/ --enable-exec --exec-path ./my-fn -- value=foo
 ```
@@ -94,7 +94,7 @@ data:
   value: foo
 ```
 
-```sh
+```shell
 kpt fn run PACKAGE_DIR/ --enable-exec
 ```
 
@@ -102,12 +102,12 @@ kpt fn run PACKAGE_DIR/ --enable-exec
 
 Build the function into a container image:
 
-```sh
+```shell
 # optional: generate a Dockerfile to contain the function
 go run ./main.go gen ./
 ```
 
-```sh
+```shell
 # build the function into an image
 docker build . -t gcr.io/project/fn-name:tag
 # optional: push the image to a container registry
@@ -116,7 +116,7 @@ docker push gcr.io/project/fn-name:tag
 
 Run the function imperatively as a container function:
 
-```sh
+```shell
 kpt fn run PACKAGE_DIR/ --image gcr.io/project/fn-name:tag -- value=foo
 ```
 
@@ -136,7 +136,7 @@ data:
   value: foo
 ```
 
-```sh
+```shell
 kpt fn run PACKAGE_DIR/
 ```
 

--- a/site/guides/producer/functions/starlark/README.md
+++ b/site/guides/producer/functions/starlark/README.md
@@ -37,7 +37,7 @@ run(ctx.resource_list["items"], an)
 
 Run the Starlark function with:
 
-```sh
+```shell
 # run c.star as a function, generating a ConfigMap with value=bar as the
 # functionConfig
 kpt fn run . --enable-star --star-path c.star -- value=bar
@@ -84,7 +84,7 @@ run(ctx.resource_list["items"], an)
 
 Run them on the directory containing `example.yaml` using:
 
-```shell script
+```shell
 kpt fn run DIR/ --enable-star
 ```
 
@@ -97,7 +97,7 @@ It is possible to debug Starlark functions using `print`
 print(ctx.resource_list["items"][0]["metadata"]["name"])
 ```
 
-```sh
+```shell
 kpt fn run . --enable-star --star-path c.star
 ```
 
@@ -114,7 +114,7 @@ their types.
 print(ctx.open_api["definitions"]["io.k8s.api.apps.v1.Deployment"]["description"])
 ```
 
-```sh
+```shell
 kpt fn run . --enable-star --star-path c.star
 ```
 

--- a/site/guides/producer/functions/ts/develop/README.md
+++ b/site/guides/producer/functions/ts/develop/README.md
@@ -42,7 +42,7 @@ running in a local container.
 1. Download the [kind binary][download-kind] version 0.5.1 or higher
 1. Use this config file:
 
-   ```sh
+   ```shell
    cat > kind.yaml <<EOF
    kind: Cluster
    apiVersion: kind.sigs.k8s.io/v1alpha3
@@ -64,7 +64,7 @@ running in a local container.
 
 1. Create the cluster:
 
-   ```sh
+   ```shell
    kind create cluster --name=kpt-functions --config=kind.yaml --image=kindest/node:v1.15.7
    ```
 
@@ -73,7 +73,7 @@ running in a local container.
 You can also use a deployed cluster in GKE. The beta k8s feature is available
 only when using GKE's `--enable-kubernetes-alpha` flag, as seen here:
 
-```sh
+```shell
 gcloud container clusters create $USER-1-15 --cluster-version=latest --region=us-central1-a --project <PROJECT>
 gcloud container clusters get-credentials $USER-1-15 --zone us-central1-a --project <PROJECT>
 ```
@@ -84,7 +84,7 @@ The SDK uses the k8s server to generate the typescript classes. If your
 function uses a Custom Resource Definition, make sure you apply it to the
 cluster used for type generation:
 
-```sh
+```shell
 kubectl apply -f /path/to/my/crd.yaml
 ```
 
@@ -92,7 +92,7 @@ kubectl apply -f /path/to/my/crd.yaml
 
 To initialize a new NPM package, first create a package directory:
 
-```sh
+```shell
 mkdir my-package
 cd my-package
 ```
@@ -101,7 +101,7 @@ cd my-package
 
 Run the interactive initializer:
 
-```sh
+```shell
 npm init kpt-functions
 ```
 
@@ -124,7 +124,7 @@ This process will create the following:
 
 Next, install all package dependencies:
 
-```sh
+```shell
 npm install
 ```
 
@@ -133,7 +133,7 @@ directory.
 
 You can run your function directly:
 
-```sh
+```shell
 node dist/my_func_run.js --help
 ```
 
@@ -145,7 +145,7 @@ this.
 You can now start implementing the function using your favorite IDE, e.g.
 [VSCode]:
 
-```sh
+```shell
 code .
 ```
 
@@ -156,20 +156,20 @@ to use the typescript library.
 
 Once you've written some code, build the package with:
 
-```sh
+```shell
 npm run build
 ```
 
 Alternatively, run the following in a separate terminal. It will continuously
 build your function as you make changes:
 
-```sh
+```shell
 npm run watch
 ```
 
 To run the tests, use:
 
-```sh
+```shell
 npm test
 ```
 
@@ -187,14 +187,14 @@ runtime.
 
 - Install the pkg CLI.
 
-  ```sh
+  ```shell
   npm install -g pkg
   ```
 
 - Install your kpt-functions package module to create your function's
   distributable file.
 
-  ```sh
+  ```shell
   npm i
   ```
 
@@ -204,14 +204,14 @@ runtime.
    file. For a `my_fn` function built using the typescript SDK, this is
    `dist/my_fn_run.js`.
 
-   ```sh
+   ```shell
    npx pkg dist/my_fn_run.js
    ```
 
 1. Pass the path to the appropriate executable for your OS when running kpt
    using the exec runtime.
 
-   ```sh
+   ```shell
    kpt fn run DIR/ --enable-exec --exec-path /path/to/my_fn_run-macos -- a=b
    ```
 
@@ -222,19 +222,19 @@ executable container image.
 
 To build the docker image:
 
-```sh
+```shell
 npm run kpt:docker-build
 ```
 
 You can now run the function container, e.g.:
 
-```sh
+```shell
 docker run gcr.io/kpt-functions-demo/my-func:dev --help
 ```
 
 To push the image to your container registry of choice:
 
-```sh
+```shell
 npm run kpt:docker-push
 ```
 
@@ -247,7 +247,7 @@ field at any time.
 The default value for the container image tag is `dev`. This can be overridden
 using`--tag` flag:
 
-```sh
+```shell
 npm run kpt:docker-build -- --tag=latest
 npm run kpt:docker-push -- --tag=latest
 ```

--- a/site/guides/producer/functions/ts/quickstart/README.md
+++ b/site/guides/producer/functions/ts/quickstart/README.md
@@ -30,26 +30,26 @@ Currently supported platforms: amd64 Linux/Mac
 
 1. Get the `demo-functions` package:
 
-   ```sh
+   ```shell
    git clone --depth 1 https://github.com/GoogleContainerTools/kpt-functions-sdk.git
    ```
 
    All subsequent commands are run from the `demo-functions` directory:
 
-   ```sh
+   ```shell
    cd kpt-functions-sdk/ts/demo-functions
    ```
 
 1. Install all dependencies:
 
-   ```sh
+   ```shell
    npm install
    ```
 
 1. Run the following in a separate terminal to continuously build your
    function as you make changes:
 
-   ```sh
+   ```shell
    npm run watch
    ```
 
@@ -74,7 +74,7 @@ Currently supported platforms: amd64 Linux/Mac
 
 1. Run the `label_namespace` function on the `example-configs` directory:
 
-   ```sh
+   ```shell
    export CONFIGS=../../example-configs
 
    kpt fn source $CONFIGS |
@@ -85,7 +85,7 @@ Currently supported platforms: amd64 Linux/Mac
    As the name suggests, this function added the given label to all
    `Namespace` objects in the `example-configs` directory:
 
-   ```sh
+   ```shell
    git diff $CONFIGS
    ```
 
@@ -124,7 +124,7 @@ Currently supported platforms: amd64 Linux/Mac
 
 1. Run `validate-rolebinding` on `example-configs`.
 
-   ```sh
+   ```shell
    kpt fn source $CONFIGS |
      node dist/validate_rolebinding_run.js -d subject_name=alice@foo-corp.com |
      kpt fn sink $CONFIGS
@@ -196,7 +196,7 @@ Currently supported platforms: amd64 Linux/Mac
 
 1. Run `expand-team-cr` on `example-configs`.
 
-   ```sh
+   ```shell
    kpt fn source $CONFIGS |
      node dist/expand_team_cr_run.js |
      kpt fn sink $CONFIGS

--- a/site/guides/producer/init/README.md
+++ b/site/guides/producer/init/README.md
@@ -52,7 +52,7 @@ be individually versioned (as version v1.0.2) by creating the tag `example/v1.0.
 ## Create a git repo
 
 <!-- @defineEnvVars @verifyStaleGuides-->
-```sh
+```shell
 REPO_NAME=my-repo
 REPO_URL="<url>"
 ```
@@ -66,7 +66,7 @@ REPO_URL=file://$(pwd)/$REPO_NAME.git
 {{% /hide %}}
 
 <!-- @setupRepo @verifyStaleGuides-->
-```sh
+```shell
 mkdir $REPO_NAME # or clone with git `git clone`
 git init $REPO_NAME # only if new repo
 ```
@@ -74,35 +74,35 @@ git init $REPO_NAME # only if new repo
 ## Create the package
 
 <!-- @createPackage @verifyStaleGuides-->
-```sh
+```shell
 mkdir $REPO_NAME/nginx
 ```
 
 Recommended: initialize the package with metadata
 
 <!-- @initPackage @verifyStaleGuides-->
-```sh
+```shell
 kpt pkg init $REPO_NAME/nginx --tag kpt.dev/app=nginx --description "kpt nginx package"
 ```
 
 ## Create configuration
 
 <!-- @addConfig @verifyStaleGuides-->
-```sh
+```shell
 curl https://raw.githubusercontent.com/kubernetes/website/master/content/en/examples/controllers/nginx-deployment.yaml --output $REPO_NAME/nginx/nginx-deployment.yaml
 ```
 
 ## Publish package to git
 
 <!-- @commitRepo @verifyStaleGuides-->
-```sh
+```shell
 (cd $REPO_NAME && git add . && git commit -m "Add nginx package")
 ```
 
 Recommended: tag the commit as a release
 
 <!-- @createTag @verifyStaleGuides-->
-```sh
+```shell
 # tag as DIR/VERSION for per-directory versioning
 (cd $REPO_NAME && git tag nginx/v0.1.0)
 # git push nginx/v0.1.0 # requires an upstream repo
@@ -111,7 +111,7 @@ Recommended: tag the commit as a release
 ## Fetch the released package
 
 <!-- @fetchPackage @verifyStaleGuides-->
-```sh
+```shell
 kpt pkg get $REPO_URL/nginx@v0.1.0 nginx
 ```
 

--- a/site/guides/producer/packages/README.md
+++ b/site/guides/producer/packages/README.md
@@ -39,7 +39,7 @@ can pull in changes to a package after fetching it.
 
 ![img](/static/images/package.svg)
 
-```sh
+```shell
 # Optional: copy the mysql-kustomize package to follow along
 kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/mysql-kustomize mysql
 ```
@@ -73,7 +73,7 @@ remote package, then you can't push changes.
 
 Example package structure:
 
-```sh
+```shell
 $ tree mysql/
 mysql/
 ├── Kptfile

--- a/site/index.html
+++ b/site/index.html
@@ -86,6 +86,7 @@
     <script src="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/js/docsify-themeable.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/docsify-corner/dist/docsify-corner.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/docsify/lib/plugins/search.min.js"></script>
+    <script src="//cdn.jsdelivr.net/npm/prismjs@1.22/components/prism-bash.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/prismjs@1.22/components/prism-yaml.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/prismjs@1.22/components/prism-go.min.js"></script>
     <script src="//cdn.jsdelivr.net/npm/prismjs@1.22/components/prism-typescript.min.js"></script>

--- a/site/installation/binaries/README.md
+++ b/site/installation/binaries/README.md
@@ -15,7 +15,7 @@ Download pre-compiled binaries.
 | [macOS (x64)][darwin]
 | [Windows (x64)][windows]
 
-```sh
+```shell
 # For linux/mac
 chmod +x kpt
 ```
@@ -23,7 +23,7 @@ chmod +x kpt
 **Note:** to run on **MacOS** the first time, it may be necessary to open the
 program from the finder with *ctrl-click open*.
 
-```sh
+```shell
 kpt version
 ```
 

--- a/site/installation/docker/README.md
+++ b/site/installation/docker/README.md
@@ -11,7 +11,7 @@ Use the docker image.
 
 [gcr.io/kpt-dev/kpt]
 
-```sh
+```shell
 docker run gcr.io/kpt-dev/kpt version
 ```
 

--- a/site/installation/gcloud/README.md
+++ b/site/installation/gcloud/README.md
@@ -9,11 +9,11 @@ description: >
 
 Install with gcloud.
 
-```sh
+```shell
 gcloud components install kpt
 ```
 
-```sh
+```shell
 kpt version
 ```
 

--- a/site/installation/homebrew/README.md
+++ b/site/installation/homebrew/README.md
@@ -9,11 +9,11 @@ description: >
 
 Install the latest release with Homebrew on MacOS
 
-```sh
+```shell
 brew tap GoogleContainerTools/kpt https://github.com/GoogleContainerTools/kpt.git
 brew install kpt
 ```
 
-```sh
+```shell
 kpt version
 ```

--- a/site/installation/source/README.md
+++ b/site/installation/source/README.md
@@ -9,13 +9,13 @@ description: >
 
 Install by compiling the source.
 
-```sh
+```shell
 GO111MODULE=on go get -v github.com/GoogleContainerTools/kpt
 ```
 
 **Note:** `kpt version` will return *unknown* for binaries installed
 with `go get`.
 
-```sh
+```shell
 kpt help
 ```

--- a/site/reference/README.md
+++ b/site/reference/README.md
@@ -36,14 +36,14 @@ The following are examples of running each kpt command group.
 
 <!--mdtogo:Examples-->
 
-```sh
+```shell
 # get a package
 $ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/helloworld-set@v0.5.0 helloworld
 fetching package /package-examples/helloworld-set from \
   https://github.com/GoogleContainerTools/kpt to helloworld
 ```
 
-```sh
+```shell
 # list setters and set a value
 $ kpt cfg list-setters helloworld
 NAME            DESCRIPTION         VALUE    TYPE     COUNT   SETBY
@@ -55,14 +55,14 @@ $ kpt cfg set helloworld replicas 3 --set-by pwittrock  --description 'reason'
 set 1 fields
 ```
 
-```sh
+```shell
 # get a package and run a validation function
 kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-sdk.git/example-configs example-configs
 mkdir results/
 kpt fn run example-configs/ --results-dir results/ --image gcr.io/kpt-functions/validate-rolebinding:results -- subject_name=bob@foo-corp.com
 ```
 
-```sh
+```shell
 # apply the package to a cluster
 $ kpt live apply --reconcile-timeout=10m helloworld
 ...
@@ -82,7 +82,7 @@ flags to allows users to specify the schema that should be used.
 
 By default, kpt will use the builtin schema.
 
-```sh
+```shell
 --k8s-schema-source
   Set the source for the OpenAPI schema. Allowed values are cluster, file, or
   builtin. If an OpenAPI schema can't be find at the given source, kpt will

--- a/site/reference/fn/README.md
+++ b/site/reference/fn/README.md
@@ -49,18 +49,18 @@ the organizational needs:
 
 <!--mdtogo:Examples-->
 
-```sh
+```shell
 # run the function defined by gcr.io/example.com/my-fn as a local container
 # against the configuration in DIR
 kpt fn run DIR/ --image gcr.io/example.com/my-fn
 ```
 
-```sh
+```shell
 # run the functions declared in files under FUNCTIONS_DIR/
 kpt fn run DIR/ --fn-path FUNCTIONS_DIR/
 ```
 
-```sh
+```shell
 # run the functions declared in files under DIR/
 kpt fn run DIR/
 ```

--- a/site/reference/fn/export/README.md
+++ b/site/reference/fn/export/README.md
@@ -25,7 +25,7 @@ cd $TEST_HOME
 ```
 
 <!-- @fetchPackage @verifyExamples-->
-```sh
+```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
 kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.5.0 DIR/
 ```
@@ -35,14 +35,14 @@ kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.5.0 DIR/
 <!--mdtogo:Examples-->
 
 <!-- @fnExport @verifyExamples-->
-```sh
+```shell
 # read functions from DIR, run them against it as one step.
 # write the generated GitHub Actions pipeline to main.yaml.
 kpt fn export DIR/ --output main.yaml --workflow github-actions
 ```
 
 <!-- @fnExport @verifyExamples-->
-```sh
+```shell
 # discover functions in FUNCTIONS_DIR and run them against resource in DIR.
 # write the generated Cloud Build pipeline to stdout.
 kpt fn export DIR/ --fn-path FUNCTIONS_DIR/ --workflow cloud-build
@@ -54,7 +54,7 @@ kpt fn export DIR/ --fn-path FUNCTIONS_DIR/ --workflow cloud-build
 
 <!--mdtogo:Long-->
 
-```sh
+```shell
 kpt fn export DIR/ [--fn-path FUNCTIONS_DIR/] --workflow ORCHESTRATOR [--output OUTPUT_FILENAME]
 
 DIR:

--- a/site/reference/fn/run/README.md
+++ b/site/reference/fn/run/README.md
@@ -25,14 +25,14 @@ reference for advanced usecases.
 
 <!--mdtogo:Long-->
 
-```sh
+```shell
 kpt fn run DIR [flags]
 ```
 
 If the container exits with non-zero status code, run will fail and print the
 container `STDERR`.
 
-```sh
+```shell
 DIR:
   Path to a package directory.  Defaults to stdin if unspecified.
 ```
@@ -51,7 +51,7 @@ cd $TEST_HOME
 ```
 
 <!-- @fetchPackage @verifyStaleExamples-->
-```sh
+```shell
 kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-catalog.git/examples/mutators/set-label/simple@b7f2350 DIR/
 ```
 
@@ -59,24 +59,24 @@ kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-catalog.git/ex
 
 <!--mdtogo:Examples-->
 
-```sh
+```shell
 # read the Resources from DIR, provide them to a container my-fun as input,
 # write my-fn output back to DIR
 kpt fn run DIR/ --image gcr.io/example.com/my-fn
 ```
 
-```sh
+```shell
 # provide the my-fn with an input ConfigMap containing `data: {foo: bar}`
 kpt fn run DIR/ --image gcr.io/example.com/my-fn:v1.0.0 -- foo=bar
 ```
 
-```sh
+```shell
 # run the functions in FUNCTIONS_DIR against the Resources in DIR
 kpt fn run DIR/ --fn-path FUNCTIONS_DIR/
 ```
 
 <!-- @fnRun @verifyStaleExamples-->
-```sh
+```shell
 # discover functions in DIR and run them against Resource in DIR.
 # functions may be scoped to a subset of Resources -- see `kpt help fn run`
 kpt fn run DIR/
@@ -94,7 +94,7 @@ specify a destination to write results to.
 
 **Example**: Run `validate-rolebinding` on an example package
 
-```sh
+```shell
 kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-sdk.git/example-configs example-configs
 mkdir results/
 kpt fn run example-configs/ --results-dir results/ --image gcr.io/kpt-functions/validate-rolebinding:results -- subject_name=bob@foo-corp.com
@@ -121,7 +121,7 @@ metadata:
     config.kubernetes.io/local-config: 'true'
 ```
 
-```sh
+```shell
 kpt pkg get https://github.com/instrumenta/kubeval.git/fixtures .
 kpt fn source fixtures/*invalid.yaml |
   kpt fn run --fn-path fc.yaml --network 2>error.txt || true
@@ -135,7 +135,7 @@ arguments as for `docker run`.
 
 **Example**: Run `kustomize-build` on a helloWorld package
 
-```sh
+```shell
 kpt pkg get https://github.com/kubernetes-sigs/kustomize/examples/helloWorld helloWorld
 kpt fn source helloWorld |
   kpt fn run --mount type=bind,src="$(pwd)/helloWorld",dst=/source --image gcr.io/kpt-functions/kustomize-build -- path=/source |
@@ -145,7 +145,7 @@ kpt fn source helloWorld |
 All volumes are mounted readonly by default. Specify `rw=true` to mount volumes
 in read-write mode.
 
-```sh
+```shell
 kpt pkg get https://github.com/kubernetes-sigs/kustomize/examples/helloWorld helloWorld
 kpt fn source helloWorld |
   kpt fn run --mount type=bind,src="$(pwd)/helloWorld",dst=/source,rw=true --image gcr.io/kpt-functions/kustomize-build -- path=/source |
@@ -228,7 +228,7 @@ and invoking them -- passing in only those resources scoped to the function.
 **Example:** Function declared in `stuff/my-function.yaml` is scoped to
 Resources in `stuff/` and is NOT scoped to Resources in `apps/`
 
-```sh
+```shell
 .
 ├── stuff
 │   ├── inscope-deployment.yaml
@@ -245,7 +245,7 @@ directory named `functions`.
 
 **Example**: This is equivalent to previous example
 
-```sh
+```shell
 .
 ├── stuff
 │   ├── inscope-deployment.yaml
@@ -261,7 +261,7 @@ directory named `functions`.
 Alternatively, you can also use `--fn-path` to explicitly provide the directory
 containing function configurations:
 
-```sh
+```shell
 kpt fn run DIR/ --fn-path FUNCTIONS_DIR/
 ```
 
@@ -281,7 +281,7 @@ arguments are passed as `data` elements in the ConfigMap.
 
 **Example**: Run `validate-rolebinding` on an example package
 
-```sh
+```shell
 kpt pkg get https://github.com/GoogleContainerTools/kpt-functions-sdk.git/example-configs example-configs
 mkdir results/
 kpt fn run example-configs/ --results-dir results/ --image gcr.io/kpt-functions/validate-rolebinding:results -- subject_name=bob@foo-corp.com
@@ -306,7 +306,7 @@ the functionConfig type.
 
 Run the function:
 
-```sh
+```shell
 kpt fn run DIR/ --image foo:v1 -- Foo a=b c=d
 ```
 
@@ -374,7 +374,7 @@ with shorter lexical file path is executed first.
 
 **Example:** Directory structure with multiple functions and corresponding ordering
 
-```sh
+```shell
 .
 ├── stuff
 │   ├── deployment.yaml

--- a/site/reference/fn/sink/README.md
+++ b/site/reference/fn/sink/README.md
@@ -19,7 +19,7 @@ about files for which it sees input resources.
 
 <!--mdtogo:Examples-->
 
-```sh
+```shell
 # run a function using explicit sources and sinks
 kpt fn source DIR/ |
   kpt fn run --image gcr.io/example.com/my-fn |
@@ -32,7 +32,7 @@ kpt fn source DIR/ |
 
 <!--mdtogo:Long-->
 
-```sh
+```shell
 kpt fn sink [DIR]
 
 DIR:

--- a/site/reference/fn/source/README.md
+++ b/site/reference/fn/source/README.md
@@ -24,7 +24,7 @@ cd $TEST_HOME
 ```
 
 <!-- @fetchPackage @verifyExamples-->
-```sh
+```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
 kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.5.0 DIR/
 ```
@@ -34,12 +34,12 @@ kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.5.0 DIR/
 <!--mdtogo:Examples-->
 
 <!-- @fnSource @verifyExamples-->
-```sh
+```shell
 # print to stdout configuration from DIR/ formatted as an input source
 kpt fn source DIR/
 ```
 
-```sh
+```shell
 # run a function using explicit sources and sinks
 kpt fn source DIR/ |
   kpt fn run --image gcr.io/example.com/my-fn |
@@ -52,7 +52,7 @@ kpt fn source DIR/ |
 
 <!--mdtogo:Long-->
 
-```sh
+```shell
 kpt fn source [DIR...]
 
 DIR:

--- a/site/reference/live/apply/README.md
+++ b/site/reference/live/apply/README.md
@@ -231,7 +231,7 @@ cd $TEST_HOME
 ```
 
 <!-- @fetchPackage @verifyExamples-->
-```sh
+```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
 kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.5.0 my-dir
 ```
@@ -250,19 +250,19 @@ kpt live init my-dir
 
 <!--mdtogo:Examples-->
 <!-- @liveApply @verifyExamples-->
-```sh
+```shell
 # apply resources and prune
 kpt live apply my-dir/
 ```
 
 <!-- @liveApply @verifyExamples-->
-```sh
+```shell
 # apply resources and wait for all the resources to be reconciled before pruning
 kpt live apply --reconcile-timeout=15m my-dir/
 ```
 
 <!-- @liveApply @verifyExamples-->
-```sh
+```shell
 # apply resources and specify how often to poll the cluster for resource status
 kpt live apply --reconcile-timeout=15m --poll-period=5s my-dir/
 ```

--- a/site/reference/live/destroy/README.md
+++ b/site/reference/live/destroy/README.md
@@ -25,7 +25,7 @@ cd $TEST_HOME
 ```
 
 <!-- @fetchPackage @verifyExamples-->
-```sh
+```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
 kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.5.0 my-dir
 ```
@@ -45,7 +45,7 @@ kpt live apply my-dir
 
 <!--mdtogo:Examples-->
 <!-- @liveDestroy @verifyExamples-->
-```sh
+```shell
 # remove all resources in a package from the cluster
 kpt live destroy my-dir/
 ```

--- a/site/reference/live/diff/README.md
+++ b/site/reference/live/diff/README.md
@@ -14,7 +14,7 @@ resource against the local package config.
 
 ### Examples
 <!--mdtogo:Examples-->
-```sh
+```shell
 # diff the config in "my-dir" against the live cluster resources
 kpt live diff my-dir/
 

--- a/site/reference/live/fetch-k8s-schema/README.md
+++ b/site/reference/live/fetch-k8s-schema/README.md
@@ -14,7 +14,7 @@ given by the context. It prints the result to stdout.
 
 ### Examples
 <!--mdtogo:Examples-->
-```sh
+```shell
 # print the schema for the cluster given by the current context
 kpt live fetch-k8s-schema
 

--- a/site/reference/live/init/README.md
+++ b/site/reference/live/init/README.md
@@ -30,7 +30,7 @@ cd $TEST_HOME
 ```
 
 <!-- @fetchPackage @verifyExamples-->
-```sh
+```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
 kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.5.0 my-dir
 ```
@@ -44,7 +44,7 @@ kind delete cluster && kind create cluster
 <!--mdtogo:Examples-->
 
 <!-- @liveInit @verifyExamples-->
-```sh
+```shell
 # initialize a package
 kpt live init my-dir/
 ```
@@ -52,14 +52,14 @@ kpt live init my-dir/
 {{% hide %}}
 
 <!-- @removeInventoryTemplate @verifyExamples-->
-```sh
+```shell
 rm my-dir/inventory-template.yaml
 ```
 
 {{% /hide %}}
 
 <!-- @liveInit @verifyExamples-->
-```sh
+```shell
 # initialize a package with a specific name for the group of resources
 kpt live init --namespace=test my-dir/
 ```

--- a/site/reference/live/preview/README.md
+++ b/site/reference/live/preview/README.md
@@ -29,7 +29,7 @@ cd $TEST_HOME
 ```
 
 <!-- @fetchPackage @verifyExamples-->
-```sh
+```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
 kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.5.0 my-dir
 ```
@@ -48,13 +48,13 @@ kpt live init my-dir
 
 <!--mdtogo:Examples-->
 <!-- @livePreview @verifyExamples-->
-```sh
+```shell
 # preview apply for a package
 kpt live preview my-dir/
 ```
 
 <!-- @livePreview @verifyExamples-->
-```sh
+```shell
 # preview destroy for a package
 kpt live preview --destroy my-dir/
 ```

--- a/site/reference/live/status/README.md
+++ b/site/reference/live/status/README.md
@@ -27,7 +27,7 @@ cd $TEST_HOME
 ```
 
 <!-- @fetchPackage @verifyExamples-->
-```sh
+```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
 kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.5.0 my-app
 ```
@@ -47,13 +47,13 @@ kpt live apply my-app
 
 <!--mdtogo:Examples-->
 <!-- @liveStatus @verifyExamples-->
-```sh
+```shell
 # Monitor status for a set of resources based on manifests. Wait until all
 # resources have reconciled.
 kpt live status my-app/
 ```
 
-```sh
+```shell
 # Monitor status for a set of resources based on manifests. Output in table format:
 kpt live status my-app/ --poll-until=forever --output=table
 ```

--- a/site/reference/pkg/README.md
+++ b/site/reference/pkg/README.md
@@ -28,7 +28,7 @@ resources rather than files.
 
 ### Examples
 <!--mdtogo:Examples-->
-```sh
+```shell
 # create your workspace
 $ mkdir hello-world-workspace
 $ cd hello-world-workspace

--- a/site/reference/pkg/desc/README.md
+++ b/site/reference/pkg/desc/README.md
@@ -23,7 +23,7 @@ cd $TEST_HOME
 ```
 
 <!-- @fetchPackage @verifyExamples-->
-```sh
+```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
 kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.5.0 hello-world
 ```
@@ -33,7 +33,7 @@ kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.5.0 hello-world
 <!--mdtogo:Examples-->
 
 <!-- @pkgDesc @verifyExamples-->
-```sh
+```shell
 # display description for the local hello-world package
 kpt pkg desc hello-world/
 ```

--- a/site/reference/pkg/diff/README.md
+++ b/site/reference/pkg/diff/README.md
@@ -31,7 +31,7 @@ cd $TEST_HOME
 ```
 
 <!-- @fetchPackage @verifyExamples-->
-```sh
+```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
 kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.5.0 hello-world
 cd hello-world
@@ -41,31 +41,31 @@ cd hello-world
 
 <!--mdtogo:Examples-->
 <!-- @pkgDiff @verifyExamples-->
-```sh
+```shell
 # Show changes in current package relative to upstream source package
 kpt pkg diff
 ```
 
-```sh
+```shell
 # Show changes in current package relative to upstream source package
 # using meld tool with auto compare option.
 kpt pkg diff --diff-tool meld --diff-tool-opts "-a"
 ```
 
 <!-- @pkgDiff @verifyExamples-->
-```sh
+```shell
 # Show changes in upstream source package between current version and
 # target version
 kpt pkg diff @v0.4.0 --diff-type remote
 ```
 
 <!-- @pkgDiff @verifyExamples-->
-```sh
+```shell
 # Show changes in current package relative to target version
 kpt pkg diff @v0.4.0 --diff-type combined
 ```
 
-```sh
+```shell
 # Show 3way changes between the local package, upstream package at original
 # version and upstream package at target version using meld
 kpt pkg diff @v0.4.0 --diff-type 3way --diff-tool meld --diff-tool-opts "-a"

--- a/site/reference/pkg/get/README.md
+++ b/site/reference/pkg/get/README.md
@@ -31,14 +31,14 @@ cd $TEST_HOME
 <!--mdtogo:Examples-->
 
 <!-- @pkgGet @verifyExamples-->
-```sh
+```shell
 # fetch package cockroachdb from github.com/kubernetes/examples/staging/cockroachdb
 # creates directory ./cockroachdb/ containing the package contents
 kpt pkg get https://github.com/kubernetes/examples.git/staging/cockroachdb@master ./
 ```
 
 <!-- @pkgGet @verifyExamples-->
-```sh
+```shell
 # fetch a cockroachdb
 # if ./my-package doesn't exist, creates directory ./my-package/ containing
 # the package contents
@@ -46,7 +46,7 @@ kpt pkg get https://github.com/kubernetes/examples.git/staging/cockroachdb@maste
 ```
 
 <!-- @pkgGet @verifyExamples-->
-```sh
+```shell
 # fetch package examples from github.com/kubernetes/examples
 # creates directory ./examples fetched from the provided commit hash
 kpt pkg get https://github.com/kubernetes/examples.git/@6fe2792 ./

--- a/site/reference/pkg/init/README.md
+++ b/site/reference/pkg/init/README.md
@@ -45,7 +45,7 @@ cd $TEST_HOME
 <!--mdtogo:Examples-->
 
 <!-- @pkgInit @verifyStaleExamples-->
-```sh
+```shell
 # writes Kptfile package meta if not found
 mkdir my-pkg
 kpt pkg init my-pkg --tag kpt.dev/app=cockroachdb \

--- a/site/reference/pkg/tree/README.md
+++ b/site/reference/pkg/tree/README.md
@@ -35,7 +35,7 @@ cd $TEST_HOME
 ```
 
 <!-- @fetchPackage @verifyExamples-->
-```sh
+```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
 kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.5.0 my-dir
 cd my-dir
@@ -45,31 +45,31 @@ cd my-dir
 
 <!--mdtogo:Examples-->
 <!-- @pkgTree @verifyExamples-->
-```sh
+```shell
 # print Resources using directory structure
 kpt pkg tree
 ```
 
 <!-- @pkgTree @verifyExamples-->
-```sh
+```shell
 # print replicas, container name, and container image and fields for Resources
 kpt pkg tree --replicas --image --name
 ```
 
 <!-- @pkgTree @verifyExamples-->
-```sh
+```shell
 # print all common Resource fields
 kpt pkg tree --all
 ```
 
 <!-- @pkgTree @verifyExamples-->
-```sh
+```shell
 # print the "foo"" annotation
 kpt pkg tree --field "metadata.annotations.foo"
 ```
 
 <!-- @pkgTree @verifyStaleExamples-->
-```sh
+```shell
 # print the status of resources piped from kubectl output with status.condition 
 type of "Completed"
 kubectl get all -o yaml | kpt pkg tree - \
@@ -77,13 +77,13 @@ kubectl get all -o yaml | kpt pkg tree - \
 ```
 
 <!-- @pkgTree @verifyStaleExamples-->
-```sh
+```shell
 # print live Resources from a cluster using owners for graph structure
 kubectl get all -o yaml | kpt pkg tree --replicas --name --image
 ```
 
 <!-- @pkgTree @verifyStaleExamples-->
-```sh
+```shell
 # print live Resources with status condition fields
 kubectl get all -o yaml | kpt pkg tree \
   --name --image --replicas \

--- a/site/reference/pkg/update/README.md
+++ b/site/reference/pkg/update/README.md
@@ -20,19 +20,19 @@ All changes must be committed to git before running update
 
 ### Examples
 <!--mdtogo:Examples-->
-```sh
+```shell
 # update my-package-dir/
 git add . && git commit -m 'some message'
 kpt pkg update my-package-dir/
 ```
 
-```sh
+```shell
 # update my-package-dir/ to match the v1.3 branch or tag
 git add . && git commit -m 'some message'
 kpt pkg update my-package-dir/@v1.3
 ```
 
-```sh
+```shell
 # update applying a git patch
 git add . && git commit -m "package updates"
 kpt pkg  update my-package-dir/@master --strategy alpha-git-patch


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/kpt/issues/1579
Adds the `bash` prism package and renames all blocks to `shell`

Example styling:
![image](https://user-images.githubusercontent.com/31711490/111837590-5adfb300-88b5-11eb-9764-368743f069a2.png)
![image](https://user-images.githubusercontent.com/31711490/111837657-73e86400-88b5-11eb-99a7-128dd77bbcee.png)
