### PR TITLE
Use Pkg type for Get, Fetch, and Update commands

### DIFF
--- a/internal/cmdupdate/cmdupdate.go
+++ b/internal/cmdupdate/cmdupdate.go
@@ -90,7 +90,7 @@ func (r *Runner) preRunE(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	r.Update.FullPackagePath = string(p.UniquePath)
+	r.Update.Pkg = p
 
 	// TODO: Make sure we handle this in a centralized library and do
 	// this consistently across all commands.
@@ -111,10 +111,10 @@ func (r *Runner) preRunE(_ *cobra.Command, args []string) error {
 func (r *Runner) runE(c *cobra.Command, _ []string) error {
 	if len(r.Update.Ref) > 0 {
 		fmt.Fprintf(c.ErrOrStderr(), "updating package %s to %s\n",
-			r.Update.FullPackagePath, r.Update.Ref)
+			r.Update.Pkg.UniquePath, r.Update.Ref)
 	} else {
 		fmt.Fprintf(c.ErrOrStderr(), "updating package %s\n",
-			r.Update.FullPackagePath)
+			r.Update.Pkg.UniquePath)
 	}
 	if err := r.Update.Run(); err != nil {
 		return err

--- a/internal/cmdupdate/cmdupdate_test.go
+++ b/internal/cmdupdate/cmdupdate_test.go
@@ -298,7 +298,7 @@ func TestCmd_path(t *testing.T) {
 
 			r := cmdupdate.NewRunner("kpt")
 			r.Command.RunE = func(cmd *cobra.Command, args []string) error {
-				if !assert.Equal(t, test.expectedFullPackagePath, r.Update.FullPackagePath) {
+				if !assert.Equal(t, test.expectedFullPackagePath, r.Update.Pkg.UniquePath.String()) {
 					t.FailNow()
 				}
 				return nil

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -147,7 +147,7 @@ func hydrate(pn *pkgNode, hctx *hydrationContext) (output []*yaml.RNode, err err
 	var input []*yaml.RNode
 
 	// determine sub packages to be hydrated
-	subpkgs, err := curr.pkg.SubPackages()
+	subpkgs, err := curr.pkg.DirectSubpackages()
 	if err != nil {
 		return output, err
 	}

--- a/internal/pkg/pkg_test.go
+++ b/internal/pkg/pkg_test.go
@@ -287,7 +287,7 @@ func TestSubpackages(t *testing.T) {
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
-			subPkgs, err := p.SubPackages()
+			subPkgs, err := p.DirectSubpackages()
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/internal/pkg/pkg_test.go
+++ b/internal/pkg/pkg_test.go
@@ -15,8 +15,12 @@
 package pkg
 
 import (
+	"path/filepath"
+	"sort"
 	"testing"
 
+	"github.com/GoogleContainerTools/kpt/internal/testutil/pkgbuilder"
+	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
@@ -182,6 +186,124 @@ spec:
 				}
 				assert.Equal(t, test.expected[i], res)
 			}
+		})
+	}
+}
+
+func TestSubpackages(t *testing.T) {
+	testCases := map[string]struct {
+		pkg      *pkgbuilder.RootPkg
+		expected []string
+	}{
+		"includes remote subpackages": {
+			pkg: pkgbuilder.NewRootPkg().
+				WithResource(pkgbuilder.DeploymentResource).
+				WithSubPackages(
+					pkgbuilder.NewSubPkg("foo").
+						WithKptfile(
+							pkgbuilder.NewKptfile().
+								WithUpstream("github.com/GoogleContainerTools/kpt",
+									"/", "main", string(kptfilev1alpha2.ResourceMerge)),
+						).
+						WithResource(pkgbuilder.ConfigMapResource),
+				),
+			expected: []string{
+				"foo",
+			},
+		},
+		"includes local subpackages": {
+			pkg: pkgbuilder.NewRootPkg().
+				WithResource(pkgbuilder.DeploymentResource).
+				WithSubPackages(
+					pkgbuilder.NewSubPkg("foo").
+						WithKptfile().
+						WithResource(pkgbuilder.ConfigMapResource),
+				),
+			expected: []string{
+				"foo",
+			},
+		},
+		"does not include root package": {
+			pkg: pkgbuilder.NewRootPkg().
+				WithKptfile().
+				WithResource(pkgbuilder.DeploymentResource),
+			expected: []string{},
+		},
+		"does not include nested remote subpackages": {
+			pkg: pkgbuilder.NewRootPkg().
+				WithResource(pkgbuilder.DeploymentResource).
+				WithSubPackages(
+					pkgbuilder.NewSubPkg("foo").
+						WithKptfile(
+							pkgbuilder.NewKptfile().
+								WithUpstream("github.com/GoogleContainerTools/kpt",
+									"/", "main", string(kptfilev1alpha2.ResourceMerge)),
+						).
+						WithResource(pkgbuilder.ConfigMapResource).
+						WithSubPackages(
+							pkgbuilder.NewSubPkg("bar").
+								WithSubPackages(
+									pkgbuilder.NewSubPkg("zork").
+										WithKptfile(
+											pkgbuilder.NewKptfile().
+												WithUpstream("github.com/GoogleContainerTools/kpt",
+													"/", "main", string(kptfilev1alpha2.ResourceMerge)),
+										).
+										WithResource(pkgbuilder.ConfigMapResource),
+								),
+						),
+				),
+			expected: []string{
+				"foo",
+			},
+		},
+		"does not include nested local subpackages": {
+			pkg: pkgbuilder.NewRootPkg().
+				WithResource(pkgbuilder.DeploymentResource).
+				WithSubPackages(
+					pkgbuilder.NewSubPkg("foo").
+						WithKptfile().
+						WithResource(pkgbuilder.ConfigMapResource).
+						WithSubPackages(
+							pkgbuilder.NewSubPkg("zork").
+								WithKptfile().
+								WithResource(pkgbuilder.ConfigMapResource),
+						),
+					pkgbuilder.NewSubPkg("subpkg").
+						WithKptfile(),
+				),
+			expected: []string{
+				"foo",
+				"subpkg",
+			},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			pkgPath := tc.pkg.ExpandPkg(t, nil)
+
+			p, err := New(pkgPath)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			subPkgs, err := p.SubPackages()
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			relPaths := []string{}
+			for _, subPkg := range subPkgs {
+				fullPath := subPkg.UniquePath.String()
+				relPath, err := filepath.Rel(pkgPath, fullPath)
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+				relPaths = append(relPaths, relPath)
+			}
+			sort.Strings(relPaths)
+
+			assert.Equal(t, tc.expected, relPaths)
 		})
 	}
 }

--- a/internal/pkg/testing/helpers.go
+++ b/internal/pkg/testing/helpers.go
@@ -1,0 +1,32 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testing
+
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/kpt/internal/pkg"
+	"github.com/stretchr/testify/assert"
+)
+
+// CreatePkgOrFail creates a new package from the provided path. Unlike the
+// pkg.New function, it fails the test instead of returning an error.
+func CreatePkgOrFail(t *testing.T, path string) *pkg.Pkg {
+	p, err := pkg.New(path)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	return p
+}

--- a/internal/util/diff/diff.go
+++ b/internal/util/diff/diff.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/GoogleContainerTools/kpt/internal/gitutil"
+	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	"github.com/GoogleContainerTools/kpt/internal/util/fetch"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
@@ -309,8 +310,13 @@ func (pg defaultPkgGetter) GetPkg(repo, path, ref string) (string, error) {
 		return dir, err
 	}
 
+	p, err := pkg.New(dir)
+	if err != nil {
+		return dir, err
+	}
+
 	cmdGet := &fetch.Command{
-		Path: dir,
+		Pkg: p,
 	}
 	err = cmdGet.Run()
 	return dir, err

--- a/internal/util/fetch/fetch_test.go
+++ b/internal/util/fetch/fetch_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
 	. "github.com/GoogleContainerTools/kpt/internal/util/fetch"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
@@ -51,6 +52,14 @@ func createKptfile(workspace *testutil.TestWorkspace, git *kptfilev1alpha2.Git, 
 	return kptfileutil.WriteFile(workspace.FullPackagePath(), kf)
 }
 
+func createPackage(t *testing.T, pkgPath string) *pkg.Pkg {
+	p, err := pkg.New(pkgPath)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	return p
+}
+
 // TestCommand_Run_failEmptyRepo verifies that Command fail if no Kptfile
 func TestCommand_Run_failNoKptfile(t *testing.T) {
 	g, w, clean := testutil.SetupRepoAndWorkspace(t, testutil.Content{
@@ -66,7 +75,7 @@ func TestCommand_Run_failNoKptfile(t *testing.T) {
 	}
 
 	err = Command{
-		Path: pkgPath,
+		Pkg: createPackage(t, pkgPath),
 	}.Run()
 	assert.EqualError(t, err, "no Kptfile found")
 }
@@ -82,7 +91,7 @@ func TestCommand_Run_failNoGit(t *testing.T) {
 	}
 
 	err = Command{
-		Path: w.FullPackagePath(),
+		Pkg: createPackage(t, w.FullPackagePath()),
 	}.Run()
 	assert.EqualError(t, err, "kptfile upstream doesn't have git information")
 }
@@ -102,7 +111,7 @@ func TestCommand_Run_failEmptyRepo(t *testing.T) {
 	}
 
 	err = Command{
-		Path: w.FullPackagePath(),
+		Pkg: createPackage(t, w.FullPackagePath()),
 	}.Run()
 	assert.EqualError(t, err, "must specify repo")
 }
@@ -122,7 +131,7 @@ func TestCommand_Run_failNoRevision(t *testing.T) {
 	}
 
 	err = Command{
-		Path: w.FullPackagePath(),
+		Pkg: createPackage(t, w.FullPackagePath()),
 	}.Run()
 	assert.EqualError(t, err, "must specify ref")
 }
@@ -146,7 +155,7 @@ func TestCommand_Run(t *testing.T) {
 
 	absPath := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	err = Command{
-		Path: w.FullPackagePath(),
+		Pkg: createPackage(t, w.FullPackagePath()),
 	}.Run()
 	assert.NoError(t, err)
 
@@ -208,7 +217,7 @@ func TestCommand_Run_subdir(t *testing.T) {
 
 	absPath := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	err = Command{
-		Path: w.FullPackagePath(),
+		Pkg: createPackage(t, w.FullPackagePath()),
 	}.Run()
 	assert.NoError(t, err)
 
@@ -286,7 +295,7 @@ func TestCommand_Run_branch(t *testing.T) {
 	}
 
 	err = Command{
-		Path: w.FullPackagePath(),
+		Pkg: createPackage(t, w.FullPackagePath()),
 	}.Run()
 	assert.NoError(t, err)
 
@@ -367,7 +376,7 @@ func TestCommand_Run_tag(t *testing.T) {
 	}
 
 	err = Command{
-		Path: w.FullPackagePath(),
+		Pkg: createPackage(t, w.FullPackagePath()),
 	}.Run()
 	assert.NoError(t, err)
 
@@ -421,7 +430,7 @@ func TestCommand_Run_failInvalidRepo(t *testing.T) {
 	}
 
 	err = Command{
-		Path: w.FullPackagePath(),
+		Pkg: createPackage(t, w.FullPackagePath()),
 	}.Run()
 	if !assert.Error(t, err) {
 		t.FailNow()
@@ -445,7 +454,7 @@ func TestCommand_Run_failInvalidBranch(t *testing.T) {
 	}
 
 	err = Command{
-		Path: w.FullPackagePath(),
+		Pkg: createPackage(t, w.FullPackagePath()),
 	}.Run()
 	if !assert.Error(t, err) {
 		t.FailNow()
@@ -472,7 +481,7 @@ func TestCommand_Run_failInvalidTag(t *testing.T) {
 	}
 
 	err = Command{
-		Path: w.FullPackagePath(),
+		Pkg: createPackage(t, w.FullPackagePath()),
 	}.Run()
 	if !assert.Error(t, err) {
 		t.FailNow()

--- a/internal/util/get/get.go
+++ b/internal/util/get/get.go
@@ -114,7 +114,7 @@ func (c Command) fetchPackages(rootPkg *pkg.Pkg) error {
 			}
 		}
 
-		subPkgs, err := p.SubPackages()
+		subPkgs, err := p.DirectSubpackages()
 		if err != nil {
 			return err
 		}

--- a/internal/util/stack/stack.go
+++ b/internal/util/stack/stack.go
@@ -14,8 +14,13 @@
 
 package stack
 
-import "fmt"
+import (
+	"fmt"
 
+	"github.com/GoogleContainerTools/kpt/internal/pkg"
+)
+
+// New returns a new stack for elements of string type.
 func New() *stack {
 	return &stack{
 		slice: make([]string, 0),
@@ -42,4 +47,33 @@ func (s *stack) Pop() string {
 
 func (s *stack) Len() int {
 	return len(s.slice)
+}
+
+// NewPkgStack returns a new stack for elements of *pkg.Pkg type.
+func NewPkgStack() *pkgStack {
+	return &pkgStack{
+		slice: make([]*pkg.Pkg, 0),
+	}
+}
+
+type pkgStack struct {
+	slice []*pkg.Pkg
+}
+
+func (ps *pkgStack) Push(p *pkg.Pkg) {
+	ps.slice = append(ps.slice, p)
+}
+
+func (ps *pkgStack) Pop() *pkg.Pkg {
+	l := len(ps.slice)
+	if l == 0 {
+		panic(fmt.Errorf("can't pop an empty stack"))
+	}
+	p := ps.slice[l-1]
+	ps.slice = ps.slice[:l-1]
+	return p
+}
+
+func (ps *pkgStack) Len() int {
+	return len(ps.slice)
 }

--- a/internal/util/update/update.go
+++ b/internal/util/update/update.go
@@ -166,7 +166,7 @@ func (u Command) Run() error {
 			return err
 		}
 
-		subPkgs, err := p.SubPackages()
+		subPkgs, err := p.DirectSubpackages()
 		if err != nil {
 			return err
 		}

--- a/internal/util/update/update_test.go
+++ b/internal/util/update/update_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	pkgtest "github.com/GoogleContainerTools/kpt/internal/pkg/testing"
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
 	"github.com/GoogleContainerTools/kpt/internal/testutil/pkgbuilder"
 	. "github.com/GoogleContainerTools/kpt/internal/util/update"
@@ -67,8 +68,8 @@ func TestCommand_Run_noRefChanges(t *testing.T) {
 
 			// Update the local package
 			if !assert.NoError(t, Command{
-				FullPackagePath: g.LocalWorkspace.FullPackagePath(),
-				Strategy:        strategy,
+				Pkg:      pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
+				Strategy: strategy,
 			}.Run()) {
 				return
 			}
@@ -118,9 +119,9 @@ func TestCommand_Run_subDir(t *testing.T) {
 
 			// Update the local package
 			if !assert.NoError(t, Command{
-				FullPackagePath: g.LocalWorkspace.FullPackagePath(),
-				Ref:             "v1.2",
-				Strategy:        strategy,
+				Pkg:      pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
+				Ref:      "v1.2",
+				Strategy: strategy,
 			}.Run()) {
 				return
 			}
@@ -174,8 +175,8 @@ func TestCommand_Run_noChanges(t *testing.T) {
 
 			// Update the local package
 			err := Command{
-				FullPackagePath: g.LocalWorkspace.FullPackagePath(),
-				Strategy:        u.updater,
+				Pkg:      pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
+				Strategy: u.updater,
 			}.Run()
 			if u.err == "" {
 				if !assert.NoError(t, err) {
@@ -233,8 +234,8 @@ func TestCommand_Run_noCommit(t *testing.T) {
 
 			// Update the local package
 			err = Command{
-				FullPackagePath: g.LocalWorkspace.FullPackagePath(),
-				Strategy:        strategy,
+				Pkg:      pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
+				Strategy: strategy,
 			}.Run()
 			if !assert.Error(t, err) {
 				return
@@ -280,8 +281,8 @@ func TestCommand_Run_noAdd(t *testing.T) {
 
 			// Update the local package
 			err = Command{
-				FullPackagePath: g.LocalWorkspace.FullPackagePath(),
-				Strategy:        strategy,
+				Pkg:      pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
+				Strategy: strategy,
 			}.Run()
 			if !assert.Error(t, err) {
 				return
@@ -446,9 +447,9 @@ func TestCommand_Run_localPackageChanges(t *testing.T) {
 
 			// run the command
 			err = Command{
-				FullPackagePath: g.LocalWorkspace.FullPackagePath(),
-				Ref:             "master",
-				Strategy:        tc.strategy,
+				Pkg:      pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
+				Ref:      "master",
+				Strategy: tc.strategy,
 			}.Run()
 
 			// check the error response
@@ -516,9 +517,9 @@ func TestCommand_Run_toBranchRef(t *testing.T) {
 
 			// Update the local package
 			if !assert.NoError(t, Command{
-				FullPackagePath: g.LocalWorkspace.FullPackagePath(),
-				Strategy:        strategy,
-				Ref:             "exp",
+				Pkg:      pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
+				Strategy: strategy,
+				Ref:      "exp",
 			}.Run()) {
 				return
 			}
@@ -576,9 +577,9 @@ func TestCommand_Run_toTagRef(t *testing.T) {
 
 			// Update the local package
 			if !assert.NoError(t, Command{
-				FullPackagePath: g.LocalWorkspace.FullPackagePath(),
-				Strategy:        strategy,
-				Ref:             "v1.0",
+				Pkg:      pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
+				Strategy: strategy,
+				Ref:      "v1.0",
 			}.Run()) {
 				return
 			}
@@ -633,9 +634,9 @@ func TestCommand_ResourceMerge_NonKRMUpdates(t *testing.T) {
 
 			// Update the local package
 			if !assert.NoError(t, Command{
-				FullPackagePath: g.LocalWorkspace.FullPackagePath(),
-				Strategy:        strategy,
-				Ref:             "v1.0",
+				Pkg:      pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
+				Strategy: strategy,
+				Ref:      "v1.0",
 			}.Run()) {
 				t.FailNow()
 			}
@@ -667,8 +668,8 @@ func TestCommand_Run_failInvalidPath(t *testing.T) {
 		t.Run(string(strategy), func(t *testing.T) {
 			path := filepath.Join("fake", "path")
 			err := Command{
-				FullPackagePath: path,
-				Strategy:        strategy,
+				Pkg:      pkgtest.CreatePkgOrFail(t, path),
+				Strategy: strategy,
 			}.Run()
 			if assert.Error(t, err) {
 				assert.Contains(t, err.Error(), "no such file or directory")
@@ -702,9 +703,9 @@ func TestCommand_Run_failInvalidRef(t *testing.T) {
 			}
 
 			err := Command{
-				FullPackagePath: g.LocalWorkspace.FullPackagePath(),
-				Ref:             "exp",
-				Strategy:        strategy,
+				Pkg:      pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
+				Ref:      "exp",
+				Strategy: strategy,
 			}.Run()
 			if !assert.Error(t, err) {
 				return
@@ -743,8 +744,8 @@ func TestCommand_Run_badStrategy(t *testing.T) {
 
 	// Update the local package
 	err := Command{
-		FullPackagePath: g.LocalWorkspace.FullPackagePath(),
-		Strategy:        strategy,
+		Pkg:      pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
+		Strategy: strategy,
 	}.Run()
 	if !assert.Error(t, err, strategy) {
 		return
@@ -1881,8 +1882,8 @@ func TestCommand_Run_subpackages(t *testing.T) {
 				}
 
 				err := Command{
-					FullPackagePath: g.LocalWorkspace.FullPackagePath(),
-					Strategy:        strategy,
+					Pkg:      pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
+					Strategy: strategy,
 				}.Run()
 
 				result := findExpectedResultForStrategy(test.expectedResults, strategy)

--- a/pkg/kptfile/kptfileutil/util.go
+++ b/pkg/kptfile/kptfileutil/util.go
@@ -156,23 +156,6 @@ func DefaultKptfile(name string) kptfilev1alpha2.KptFile {
 	}
 }
 
-// HasKptfile checks if there exists a Kptfile on the provided path.
-func HasKptfile(path string) (bool, error) {
-	_, err := os.Stat(filepath.Join(path, kptfilev1alpha2.KptFileName))
-
-	// If we got an error that wasn't IsNotExist, something went wrong and
-	// we don't really know if the file exists or not.
-	if err != nil && !os.IsNotExist(err) {
-		return false, err
-	}
-
-	// If the error is IsNotExist, we know the file doesn't exist.
-	if os.IsNotExist(err) {
-		return false, nil
-	}
-	return true, nil
-}
-
 func MergeAndUpdateLocal(local, updated, original string) error {
 	// hasUpdatedKf := true
 	updatedKf, err := ReadFile(updated)


### PR DESCRIPTION
Updates the `Get`, `Fetch`, and `Update` functionality to use the `pkg.Pkg` structure. 

As part of this, it also makes some changes to the `pkg.Pkg` functionality:
 * The `pkg.Kptfile()` function returns an error if a `Kptfile` doesn't exist instead of returning an empty Kptfile. We no longer have the concept of implicit packages.
 * Updates the `pkg.Subpackages` function to include all subpackages, and not only subpackages in the direct subfolders. Also adds tests for this function.

Must merge after https://github.com/GoogleContainerTools/kpt/pull/1568