### PR TITLE
Ensure no kpt.dev section pages are blank.

### DIFF
--- a/site/concepts/README.md
+++ b/site/concepts/README.md
@@ -9,3 +9,6 @@ menu:
 description: >
    Concepts
 ---
+
+Explore kpt's [architecture](/concepts/architecture/) and [API conventions](/concepts/api-conventions/),
+as well as the goals and design decisions of [packaging](/concepts/packaging/) and [functions](/concepts/functions/).

--- a/site/guides/README.md
+++ b/site/guides/README.md
@@ -8,5 +8,7 @@ menu:
     weight: 2
 ---
 
-
+There are [guides for workflows related to consuming packages](/guides/consumer/) published by other teams or organizations,
+[guides for publishing configuration packages](/guides/producer/) for others to consume,
+and [guides for using kpt with the Kubernetes ecosystem](/guides/ecosystem/).
 

--- a/site/guides/consumer/sidebar.md
+++ b/site/guides/consumer/sidebar.md
@@ -10,7 +10,7 @@
         - [Apply](guides/consumer/apply/)
         - [Update](guides/consumer/update/)
         - [Running Functions](guides/consumer/function/)
-            - [Function Catalog](guides/consumer/function/catalog/)
+            - Function Catalog
                 - [Generators](guides/consumer/function/catalog/generators/)
                 - [Sinks](guides/consumer/function/catalog/sinks/)
                 - [Sources](guides/consumer/function/catalog/sources/)

--- a/site/installation/README.md
+++ b/site/installation/README.md
@@ -7,3 +7,9 @@ menu:
   main:
     weight: 1
 ---
+
+Users can install kpt as a [gcloud component](/installation/gcloud/), a 
+[brew tap](/installation/homebrew/), or from [source](/installation/source/).
+
+Alternatively, kpt can be [run in a docker container](/installation/docker/) or
+from [statically compiled go binaries](/installation/binaries/).


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/kpt/issues/1569
Adds summary content to Guides, Installation and Concepts pages.
Removes function catalog link.