### PR TITLE
Support deletion of packages from upstream

### DIFF
--- a/internal/testutil/setup_manager.go
+++ b/internal/testutil/setup_manager.go
@@ -114,13 +114,13 @@ func (g *TestSetupManager) Init() bool {
 		return false
 	}
 
-	// Modify local workspace after initial fetch.
-	if err := UpdateGitDir(g.T, Local, g.LocalWorkspace, g.LocalChanges, g.Repos); err != nil {
+	// Modify other repos after initial fetch.
+	if err := UpdateRepos(g.T, g.Repos, g.ReposChanges); err != nil {
 		return false
 	}
 
-	// Modify other repos after initial fetch.
-	if err := UpdateRepos(g.T, g.Repos, g.ReposChanges); err != nil {
+	// Modify local workspace after initial fetch.
+	if err := UpdateGitDir(g.T, Local, g.LocalWorkspace, g.LocalChanges, g.Repos); err != nil {
 		return false
 	}
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -462,7 +462,12 @@ func SetupRepos(t *testing.T, repoContent map[string][]Content) (map[string]*Tes
 // UpdateRepos updates the existing repos with any additional Content
 // items in the repoContent slice.
 func UpdateRepos(t *testing.T, repos map[string]*TestGitRepo, repoContent map[string][]Content) error {
-	for name := range repoContent {
+	ordering, err := findRepoOrdering(repoContent)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	for _, name := range ordering {
 		data := repoContent[name]
 		if len(data) < 1 {
 			continue

--- a/internal/util/update/common.go
+++ b/internal/util/update/common.go
@@ -1,0 +1,41 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package update
+
+import (
+	"reflect"
+
+	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
+)
+
+func PkgHasLocalChanges(local, origin string) (bool, error) {
+	originKf, err := kptfileutil.ReadFile(origin)
+	if err != nil {
+		return false, err
+	}
+
+	localKf, err := kptfileutil.ReadFile(local)
+	if err != nil {
+		return false, err
+	}
+
+	// If the upstream information in local has changed from origin, it
+	// means the user had updated the package independently and we don't
+	// want to override it.
+	if !reflect.DeepEqual(localKf.Upstream.Git, originKf.Upstream.Git) {
+		return true, nil
+	}
+	return false, nil
+}

--- a/internal/util/update/common.go
+++ b/internal/util/update/common.go
@@ -20,7 +20,9 @@ import (
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
 )
 
-func PkgHasLocalChanges(local, origin string) (bool, error) {
+// PkgHasUpdatedUpstream checks if the the local package has different
+// upstream information than origin.
+func PkgHasUpdatedUpstream(local, origin string) (bool, error) {
 	originKf, err := kptfileutil.ReadFile(origin)
 	if err != nil {
 		return false, err

--- a/internal/util/update/fastforward.go
+++ b/internal/util/update/fastforward.go
@@ -40,12 +40,9 @@ var kptfileSet = func() sets.String {
 
 // We should try to pull the common code up into the Update command.
 func (u FastForwardUpdater) Update(options UpdateOptions) error {
-	localPath := filepath.Join(options.LocalPath, options.RelPackagePath)
-	originalPath := filepath.Join(options.OriginPath, options.RelPackagePath)
-
 	// Verify that there are no local changes that would prevent us from
 	// using the FastForward strategy.
-	if err := u.checkForLocalChanges(localPath, originalPath); err != nil {
+	if err := u.checkForLocalChanges(options.LocalPath, options.OriginPath); err != nil {
 		return err
 	}
 

--- a/internal/util/update/fastforward_test.go
+++ b/internal/util/update/fastforward_test.go
@@ -16,6 +16,7 @@
 package update_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
@@ -173,9 +174,9 @@ func TestUpdate_FastForward(t *testing.T) {
 
 			err := updater.Update(UpdateOptions{
 				RelPackagePath: tc.relPackagePath,
-				OriginPath:     origin,
-				LocalPath:      local,
-				UpdatedPath:    updated,
+				OriginPath:     filepath.Join(origin, tc.relPackagePath),
+				LocalPath:      filepath.Join(local, tc.relPackagePath),
+				UpdatedPath:    filepath.Join(updated, tc.relPackagePath),
 				IsRoot:         tc.isRoot,
 			})
 			if !assert.NoError(t, err) {

--- a/internal/util/update/replace.go
+++ b/internal/util/update/replace.go
@@ -28,10 +28,7 @@ import (
 type ReplaceUpdater struct{}
 
 func (u ReplaceUpdater) Update(options UpdateOptions) error {
-	localPath := filepath.Join(options.LocalPath, options.RelPackagePath)
-	updatedPath := filepath.Join(options.UpdatedPath, options.RelPackagePath)
-
-	paths, err := pkgutil.FindLocalRecursiveSubpackagesForPaths(localPath, updatedPath)
+	paths, err := pkgutil.FindLocalRecursiveSubpackagesForPaths(options.LocalPath, options.UpdatedPath)
 	if err != nil {
 		return err
 	}
@@ -41,8 +38,8 @@ func (u ReplaceUpdater) Update(options UpdateOptions) error {
 		if p == "." && options.IsRoot {
 			isRootPkg = true
 		}
-		localSubPkgPath := filepath.Join(localPath, p)
-		updatedSubPkgPath := filepath.Join(updatedPath, p)
+		localSubPkgPath := filepath.Join(options.LocalPath, p)
+		updatedSubPkgPath := filepath.Join(options.UpdatedPath, p)
 
 		err = pkgutil.RemovePackageContent(localSubPkgPath, !isRootPkg)
 		if err != nil {

--- a/internal/util/update/replace_test.go
+++ b/internal/util/update/replace_test.go
@@ -16,6 +16,7 @@
 package update_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
@@ -173,9 +174,9 @@ func TestUpdate_Replace(t *testing.T) {
 
 			err := updater.Update(UpdateOptions{
 				RelPackagePath: tc.relPackagePath,
-				OriginPath:     origin,
-				LocalPath:      local,
-				UpdatedPath:    updated,
+				OriginPath:     filepath.Join(origin, tc.relPackagePath),
+				LocalPath:      filepath.Join(local, tc.relPackagePath),
+				UpdatedPath:    filepath.Join(updated, tc.relPackagePath),
 				IsRoot:         tc.isRoot,
 			})
 			if !assert.NoError(t, err) {

--- a/internal/util/update/resource-merge.go
+++ b/internal/util/update/resource-merge.go
@@ -38,7 +38,7 @@ type ResourceMergeUpdater struct{}
 
 func (u ResourceMergeUpdater) Update(options UpdateOptions) error {
 	if !options.IsRoot {
-		hasChanges, err := PkgHasLocalChanges(options.LocalPath, options.OriginPath)
+		hasChanges, err := PkgHasUpdatedUpstream(options.LocalPath, options.OriginPath)
 		if err != nil {
 			return err
 		}

--- a/internal/util/update/resource-merge_test.go
+++ b/internal/util/update/resource-merge_test.go
@@ -164,7 +164,8 @@ func TestUpdate_ResourceMerge(t *testing.T) {
 			origin: pkgbuilder.NewRootPkg().
 				WithKptfile(
 					pkgbuilder.NewKptfile().
-						WithUpstream("github.com/GoogleContainerTools/kpt", "/", "master", "resource-merge"),
+						WithUpstream("github.com/GoogleContainerTools/kpt", "/", "master", "resource-merge").
+						WithUpstreamLock("github.com/GoogleContainerTools/kpt", "/", "master", "abc123"),
 				).
 				WithResource(pkgbuilder.DeploymentResource),
 			local: pkgbuilder.NewRootPkg().
@@ -177,7 +178,8 @@ func TestUpdate_ResourceMerge(t *testing.T) {
 			updated: pkgbuilder.NewRootPkg().
 				WithKptfile(
 					pkgbuilder.NewKptfile().
-						WithUpstream("github.com/GoogleContainerTools/kpt", "/", "v1.0", "resource-merge"),
+						WithUpstream("github.com/GoogleContainerTools/kpt", "/", "v1.0", "resource-merge").
+						WithUpstreamLock("github.com/GoogleContainerTools/kpt", "/", "v1.0", "def456"),
 				).
 				WithResource(pkgbuilder.ConfigMapResource),
 			relPackagePath: "/",
@@ -186,7 +188,7 @@ func TestUpdate_ResourceMerge(t *testing.T) {
 				WithKptfile(
 					pkgbuilder.NewKptfile().
 						WithUpstream("github.com/GoogleContainerTools/kpt", "/", "v1.0", "resource-merge").
-						WithUpstreamLock("github.com/GoogleContainerTools/kpt", "/", "master", "abc123"),
+						WithUpstreamLock("github.com/GoogleContainerTools/kpt", "/", "v1.0", "def456"),
 				).
 				WithResource(pkgbuilder.ConfigMapResource),
 		},
@@ -194,7 +196,8 @@ func TestUpdate_ResourceMerge(t *testing.T) {
 			origin: pkgbuilder.NewRootPkg().
 				WithKptfile(
 					pkgbuilder.NewKptfile().
-						WithUpstream("github.com/GoogleContainerTools/kpt", "/", "main", "resource-merge"),
+						WithUpstream("github.com/GoogleContainerTools/kpt", "/", "main", "resource-merge").
+						WithUpstreamLock("github.com/GoogleContainerTools/kpt", "/", "main", "abc123"),
 				).
 				WithResource(pkgbuilder.DeploymentResource),
 			local: pkgbuilder.NewRootPkg().
@@ -207,7 +210,8 @@ func TestUpdate_ResourceMerge(t *testing.T) {
 			updated: pkgbuilder.NewRootPkg().
 				WithKptfile(
 					pkgbuilder.NewKptfile().
-						WithUpstream("github.com/GoogleContainerTools/kpt", "/", "v1.0", "resource-merge"),
+						WithUpstream("github.com/GoogleContainerTools/kpt", "/", "v1.0", "resource-merge").
+						WithUpstreamLock("github.com/GoogleContainerTools/kpt", "/", "v1.0", "qwerty"),
 				).
 				WithResource(pkgbuilder.ConfigMapResource),
 			relPackagePath: "/",

--- a/internal/util/update/update.go
+++ b/internal/util/update/update.go
@@ -231,7 +231,7 @@ func (u Command) updatePackage(p *pkg.Pkg) error {
 			case !originalExists && !updatedExists:
 				continue
 			case originalExists && !updatedExists:
-				hasChanges, err := PkgHasLocalChanges(localPath, originPath)
+				hasChanges, err := PkgHasUpdatedUpstream(localPath, originPath)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
This updates the packaging functionality to handle deletion of packages in upstream. During update, a package that is deleted in upstream will also be deleted in the local fork. The only current exception is if the upstream information in the package Kptfile has changed. Eventually we should do a full diff with all resources to determine if there are local changes, but this would also need to be aware of hydration. We have an issue to address this: https://github.com/GoogleContainerTools/kpt/issues/1438

Fixes: #1464 