### PR TITLE
Fix Dockerfile Location

### DIFF
--- a/release/branch/cloudbuild.yaml
+++ b/release/branch/cloudbuild.yaml
@@ -123,7 +123,7 @@ steps:
 
   # build docker image
   - name: 'gcr.io/cloud-builders/docker'
-    args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/kpt:${BRANCH_NAME}', '-f', './release/Dockerfile', '.' ]
+    args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/kpt:${BRANCH_NAME}', '-f', 'release/Dockerfile', '.' ]
     dir: 'kpt'
 
   # push the container image

--- a/release/branch/cloudbuild.yaml
+++ b/release/branch/cloudbuild.yaml
@@ -123,7 +123,7 @@ steps:
 
   # build docker image
   - name: 'gcr.io/cloud-builders/docker'
-    args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/kpt:${BRANCH_NAME}', '.' ]
+    args: [ 'build', '-t', 'gcr.io/$PROJECT_ID/kpt:${BRANCH_NAME}', '-f', './release/Dockerfile', '.' ]
     dir: 'kpt'
 
   # push the container image


### PR DESCRIPTION
Kpt Cloud Build runs are failing on pushes to master because the Dockerfile they expect has been moved. This updates the path so those jobs should be able to complete.

This is causing behavior like what is seen here: https://github.com/GoogleContainerTools/kpt/runs/2168255035