### PR TITLE
added the min of 3 args for a set command

### DIFF
--- a/commands/configcmd.go
+++ b/commands/configcmd.go
@@ -147,6 +147,7 @@ func SetCommand(parent string) *cobra.Command {
 	kustomizeCmd.SilenceUsage = true
 	kustomizeCmd.SilenceErrors = true
 	var autoRun bool
+	setCmd.Args = cobra.MinimumNArgs(3)
 	setCmd.Flags().BoolVar(&autoRun, "auto-run", true,
 		`Automatically run functions after setting (if enabled for the package)`)
 	setCmd.RunE = func(c *cobra.Command, args []string) error {


### PR DESCRIPTION
The set command inherited the min args from kustomize which only has them set to 2.  In kpt alpha1 due to the requirement to have a directory it only passes 1 argument to kustomize set command and that generates a panic.

This change stops command that don't have enough arguments prior.  Examples:
```
 ~/src/sandbox » kpt cfg set gh1593
error: requires at least 3 arg(s), only received 1
 ~/src/sandbox » kpt cfg set gh1593 mysqlpw
error: requires at least 3 arg(s), only received 2
```

Fixes #1593 

## Testing
There doesn't seem to be a list of unit tests right now that tests the CLI and given that churn between alpha1 and v1 I am going to let this one be untested.


## Additional work
There are many things to clean up on the help page for the command like this output:
```
`set` maybe be used to:

- edit configuration programmatically from the cli
- create reusable bundles of configuration with custom setters

  DIR

    A directory containing Resource configuration.

  NAME

    Optional.  The name of the setter to perform or display.

  VALUE

    Optional.  The value to set on the field.
```
not sure what set with no name or value would do... but given the major rework of setters this might be a good thing to revisit later.
