### PR TITLE
[WIP] New error type

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,144 @@
+package errors
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/GoogleContainerTools/kpt/internal/pkg"
+)
+
+// Error is an implementation of the error interface used in the kpt
+// codebase.
+// It is based on the design in https://commandcenter.blogspot.com/2017/12/error-handling-in-upspin.html
+type Error struct {
+	Path pkg.UniquePath
+
+	Op Op
+
+	Kind Kind
+
+	Err error
+}
+
+func pad(b *strings.Builder, str string) {
+	if b.Len() == 0 {
+		return
+	}
+	b.WriteString(str)
+}
+
+func (e *Error) Error() string {
+	b := new(strings.Builder)
+
+	if e.Op != "" {
+		pad(b, ": ")
+		b.WriteString(string(e.Op))
+	}
+
+	if e.Path != "" {
+		pad(b, ": ")
+		b.WriteString(e.Path.String())
+	}
+
+	if e.Kind != 0 {
+		pad(b, ": ")
+		b.WriteString(e.Kind.String())
+	}
+
+	if e.Err != nil {
+		if wrappedErr, ok := e.Err.(*Error); ok {
+			if !wrappedErr.Zero() {
+				pad(b, "\n\t")
+				b.WriteString(wrappedErr.Error())
+			}
+		} else {
+			pad(b, ": ")
+			b.WriteString(e.Err.Error())
+		}
+	}
+	if b.Len() == 0 {
+		return "no error"
+	}
+	return b.String()
+}
+
+func (e *Error) Zero() bool {
+	return e.Op == "" && e.Path == "" && e.Kind == 0 && e.Err == nil
+}
+
+type Op string
+
+type Kind int
+
+const (
+	Other        Kind = iota // Unclassified. Will not be printed.
+	Exist                    // Item already exists.
+	Internal                 // Internal error.
+	InvalidParam             // Value is not valid.
+	MissingParam             // Required value is missing or empty.
+	Git                      // Errors from Git
+)
+
+func (k Kind) String() string {
+	switch k {
+	case Other:
+		return "other error"
+	case Exist:
+		return "item already exist"
+	case Internal:
+		return "internal error"
+	case InvalidParam:
+		return "invalid parameter value"
+	case MissingParam:
+		return "missing parameter value"
+	case Git:
+		return "git error"
+	}
+	return "unknown kind"
+}
+
+func E(args ...interface{}) error {
+	if len(args) == 0 {
+		panic("errors.E must have at least one argument")
+	}
+
+	e := &Error{}
+	for _, arg := range args {
+		switch a := arg.(type) {
+		case pkg.UniquePath:
+			e.Path = a
+		case Op:
+			e.Op = a
+		case Kind:
+			e.Kind = a
+		case *Error:
+			cp := *a
+			e.Err = &cp
+		case error:
+			e.Err = a
+		case string:
+			e.Err = fmt.Errorf(a)
+		default:
+			panic(fmt.Errorf("unknown type %T for value %v in call to error.E", a, a))
+		}
+	}
+
+	wrappedErr, ok := e.Err.(*Error)
+	if !ok {
+		return e
+	}
+
+	if e.Path == wrappedErr.Path {
+		wrappedErr.Path = ""
+	}
+
+	if e.Op == wrappedErr.Op {
+		wrappedErr.Op = ""
+	}
+
+	if e.Kind == wrappedErr.Kind {
+		wrappedErr.Kind = 0
+	}
+
+	return e
+}

--- a/internal/testutil/setup_manager.go
+++ b/internal/testutil/setup_manager.go
@@ -114,13 +114,13 @@ func (g *TestSetupManager) Init() bool {
 		return false
 	}
 
-	// Modify local workspace after initial fetch.
-	if err := UpdateGitDir(g.T, Local, g.LocalWorkspace, g.LocalChanges, g.Repos); err != nil {
+	// Modify other repos after initial fetch.
+	if err := UpdateRepos(g.T, g.Repos, g.ReposChanges); err != nil {
 		return false
 	}
 
-	// Modify other repos after initial fetch.
-	if err := UpdateRepos(g.T, g.Repos, g.ReposChanges); err != nil {
+	// Modify local workspace after initial fetch.
+	if err := UpdateGitDir(g.T, Local, g.LocalWorkspace, g.LocalChanges, g.Repos); err != nil {
 		return false
 	}
 

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -462,7 +462,12 @@ func SetupRepos(t *testing.T, repoContent map[string][]Content) (map[string]*Tes
 // UpdateRepos updates the existing repos with any additional Content
 // items in the repoContent slice.
 func UpdateRepos(t *testing.T, repos map[string]*TestGitRepo, repoContent map[string][]Content) error {
-	for name := range repoContent {
+	ordering, err := findRepoOrdering(repoContent)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	for _, name := range ordering {
 		data := repoContent[name]
 		if len(data) < 1 {
 			continue

--- a/internal/util/fetch/fetch.go
+++ b/internal/util/fetch/fetch.go
@@ -23,13 +23,13 @@ import (
 	"path"
 	"strings"
 
+	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/gitutil"
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	"github.com/GoogleContainerTools/kpt/internal/util/git"
 	"github.com/GoogleContainerTools/kpt/internal/util/pkgutil"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
-	"sigs.k8s.io/kustomize/kyaml/errors"
 )
 
 // Command takes the upstream information in the Kptfile at the path for the
@@ -41,13 +41,14 @@ type Command struct {
 
 // Run runs the Command.
 func (c Command) Run() error {
+	const op errors.Op = "fetch.Run"
 	kf, err := c.Pkg.Kptfile()
 	if err != nil {
-		return fmt.Errorf("no Kptfile found")
+		return errors.E(op, c.Pkg.UniquePath, err)
 	}
 
 	if err := c.validate(kf); err != nil {
-		return err
+		return errors.E(op, c.Pkg.UniquePath, err)
 	}
 
 	g := kf.Upstream.Git
@@ -58,7 +59,7 @@ func (c Command) Run() error {
 	}
 	err = cloneAndCopy(repoSpec, c.Pkg.UniquePath.String())
 	if err != nil {
-		return err
+		return errors.E(op, c.Pkg.UniquePath, err)
 	}
 	return nil
 }
@@ -66,23 +67,29 @@ func (c Command) Run() error {
 // validate makes sure the Kptfile has the necessary information to fetch
 // the package.
 func (c Command) validate(kf *kptfilev1alpha2.KptFile) error {
+	const op errors.Op = "fetch.validate"
 	if kf.Upstream == nil {
-		return fmt.Errorf("kptfile doesn't contain upstream information")
+		return errors.E(op, c.Pkg.UniquePath, errors.MissingParam,
+			"kptfile doesn't contain upstream information")
 	}
 
 	if kf.Upstream.Git == nil {
-		return fmt.Errorf("kptfile upstream doesn't have git information")
+		return errors.E(op, c.Pkg.UniquePath, errors.MissingParam,
+			"kptfile upstream doesn't have git information")
 	}
 
 	g := kf.Upstream.Git
 	if len(g.Repo) == 0 {
-		return errors.Errorf("must specify repo")
+		return errors.E(op, c.Pkg.UniquePath, errors.MissingParam,
+			"must specify repo")
 	}
 	if len(g.Ref) == 0 {
-		return errors.Errorf("must specify ref")
+		return errors.E(op, c.Pkg.UniquePath, errors.MissingParam,
+			"must specify ref")
 	}
 	if len(g.Directory) == 0 {
-		return errors.Errorf("must specify directory")
+		return errors.E(op, c.Pkg.UniquePath, errors.MissingParam,
+			"must specify directory")
 	}
 	return nil
 }
@@ -91,18 +98,18 @@ func (c Command) validate(kf *kptfilev1alpha2.KptFile) error {
 // directory specified by dest. The provided name is set as `metadata.name`
 // of the Kptfile of the package.
 func cloneAndCopy(r *git.RepoSpec, dest string) error {
+	const op errors.Op = "fetch.cloneAndCopy"
 	if err := ClonerUsingGitExec(r); err != nil {
-		return errors.Errorf("failed to clone git repo: %v", err)
+		return errors.E(op, err)
 	}
 	defer os.RemoveAll(r.Dir)
 
 	if err := pkgutil.CopyPackageWithSubpackages(r.AbsPath(), dest); err != nil {
-		return errors.WrapPrefixf(err, "missing subdirectory %s in repo %s at ref %s\n",
-			r.Path, r.OrgRepo, r.Ref)
+		return errors.E(op, err)
 	}
 
 	if err := UpsertKptfile(dest, r); err != nil {
-		return errors.Wrap(err)
+		return errors.E(op, "failed to update Kptfile")
 	}
 	return nil
 }
@@ -114,6 +121,7 @@ func cloneAndCopy(r *git.RepoSpec, dest string) error {
 // relies on the private clonerUsingGitExec function to try fetching different
 // refs.
 func ClonerUsingGitExec(repoSpec *git.RepoSpec) error {
+	const op errors.Op = "fetch.ClonerUsingGitExec"
 	// look for a tag with the directory as a prefix for versioning
 	// subdirectories independently
 	originalRef := repoSpec.Ref
@@ -124,7 +132,7 @@ func ClonerUsingGitExec(repoSpec *git.RepoSpec) error {
 
 	defaultRef, err := gitutil.DefaultRef(repoSpec.OrgRepo)
 	if err != nil {
-		return err
+		return errors.E(op, errors.Git, err)
 	}
 
 	// clone the repo to a tmp directory.
@@ -137,10 +145,11 @@ func ClonerUsingGitExec(repoSpec *git.RepoSpec) error {
 
 	if err != nil {
 		if strings.HasPrefix(repoSpec.Path, "blob/") {
-			return errors.Errorf("failed to clone git repo containing /blob/, "+
-				"you may need to remove /blob/%s from the url:\n%v", defaultRef, err)
+			return errors.E(op, errors.Git,
+				fmt.Errorf("failed to clone git repo containing /blob/, "+
+					"you may need to remove /blob/%s from the url: %w", defaultRef, err))
 		}
-		return errors.Errorf("failed to clone git repo: %v", err)
+		return errors.E(op, errors.Git, err)
 	}
 
 	return nil
@@ -150,14 +159,15 @@ func ClonerUsingGitExec(repoSpec *git.RepoSpec) error {
 // a local temp directory. This is used by the public ClonerUsingGitExec
 // function to allow trying multiple different refs.
 func clonerUsingGitExec(repoSpec *git.RepoSpec) error {
+	const op errors.Op = "fetch.clonerUsingGitExec"
 	gitProgram, err := exec.LookPath("git")
 	if err != nil {
-		return errors.WrapPrefixf(err, "no 'git' program on path")
+		return errors.E(op, errors.Git, "no 'git' program on path", err)
 	}
 
 	repoSpec.Dir, err = ioutil.TempDir("", "kpt-get-")
 	if err != nil {
-		return err
+		return errors.E(op, errors.Internal, err)
 	}
 	cmd := exec.Command(gitProgram, "init", repoSpec.Dir)
 	var out bytes.Buffer
@@ -165,9 +175,11 @@ func clonerUsingGitExec(repoSpec *git.RepoSpec) error {
 	cmd.Stderr = &out
 	err = cmd.Run()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error initializing empty git repo: %s", out.String())
-		return errors.WrapPrefixf(err, "trouble initializing empty git repo in %s",
-			repoSpec.Dir)
+		return errors.E(op, errors.Git, &execError{
+			Msg:    "failed to initialize empty git repo",
+			Err:    err,
+			Output: out.String(),
+		})
 	}
 
 	cmd = exec.Command(gitProgram, "remote", "add", "origin", repoSpec.CloneSpec())
@@ -176,16 +188,17 @@ func clonerUsingGitExec(repoSpec *git.RepoSpec) error {
 	cmd.Dir = repoSpec.Dir
 	err = cmd.Run()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error setting git remote: %s", out.String())
-		return errors.WrapPrefixf(
-			err,
-			"trouble adding remote %s",
-			repoSpec.CloneSpec())
+		return errors.E(op, errors.Git, &execError{
+			Msg:    fmt.Sprintf("failed to set git remote %s", repoSpec.CloneSpec()),
+			Err:    err,
+			Output: out.String(),
+		})
 	}
 	if repoSpec.Ref == "" {
 		repoSpec.Ref, err = gitutil.DefaultRef(repoSpec.Dir)
 		if err != nil {
-			return err
+			return errors.E(op, errors.Git,
+				fmt.Errorf("failed to look up default ref for git clone"))
 		}
 	}
 
@@ -196,8 +209,12 @@ func clonerUsingGitExec(repoSpec *git.RepoSpec) error {
 		cmd.Dir = repoSpec.Dir
 		err = cmd.Run()
 		if err != nil {
-			return errors.WrapPrefixf(err, "trouble fetching %s, "+
-				"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials", repoSpec.Ref)
+			return errors.E(op, errors.Git, &execError{
+				Msg: fmt.Sprintf("failed to fetch %q, "+
+					"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials", repoSpec.Ref),
+				Err:    err,
+				Output: out.String(),
+			})
 		}
 		cmd = exec.Command(gitProgram, "reset", "--hard", "FETCH_HEAD")
 		cmd.Stdout = &out
@@ -205,8 +222,11 @@ func clonerUsingGitExec(repoSpec *git.RepoSpec) error {
 		cmd.Dir = repoSpec.Dir
 		err = cmd.Run()
 		if err != nil {
-			return errors.WrapPrefixf(
-				err, "trouble hard resetting empty repository to %s", repoSpec.Ref)
+			return errors.E(op, errors.Git, &execError{
+				Msg:    fmt.Sprintf("failed to hard reset empty repository to %q", repoSpec.Ref),
+				Err:    err,
+				Output: out.String(),
+			})
 		}
 		return nil
 	}()
@@ -216,17 +236,24 @@ func clonerUsingGitExec(repoSpec *git.RepoSpec) error {
 		cmd.Stderr = &out
 		cmd.Dir = repoSpec.Dir
 		if err = cmd.Run(); err != nil {
-			return errors.WrapPrefixf(err, "trouble fetching origin, "+
-				"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials")
+			return errors.E(op, errors.Git, &execError{
+				Msg: fmt.Sprintf("failed to fetch origin, " +
+					"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials"),
+				Err:    err,
+				Output: out.String(),
+			})
 		}
 		cmd = exec.Command(gitProgram, "reset", "--hard", repoSpec.Ref)
 		cmd.Stdout = &out
 		cmd.Stderr = &out
 		cmd.Dir = repoSpec.Dir
 		if err = cmd.Run(); err != nil {
-			return errors.WrapPrefixf(
-				err, "trouble hard resetting empty repository to %s, "+
-					"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials", repoSpec.Ref)
+			return errors.E(op, errors.Git, &execError{
+				Msg: fmt.Sprintf("failed to hard reset empty repository to %q, "+
+					"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials", repoSpec.Ref),
+				Err:    err,
+				Output: out.String(),
+			})
 		}
 	}
 
@@ -235,11 +262,30 @@ func clonerUsingGitExec(repoSpec *git.RepoSpec) error {
 	cmd.Dir = repoSpec.Dir
 	err = cmd.Run()
 	if err != nil {
-		return errors.WrapPrefixf(err, "trouble fetching submodules for %s, "+
-			"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials", repoSpec.Ref)
+		return errors.E(op, errors.Git, &execError{
+			Msg: fmt.Sprintf("failed to fetch submodules for %q, "+
+				"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials", repoSpec.Ref),
+			Err:    err,
+			Output: out.String(),
+		})
 	}
 
 	return nil
+}
+
+type execError struct {
+	Msg    string
+	Output string
+	Err    error
+}
+
+func (e *execError) Error() string {
+	b := new(strings.Builder)
+	b.WriteString(e.Msg)
+	b.WriteString(": ")
+	b.WriteString(e.Err.Error())
+	// TODO: Consider if we should print the stdout/stderr output here as well.
+	return b.String()
 }
 
 // UpsertKptfile populates the KptFile values, merging any cloned KptFile and the

--- a/internal/util/fetch/fetch_test.go
+++ b/internal/util/fetch/fetch_test.go
@@ -77,7 +77,10 @@ func TestCommand_Run_failNoKptfile(t *testing.T) {
 	err = Command{
 		Pkg: createPackage(t, pkgPath),
 	}.Run()
-	assert.EqualError(t, err, "no Kptfile found")
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+	assert.Contains(t, err.Error(), "unable to read Kptfile")
 }
 
 // TestCommand_Run_failEmptyRepo verifies that Command fail if not repo is provided.
@@ -93,7 +96,10 @@ func TestCommand_Run_failNoGit(t *testing.T) {
 	err = Command{
 		Pkg: createPackage(t, w.FullPackagePath()),
 	}.Run()
-	assert.EqualError(t, err, "kptfile upstream doesn't have git information")
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+	assert.Contains(t, err.Error(), "kptfile upstream doesn't have git information")
 }
 
 // TestCommand_Run_failEmptyRepo verifies that Command fail if not repo is provided.
@@ -113,7 +119,10 @@ func TestCommand_Run_failEmptyRepo(t *testing.T) {
 	err = Command{
 		Pkg: createPackage(t, w.FullPackagePath()),
 	}.Run()
-	assert.EqualError(t, err, "must specify repo")
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+	assert.Contains(t, err.Error(), "must specify repo")
 }
 
 // TestCommand_Run_failEmptyRepo verifies that Command fail if not repo is provided.
@@ -133,7 +142,10 @@ func TestCommand_Run_failNoRevision(t *testing.T) {
 	err = Command{
 		Pkg: createPackage(t, w.FullPackagePath()),
 	}.Run()
-	assert.EqualError(t, err, "must specify ref")
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+	assert.Contains(t, err.Error(), "must specify ref")
 }
 
 // TestCommand_Run verifies that Command will clone the HEAD of the master branch.

--- a/internal/util/get/get_test.go
+++ b/internal/util/get/get_test.go
@@ -15,7 +15,6 @@
 package get_test
 
 import (
-	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -37,7 +36,10 @@ func TestCommand_Run_failEmptyRepo(t *testing.T) {
 	err := Command{
 		Destination: w.WorkspaceDirectory,
 	}.Run()
-	assert.EqualError(t, err, "must specify git repo information")
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+	assert.Contains(t, err.Error(), "must specify git repo information")
 }
 
 // TestCommand_Run_failEmptyRepo verifies that Command fail if not repo is provided.
@@ -51,7 +53,10 @@ func TestCommand_Run_failNoRevision(t *testing.T) {
 		},
 		Destination: w.WorkspaceDirectory,
 	}.Run()
-	assert.EqualError(t, err, "must specify ref")
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+	assert.Contains(t, err.Error(), "must specify ref")
 }
 
 // TestCommand_Run verifies that Command will clone the HEAD of the master branch.
@@ -533,7 +538,10 @@ func TestCommand_Run_failExistingDir(t *testing.T) {
 		},
 		Destination: absPath,
 	}.Run()
-	assert.EqualError(t, err, fmt.Sprintf("destination directory %s already exists", absPath))
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+	assert.Contains(t, err.Error(), "directory already exists")
 
 	// verify files are unchanged
 	g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset1), absPath)

--- a/internal/util/update/common.go
+++ b/internal/util/update/common.go
@@ -1,0 +1,41 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package update
+
+import (
+	"reflect"
+
+	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
+)
+
+func PkgHasLocalChanges(local, origin string) (bool, error) {
+	originKf, err := kptfileutil.ReadFile(origin)
+	if err != nil {
+		return false, err
+	}
+
+	localKf, err := kptfileutil.ReadFile(local)
+	if err != nil {
+		return false, err
+	}
+
+	// If the upstream information in local has changed from origin, it
+	// means the user had updated the package independently and we don't
+	// want to override it.
+	if !reflect.DeepEqual(localKf.Upstream.Git, originKf.Upstream.Git) {
+		return true, nil
+	}
+	return false, nil
+}

--- a/internal/util/update/common.go
+++ b/internal/util/update/common.go
@@ -20,7 +20,9 @@ import (
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
 )
 
-func PkgHasLocalChanges(local, origin string) (bool, error) {
+// PkgHasUpdatedUpstream checks if the the local package has different
+// upstream information than origin.
+func PkgHasUpdatedUpstream(local, origin string) (bool, error) {
 	originKf, err := kptfileutil.ReadFile(origin)
 	if err != nil {
 		return false, err

--- a/internal/util/update/fastforward.go
+++ b/internal/util/update/fastforward.go
@@ -40,12 +40,9 @@ var kptfileSet = func() sets.String {
 
 // We should try to pull the common code up into the Update command.
 func (u FastForwardUpdater) Update(options UpdateOptions) error {
-	localPath := filepath.Join(options.LocalPath, options.RelPackagePath)
-	originalPath := filepath.Join(options.OriginPath, options.RelPackagePath)
-
 	// Verify that there are no local changes that would prevent us from
 	// using the FastForward strategy.
-	if err := u.checkForLocalChanges(localPath, originalPath); err != nil {
+	if err := u.checkForLocalChanges(options.LocalPath, options.OriginPath); err != nil {
 		return err
 	}
 

--- a/internal/util/update/fastforward_test.go
+++ b/internal/util/update/fastforward_test.go
@@ -16,6 +16,7 @@
 package update_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
@@ -173,9 +174,9 @@ func TestUpdate_FastForward(t *testing.T) {
 
 			err := updater.Update(UpdateOptions{
 				RelPackagePath: tc.relPackagePath,
-				OriginPath:     origin,
-				LocalPath:      local,
-				UpdatedPath:    updated,
+				OriginPath:     filepath.Join(origin, tc.relPackagePath),
+				LocalPath:      filepath.Join(local, tc.relPackagePath),
+				UpdatedPath:    filepath.Join(updated, tc.relPackagePath),
 				IsRoot:         tc.isRoot,
 			})
 			if !assert.NoError(t, err) {

--- a/internal/util/update/replace.go
+++ b/internal/util/update/replace.go
@@ -28,10 +28,7 @@ import (
 type ReplaceUpdater struct{}
 
 func (u ReplaceUpdater) Update(options UpdateOptions) error {
-	localPath := filepath.Join(options.LocalPath, options.RelPackagePath)
-	updatedPath := filepath.Join(options.UpdatedPath, options.RelPackagePath)
-
-	paths, err := pkgutil.FindLocalRecursiveSubpackagesForPaths(localPath, updatedPath)
+	paths, err := pkgutil.FindLocalRecursiveSubpackagesForPaths(options.LocalPath, options.UpdatedPath)
 	if err != nil {
 		return err
 	}
@@ -41,8 +38,8 @@ func (u ReplaceUpdater) Update(options UpdateOptions) error {
 		if p == "." && options.IsRoot {
 			isRootPkg = true
 		}
-		localSubPkgPath := filepath.Join(localPath, p)
-		updatedSubPkgPath := filepath.Join(updatedPath, p)
+		localSubPkgPath := filepath.Join(options.LocalPath, p)
+		updatedSubPkgPath := filepath.Join(options.UpdatedPath, p)
 
 		err = pkgutil.RemovePackageContent(localSubPkgPath, !isRootPkg)
 		if err != nil {

--- a/internal/util/update/replace_test.go
+++ b/internal/util/update/replace_test.go
@@ -16,6 +16,7 @@
 package update_test
 
 import (
+	"path/filepath"
 	"testing"
 
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
@@ -173,9 +174,9 @@ func TestUpdate_Replace(t *testing.T) {
 
 			err := updater.Update(UpdateOptions{
 				RelPackagePath: tc.relPackagePath,
-				OriginPath:     origin,
-				LocalPath:      local,
-				UpdatedPath:    updated,
+				OriginPath:     filepath.Join(origin, tc.relPackagePath),
+				LocalPath:      filepath.Join(local, tc.relPackagePath),
+				UpdatedPath:    filepath.Join(updated, tc.relPackagePath),
 				IsRoot:         tc.isRoot,
 			})
 			if !assert.NoError(t, err) {

--- a/internal/util/update/resource-merge.go
+++ b/internal/util/update/resource-merge.go
@@ -38,7 +38,7 @@ type ResourceMergeUpdater struct{}
 
 func (u ResourceMergeUpdater) Update(options UpdateOptions) error {
 	if !options.IsRoot {
-		hasChanges, err := PkgHasLocalChanges(options.LocalPath, options.OriginPath)
+		hasChanges, err := PkgHasUpdatedUpstream(options.LocalPath, options.OriginPath)
 		if err != nil {
 			return err
 		}

--- a/internal/util/update/resource-merge_test.go
+++ b/internal/util/update/resource-merge_test.go
@@ -164,7 +164,8 @@ func TestUpdate_ResourceMerge(t *testing.T) {
 			origin: pkgbuilder.NewRootPkg().
 				WithKptfile(
 					pkgbuilder.NewKptfile().
-						WithUpstream("github.com/GoogleContainerTools/kpt", "/", "master", "resource-merge"),
+						WithUpstream("github.com/GoogleContainerTools/kpt", "/", "master", "resource-merge").
+						WithUpstreamLock("github.com/GoogleContainerTools/kpt", "/", "master", "abc123"),
 				).
 				WithResource(pkgbuilder.DeploymentResource),
 			local: pkgbuilder.NewRootPkg().
@@ -177,7 +178,8 @@ func TestUpdate_ResourceMerge(t *testing.T) {
 			updated: pkgbuilder.NewRootPkg().
 				WithKptfile(
 					pkgbuilder.NewKptfile().
-						WithUpstream("github.com/GoogleContainerTools/kpt", "/", "v1.0", "resource-merge"),
+						WithUpstream("github.com/GoogleContainerTools/kpt", "/", "v1.0", "resource-merge").
+						WithUpstreamLock("github.com/GoogleContainerTools/kpt", "/", "v1.0", "def456"),
 				).
 				WithResource(pkgbuilder.ConfigMapResource),
 			relPackagePath: "/",
@@ -186,7 +188,7 @@ func TestUpdate_ResourceMerge(t *testing.T) {
 				WithKptfile(
 					pkgbuilder.NewKptfile().
 						WithUpstream("github.com/GoogleContainerTools/kpt", "/", "v1.0", "resource-merge").
-						WithUpstreamLock("github.com/GoogleContainerTools/kpt", "/", "master", "abc123"),
+						WithUpstreamLock("github.com/GoogleContainerTools/kpt", "/", "v1.0", "def456"),
 				).
 				WithResource(pkgbuilder.ConfigMapResource),
 		},
@@ -194,7 +196,8 @@ func TestUpdate_ResourceMerge(t *testing.T) {
 			origin: pkgbuilder.NewRootPkg().
 				WithKptfile(
 					pkgbuilder.NewKptfile().
-						WithUpstream("github.com/GoogleContainerTools/kpt", "/", "main", "resource-merge"),
+						WithUpstream("github.com/GoogleContainerTools/kpt", "/", "main", "resource-merge").
+						WithUpstreamLock("github.com/GoogleContainerTools/kpt", "/", "main", "abc123"),
 				).
 				WithResource(pkgbuilder.DeploymentResource),
 			local: pkgbuilder.NewRootPkg().
@@ -207,7 +210,8 @@ func TestUpdate_ResourceMerge(t *testing.T) {
 			updated: pkgbuilder.NewRootPkg().
 				WithKptfile(
 					pkgbuilder.NewKptfile().
-						WithUpstream("github.com/GoogleContainerTools/kpt", "/", "v1.0", "resource-merge"),
+						WithUpstream("github.com/GoogleContainerTools/kpt", "/", "v1.0", "resource-merge").
+						WithUpstreamLock("github.com/GoogleContainerTools/kpt", "/", "v1.0", "qwerty"),
 				).
 				WithResource(pkgbuilder.ConfigMapResource),
 			relPackagePath: "/",

--- a/internal/util/update/update.go
+++ b/internal/util/update/update.go
@@ -231,7 +231,7 @@ func (u Command) updatePackage(p *pkg.Pkg) error {
 			case !originalExists && !updatedExists:
 				continue
 			case originalExists && !updatedExists:
-				hasChanges, err := PkgHasLocalChanges(localPath, originPath)
+				hasChanges, err := PkgHasUpdatedUpstream(localPath, originPath)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
POC for implementing error handling in kpt using the approach from https://commandcenter.blogspot.com/2017/12/error-handling-in-upspin.html

Some known issues:
 * No obvious way to pass along both an existing error and a string providing more context. There are [examples](https://github.com/GoogleContainerTools/kpt/pull/1602/commits/98f0ba0126c60f872346cee7199b45c66da67362#diff-7f95dd60520d3da41a3f0c1f4cdaead5a87419583ee63f64d532f3695813375cR152) where it seems it would be useful.
 * This approach would probably lead to almost all errors being the same type, which means checking for specific error types doesn't work. But I think we in some cases want to detect certain errors in the cobra command level and print more specific and helpful messages to the user. 