### PR TITLE
Add workaround for dependency license scan.

### DIFF
--- a/scripts/create-licenses.sh
+++ b/scripts/create-licenses.sh
@@ -178,6 +178,15 @@ for PACKAGE in $(go list -m -json all | jq -r .Path | sort -f); do
     # echo "$PACKAGE doesn't exist in vendor, skipping" > /dev/stderr
     continue
   fi
+  # TODO: samwronski - remove this edge case
+  # The above if statement skips dependencies which did not get checked out with
+  # `go mod vendor` however that does not catch this edge case.
+  # Kpt currently depends on 2 versions of posener. Because v2 *is* checked out
+  # the directory does exist causing the above check to pass. However this repo
+  # is not included in the vendor directory so a license will not be found.
+  if [[ ! -e "github.com/posener/complete" ]]; then
+    continue
+  fi
 
   process_content "${PACKAGE}" LICENSE
   process_content "${PACKAGE}" COPYRIGHT


### PR DESCRIPTION
This is a workaround for #1604 that adds an explicit exception for `github.com/posener/complete`.

To recreate the error this is addressing:

```sh
go mod vendor
go list -m -json all | grep posener
```

Because the source of v1 of `posener` is not in the `vendor` directory but `posener/v2` exists the check will ignore existing safeguards meant to catch this case. The `LICENSE` does not exist because the dependency doesn't exist.

**Looking for Feedback**: I was not able to find a more elegant way of solving this. If you know of one we will probably want to use that instead.

This is intended as a short term solution to unblock Kpt releases by specifically excluding the `github.com/posener/complete` project from the check.