### PR TITLE
Fix GoReleaser release publish owner

### DIFF
--- a/release/README.md
+++ b/release/README.md
@@ -62,6 +62,10 @@ Otherwise the first steps that checkout the code will not include your local
 changes and all future steps will not include those changes. This includes any
 modifications to `goreleaser.yaml`!
 
+> Before following these steps you will need to manually update
+`release/tag/goreleaser.yaml` so that `release.github.owner` points to your
+GitHub account.
+
 1. Setup your gcloud profile.
 2. Create and enable the Google Cloud Secret Manager on the profile
 3. Create a GitHub Personal Access Token and save it as `github-token` in the

--- a/release/tag/goreleaser.yaml
+++ b/release/tag/goreleaser.yaml
@@ -49,5 +49,5 @@ changelog:
       - Merge branch
 release:
   github:
-    owner: "{{ .Env._GITHUB_USER }}"
+    owner: "GoogleContainerTools"
     name: kpt


### PR DESCRIPTION
This is intended to resolve a problem with GoReleaser which parameterized the release owner destination. While that change worked locally it is failing during release causing GoReleaser to attempt to publish to: `https://api.github.com/repos/%7B%7B%20.Env._GITHUB_USER%20%7D%7D/kpt/releases` which fails.

This reverts this to a hardcoded value and introduces a note that testing releases will require manually replacing this.