### PR TITLE
improve error handling in `fn render` command

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -15,6 +15,7 @@
 package commands
 
 import (
+	"context"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -30,9 +31,9 @@ func NormalizeCommand(c ...*cobra.Command) {
 }
 
 // GetKptCommands returns the set of kpt commands to be registered
-func GetKptCommands(name string, f util.Factory) []*cobra.Command {
+func GetKptCommands(ctx context.Context, name string, f util.Factory) []*cobra.Command {
 	var c []*cobra.Command
-	fnCmd := GetFnCommand(name)
+	fnCmd := GetFnCommand(ctx, name)
 	pkgCmd := GetPkgCommand(name)
 	liveCmd := GetLiveCommand(name, f)
 

--- a/commands/fncmd.go
+++ b/commands/fncmd.go
@@ -15,6 +15,8 @@
 package commands
 
 import (
+	"context"
+
 	"github.com/GoogleContainerTools/kpt/internal/cmdexport"
 	"github.com/GoogleContainerTools/kpt/internal/cmdfndoc"
 	"github.com/GoogleContainerTools/kpt/internal/cmdrender"
@@ -25,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func GetFnCommand(name string) *cobra.Command {
+func GetFnCommand(ctx context.Context, name string) *cobra.Command {
 	functions := &cobra.Command{
 		Use:     "fn",
 		Short:   fndocs.FnShort,
@@ -49,7 +51,7 @@ func GetFnCommand(name string) *cobra.Command {
 	eval.Long = fndocs.RunShort + "\n" + fndocs.RunLong
 	eval.Example = fndocs.RunExamples
 
-	render := cmdrender.NewCommand(name)
+	render := cmdrender.NewCommand(ctx, name)
 
 	doc := cmdfndoc.NewCommand(name)
 	doc.Short = fndocs.DocShort

--- a/internal/cmdrender/cmd.go
+++ b/internal/cmdrender/cmd.go
@@ -53,11 +53,13 @@ type Runner struct {
 }
 
 func (r *Runner) preRunE(c *cobra.Command, args []string) error {
+	const op errors.Op = "fn.preRunE"
+
 	if len(args) == 0 {
 		// no pkg path specified, default to current working dir
 		wd, err := os.Getwd()
 		if err != nil {
-			return errors.E(errors.Op("pkg.Read"), err)
+			return errors.E(op, err)
 		}
 		r.pkgPath = wd
 	} else {

--- a/internal/cmdrender/executor.go
+++ b/internal/cmdrender/executor.go
@@ -15,13 +15,16 @@
 package cmdrender
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 
+	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
+	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"github.com/GoogleContainerTools/kpt/internal/types"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 	"sigs.k8s.io/kustomize/kyaml/kio"
@@ -33,13 +36,17 @@ import (
 // Executor hydrates a given pkg.
 type Executor struct {
 	PkgPath string
+	Printer printer.Printer
 }
 
 // Execute runs a pipeline.
-func (e *Executor) Execute() error {
+func (e *Executor) Execute(ctx context.Context) error {
+	op := errors.Op("fn.render")
+	pr := printer.FromContext(ctx)
+
 	root, err := newPkgNode(e.PkgPath, nil)
 	if err != nil {
-		return err
+		return errors.E(op, types.UniquePath(e.PkgPath), err)
 	}
 
 	// initialize hydration context
@@ -48,9 +55,9 @@ func (e *Executor) Execute() error {
 		pkgs: map[types.UniquePath]*pkgNode{},
 	}
 
-	resources, err := hydrate(root, hctx)
+	resources, err := hydrate(ctx, root, hctx)
 	if err != nil {
-		return fmt.Errorf("failed to run pipeline in package %s %w", root.pkg, err)
+		return errors.E(op, root.pkg.UniquePath, err)
 	}
 
 	if err = trackOutputFiles(hctx); err != nil {
@@ -67,6 +74,7 @@ func (e *Executor) Execute() error {
 		return err
 	}
 
+	pr.PkgPrintf(root.pkg.UniquePath, "rendered successfully\n")
 	return nil
 }
 
@@ -107,21 +115,29 @@ type pkgNode struct {
 
 // newPkgNode returns a pkgNode instance given a path or pkg.
 func newPkgNode(path string, p *pkg.Pkg) (pn *pkgNode, err error) {
+	op := errors.Op("pkg.read")
+
 	if path == "" && p == nil {
 		return pn, fmt.Errorf("missing package path %s or package", path)
 	}
 	if path != "" {
 		p, err = pkg.New(path)
 		if err != nil {
-			return pn, fmt.Errorf("failed to read package %w", err)
+			return pn, errors.E(op, p.UniquePath, err)
 		}
 	}
 	// Note: Ensuring the presence of Kptfile can probably be moved
 	// to the lower level pkg abstraction, but not sure if that
 	// is desired in all the cases. So revisit this.
-	if _, err = p.Kptfile(); err != nil {
-		return pn, fmt.Errorf("failed to read kptfile for package %s %w", p, err)
+	kf, err := p.Kptfile()
+	if err != nil {
+		return pn, errors.E(op, p.UniquePath, err)
 	}
+
+	if err := kf.Validate(); err != nil {
+		return pn, errors.E(op, p.UniquePath, err)
+	}
+
 	pn = &pkgNode{
 		pkg:   p,
 		state: Dry, // package starts in dry state
@@ -144,19 +160,22 @@ func (s hydrationState) String() string {
 }
 
 // hydrate hydrates given pkg and returns wet resources.
-func hydrate(pn *pkgNode, hctx *hydrationContext) (output []*yaml.RNode, err error) {
+func hydrate(ctx context.Context, pn *pkgNode, hctx *hydrationContext) (output []*yaml.RNode, err error) {
+	op := errors.Op("pkg.render")
+
 	curr, found := hctx.pkgs[pn.pkg.UniquePath]
 	if found {
 		switch curr.state {
 		case Hydrating:
 			// we detected a cycle
-			err = fmt.Errorf("found cycle in dependencies for package %s", curr.pkg)
-			return output, err
+			err = fmt.Errorf("cycle detected in pkg dependencies")
+			return output, errors.E(op, curr.pkg.UniquePath, err)
 		case Wet:
 			output = curr.resources
-			return output, err
+			return output, nil
 		default:
-			return output, fmt.Errorf("package %s detected in invalid state", curr.pkg)
+			return output, errors.E(op, curr.pkg.UniquePath,
+				fmt.Errorf("package found in invalid state %v", curr.state))
 		}
 	}
 	// add it to the discovered package list
@@ -167,7 +186,7 @@ func hydrate(pn *pkgNode, hctx *hydrationContext) (output []*yaml.RNode, err err
 
 	relPath, err := curr.pkg.RelativePathTo(hctx.root.pkg)
 	if err != nil {
-		return nil, err
+		return nil, errors.E(op, curr.pkg.UniquePath, err)
 	}
 
 	var input []*yaml.RNode
@@ -175,7 +194,7 @@ func hydrate(pn *pkgNode, hctx *hydrationContext) (output []*yaml.RNode, err err
 	// determine sub packages to be hydrated
 	subpkgs, err := curr.pkg.DirectSubpackages()
 	if err != nil {
-		return output, err
+		return output, errors.E(op, curr.pkg.UniquePath, err)
 	}
 	// hydrate recursively and gather hydated transitive resources.
 	for _, subpkg := range subpkgs {
@@ -183,13 +202,12 @@ func hydrate(pn *pkgNode, hctx *hydrationContext) (output []*yaml.RNode, err err
 		var subPkgNode *pkgNode
 
 		if subPkgNode, err = newPkgNode("", subpkg); err != nil {
-			return output, err
+			return output, errors.E(op, subpkg.UniquePath, err)
 		}
 
-		transitiveResources, err = hydrate(subPkgNode, hctx)
+		transitiveResources, err = hydrate(ctx, subPkgNode, hctx)
 		if err != nil {
-			err = fmt.Errorf("failed to run pipeline on subpackage %s %w", subpkg, err)
-			return output, err
+			return output, errors.E(op, subpkg.UniquePath, err)
 		}
 
 		input = append(input, transitiveResources...)
@@ -198,7 +216,7 @@ func hydrate(pn *pkgNode, hctx *hydrationContext) (output []*yaml.RNode, err err
 	// gather resources present at the current package
 	currPkgResources, err := curr.pkg.LocalResources(false)
 	if err != nil {
-		return output, err
+		return output, errors.E(op, curr.pkg.UniquePath, err)
 	}
 
 	// ensure input resource's paths are relative to root pkg.
@@ -215,9 +233,9 @@ func hydrate(pn *pkgNode, hctx *hydrationContext) (output []*yaml.RNode, err err
 	// include current package's resources in the input resource list
 	input = append(input, currPkgResources...)
 
-	output, err = curr.runPipeline(input)
+	output, err = curr.runPipeline(ctx, input)
 	if err != nil {
-		return output, err
+		return output, errors.E(op, curr.pkg.UniquePath, err)
 	}
 
 	// ensure generated resource's file path are relative to root pkg.
@@ -234,23 +252,25 @@ func hydrate(pn *pkgNode, hctx *hydrationContext) (output []*yaml.RNode, err err
 }
 
 // runPipeline runs the pipeline defined at current pkgNode on given input resources.
-func (pn *pkgNode) runPipeline(input []*yaml.RNode) ([]*yaml.RNode, error) {
+func (pn *pkgNode) runPipeline(ctx context.Context, input []*yaml.RNode) ([]*yaml.RNode, error) {
+	op := errors.Op("pipeline.run")
+
 	if len(input) == 0 {
 		return nil, nil
 	}
 
 	pl, err := pn.pkg.Pipeline()
 	if err != nil {
-		return nil, fmt.Errorf("pipeline read: %s %w", pn.pkg, err)
+		return nil, err
 	}
 
 	if pl.IsEmpty() {
 		return input, nil
 	}
 
-	fnChain, err := fnChain(pl, pn.pkg.UniquePath)
+	fnChain, err := fnChain(ctx, pl, pn.pkg.UniquePath)
 	if err != nil {
-		return nil, fmt.Errorf("function filters: %w", err)
+		return nil, errors.E(op, pn.pkg.UniquePath, err)
 	}
 
 	output := &kio.PackageBuffer{}
@@ -264,7 +284,7 @@ func (pn *pkgNode) runPipeline(input []*yaml.RNode) ([]*yaml.RNode, error) {
 	}
 	err = kioPipeline.Execute()
 	if err != nil {
-		return nil, fmt.Errorf("pipeline run: %v %w", pn.pkg, err)
+		return nil, errors.E(op, pn.pkg.UniquePath, err)
 	}
 	return output.Nodes, nil
 }
@@ -299,7 +319,7 @@ func adjustRelPath(resources []*yaml.RNode, relPath string) ([]*yaml.RNode, erro
 
 // fnChain returns a slice of function runners from the
 // functions and configs defined in pipeline.
-func fnChain(pl *kptfilev1alpha2.Pipeline, pkgPath types.UniquePath) ([]kio.Filter, error) {
+func fnChain(ctx context.Context, pl *kptfilev1alpha2.Pipeline, pkgPath types.UniquePath) ([]kio.Filter, error) {
 	fns := []kptfilev1alpha2.Function{}
 	fns = append(fns, pl.Mutators...)
 	// TODO: Validators cannot modify resources.
@@ -307,7 +327,7 @@ func fnChain(pl *kptfilev1alpha2.Pipeline, pkgPath types.UniquePath) ([]kio.Filt
 	var runners []kio.Filter
 	for i := range fns {
 		fn := fns[i]
-		r, err := newFnRunner(&fn, pkgPath)
+		r, err := newFnRunner(ctx, &fn, pkgPath)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cmdrender/executor.go
+++ b/internal/cmdrender/executor.go
@@ -41,8 +41,9 @@ type Executor struct {
 
 // Execute runs a pipeline.
 func (e *Executor) Execute(ctx context.Context) error {
-	op := errors.Op("fn.render")
-	pr := printer.FromContext(ctx)
+	const op errors.Op = "fn.render"
+
+	pr := printer.FromContextOrDie(ctx)
 
 	root, err := newPkgNode(e.PkgPath, nil)
 	if err != nil {
@@ -115,7 +116,7 @@ type pkgNode struct {
 
 // newPkgNode returns a pkgNode instance given a path or pkg.
 func newPkgNode(path string, p *pkg.Pkg) (pn *pkgNode, err error) {
-	op := errors.Op("pkg.read")
+	const op errors.Op = "pkg.read"
 
 	if path == "" && p == nil {
 		return pn, fmt.Errorf("missing package path %s or package", path)
@@ -161,7 +162,7 @@ func (s hydrationState) String() string {
 
 // hydrate hydrates given pkg and returns wet resources.
 func hydrate(ctx context.Context, pn *pkgNode, hctx *hydrationContext) (output []*yaml.RNode, err error) {
-	op := errors.Op("pkg.render")
+	const op errors.Op = "pkg.render"
 
 	curr, found := hctx.pkgs[pn.pkg.UniquePath]
 	if found {
@@ -253,7 +254,7 @@ func hydrate(ctx context.Context, pn *pkgNode, hctx *hydrationContext) (output [
 
 // runPipeline runs the pipeline defined at current pkgNode on given input resources.
 func (pn *pkgNode) runPipeline(ctx context.Context, input []*yaml.RNode) ([]*yaml.RNode, error) {
-	op := errors.Op("pipeline.run")
+	const op errors.Op = "pipeline.run"
 
 	if len(input) == 0 {
 		return nil, nil

--- a/internal/cmdrender/pipeline_function.go
+++ b/internal/cmdrender/pipeline_function.go
@@ -17,12 +17,14 @@
 package cmdrender
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 
 	"github.com/GoogleContainerTools/kpt/internal/cmdrender/runtime"
+	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/types"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
@@ -32,14 +34,16 @@ import (
 
 // newFnRunner returns a fnRunner from the image and configs of
 // this function.
-func newFnRunner(f *kptfilev1alpha2.Function, pkgPath types.UniquePath) (kio.Filter, error) {
+func newFnRunner(ctx context.Context, f *kptfilev1alpha2.Function, pkgPath types.UniquePath) (kio.Filter, error) {
 	config, err := newFnConfig(f, pkgPath)
 	if err != nil {
 		return nil, err
 	}
 
 	cfn := &runtime.ContainerFn{
+		Path:  pkgPath,
 		Image: f.Image,
+		Ctx:   ctx,
 	}
 
 	return &runtimeutil.FunctionFilter{
@@ -49,21 +53,25 @@ func newFnRunner(f *kptfilev1alpha2.Function, pkgPath types.UniquePath) (kio.Fil
 }
 
 func newFnConfig(f *kptfilev1alpha2.Function, pkgPath types.UniquePath) (*yaml.RNode, error) {
+	op := errors.Op("fn.readConfig")
+	fn := errors.Fn(f.Image)
+
 	var node *yaml.RNode
 	switch {
 	case f.ConfigPath != "":
-		path := path.Join(string(pkgPath), f.ConfigPath)
+		path := filepath.Join(string(pkgPath), f.ConfigPath)
 		file, err := os.Open(path)
 		if err != nil {
-			return nil, fmt.Errorf("failed to open config file path %s: %w", f.ConfigPath, err)
+			return nil, errors.E(op, fn,
+				fmt.Errorf("missing function config %q", f.ConfigPath))
 		}
 		b, err := ioutil.ReadAll(file)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read content from config file: %w", err)
+			return nil, errors.E(op, fn, err)
 		}
 		node, err = yaml.Parse(string(b))
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse config %s: %w", string(b), err)
+			return nil, errors.E(op, fn, fmt.Errorf("invalid function config %q %w", f.ConfigPath, err))
 		}
 		// directly use the config from file
 		return node, nil
@@ -76,22 +84,19 @@ func newFnConfig(f *kptfilev1alpha2.Function, pkgPath types.UniquePath) (*yaml.R
 			return nil, nil
 		}
 		// create a ConfigMap only for configMap config
-		configNode, err := yaml.Parse(`
+		configNode := yaml.MustParse(`
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: function-input
 data: {}
 `)
+		err := configNode.PipeE(yaml.SetField("data", node))
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse function config skeleton: %w", err)
-		}
-		err = configNode.PipeE(yaml.SetField("data", node))
-		if err != nil {
-			return nil, fmt.Errorf("failed to set 'data' field: %w", err)
+			return nil, errors.E(op, fn, err)
 		}
 		return configNode, nil
 	}
-	// no need to reutrn ConfigMap if no config given
+	// no need to return ConfigMap if no config given
 	return nil, nil
 }

--- a/internal/cmdrender/pipeline_function.go
+++ b/internal/cmdrender/pipeline_function.go
@@ -53,8 +53,8 @@ func newFnRunner(ctx context.Context, f *kptfilev1alpha2.Function, pkgPath types
 }
 
 func newFnConfig(f *kptfilev1alpha2.Function, pkgPath types.UniquePath) (*yaml.RNode, error) {
-	op := errors.Op("fn.readConfig")
-	fn := errors.Fn(f.Image)
+	const op errors.Op = "fn.readConfig"
+	var fn errors.Fn = errors.Fn(f.Image)
 
 	var node *yaml.RNode
 	switch {

--- a/internal/cmdrender/runtime/container.go
+++ b/internal/cmdrender/runtime/container.go
@@ -58,7 +58,7 @@ type ContainerFn struct {
 // It reads the input from the given reader and writes the output
 // to the provided writer.
 func (f *ContainerFn) Run(reader io.Reader, writer io.Writer) error {
-	pr := printer.FromContext(f.Ctx)
+	pr := printer.FromContextOrDie(f.Ctx)
 	errSink := bytes.Buffer{}
 	cmd, cancel := f.getDockerCmd()
 	defer cancel()

--- a/internal/cmdrender/runtime/container.go
+++ b/internal/cmdrender/runtime/container.go
@@ -15,12 +15,15 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"time"
+
+	"github.com/GoogleContainerTools/kpt/internal/printer"
+	"github.com/GoogleContainerTools/kpt/internal/types"
 )
 
 // containerNetworkName is a type for network name used in container
@@ -41,6 +44,8 @@ type ContainerFnPermission struct {
 // ContainerFn implements a KRMFn which run a containerized
 // KRM function
 type ContainerFn struct {
+	Ctx  context.Context
+	Path types.UniquePath
 	// Image is the container image to run
 	Image string
 	// Container function will be killed after this timeour.
@@ -49,18 +54,24 @@ type ContainerFn struct {
 	Perm    ContainerFnPermission
 }
 
-// Run implements KRMFn. It will run the container function with
-// stdin from r and write the output to w
+// Run runs the container function using docker runtime.
+// It reads the input from the given reader and writes the output
+// to the provided writer.
 func (f *ContainerFn) Run(reader io.Reader, writer io.Writer) error {
+	pr := printer.FromContext(f.Ctx)
+	errSink := bytes.Buffer{}
 	cmd, cancel := f.getDockerCmd()
 	defer cancel()
 	cmd.Stdin = reader
 	cmd.Stdout = writer
-	cmd.Stderr = os.Stderr
-	err := cmd.Run()
-	if err != nil {
-		return fmt.Errorf("error in running container: %w", err)
+	cmd.Stderr = &errSink
+
+	pr.PkgPrintf(f.Path, "running function %q: ", f.Image)
+	if err := cmd.Run(); err != nil {
+		pr.Printf("FAILED\n")
+		return fmt.Errorf("%s", errSink.String())
 	}
+	pr.Printf("SUCCESS\n")
 	return nil
 }
 

--- a/internal/cmdrender/runtime/container_test.go
+++ b/internal/cmdrender/runtime/container_test.go
@@ -18,9 +18,11 @@ package runtime_test
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/GoogleContainerTools/kpt/internal/cmdrender/runtime"
+	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -45,9 +47,13 @@ func TestContainerFn(t *testing.T) {
 
 	for _, tt := range tests {
 		tt := tt
+		ctx := context.Background()
 		t.Run(tt.name, func(t *testing.T) {
-			instance := runtime.ContainerFn{}
-			instance.Image = tt.image
+			outBuff, errBuff := &bytes.Buffer{}, &bytes.Buffer{}
+			instance := runtime.ContainerFn{
+				Ctx:   printer.WithContext(ctx, printer.New(outBuff, errBuff)),
+				Image: tt.image,
+			}
 			input := bytes.NewBufferString(tt.input)
 			output := &bytes.Buffer{}
 			err := instance.Run(input, output)

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -60,7 +60,12 @@ func (e *Error) Error() string {
 	if e.Path != "" {
 		pad(b, ": ")
 		b.WriteString("pkg ")
-		b.WriteString(e.Path.RelativePath())
+		// try to print relative path of the pkg if we can else use abs path
+		relPath, err := e.Path.RelativePath()
+		if err != nil {
+			relPath = string(e.Path)
+		}
+		b.WriteString(relPath)
 	}
 
 	if e.Fn != "" {

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"strings"
 
+	goerrors "errors"
+
 	"github.com/GoogleContainerTools/kpt/internal/types"
 )
 
@@ -36,6 +38,9 @@ type Error struct {
 
 	// Op is the operation being performed, for ex. pkg.get, fn.render
 	Op Op
+
+	// Fn is the kpt function being run either as part of "fn render" or "fn eval"
+	Fn Fn
 
 	// Class refers to class of errors
 	Class Class
@@ -55,7 +60,13 @@ func (e *Error) Error() string {
 	if e.Path != "" {
 		pad(b, ": ")
 		b.WriteString("pkg ")
-		b.WriteString(string(e.Path))
+		b.WriteString(e.Path.RelativePath())
+	}
+
+	if e.Fn != "" {
+		pad(b, ": ")
+		b.WriteString("fn ")
+		b.WriteString(string(e.Fn))
 	}
 
 	if e.Class != 0 {
@@ -64,7 +75,8 @@ func (e *Error) Error() string {
 	}
 
 	if e.Err != nil {
-		if wrappedErr, ok := e.Err.(*Error); ok {
+		var wrappedErr *Error
+		if As(e.Err, &wrappedErr) {
 			if !wrappedErr.Zero() {
 				pad(b, ":\n\t")
 				b.WriteString(wrappedErr.Error())
@@ -89,11 +101,18 @@ func pad(b *strings.Builder, str string) {
 }
 
 func (e *Error) Zero() bool {
-	return e.Op == "" && e.Path == "" && e.Class == 0 && e.Err == nil
+	return e.Op == "" && e.Path == "" && e.Fn == "" && e.Class == 0 && e.Err == nil
+}
+
+func (e *Error) Unwrap() error {
+	return e.Err
 }
 
 // Op describes the operation being performed.
 type Op string
+
+// Fn describes the kpt function associated with the error.
+type Fn string
 
 // Class describes the class of errors encountered.
 type Class int
@@ -137,6 +156,8 @@ func E(args ...interface{}) error {
 			e.Path = a
 		case Op:
 			e.Op = a
+		case Fn:
+			e.Fn = a
 		case Class:
 			e.Class = a
 		case *Error:
@@ -150,12 +171,10 @@ func E(args ...interface{}) error {
 			panic(fmt.Errorf("unknown type %T for value %v in call to error.E", a, a))
 		}
 	}
-
 	wrappedErr, ok := e.Err.(*Error)
 	if !ok {
 		return e
 	}
-
 	if e.Path == wrappedErr.Path {
 		wrappedErr.Path = ""
 	}
@@ -164,9 +183,23 @@ func E(args ...interface{}) error {
 		wrappedErr.Op = ""
 	}
 
+	if e.Fn == wrappedErr.Fn {
+		wrappedErr.Fn = ""
+	}
+
 	if e.Class == wrappedErr.Class {
 		wrappedErr.Class = 0
 	}
-
 	return e
+}
+
+// Is reports whether any error in err's chain matches target.
+func Is(err, target error) bool {
+	return goerrors.Is(err, target)
+}
+
+// As finds the first error in err's chain that matches target, and if so, sets
+// target to that error value and returns true. Otherwise, it returns false.
+func As(err error, target interface{}) bool {
+	return goerrors.As(err, target)
 }

--- a/internal/pkg/pkg.go
+++ b/internal/pkg/pkg.go
@@ -22,14 +22,13 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/GoogleContainerTools/kpt/internal/errors"
+	"github.com/GoogleContainerTools/kpt/internal/types"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 	"sigs.k8s.io/kustomize/kyaml/sets"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
-
-	"github.com/GoogleContainerTools/kpt/internal/errors"
-	"github.com/GoogleContainerTools/kpt/internal/types"
 )
 
 const CurDir = "."
@@ -94,7 +93,8 @@ func (p *Pkg) Kptfile() (*kptfilev1alpha2.KptFile, error) {
 // have an internal version of Kptfile that all the code uses. In that case,
 // we will have to implement pieces for IO/Conversion with right interfaces.
 func readKptfile(p string) (*kptfilev1alpha2.KptFile, error) {
-	op := errors.Op("pkg.readKptfile")
+	const op errors.Op = "pkg.readKptfile"
+
 	kf := &kptfilev1alpha2.KptFile{}
 
 	f, err := os.Open(filepath.Join(p, kptfilev1alpha2.KptFileName))
@@ -192,7 +192,7 @@ const (
 // TODO: For now this accepts the path as a string type. See if we can leverage
 // the package type here.
 func Subpackages(rootPath string, matcher SubpackageMatcher, recursive bool) ([]string, error) {
-	op := errors.Op("pkg.Subpackages")
+	const op errors.Op = "pkg.Subpackages"
 
 	_, err := os.Stat(rootPath)
 	if err != nil && !os.IsNotExist(err) {
@@ -302,7 +302,7 @@ func IsPackageUnfetched(path string) (bool, error) {
 
 // LocalResources returns resources that belong to this package excluding the subpackage resources.
 func (p *Pkg) LocalResources(includeMetaResources bool) (resources []*yaml.RNode, err error) {
-	op := errors.Op("pkg.readResources")
+	const op errors.Op = "pkg.readResources"
 
 	hasKptfile, err := IsPackageDir(p.UniquePath.String())
 	if err != nil {

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1,0 +1,81 @@
+// Package printer defines utilities to display kpt CLI output.
+package printer
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/GoogleContainerTools/kpt/internal/types"
+)
+
+// Printer defines capabilities to display content in kpt CLI.
+// The main intention, at the moment, is to abstract away printing
+// output in the CLI so that we can evolve the kpt CLI UX.
+type Printer interface {
+	PkgPrintf(pkgPath types.UniquePath, format string, args ...interface{})
+	Printf(format string, args ...interface{})
+}
+
+// New returns an instance of Printer.
+func New(outStream, errStream io.Writer) Printer {
+	if outStream == nil {
+		outStream = os.Stdout
+	}
+	if errStream == nil {
+		errStream = os.Stderr
+	}
+	return &printer{
+		outStream: outStream,
+		errStream: errStream,
+	}
+}
+
+// printer implements default Printer to be used in kpt codebase.
+type printer struct {
+	outStream io.Writer
+	errStream io.Writer
+}
+
+// PkgPrintf accepts an optional pkgpath to display the message with
+// package context.
+func (pr *printer) PkgPrintf(pkgPath types.UniquePath, format string, args ...interface{}) {
+	if string(pkgPath) != "" {
+		format = fmt.Sprintf("package %q: ", pkgPath.RelativePath()) + format
+	}
+	fmt.Fprintf(pr.outStream, format, args...)
+}
+
+// The key type is unexported to prevent collisions with context keys defined in
+// other packages.
+type contextKey int
+
+// printerKey is the context key for the printer.  Its value of zero is
+// arbitrary.  If this package defined other context keys, they would have
+// different integer values.
+const printerKey contextKey = 0
+
+// Printf is the wrapper over fmt.Printf that displays the output to
+// the configured output writer.
+func (pr *printer) Printf(format string, args ...interface{}) {
+	fmt.Fprintf(pr.outStream, format, args...)
+}
+
+// Helper functions to set and retrieve printer instance from a context.
+// Defining them here avoids the context key collision.
+
+// FromContext returns associated printer instance.
+func FromContext(ctx context.Context) Printer {
+	pr, ok := ctx.Value(printerKey).(*printer)
+	if ok {
+		return pr
+	}
+	return nil
+}
+
+// WithContext creates new context from the given parent context
+// by setting the printer instance.
+func WithContext(ctx context.Context, pr Printer) context.Context {
+	return context.WithValue(ctx, printerKey, pr)
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -15,12 +15,34 @@
 // Package types defines the basic types used by the kpt codebase.
 package types
 
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
 // UniquePath represents absolute unique OS-defined path to the package directory on the filesystem.
 type UniquePath string
 
 // String returns the absolute path in string format.
 func (u UniquePath) String() string {
 	return string(u)
+}
+
+// RelativePath returns the relative path to current working directory.
+func (u UniquePath) RelativePath() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return string(u)
+	}
+	rPath, err := filepath.Rel(cwd, string(u))
+	if err != nil {
+		return string(u)
+	}
+	if strings.HasPrefix(rPath, "..") {
+		return string(u)
+	}
+	return rPath
 }
 
 // DisplayPath represents Slash-separated path to the package directory on the filesytem relative

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -30,19 +30,19 @@ func (u UniquePath) String() string {
 }
 
 // RelativePath returns the relative path to current working directory.
-func (u UniquePath) RelativePath() string {
+func (u UniquePath) RelativePath() (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
-		return string(u)
+		return "", err
 	}
 	rPath, err := filepath.Rel(cwd, string(u))
 	if err != nil {
-		return string(u)
+		return string(u), err
 	}
 	if strings.HasPrefix(rPath, "..") {
-		return string(u)
+		return string(u), nil
 	}
-	return rPath
+	return rPath, nil
 }
 
 // DisplayPath represents Slash-separated path to the package directory on the filesytem relative

--- a/internal/util/cmdutil/cmdutil.go
+++ b/internal/util/cmdutil/cmdutil.go
@@ -89,7 +89,8 @@ func ResolveAbsAndRelPaths(path string) (string, string, error) {
 // DockerCmdAvailable runs `docker ps` to check that the docker command is
 // available, and returns an error with installation instructions if it is not
 func DockerCmdAvailable() error {
-	op := errors.Op("docker.check")
+	const op errors.Op = "docker.check"
+
 	suggestedText := `Docker is required to run this command.
 To install docker, follow the instructions at https://docs.docker.com/get-docker/
 `
@@ -99,7 +100,7 @@ To install docker, follow the instructions at https://docs.docker.com/get-docker
 	cmd.Stderr = buffer
 	err := cmd.Run()
 	if err != nil {
-		return errors.E(op, suggestedText, fmt.Errorf("%s", suggestedText))
+		return errors.E(op, fmt.Errorf("%s", suggestedText))
 	}
 	return nil
 }

--- a/internal/util/cmdutil/cmdutil.go
+++ b/internal/util/cmdutil/cmdutil.go
@@ -22,7 +22,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/go-errors/errors"
+	"github.com/GoogleContainerTools/kpt/internal/errors"
+	goerrors "github.com/go-errors/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -42,7 +43,7 @@ func FixDocs(old, new string, c *cobra.Command) {
 func PrintErrorStacktrace(err error) {
 	e := os.Getenv(StackTraceOnErrors)
 	if StackOnError || e == trueString || e == "1" {
-		if err, ok := err.(*errors.Error); ok {
+		if err, ok := err.(*goerrors.Error); ok {
 			fmt.Fprintf(os.Stderr, "%s", err.Stack())
 		}
 	}
@@ -88,14 +89,17 @@ func ResolveAbsAndRelPaths(path string) (string, string, error) {
 // DockerCmdAvailable runs `docker ps` to check that the docker command is
 // available, and returns an error with installation instructions if it is not
 func DockerCmdAvailable() error {
+	op := errors.Op("docker.check")
+	suggestedText := `Docker is required to run this command.
+To install docker, follow the instructions at https://docs.docker.com/get-docker/
+`
+	buffer := &bytes.Buffer{}
+
 	cmd := exec.Command("docker", "version")
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
+	cmd.Stderr = buffer
 	err := cmd.Run()
 	if err != nil {
-		return fmt.Errorf(stderr.String() +
-			`Docker is required to run this command. 
-To install docker, follow the instructions at https://docs.docker.com/get-docker/`)
+		return errors.E(op, suggestedText, fmt.Errorf("%s", suggestedText))
 	}
 	return nil
 }

--- a/pkg/test/runner/config.go
+++ b/pkg/test/runner/config.go
@@ -47,19 +47,24 @@ type EvalTestCaseConfig struct {
 type TestCaseConfig struct {
 	// ExitCode is the expected exit code from the kpt commands. Default: 0
 	ExitCode int `json:"exitCode,omitempty" yaml:"exitCode,omitempty"`
+
 	// NonIdempotent indicates if the test case is not idempotent.
 	// By default, tests are assumed to be idempotent, so it defaults to false.
 	NonIdempotent bool `json:"nonIdempotent,omitempty" yaml:"nonIdempotent,omitempty"`
+
 	// Skip means should this test case be skipped. Default: false
 	Skip bool `json:"skip,omitempty" yaml:"skip,omitempty"`
+
 	// Debug means will the debug behavior be enabled. Default: false
 	// Debug behavior:
 	//  1. Keep the temporary directory used to run the test cases
 	//    after test.
 	Debug bool `json:"debug,omitempty" yaml:"debug,omitempty"`
+
 	// TestType is the type of the test case. Possible value: ['render', 'eval']
 	// Default: 'eval'
 	TestType string `json:"testType,omitempty" yaml:"testType,omitempty"`
+
 	// EvalConfig is the configs for eval tests
 	EvalConfig *EvalTestCaseConfig `json:",inline" yaml:",inline"`
 }


### PR DESCRIPTION
This is an experimental PR to try out a new pattern for error handling (inspired by https://commandcenter.blogspot.com/2017/12/error-handling-in-upspin.html)

This PR:

- Adds a printer to print output to CLI.
- Introduces ctx parameter of type `context.Context` that makes it easy to make dependencies such as printer available in rest of the call stack
- Improve the error handling for `fn render`
- Prints basic progress for `fn render`

Note to reviewers: I think this is still a starting point that needs to be iterated upon, but much better than where we are today in error/progress reporting for `fn render`.