### PR TITLE
add errors pkg

### DIFF
--- a/internal/cmdupdate/cmdupdate.go
+++ b/internal/cmdupdate/cmdupdate.go
@@ -23,6 +23,7 @@ import (
 
 	docs "github.com/GoogleContainerTools/kpt/internal/docs/generated/pkgdocs"
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
+	"github.com/GoogleContainerTools/kpt/internal/types"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/update"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
@@ -123,7 +124,7 @@ func (r *Runner) runE(c *cobra.Command, _ []string) error {
 	return nil
 }
 
-func resolveRelPath(path pkg.UniquePath) (string, error) {
+func resolveRelPath(path types.UniquePath) (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return "", err

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,0 +1,167 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package errors defines the error handling used by Kpt codebase.
+package errors
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/GoogleContainerTools/kpt/internal/types"
+)
+
+// Error is an implementation of the error interface used in the kpt
+// codebase.
+// It is based on the design in https://commandcenter.blogspot.com/2017/12/error-handling-in-upspin.html
+type Error struct {
+	// Path is the path name of the object involved in Kpt operation.
+	Path types.UniquePath
+
+	// Op is the operation being performed, for ex. pkg.get, fn.render
+	Op Op
+
+	// Kind refers to classs of errors
+	Kind Kind
+
+	// Err refers to wrapped error (if any)
+	Err error
+}
+
+func (e *Error) Error() string {
+	b := new(strings.Builder)
+
+	if e.Op != "" {
+		pad(b, ": ")
+		b.WriteString(string(e.Op))
+	}
+
+	if e.Path != "" {
+		pad(b, ": ")
+		b.WriteString("pkg ")
+		b.WriteString(string(e.Path))
+	}
+
+	if e.Kind != 0 {
+		pad(b, ": ")
+		b.WriteString(e.Kind.String())
+	}
+
+	if e.Err != nil {
+		if wrappedErr, ok := e.Err.(*Error); ok {
+			if !wrappedErr.Zero() {
+				pad(b, ":\n\t")
+				b.WriteString(wrappedErr.Error())
+			}
+		} else {
+			pad(b, ": ")
+			b.WriteString(e.Err.Error())
+		}
+	}
+	if b.Len() == 0 {
+		return "no error"
+	}
+	return b.String()
+}
+
+// pad appends given str to the string buffer.
+func pad(b *strings.Builder, str string) {
+	if b.Len() == 0 {
+		return
+	}
+	b.WriteString(str)
+}
+
+func (e *Error) Zero() bool {
+	return e.Op == "" && e.Path == "" && e.Kind == 0 && e.Err == nil
+}
+
+// Op describes the operation being performed.
+type Op string
+
+// Kind describes the class of errors encountered.
+type Kind int
+
+const (
+	Other        Kind = iota // Unclassified. Will not be printed.
+	Exist                    // Item already exists.
+	Internal                 // Internal error.
+	InvalidParam             // Value is not valid.
+	MissingParam             // Required value is missing or empty.
+	Git                      // Errors from Git
+)
+
+func (k Kind) String() string {
+	switch k {
+	case Other:
+		return "other error"
+	case Exist:
+		return "item already exist"
+	case Internal:
+		return "internal error"
+	case InvalidParam:
+		return "invalid parameter value"
+	case MissingParam:
+		return "missing parameter value"
+	case Git:
+		return "git error"
+	}
+	return "unknown kind"
+}
+
+func E(args ...interface{}) error {
+	if len(args) == 0 {
+		panic("errors.E must have at least one argument")
+	}
+
+	e := &Error{}
+	for _, arg := range args {
+		switch a := arg.(type) {
+		case types.UniquePath:
+			e.Path = a
+		case Op:
+			e.Op = a
+		case Kind:
+			e.Kind = a
+		case *Error:
+			cp := *a
+			e.Err = &cp
+		case error:
+			e.Err = a
+		case string:
+			e.Err = fmt.Errorf(a)
+		default:
+			panic(fmt.Errorf("unknown type %T for value %v in call to error.E", a, a))
+		}
+	}
+
+	wrappedErr, ok := e.Err.(*Error)
+	if !ok {
+		return e
+	}
+
+	if e.Path == wrappedErr.Path {
+		wrappedErr.Path = ""
+	}
+
+	if e.Op == wrappedErr.Op {
+		wrappedErr.Op = ""
+	}
+
+	if e.Kind == wrappedErr.Kind {
+		wrappedErr.Kind = 0
+	}
+
+	return e
+}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package errors defines the error handling used by Kpt codebase.
+// Package errors defines the error handling used by kpt codebase.
 package errors
 
 import (

--- a/internal/pipeline/executor.go
+++ b/internal/pipeline/executor.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
+	"github.com/GoogleContainerTools/kpt/internal/types"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
@@ -44,7 +45,7 @@ func (e *Executor) Execute() error {
 	// initialize hydration context
 	hctx := &hydrationContext{
 		root: root,
-		pkgs: map[pkg.UniquePath]*pkgNode{},
+		pkgs: map[types.UniquePath]*pkgNode{},
 	}
 
 	resources, err := hydrate(root, hctx)
@@ -78,7 +79,7 @@ type hydrationContext struct {
 
 	// pkgs refers to the packages undergoing hydration. pkgs are key'd by their
 	// unique paths.
-	pkgs map[pkg.UniquePath]*pkgNode
+	pkgs map[types.UniquePath]*pkgNode
 
 	// inputFiles is a set of filepaths containing input resources to the
 	// functions across all the packages during hydration.
@@ -297,7 +298,7 @@ func adjustRelPath(resources []*yaml.RNode, relPath string) ([]*yaml.RNode, erro
 
 // fnChain returns a slice of function runners from the
 // functions and configs defined in pipeline.
-func fnChain(pl *kptfilev1alpha2.Pipeline, pkgPath pkg.UniquePath) ([]kio.Filter, error) {
+func fnChain(pl *kptfilev1alpha2.Pipeline, pkgPath types.UniquePath) ([]kio.Filter, error) {
 	fns := []kptfilev1alpha2.Function{}
 	fns = append(fns, pl.Mutators...)
 	// TODO: Validators cannot modify resources.

--- a/internal/pipeline/pipeline_function.go
+++ b/internal/pipeline/pipeline_function.go
@@ -23,7 +23,7 @@ import (
 	"path"
 
 	"github.com/GoogleContainerTools/kpt/internal/pipeline/runtime"
-	"github.com/GoogleContainerTools/kpt/internal/pkg"
+	"github.com/GoogleContainerTools/kpt/internal/types"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
 	"sigs.k8s.io/kustomize/kyaml/kio"
@@ -32,7 +32,7 @@ import (
 
 // newFnRunner returns a fnRunner from the image and configs of
 // this function.
-func newFnRunner(f *kptfilev1alpha2.Function, pkgPath pkg.UniquePath) (kio.Filter, error) {
+func newFnRunner(f *kptfilev1alpha2.Function, pkgPath types.UniquePath) (kio.Filter, error) {
 	config, err := newFnConfig(f, pkgPath)
 	if err != nil {
 		return nil, err
@@ -48,7 +48,7 @@ func newFnRunner(f *kptfilev1alpha2.Function, pkgPath pkg.UniquePath) (kio.Filte
 	}, nil
 }
 
-func newFnConfig(f *kptfilev1alpha2.Function, pkgPath pkg.UniquePath) (*yaml.RNode, error) {
+func newFnConfig(f *kptfilev1alpha2.Function, pkgPath types.UniquePath) (*yaml.RNode, error) {
 	var node *yaml.RNode
 	switch {
 	case f.ConfigPath != "":

--- a/internal/pipeline/pipeline_function_test.go
+++ b/internal/pipeline/pipeline_function_test.go
@@ -34,7 +34,7 @@ import (
 	"path"
 	"testing"
 
-	"github.com/GoogleContainerTools/kpt/internal/pkg"
+	"github.com/GoogleContainerTools/kpt/internal/types"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
@@ -111,7 +111,7 @@ data: {foo: bar}
 				assert.NoError(t, err, "unexpected error")
 				c.fn.ConfigPath = path.Base(tmp.Name())
 			}
-			cn, err := newFnConfig(&c.fn, pkg.UniquePath(os.TempDir()))
+			cn, err := newFnConfig(&c.fn, types.UniquePath(os.TempDir()))
 			assert.NoError(t, err, "unexpected error")
 			actual, err := cn.String()
 			assert.NoError(t, err, "unexpected error")

--- a/internal/pkg/pkg.go
+++ b/internal/pkg/pkg.go
@@ -23,6 +23,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/GoogleContainerTools/kpt/internal/types"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
@@ -30,27 +31,13 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
-// UniquePath represents absolute unique OS-defined path to the package directory on the filesystem.
-type UniquePath string
-
-// String returns the absolute path in string format.
-func (u UniquePath) String() string {
-	return string(u)
-}
-
-// DisplayPath represents Slash-separated path to the package directory on the filesytem relative
-// to current working directory.
-// This is not guaranteed to be unique (e.g. in presence of symlinks) and should only
-// be used for display purposes and is subject to change.
-type DisplayPath string
-
 const CurDir = "."
 const ParentDir = ".."
 
 // Pkg represents a kpt package with a one-to-one mapping to a directory on the local filesystem.
 type Pkg struct {
-	UniquePath  UniquePath
-	DisplayPath DisplayPath
+	UniquePath  types.UniquePath
+	DisplayPath types.DisplayPath
 
 	// A package can contain zero or one Kptfile meta resource.
 	// A nil value represents an implicit package.
@@ -80,7 +67,10 @@ func New(path string) (*Pkg, error) {
 		relPath = filepath.Clean(path)
 		absPath = filepath.Join(cwd, path)
 	}
-	return &Pkg{UniquePath: UniquePath(absPath), DisplayPath: DisplayPath(relPath)}, nil
+	return &Pkg{
+		UniquePath:  types.UniquePath(absPath),
+		DisplayPath: types.DisplayPath(relPath),
+	}, nil
 }
 
 // Kptfile returns the Kptfile meta resource by lazy loading it from the filesytem.

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package types defines the basic types used by the Kpt codebase.
+// Package types defines the basic types used by the kpt codebase.
 package types
 
 // UniquePath represents absolute unique OS-defined path to the package directory on the filesystem.

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -1,0 +1,30 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package types defines the basic types used by the Kpt codebase.
+package types
+
+// UniquePath represents absolute unique OS-defined path to the package directory on the filesystem.
+type UniquePath string
+
+// String returns the absolute path in string format.
+func (u UniquePath) String() string {
+	return string(u)
+}
+
+// DisplayPath represents Slash-separated path to the package directory on the filesytem relative
+// to current working directory.
+// This is not guaranteed to be unique (e.g. in presence of symlinks) and should only
+// be used for display purposes and is subject to change.
+type DisplayPath string


### PR DESCRIPTION
This error implements `errors` type that will be used for error handling in the kpt codebase. This work is inspired by the design mentioned in https://commandcenter.blogspot.com/2017/12/error-handling-in-upspin.html

Here is a PR https://github.com/GoogleContainerTools/kpt/pull/1634 that uses this error pkg to improve error handling in `kpt fn render`.

Here is another https://github.com/GoogleContainerTools/kpt/pull/1602 that uses this error pkg in packaging commands.