### PR TITLE
Add documentation about `kpt-gcloud` image

### DIFF
--- a/site/installation/docker/README.md
+++ b/site/installation/docker/README.md
@@ -7,12 +7,24 @@ description: >
     Run kpt in a docker container.
 ---
 
-Use the docker image.
+Use one of the kpt docker images.
 
-[gcr.io/kpt-dev/kpt]
+## [gcr.io/kpt-dev/kpt]
 
 ```shell
 docker run gcr.io/kpt-dev/kpt version
 ```
 
+## [gcr.io/kpt-dev/kpt-gcloud]
+
+An image which includes kpt based upon the Google [cloud-sdk] alpine image.
+
+```shell
+docker run gcr.io/kpt-dev/kpt-gcloud version
+```
+
 [gcr.io/kpt-dev/kpt]: https://console.cloud.google.com/gcr/images/kpt-dev/GLOBAL/kpt?gcrImageListsize=30
+
+[gcr.io/kpt-dev/kpt-gcloud]: https://console.cloud.google.com/gcr/images/kpt-dev/GLOBAL/kpt-gcloud?gcrImageListsize=30
+
+[cloud-sdk]: https://github.com/GoogleCloudPlatform/cloud-sdk-docker

--- a/site/installation/docker/README.md
+++ b/site/installation/docker/README.md
@@ -9,6 +9,13 @@ description: >
 
 Use one of the kpt docker images.
 
+| Feature   |:`kpt`:|:`kpt-gcloud`:|
+| --------- |:-----:|:------------:|
+| kpt       | X     | X            |
+| git       | X     | X            |
+| diffutils | X     | X            |
+| gcloud    |       | X            |
+
 ## [gcr.io/kpt-dev/kpt]
 
 ```shell

--- a/site/installation/docker/README.md
+++ b/site/installation/docker/README.md
@@ -9,7 +9,7 @@ description: >
 
 Use one of the kpt docker images.
 
-| Feature   |:`kpt`:|:`kpt-gcloud`:|
+| Feature   | `kpt` | `kpt-gcloud` |
 | --------- |:-----:|:------------:|
 | kpt       | X     | X            |
 | git       | X     | X            |


### PR DESCRIPTION
This updates the kpt docker documentation on kpt.dev to include the `kpt-gcloud`.

Related to #1506