### PR TITLE
Update Go to 1.15 in Releases + Check Licenses CI

### DIFF
--- a/.github/workflows/checkLicenses.yml
+++ b/.github/workflows/checkLicenses.yml
@@ -28,7 +28,9 @@ jobs:
       - uses: actions/checkout@v2
       - run: |
           ./scripts/create-licenses.sh
+      # Upload the licenses list so it's available if needed
       - uses: actions/upload-artifact@v2
         with:
           name: Licenses
           path: LICENSES.txt
+          retention-days: 7 # Reduce retention time from 90 days to 7

--- a/.github/workflows/checkLicenses.yml
+++ b/.github/workflows/checkLicenses.yml
@@ -1,0 +1,34 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Check Licenses
+on:
+  push:
+    branches:
+      - master
+      - check-licenes
+  pull_request:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          ./scripts/create-licenses.sh
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Licenses
+          path: LICENSES.txt

--- a/.github/workflows/checkLicenses.yml
+++ b/.github/workflows/checkLicenses.yml
@@ -27,6 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.15
       - run: |
           ./scripts/create-licenses.sh
       # Upload the licenses list so it's available if needed

--- a/.github/workflows/checkLicenses.yml
+++ b/.github/workflows/checkLicenses.yml
@@ -17,10 +17,11 @@ on:
   push:
     branches:
       - master
-      - check-licenes
+      - next
   pull_request:
     branches:
       - master
+      - next
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/release/Dockerfile
+++ b/release/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.13-stretch
+FROM golang:1.15-stretch
 ENV CGO_ENABLED=0
 ENV GO111MODULE=on
 

--- a/release/Dockerfile.kpt-build
+++ b/release/Dockerfile.kpt-build
@@ -1,3 +1,3 @@
-FROM golang:1.13
+FROM golang:1.15
 RUN apt-get -qqy update && \
     apt-get install -qqy tar bzip2 gzip jq zip

--- a/release/gcloud/Dockerfile
+++ b/release/gcloud/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.13-stretch AS build
+FROM golang:1.15-stretch AS build
 ENV CGO_ENABLED=0
 ENV GO111MODULE=on
 

--- a/scripts/create-licenses.sh
+++ b/scripts/create-licenses.sh
@@ -169,7 +169,7 @@ mv ${V2_LICENSE_DIR}/v2/LICENSE ${V2_LICENSE_DIR}
 
 # Loop through every vendored package
 mozilla_repos=""
-for PACKAGE in $(go list -m -json all | jq -r .Path | sort -f); do
+for PACKAGE in $(go list -mod=mod -m -json all | jq -r .Path | sort -f); do
   if [[ -e "staging/src/${PACKAGE}" ]]; then
     # echo "$PACKAGE is a staging package, skipping" > /dev/stderr
     continue


### PR DESCRIPTION
This introduces a new CI Check that runs the `create-licenses.sh` script and saves the results for 7 days in a GitHub Artifact for reference. These artifacts can be viewed while available by browsing the GitHub Action job (Example available for next week: https://github.com/runewake2/kpt/actions/runs/709503762). This allows the resulting licenses file to be manually validated if needed. Currently a job failure should not produce an artifact. More info about how artifact uploads work is [here](https://github.com/actions/upload-artifact).

Additionally Kpt's GitHub Actions and Docker Images used during Cloud Build have been brought into alignment on Go Version. They should all use Go version 1.15 now.

The `create-licenses.sh` script has been updated to support 1.15.

The new CI check is included to help verify these changes and so licensing issues are detected during the PR's that would introduce them.

> Note: This should be merged into kpt `next` as well. While the workflow file mentions `next` this is only to keep the workflow definitions identical across branches. This PR should not cause pr's or pushes against `next` to run this job until it is merged into the next branch.