### PR TITLE
Update idempotent test in e2e driver

### DIFF
--- a/e2e/testdata/fn-eval/simple-function/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/simple-function/.expected/config.yaml
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runCount: 2
 testType: eval
 image: gcr.io/kpt-fn/set-namespace:unstable
 args:

--- a/pkg/test/runner/config.go
+++ b/pkg/test/runner/config.go
@@ -44,7 +44,8 @@ type EvalTestCaseConfig struct {
 type TestCaseConfig struct {
 	// ExitCode is the expected exit code from the kpt commands. Default: 0
 	ExitCode int `json:"exitCode,omitempty" yaml:"exitCode,omitempty"`
-	// NonIdempotent asks to not test idempotency of this test case. Default: false
+	// NonIdempotent indicates if the test case is not idempotent.
+	// By default, tests are assumed to be idempotent, so it defaults to false.
 	NonIdempotent bool `json:"nonIdempotent,omitempty" yaml:"nonIdempotent,omitempty"`
 	// Skip means should this test case be skipped. Default: false
 	Skip bool `json:"skip,omitempty" yaml:"skip,omitempty"`

--- a/pkg/test/runner/config.go
+++ b/pkg/test/runner/config.go
@@ -44,9 +44,8 @@ type EvalTestCaseConfig struct {
 type TestCaseConfig struct {
 	// ExitCode is the expected exit code from the kpt commands. Default: 0
 	ExitCode int `json:"exitCode,omitempty" yaml:"exitCode,omitempty"`
-	// RunCount is how many times the test will run. Each iteration will be
-	// immediately run after previous one. Default: 1
-	RunCount int `json:"runCount,omitempty" yaml:"runCount,omitempty"`
+	// NonIdempotent asks to not test idempotency of this test case. Default: false
+	NonIdempotent bool `json:"nonIdempotent,omitempty" yaml:"nonIdempotent,omitempty"`
 	// Skip means should this test case be skipped. Default: false
 	Skip bool `json:"skip,omitempty" yaml:"skip,omitempty"`
 	// Debug means will the debug behavior be enabled. Default: false
@@ -61,13 +60,19 @@ type TestCaseConfig struct {
 	EvalConfig *EvalTestCaseConfig `json:",inline" yaml:",inline"`
 }
 
+func (c *TestCaseConfig) RunCount() int {
+	if c.NonIdempotent {
+		return 1
+	}
+	return 2
+}
+
 func newTestCaseConfig(path string) (TestCaseConfig, error) {
 	configPath := filepath.Join(path, expectedDir, expectedConfigFile)
 	b, err := ioutil.ReadFile(configPath)
 	if os.IsNotExist(err) {
 		// return default config
 		return TestCaseConfig{
-			RunCount: 1,
 			TestType: CommandFnRender,
 		}, nil
 	}
@@ -79,9 +84,6 @@ func newTestCaseConfig(path string) (TestCaseConfig, error) {
 	err = yaml.Unmarshal(b, &config)
 	if err != nil {
 		return config, fmt.Errorf("failed to unmarshal config file: %s\n: %w", string(b), err)
-	}
-	if config.RunCount == 0 {
-		config.RunCount = 1
 	}
 	if config.TestType == "" {
 		// by default we test pipeline

--- a/pkg/test/runner/runner.go
+++ b/pkg/test/runner/runner.go
@@ -128,7 +128,7 @@ func (r *Runner) runFnEval() error {
 	var output string
 	var fnErr error
 	command := run.GetMain()
-	for i := 0; i < r.testCase.Config.RunCount; i++ {
+	for i := 0; i < r.testCase.Config.RunCount(); i++ {
 		command.SetArgs(kptArgs)
 		outputWriter := bytes.NewBuffer(nil)
 		command.SetOutput(outputWriter)
@@ -195,7 +195,7 @@ func (r *Runner) runFnRender() error {
 	var fnErr error
 	command := run.GetMain()
 	kptArgs := []string{"fn", "render", tmpPkgPath}
-	for i := 0; i < r.testCase.Config.RunCount; i++ {
+	for i := 0; i < r.testCase.Config.RunCount(); i++ {
 		command.SetArgs(kptArgs)
 		fnErr = command.Execute()
 		if fnErr != nil {

--- a/pkg/test/runner/runner.go
+++ b/pkg/test/runner/runner.go
@@ -29,10 +29,11 @@ import (
 
 // Runner runs an e2e test
 type Runner struct {
-	pkgName  string
-	testCase TestCase
-	cmd      string
-	t        *testing.T
+	pkgName       string
+	testCase      TestCase
+	cmd           string
+	t             *testing.T
+	initialCommit string
 }
 
 const (
@@ -139,18 +140,18 @@ func (r *Runner) runFnEval() error {
 			break
 		}
 		output = outputWriter.String()
+		// Update the diff file or results file if updateExpectedEnv is set.
+		if strings.ToLower(os.Getenv(updateExpectedEnv)) == "true" {
+			return r.updateExpected(tmpPkgPath, resultsPath, filepath.Join(r.testCase.Path, expectedDir))
+		}
+
+		// compare results
+		err = r.compareResult(fnErr, tmpPkgPath, resultsPath)
+		if err != nil {
+			return fmt.Errorf("%w\nkpt output:\n%s", err, output)
+		}
 	}
 
-	// Update the diff file or results file if updateExpectedEnv is set.
-	if strings.ToLower(os.Getenv(updateExpectedEnv)) == "true" {
-		return updateExpected(tmpPkgPath, resultsPath, filepath.Join(r.testCase.Path, expectedDir))
-	}
-
-	// compare results
-	err = r.compareResult(fnErr, tmpPkgPath, resultsPath)
-	if err != nil {
-		return fmt.Errorf("%w\nkpt output:\n%s", err, output)
-	}
 	return nil
 }
 
@@ -204,17 +205,16 @@ func (r *Runner) runFnRender() error {
 			}
 			break
 		}
-	}
+		// Update the diff file or results file if updateExpectedEnv is set.
+		if strings.ToLower(os.Getenv(updateExpectedEnv)) == "true" {
+			// TODO: `fn render` doesn't support result file now
+			// use empty string to skip update results
+			return r.updateExpected(tmpPkgPath, "", filepath.Join(r.testCase.Path, expectedDir))
+		}
 
-	// Update the diff file or results file if updateExpectedEnv is set.
-	if strings.ToLower(os.Getenv(updateExpectedEnv)) == "true" {
-		// TODO: `fn render` doesn't support result file now
-		// use empty string to skip update results
-		return updateExpected(tmpPkgPath, "", filepath.Join(r.testCase.Path, expectedDir))
+		// compare results
+		err = r.compareResult(fnErr, tmpPkgPath, orgPkgPath)
 	}
-
-	// compare results
-	err = r.compareResult(fnErr, tmpPkgPath, orgPkgPath)
 	return err
 }
 
@@ -229,7 +229,13 @@ func (r *Runner) preparePackage(pkgPath string) error {
 		return err
 	}
 
-	return gitCommit(pkgPath, "first")
+	err = gitCommit(pkgPath, "first")
+	if err != nil {
+		return err
+	}
+
+	r.initialCommit, err = getCommitHash(pkgPath)
+	return err
 }
 
 func (r *Runner) compareResult(exitErr error, tmpPkgPath, resultsPath string) error {
@@ -266,7 +272,7 @@ func (r *Runner) compareResult(exitErr error, tmpPkgPath, resultsPath string) er
 	}
 
 	// compare diff
-	actual, err := readActualDiff(tmpPkgPath)
+	actual, err := readActualDiff(tmpPkgPath, r.initialCommit)
 	if err != nil {
 		return fmt.Errorf("failed to read actual diff: %w", err)
 	}
@@ -301,7 +307,7 @@ func readActualResults(resultsPath string) (string, error) {
 	return strings.TrimSpace(string(actualResults)), nil
 }
 
-func readActualDiff(path string) (string, error) {
+func readActualDiff(path, origHash string) (string, error) {
 	err := gitAddAll(path)
 	if err != nil {
 		return "", err
@@ -311,7 +317,7 @@ func readActualDiff(path string) (string, error) {
 		return "", err
 	}
 	// diff with first commit
-	actualDiff, err := gitDiff(path, "HEAD^", "HEAD")
+	actualDiff, err := gitDiff(path, origHash, "HEAD")
 	if err != nil {
 		return "", err
 	}
@@ -351,14 +357,14 @@ func newExpected(path string) (expected, error) {
 	return e, nil
 }
 
-func updateExpected(tmpPkgPath, resultsPath, sourceOfTruthPath string) error {
+func (r *Runner) updateExpected(tmpPkgPath, resultsPath, sourceOfTruthPath string) error {
 	// We update results directory only when a result file already exists.
 	l, err := ioutil.ReadDir(resultsPath)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
 	if err != nil && os.IsNotExist(err) {
-		actualDiff, err := readActualDiff(tmpPkgPath)
+		actualDiff, err := readActualDiff(tmpPkgPath, r.initialCommit)
 		if err != nil {
 			return err
 		}

--- a/pkg/test/runner/util.go
+++ b/pkg/test/runner/util.go
@@ -74,6 +74,14 @@ func gitDiff(d, commit1, commit2 string) (string, error) {
 	return o, nil
 }
 
+func getCommitHash(d string) (string, error) {
+	o, err := runCommand(d, "git", []string{"log", "-n", "1", "--pretty=format:%h"})
+	if err != nil {
+		return "", fmt.Errorf("git log error: %w, output: %s", err, o)
+	}
+	return o, nil
+}
+
 func diffStrings(actual, expected string) (string, error) {
 	tmpDir, err := ioutil.TempDir("", "kpt-e2e-diff-*")
 	if err != nil {


### PR DESCRIPTION
https://github.com/GoogleContainerTools/kpt/pull/1646#discussion_r605824173

Use `nonIdempotent` instead of `idempotent` because we cannot distinguish the `false` from explicit config and omitting it in config file. 