### PR TITLE
Don't consume extra content as the title block.

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -177,7 +177,7 @@
       // title: Page Title
       // +++
       function processHugoTitleHeading(content) {
-        const titleBlock = /^[\+\-]{3}[\s\S]*^[\+\-]{3}$/m;
+        const titleBlock = /^[\+\-]{3}[\s\S]*?^[\+\-]{3}$/m;
         const titleMatch = content.match(/title:\s*["'](.*)["']/);
 
         const titleHeading = titleMatch ? `# ${titleMatch[1]}` : "";


### PR DESCRIPTION
Fixes accidentally grabbing more content between hugo title delimiters.
Example: https://kpt-dev-ee2a9--bad-titles-0tgvg2bo.web.app/reference/pkg/cat/