### PR TITLE
Preview docs with no caching

### DIFF
--- a/.github/workflows/checkSite.yml
+++ b/.github/workflows/checkSite.yml
@@ -35,15 +35,5 @@ jobs:
         working-directory: href-checker
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
-      - name: Build Site
-        uses: docker/build-push-action@v2
-        with:
-          context: ./site
-          load: true
-          tags: kpt-site:latest
-      - name: Run Site
-        run: docker run -p 3000:80 -d kpt-site:latest 
       - name: Run Site Checker
-        shell: bash
-        # Find all potential entrypoints (stripping out themes directory until it's removed) and check them for Docsify 404s.
-        run: find site -name README.md -printf "%P\n" | grep -v node_modules | grep -v themes | sed "s/README.md//" | sed "s/^/http:\/\/localhost:3000\//" | xargs -n1 sh -c '! (npx href-checker/ $0 --bad-content="404 - Not found" --silent --no-off-site -c=15 | grep .) || exit 255'
+        run: make site-check

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ gencatalog:
 	(cd site/content/en/guides/consumer/function/catalog/catalog && npm run gen-docs)
 
 site-run-server:
-	chmod o+rx -R site/
+	setfacl -Rd -m o::rx site/ && chmod o+rx -R site/
 	docker stop $$(docker ps -q --filter ancestor=kpt-site:latest) || docker build site/ -t kpt-site:latest
 	docker run -v `pwd`/site:/usr/share/nginx/html -p 3000:80 -d kpt-site:latest
 

--- a/Makefile
+++ b/Makefile
@@ -92,9 +92,7 @@ gencatalog:
 	(cd site/content/en/guides/consumer/function/catalog/catalog && npm run gen-docs)
 
 site-run-server:
-	setfacl -Rd -m o::rx site/ && chmod o+rx -R site/
-	docker stop $$(docker ps -q --filter ancestor=kpt-site:latest) || docker build site/ -t kpt-site:latest
-	docker run -v `pwd`/site:/usr/share/nginx/html -p 3000:80 -d kpt-site:latest
+	./scripts/run-site.sh
 
 site-check:
 	make site-run-server

--- a/Makefile
+++ b/Makefile
@@ -92,9 +92,12 @@ gencatalog:
 	(cd site/content/en/guides/consumer/function/catalog/catalog && npm run gen-docs)
 
 site-run-server:
-	npx http-server site/ -p 3000
+	chmod o+rx -R site/
+	docker stop $$(docker ps -q --filter ancestor=kpt-site:latest) || docker build site/ -t kpt-site:latest
+	docker run -v `pwd`/site:/usr/share/nginx/html -p 3000:80 -d kpt-site:latest
 
 site-check:
+	make site-run-server
 	./scripts/check-site.sh
 
 site-verify-guides:

--- a/scripts/check-site.sh
+++ b/scripts/check-site.sh
@@ -15,9 +15,6 @@
 
 set -o pipefail
 
-docker stop $(docker ps -q --filter ancestor=kpt-site-check:latest) &>/dev/null
-docker build site/ -t kpt-site-check:latest
-docker run -p 3000:80 -d kpt-site-check:latest 
 cd site
 npm i
 echo "Starting check."

--- a/scripts/run-site.sh
+++ b/scripts/run-site.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 # Set read/execute permissions for newly created site files in macOS or Linux.
-setfacl -Rd -m o::rx site/ || chmod -R +a "everyone allow read,execute,file_inherit,directory_inherit" site/
+setfacl -Rd -m o::rx site/ 2> /dev/null || chmod -R +a "everyone allow read,execute,file_inherit,directory_inherit" site/
 # Set read/execute permissions for existing site files.
 chmod -R o+rx site/
 # Terminate running kpt-site docker containers and rebuild.

--- a/scripts/run-site.sh
+++ b/scripts/run-site.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Set read/execute permissions for newly created site files in macOS or Linux.
+setfacl -Rd -m o::rx site/ || chmod -R +a "everyone allow read,execute,file_inherit,directory_inherit" site/
+# Set read/execute permissions for existing site files.
+chmod -R o+rx site/
+# Terminate running kpt-site docker containers and rebuild.
+docker stop $(docker ps -q --filter ancestor=kpt-site:latest) || docker build site/ -t kpt-site:latest
+# Mount the site directory as the default content for the docker container.
+docker run -v `pwd`/site:/usr/share/nginx/html -p 3000:80 -d kpt-site:latest

--- a/site/Dockerfile
+++ b/site/Dockerfile
@@ -1,9 +1,6 @@
 FROM nginx:1.18.0-alpine
 COPY . /usr/share/nginx/html
 COPY site_check.conf /etc/nginx/conf.d/configfile.template
-# .conf file can be visible from this location.
-RUN chown -R "$USER":nginx /usr/share/nginx/html
-RUN chmod +r -R /usr/share/nginx/html
 
 ENV PORT 80
 ENV HOST 0.0.0.0

--- a/site/site_check.conf
+++ b/site/site_check.conf
@@ -1,6 +1,7 @@
 server {
     listen       $PORT;
     server_name  localhost;
+    add_header Cache-Control 'no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0';
 
     location ~* README.md$ {
         root   /usr/share/nginx/html;


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/kpt/issues/1680
Also normalizes docs previewing for site checking between local dev environment and GHA.