### PR TITLE
Handle kptfile pipeline in updates

### DIFF
--- a/internal/testutil/pkgbuilder/builder.go
+++ b/internal/testutil/pkgbuilder/builder.go
@@ -304,6 +304,7 @@ func (sp *SubPkg) WithSubPackages(ps ...*SubPkg) *SubPkg {
 type Kptfile struct {
 	Upstream     *Upstream
 	UpstreamLock *UpstreamLock
+	Pipeline     *Pipeline
 }
 
 func NewKptfile() *Kptfile {
@@ -379,6 +380,27 @@ type UpstreamLock struct {
 	Ref     string
 	Index   int
 	Commit  string
+}
+
+func (k *Kptfile) WithPipeline(functions ...Function) *Kptfile {
+	k.Pipeline = &Pipeline{
+		Functions: functions,
+	}
+	return k
+}
+
+type Pipeline struct {
+	Functions []Function
+}
+
+func NewFunction(image string) Function {
+	return Function{
+		Image: image,
+	}
+}
+
+type Function struct {
+	Image string
 }
 
 // RemoteSubpackage contains information about remote subpackages that should
@@ -493,6 +515,13 @@ upstreamLock:
     directory: {{.Pkg.Kptfile.UpstreamLock.Dir}}
     ref: {{.Pkg.Kptfile.UpstreamLock.Ref}}
     repo: {{.Pkg.Kptfile.UpstreamLock.Repo}}
+{{- end }}
+{{- if .Pkg.Kptfile.Pipeline }}
+pipeline:
+  mutators:
+{{- range .Pkg.Kptfile.Pipeline.Functions }}
+  - image: {{ .Image }}
+{{- end }}
 {{- end }}
 `
 

--- a/internal/util/get/get_test.go
+++ b/internal/util/get/get_test.go
@@ -811,6 +811,7 @@ func TestCommand_Run_subpackages(t *testing.T) {
 				).
 				WithResource(pkgbuilder.DeploymentResource),
 		},
+
 		"basic package with non-KRM files": {
 			directory: "/",
 			ref:       "master",
@@ -831,6 +832,35 @@ func TestCommand_Run_subpackages(t *testing.T) {
 						WithUpstreamLockRef("upstream", "/", "master", 0),
 				).
 				WithFile("foo.txt", `this is a test`),
+		},
+		"basic package with pipeline": {
+			directory: "/",
+			ref:       "master",
+			reposContent: map[string][]testutil.Content{
+				testutil.Upstream: {
+					{
+						Branch: "master",
+						Pkg: pkgbuilder.NewRootPkg().
+							WithKptfile(
+								pkgbuilder.NewKptfile().
+									WithPipeline(
+										pkgbuilder.NewFunction("gcr.io/kpt-dev/foo:latest"),
+									),
+							).
+							WithResource(pkgbuilder.DeploymentResource),
+					},
+				},
+			},
+			expectedResult: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithUpstreamRef("upstream", "/", "master", "resource-merge").
+						WithUpstreamLockRef("upstream", "/", "master", 0).
+						WithPipeline(
+							pkgbuilder.NewFunction("gcr.io/kpt-dev/foo:latest"),
+						),
+				).
+				WithResource(pkgbuilder.DeploymentResource),
 		},
 		"basic package with no Kptfile in upstream": {
 			directory: "/",

--- a/pkg/kptfile/kptfileutil/util_test.go
+++ b/pkg/kptfile/kptfileutil/util_test.go
@@ -17,7 +17,9 @@ package kptfileutil
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
@@ -151,6 +153,342 @@ upstreamBadField:
 	assert.Equal(t, kptfilev1alpha2.KptFile{}, f)
 }
 
-func TestMerge(t *testing.T) {
+func TestUpdateKptfile(t *testing.T) {
+	writeKptfileToTemp := func(name string, content string) string {
+		dir, err := ioutil.TempDir("", name)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+		err = ioutil.WriteFile(filepath.Join(dir, kptfilev1alpha2.KptFileName), []byte(content), 0600)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+		return dir
+	}
+
+	testCases := map[string]struct {
+		origin         string
+		updated        string
+		local          string
+		updateUpstream bool
+		expected       string
+	}{
+		"no pipeline and no upstream info": {
+			origin: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: base
+`,
+			updated: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: base
+`,
+			local: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+`,
+			updateUpstream: false,
+			expected: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+`,
+		},
+
+		"upstream information is not copied from upstream unless updateUpstream is true": {
+			origin: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+upstream:
+  type: git
+  git:
+    repo: github.com/GoogleContainerTools/kpt
+    directory: /
+    ref: v1
+`,
+			updated: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+upstream:
+  type: git
+  git:
+    repo: github.com/GoogleContainerTools/kpt
+    directory: /
+    ref: v2
+`,
+			local: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+`,
+			updateUpstream: false,
+			expected: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+`,
+		},
+
+		"upstream information is copied from upstream when updateUpstream is true": {
+			origin: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+upstream:
+  type: git
+  git:
+    repo: github.com/GoogleContainerTools/kpt
+    directory: /
+    ref: v1
+`,
+			updated: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+upstream:
+  type: git
+  git:
+    repo: github.com/GoogleContainerTools/kpt
+    directory: /
+    ref: v2
+upstreamLock:
+  type: git
+  gitLock:
+    repo: github.com/GoogleContainerTools/kpt
+    directory: /
+    ref: v2
+    commit: abc123
+`,
+			local: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+`,
+			updateUpstream: true,
+			expected: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+upstream:
+  type: git
+  git:
+    repo: github.com/GoogleContainerTools/kpt
+    directory: /
+    ref: v2
+upstreamLock:
+  type: git
+  gitLock:
+    repo: github.com/GoogleContainerTools/kpt
+    directory: /
+    ref: v2
+    commit: abc123
+`,
+		},
+
+		"pipeline in upstream replaces local": {
+			origin: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+pipeline:
+  mutators:
+  - image: foo:bar
+`,
+			updated: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+pipeline:
+  mutators:
+  - image: foo:bar
+  - image: some:image
+`,
+			local: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+pipeline:
+  mutators:
+  - image: my:image
+  - image: foo:bar
+`,
+			updateUpstream: true,
+			expected: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+pipeline:
+  mutators:
+  - image: foo:bar
+  - image: some:image
+`,
+		},
+
+		"pipeline in local remains if there are no changes in upstream": {
+			origin: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+pipeline:
+  mutators:
+  - image: foo:bar
+`,
+			updated: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+pipeline:
+  mutators:
+  - image: foo:bar
+`,
+			local: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+pipeline:
+  mutators:
+  - image: my:image
+  - image: foo:bar
+`,
+			updateUpstream: true,
+			expected: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+pipeline:
+  mutators:
+  - image: my:image
+  - image: foo:bar
+`,
+		},
+
+		"pipeline remains if it is only added locally": {
+			origin: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+`,
+			updated: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+`,
+			local: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+pipeline:
+  mutators:
+  - image: my:image
+  - image: foo:bar
+`,
+			updateUpstream: true,
+			expected: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+pipeline:
+  mutators:
+  - image: my:image
+  - image: foo:bar
+`,
+		},
+
+		"pipeline in local is emptied if it is gone from upstream": {
+			origin: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+pipeline:
+  mutators:
+  - image: foo:bar
+`,
+			updated: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+`,
+			local: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+pipeline:
+  mutators:
+  - image: my:image
+  - image: foo:bar
+`,
+			updateUpstream: false,
+			expected: `
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: foo
+pipeline: {}
+`,
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			files := map[string]string{
+				"origin":  tc.origin,
+				"updated": tc.updated,
+				"local":   tc.local,
+			}
+			dirs := make(map[string]string)
+			for n, content := range files {
+				dir := writeKptfileToTemp(n, content)
+				dirs[n] = dir
+			}
+			defer func() {
+				for _, p := range dirs {
+					_ = os.RemoveAll(p)
+				}
+			}()
+
+			err := UpdateKptfile(dirs["local"], dirs["updated"], dirs["origin"], tc.updateUpstream)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			c, err := ioutil.ReadFile(filepath.Join(dirs["local"], kptfilev1alpha2.KptFileName))
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			assert.Equal(t, strings.TrimSpace(tc.expected)+"\n", string(c))
+		})
+	}
 
 }

--- a/pkg/kptfile/kptfileutil/util_test.go
+++ b/pkg/kptfile/kptfileutil/util_test.go
@@ -309,7 +309,7 @@ metadata:
   name: foo
 pipeline:
   mutators:
-  - image: foo:bar
+    - image: foo:bar
 `,
 			updated: `
 apiVersion: kpt.dev/v1alpha2
@@ -318,8 +318,10 @@ metadata:
   name: foo
 pipeline:
   mutators:
-  - image: foo:bar
-  - image: some:image
+    - image: foo:bar
+      configMap:
+        source: updated
+    - image: some:image
 `,
 			local: `
 apiVersion: kpt.dev/v1alpha2
@@ -328,8 +330,10 @@ metadata:
   name: foo
 pipeline:
   mutators:
-  - image: my:image
-  - image: foo:bar
+    - image: my:image
+      configMap:
+        source: local
+    - image: foo:bar
 `,
 			updateUpstream: true,
 			expected: `
@@ -339,8 +343,10 @@ metadata:
   name: foo
 pipeline:
   mutators:
-  - image: foo:bar
-  - image: some:image
+    - image: foo:bar
+      configMap:
+        source: updated
+    - image: some:image
 `,
 		},
 
@@ -352,7 +358,7 @@ metadata:
   name: foo
 pipeline:
   mutators:
-  - image: foo:bar
+    - image: foo:bar
 `,
 			updated: `
 apiVersion: kpt.dev/v1alpha2
@@ -361,7 +367,7 @@ metadata:
   name: foo
 pipeline:
   mutators:
-  - image: foo:bar
+    - image: foo:bar
 `,
 			local: `
 apiVersion: kpt.dev/v1alpha2
@@ -370,8 +376,13 @@ metadata:
   name: foo
 pipeline:
   mutators:
-  - image: my:image
-  - image: foo:bar
+    - image: my:image
+      config:
+        apiVersion: kpt.dev/v1alpha2
+        kind: Function
+        spec:
+          foo: bar
+    - image: foo:bar
 `,
 			updateUpstream: true,
 			expected: `
@@ -381,8 +392,13 @@ metadata:
   name: foo
 pipeline:
   mutators:
-  - image: my:image
-  - image: foo:bar
+    - image: my:image
+      config:
+        apiVersion: kpt.dev/v1alpha2
+        kind: Function
+        spec:
+          foo: bar
+    - image: foo:bar
 `,
 		},
 
@@ -406,8 +422,8 @@ metadata:
   name: foo
 pipeline:
   mutators:
-  - image: my:image
-  - image: foo:bar
+    - image: my:image
+    - image: foo:bar
 `,
 			updateUpstream: true,
 			expected: `
@@ -417,8 +433,8 @@ metadata:
   name: foo
 pipeline:
   mutators:
-  - image: my:image
-  - image: foo:bar
+    - image: my:image
+    - image: foo:bar
 `,
 		},
 
@@ -430,7 +446,7 @@ metadata:
   name: foo
 pipeline:
   mutators:
-  - image: foo:bar
+    - image: foo:bar
 `,
 			updated: `
 apiVersion: kpt.dev/v1alpha2
@@ -445,8 +461,8 @@ metadata:
   name: foo
 pipeline:
   mutators:
-  - image: my:image
-  - image: foo:bar
+    - image: my:image
+    - image: foo:bar
 `,
 			updateUpstream: false,
 			expected: `


### PR DESCRIPTION
This PR adds support for merging of pipelines in the Kptfile. This merges the pipeline as a non-associative list, which essentially means that changes in upstream will replace any local changes. Long-term we want to have a better solution.

Fixes: https://github.com/GoogleContainerTools/kpt/issues/1616