### PR TITLE
Better error handling for get and update

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -34,7 +34,7 @@ func NormalizeCommand(c ...*cobra.Command) {
 func GetKptCommands(ctx context.Context, name string, f util.Factory) []*cobra.Command {
 	var c []*cobra.Command
 	fnCmd := GetFnCommand(ctx, name)
-	pkgCmd := GetPkgCommand(name)
+	pkgCmd := GetPkgCommand(ctx, name)
 	liveCmd := GetLiveCommand(name, f)
 
 	c = append(c, pkgCmd, fnCmd, liveCmd)

--- a/commands/pkgcmd.go
+++ b/commands/pkgcmd.go
@@ -15,6 +15,8 @@
 package commands
 
 import (
+	"context"
+
 	"github.com/GoogleContainerTools/kpt/internal/cmddiff"
 	"github.com/GoogleContainerTools/kpt/internal/cmdget"
 	"github.com/GoogleContainerTools/kpt/internal/cmdinit"
@@ -25,7 +27,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func GetPkgCommand(name string) *cobra.Command {
+func GetPkgCommand(ctx context.Context, name string) *cobra.Command {
 	pkg := &cobra.Command{
 		Use:     "pkg",
 		Short:   pkgdocs.PkgShort,
@@ -45,8 +47,8 @@ func GetPkgCommand(name string) *cobra.Command {
 	}
 
 	pkg.AddCommand(
-		cmdget.NewCommand(name), cmdinit.NewCommand(name),
-		cmdupdate.NewCommand(name), cmddiff.NewCommand(name),
+		cmdget.NewCommand(ctx, name), cmdinit.NewCommand(name),
+		cmdupdate.NewCommand(ctx, name), cmddiff.NewCommand(ctx, name),
 		cmdcat.NewCommand(name), cmdtree.NewCommand(name),
 	)
 	return pkg

--- a/internal/cmddiff/cmddiff.go
+++ b/internal/cmddiff/cmddiff.go
@@ -16,6 +16,7 @@
 package cmddiff
 
 import (
+	"context"
 	"os"
 
 	"github.com/GoogleContainerTools/kpt/internal/docs/generated/pkgdocs"
@@ -27,8 +28,10 @@ import (
 )
 
 // NewRunner returns a command runner.
-func NewRunner(parent string) *Runner {
-	r := &Runner{}
+func NewRunner(ctx context.Context, parent string) *Runner {
+	r := &Runner{
+		ctx: ctx,
+	}
 	c := &cobra.Command{
 		Use:          "diff [PKG_PATH@VERSION] [flags]",
 		Short:        pkgdocs.DiffShort,
@@ -58,12 +61,13 @@ func NewRunner(parent string) *Runner {
 }
 
 // NewCommand returns a diff command instance.
-func NewCommand(parent string) *cobra.Command {
-	return NewRunner(parent).C
+func NewCommand(ctx context.Context, parent string) *cobra.Command {
+	return NewRunner(ctx, parent).C
 }
 
 // Runner contains the run function
 type Runner struct {
+	ctx context.Context
 	diff.Command
 	C        *cobra.Command
 	diffType string
@@ -101,5 +105,5 @@ func (r *Runner) preRunE(_ *cobra.Command, args []string) error {
 }
 
 func (r *Runner) runE(c *cobra.Command, args []string) error {
-	return r.Run()
+	return r.Run(r.ctx)
 }

--- a/internal/cmddiff/cmddiff_test.go
+++ b/internal/cmddiff/cmddiff_test.go
@@ -20,12 +20,13 @@ import (
 
 	"github.com/GoogleContainerTools/kpt/internal/cmddiff"
 	"github.com/GoogleContainerTools/kpt/internal/cmdget"
+	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestCmdInvalidDiffType(t *testing.T) {
-	runner := cmddiff.NewRunner("")
+	runner := cmddiff.NewRunner(fake.CtxWithNilPrinter(), "")
 	runner.C.SetArgs([]string{"--diff-type", "invalid"})
 	runner.C.SilenceErrors = true
 	err := runner.C.Execute()
@@ -35,7 +36,7 @@ func TestCmdInvalidDiffType(t *testing.T) {
 }
 
 func TestCmdInvalidDiffTool(t *testing.T) {
-	runner := cmddiff.NewRunner("")
+	runner := cmddiff.NewRunner(fake.CtxWithNilPrinter(), "")
 	runner.C.SetArgs([]string{"--diff-tool", "nodiff"})
 	runner.C.SilenceErrors = true
 	err := runner.C.Execute()
@@ -55,12 +56,12 @@ func TestCmdExecute(t *testing.T) {
 
 	dest := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 
-	getRunner := cmdget.NewRunner("")
+	getRunner := cmdget.NewRunner(fake.CtxWithNilPrinter(), "")
 	getRunner.Command.SetArgs([]string{"file://" + g.RepoDirectory + ".git/", "./"})
 	err := getRunner.Command.Execute()
 	assert.NoError(t, err)
 
-	runner := cmddiff.NewRunner("")
+	runner := cmddiff.NewRunner(fake.CtxWithNilPrinter(), "")
 	runner.C.SetArgs([]string{dest, "--diff-type", "local"})
 	runner.C.SilenceErrors = true
 	err = runner.C.Execute()

--- a/internal/cmdget/cmdget_test.go
+++ b/internal/cmdget/cmdget_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/GoogleContainerTools/kpt/internal/cmdget"
 	"github.com/GoogleContainerTools/kpt/internal/gitutil"
+	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 	"github.com/spf13/cobra"
@@ -42,7 +43,7 @@ func TestCmd_execute(t *testing.T) {
 
 	dest := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 
-	r := cmdget.NewRunner("kpt")
+	r := cmdget.NewRunner(fake.CtxWithNilPrinter(), "kpt")
 	// defaults LOCAL_DEST_DIR to current working directory
 	r.Command.SetArgs([]string{"file://" + g.RepoDirectory + ".git/"})
 	err := r.Command.Execute()
@@ -101,7 +102,7 @@ func TestCmdMainBranch_execute(t *testing.T) {
 		t.FailNow()
 	}
 
-	r := cmdget.NewRunner("kpt")
+	r := cmdget.NewRunner(fake.CtxWithNilPrinter(), "kpt")
 	r.Command.SetArgs([]string{"file://" + g.RepoDirectory + ".git/", "./"})
 	err = r.Command.Execute()
 
@@ -145,7 +146,7 @@ func TestCmdMainBranch_execute(t *testing.T) {
 
 // TestCmd_fail verifies that that command returns an error rather than exiting the process
 func TestCmd_fail(t *testing.T) {
-	r := cmdget.NewRunner("kpt")
+	r := cmdget.NewRunner(fake.CtxWithNilPrinter(), "kpt")
 	r.Command.SilenceErrors = true
 	r.Command.SilenceUsage = true
 	r.Command.SetArgs([]string{"file://" + filepath.Join("not", "real", "dir") + ".git/@master", "./"})
@@ -213,7 +214,8 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 			},
 			runE: failRun,
 			validations: func(_ string, r *cmdget.Runner, err error) {
-				assert.EqualError(t, err, "ambiguous repo/dir@version specify '.git' in argument")
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "ambiguous repo/dir@version specify '.git' in argument")
 			},
 		},
 		"repo arg is split up correctly into ref and repo": {
@@ -373,7 +375,7 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 			err = os.Mkdir(filepath.Join(d, "package"), 0700)
 			assert.NoError(t, err)
 
-			r := cmdget.NewRunner("kpt")
+			r := cmdget.NewRunner(fake.CtxWithNilPrinter(), "kpt")
 			r.Command.SilenceErrors = true
 			r.Command.SilenceUsage = true
 			r.Command.RunE = tc.runE

--- a/internal/cmdupdate/cmdupdate.go
+++ b/internal/cmdupdate/cmdupdate.go
@@ -16,24 +16,27 @@
 package cmdupdate
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	docs "github.com/GoogleContainerTools/kpt/internal/docs/generated/pkgdocs"
+	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	"github.com/GoogleContainerTools/kpt/internal/types"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/update"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 	"github.com/spf13/cobra"
-	"sigs.k8s.io/kustomize/kyaml/errors"
 )
 
 // NewRunner returns a command runner.
-func NewRunner(parent string) *Runner {
-	r := &Runner{}
+func NewRunner(ctx context.Context, parent string) *Runner {
+	r := &Runner{
+		ctx: ctx,
+	}
 	c := &cobra.Command{
 		Use:        "update [PKG_PATH@VERSION] [flags]",
 		Short:      docs.UpdateShort,
@@ -60,19 +63,21 @@ func NewRunner(parent string) *Runner {
 	return r
 }
 
-func NewCommand(parent string) *cobra.Command {
-	return NewRunner(parent).Command
+func NewCommand(ctx context.Context, parent string) *cobra.Command {
+	return NewRunner(ctx, parent).Command
 }
 
 // Runner contains the run function.
 // TODO, support listing versions
 type Runner struct {
+	ctx      context.Context
 	strategy string
 	Update   update.Command
 	Command  *cobra.Command
 }
 
 func (r *Runner) preRunE(_ *cobra.Command, args []string) error {
+	const op errors.Op = "cmdupdate.preRunE"
 	if len(args) == 0 {
 		args = append(args, pkg.CurDir)
 	}
@@ -84,12 +89,12 @@ func (r *Runner) preRunE(_ *cobra.Command, args []string) error {
 
 	parts := strings.Split(args[0], "@")
 	if len(parts) > 2 {
-		return errors.Errorf("at most 1 version permitted")
+		return errors.E(op, errors.InvalidParam, fmt.Errorf("at most 1 version permitted"))
 	}
 
 	p, err := pkg.New(parts[0])
 	if err != nil {
-		return err
+		return errors.E(op, err)
 	}
 
 	r.Update.Pkg = p
@@ -98,10 +103,10 @@ func (r *Runner) preRunE(_ *cobra.Command, args []string) error {
 	// this consistently across all commands.
 	relPath, err := resolveRelPath(p.UniquePath)
 	if err != nil {
-		return err
+		return errors.E(op, p.UniquePath, err)
 	}
 	if strings.HasPrefix(relPath, pkg.ParentDir) {
-		return errors.Errorf("package path must be under current working directory")
+		return errors.E(op, p.UniquePath, fmt.Errorf("package path must be under current working directory"))
 	}
 
 	if len(parts) > 1 {
@@ -111,6 +116,7 @@ func (r *Runner) preRunE(_ *cobra.Command, args []string) error {
 }
 
 func (r *Runner) runE(c *cobra.Command, _ []string) error {
+	const op errors.Op = "cmdupdate.runE"
 	if len(r.Update.Ref) > 0 {
 		fmt.Fprintf(c.ErrOrStderr(), "updating package %s to %s\n",
 			r.Update.Pkg.UniquePath, r.Update.Ref)
@@ -118,22 +124,25 @@ func (r *Runner) runE(c *cobra.Command, _ []string) error {
 		fmt.Fprintf(c.ErrOrStderr(), "updating package %s\n",
 			r.Update.Pkg.UniquePath)
 	}
-	if err := r.Update.Run(); err != nil {
-		return err
+	if err := r.Update.Run(r.ctx); err != nil {
+		return errors.E(op, r.Update.Pkg.UniquePath, err)
 	}
 
 	return nil
 }
 
 func resolveRelPath(path types.UniquePath) (string, error) {
+	const op errors.Op = "cmdupdate.resolveRelPath"
 	cwd, err := os.Getwd()
 	if err != nil {
-		return "", err
+		return "", errors.E(op, errors.IO,
+			fmt.Errorf("error looking up current working directory: %w", err))
 	}
 
 	relPath, err := filepath.Rel(cwd, path.String())
 	if err != nil {
-		return "", err
+		return "", errors.E(op, errors.IO,
+			fmt.Errorf("error resolving the relative path: %w", err))
 	}
 	return relPath, nil
 }

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -129,6 +129,8 @@ const (
 	InvalidParam              // Value is not valid.
 	MissingParam              // Required value is missing or empty.
 	Git                       // Errors from Git
+	IO                        // Error doing IO operations
+	YAML                      // yaml document can't be parsed
 )
 
 func (c Class) String() string {
@@ -145,6 +147,10 @@ func (c Class) String() string {
 		return "missing parameter value"
 	case Git:
 		return "git error"
+	case IO:
+		return "IO error"
+	case YAML:
+		return "yaml parsing error"
 	}
 	return "unknown kind"
 }

--- a/internal/printer/fake/fake.go
+++ b/internal/printer/fake/fake.go
@@ -1,0 +1,36 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"context"
+
+	"github.com/GoogleContainerTools/kpt/internal/printer"
+	"github.com/GoogleContainerTools/kpt/internal/types"
+)
+
+// NilPrinter implements the printer.Printer interface and just ignores
+// all print calls.
+type NilPrinter struct{}
+
+func (np *NilPrinter) PkgPrintf(types.UniquePath, string, ...interface{}) {}
+
+func (np *NilPrinter) Printf(string, ...interface{}) {}
+
+// CtxWithNilPrinter returns a new context with the NilPrinter added.
+func CtxWithNilPrinter() context.Context {
+	ctx := context.Background()
+	return printer.WithContext(ctx, &NilPrinter{})
+}

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Package printer defines utilities to display kpt CLI output.
 package printer
 
@@ -72,7 +86,7 @@ func (pr *printer) Printf(format string, args ...interface{}) {
 
 // FromContext returns printer instance associated with the context.
 func FromContextOrDie(ctx context.Context) Printer {
-	pr, ok := ctx.Value(printerKey).(*printer)
+	pr, ok := ctx.Value(printerKey).(Printer)
 	if ok {
 		return pr
 	}

--- a/internal/testutil/setup_manager.go
+++ b/internal/testutil/setup_manager.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/kpt/internal/gitutil"
+	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
 	"github.com/GoogleContainerTools/kpt/internal/testutil/pkgbuilder"
 	"github.com/GoogleContainerTools/kpt/internal/util/get"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
@@ -103,7 +104,7 @@ func (g *TestSetupManager) Init() bool {
 			Repo:      g.Repos[Upstream].RepoDirectory,
 			Ref:       g.GetRef,
 			Directory: g.GetSubDirectory,
-		}}.Run()) {
+		}}.Run(fake.CtxWithNilPrinter())) {
 		return false
 	}
 	localGit := gitutil.NewLocalGitRunner(g.LocalWorkspace.WorkspaceDirectory)

--- a/internal/util/diff/diff_test.go
+++ b/internal/util/diff/diff_test.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
 	. "github.com/GoogleContainerTools/kpt/internal/util/diff"
 	"github.com/stretchr/testify/assert"
@@ -232,7 +233,7 @@ func TestCommand_Diff(t *testing.T) {
 				DiffTool:     "diff",
 				DiffToolOpts: "-r -i -w",
 				Output:       diffOutput,
-			}).Run()
+			}).Run(fake.CtxWithNilPrinter())
 			assert.NoError(t, err)
 
 			filteredOutput := filterDiffMetadata(diffOutput)

--- a/internal/util/fetch/fetch.go
+++ b/internal/util/fetch/fetch.go
@@ -16,6 +16,7 @@ package fetch
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -23,13 +24,15 @@ import (
 	"path"
 	"strings"
 
+	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/gitutil"
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
+	"github.com/GoogleContainerTools/kpt/internal/printer"
+	"github.com/GoogleContainerTools/kpt/internal/types"
 	"github.com/GoogleContainerTools/kpt/internal/util/git"
 	"github.com/GoogleContainerTools/kpt/internal/util/pkgutil"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
-	"sigs.k8s.io/kustomize/kyaml/errors"
 )
 
 // Command takes the upstream information in the Kptfile at the path for the
@@ -40,14 +43,15 @@ type Command struct {
 }
 
 // Run runs the Command.
-func (c Command) Run() error {
+func (c Command) Run(ctx context.Context) error {
+	const op errors.Op = "fetch.Run"
 	kf, err := c.Pkg.Kptfile()
 	if err != nil {
-		return fmt.Errorf("no Kptfile found")
+		return errors.E(op, c.Pkg.UniquePath, fmt.Errorf("no Kptfile found"))
 	}
 
 	if err := c.validate(kf); err != nil {
-		return err
+		return errors.E(op, c.Pkg.UniquePath, err)
 	}
 
 	g := kf.Upstream.Git
@@ -56,9 +60,9 @@ func (c Command) Run() error {
 		Path:    g.Directory,
 		Ref:     g.Ref,
 	}
-	err = cloneAndCopy(repoSpec, c.Pkg.UniquePath.String())
+	err = cloneAndCopy(ctx, repoSpec, c.Pkg.UniquePath.String())
 	if err != nil {
-		return err
+		return errors.E(op, c.Pkg.UniquePath, err)
 	}
 	return nil
 }
@@ -66,23 +70,24 @@ func (c Command) Run() error {
 // validate makes sure the Kptfile has the necessary information to fetch
 // the package.
 func (c Command) validate(kf *kptfilev1alpha2.KptFile) error {
+	const op errors.Op = "validate"
 	if kf.Upstream == nil {
-		return fmt.Errorf("kptfile doesn't contain upstream information")
+		return errors.E(op, errors.MissingParam, fmt.Errorf("kptfile doesn't contain upstream information"))
 	}
 
 	if kf.Upstream.Git == nil {
-		return fmt.Errorf("kptfile upstream doesn't have git information")
+		return errors.E(op, errors.MissingParam, fmt.Errorf("kptfile upstream doesn't have git information"))
 	}
 
 	g := kf.Upstream.Git
 	if len(g.Repo) == 0 {
-		return errors.Errorf("must specify repo")
+		return errors.E(op, errors.MissingParam, fmt.Errorf("must specify repo"))
 	}
 	if len(g.Ref) == 0 {
-		return errors.Errorf("must specify ref")
+		return errors.E(op, errors.MissingParam, fmt.Errorf("must specify ref"))
 	}
 	if len(g.Directory) == 0 {
-		return errors.Errorf("must specify directory")
+		return errors.E(op, errors.MissingParam, fmt.Errorf("must specify directory"))
 	}
 	return nil
 }
@@ -90,23 +95,26 @@ func (c Command) validate(kf *kptfilev1alpha2.KptFile) error {
 // cloneAndCopy fetches the provided repo and copies the content into the
 // directory specified by dest. The provided name is set as `metadata.name`
 // of the Kptfile of the package.
-func cloneAndCopy(r *git.RepoSpec, dest string) error {
-	if err := ClonerUsingGitExec(r); err != nil {
-		return errors.Errorf("failed to clone git repo: %v", err)
+func cloneAndCopy(ctx context.Context, r *git.RepoSpec, dest string) error {
+	const op errors.Op = "fetch.cloneAndCopy"
+	p := printer.FromContextOrDie(ctx)
+	p.Printf("cloning %s@%s\n", r.OrgRepo, r.Ref)
+	if err := ClonerUsingGitExec(ctx, r); err != nil {
+		return errors.E(op, errors.Git, types.UniquePath(dest), err)
 	}
 	defer os.RemoveAll(r.Dir)
 
+	p.Printf("copying %q to %s\n", r.Path, dest)
 	if err := pkgutil.CopyPackageWithSubpackages(r.AbsPath(), dest); err != nil {
-		return errors.WrapPrefixf(err, "missing subdirectory %s in repo %s at ref %s\n",
-			r.Path, r.OrgRepo, r.Ref)
+		return errors.E(op, types.UniquePath(dest), err)
 	}
 
 	if err := kptfileutil.UpdateKptfileWithoutOrigin(dest, r.AbsPath(), false); err != nil {
-		return err
+		return errors.E(op, types.UniquePath(dest), err)
 	}
 
 	if err := kptfileutil.UpdateUpstreamLockFromGit(dest, r); err != nil {
-		return errors.Wrap(err)
+		return errors.E(op, errors.Git, types.UniquePath(dest), err)
 	}
 	return nil
 }
@@ -117,7 +125,8 @@ func cloneAndCopy(r *git.RepoSpec, dest string) error {
 // for versioning multiple kpt packages in a single repo independently. It
 // relies on the private clonerUsingGitExec function to try fetching different
 // refs.
-func ClonerUsingGitExec(repoSpec *git.RepoSpec) error {
+func ClonerUsingGitExec(ctx context.Context, repoSpec *git.RepoSpec) error {
+	const op errors.Op = "fetch.ClonerUsingGitExec"
 	// look for a tag with the directory as a prefix for versioning
 	// subdirectories independently
 	originalRef := repoSpec.Ref
@@ -128,23 +137,24 @@ func ClonerUsingGitExec(repoSpec *git.RepoSpec) error {
 
 	defaultRef, err := gitutil.DefaultRef(repoSpec.OrgRepo)
 	if err != nil {
-		return err
+		return errors.E(op, errors.Git, err)
 	}
 
 	// clone the repo to a tmp directory.
 	// delete the tmp directory later.
-	err = clonerUsingGitExec(repoSpec)
+	err = clonerUsingGitExec(ctx, repoSpec)
 	if err != nil && originalRef != repoSpec.Ref {
 		repoSpec.Ref = originalRef
-		err = clonerUsingGitExec(repoSpec)
+		err = clonerUsingGitExec(ctx, repoSpec)
 	}
 
 	if err != nil {
 		if strings.HasPrefix(repoSpec.Path, "blob/") {
-			return errors.Errorf("failed to clone git repo containing /blob/, "+
-				"you may need to remove /blob/%s from the url:\n%v", defaultRef, err)
+			p := printer.FromContextOrDie(ctx)
+			p.Printf("git repo contains /blob/, you may need to remove /blob/%s", defaultRef)
+			return errors.E(op, errors.Git, err)
 		}
-		return errors.Errorf("failed to clone git repo: %v", err)
+		return errors.E(op, errors.Git, err)
 	}
 
 	return nil
@@ -153,95 +163,106 @@ func ClonerUsingGitExec(repoSpec *git.RepoSpec) error {
 // clonerUsingGitExec is the implementation for cloning a repo from git into
 // a local temp directory. This is used by the public ClonerUsingGitExec
 // function to allow trying multiple different refs.
-func clonerUsingGitExec(repoSpec *git.RepoSpec) error {
-	gitProgram, err := exec.LookPath("git")
-	if err != nil {
-		return errors.WrapPrefixf(err, "no 'git' program on path")
-	}
-
+func clonerUsingGitExec(ctx context.Context, repoSpec *git.RepoSpec) error {
+	const op errors.Op = "fetch.clonerUsingGitExec"
+	var err error
 	repoSpec.Dir, err = ioutil.TempDir("", "kpt-get-")
 	if err != nil {
-		return err
+		return errors.E(op, errors.Internal, fmt.Errorf("error creating temp directory: %w", err))
 	}
-	cmd := exec.Command(gitProgram, "init", repoSpec.Dir)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	err = cmd.Run()
+	err = runGitExec(ctx, repoSpec.Dir, "init", repoSpec.Dir)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error initializing empty git repo: %s", out.String())
-		return errors.WrapPrefixf(err, "trouble initializing empty git repo in %s",
-			repoSpec.Dir)
+		return errors.E(op, errors.Git, fmt.Errorf("trouble initializing empty git repo in %s: %w",
+			repoSpec.Dir, err))
 	}
 
-	cmd = exec.Command(gitProgram, "remote", "add", "origin", repoSpec.CloneSpec())
-	cmd.Stdout = &out
-	cmd.Stderr = &out
-	cmd.Dir = repoSpec.Dir
-	err = cmd.Run()
+	err = runGitExec(ctx, repoSpec.Dir, "remote", "add", "origin", repoSpec.CloneSpec())
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error setting git remote: %s", out.String())
-		return errors.WrapPrefixf(
-			err,
-			"trouble adding remote %s",
-			repoSpec.CloneSpec())
+		return errors.E(op, errors.Git, fmt.Errorf("error adding remote %s: %w", repoSpec.CloneSpec(), err))
 	}
 	if repoSpec.Ref == "" {
 		repoSpec.Ref, err = gitutil.DefaultRef(repoSpec.Dir)
 		if err != nil {
-			return err
+			return errors.E(op, errors.Git, fmt.Errorf("error looking up default branch for repo: %w", err))
 		}
 	}
 
 	err = func() error {
-		cmd = exec.Command(gitProgram, "fetch", "origin", "--depth=1", repoSpec.Ref)
-		cmd.Stdout = &out
-		cmd.Stderr = &out
-		cmd.Dir = repoSpec.Dir
-		err = cmd.Run()
+		err = runGitExec(ctx, repoSpec.Dir, "fetch", "origin", "--depth=1", repoSpec.Ref)
 		if err != nil {
-			return errors.WrapPrefixf(err, "trouble fetching %s, "+
-				"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials", repoSpec.Ref)
+			return errors.E(op, errors.Git, fmt.Errorf("trouble fetching %s, "+
+				"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials: %w", repoSpec.Ref, err))
 		}
-		cmd = exec.Command(gitProgram, "reset", "--hard", "FETCH_HEAD")
-		cmd.Stdout = &out
-		cmd.Stderr = &out
-		cmd.Dir = repoSpec.Dir
-		err = cmd.Run()
+
+		err = runGitExec(ctx, repoSpec.Dir, "reset", "--hard", "FETCH_HEAD")
 		if err != nil {
-			return errors.WrapPrefixf(
-				err, "trouble hard resetting empty repository to %s", repoSpec.Ref)
+			return errors.E(op, errors.Git,
+				fmt.Errorf("trouble hard resetting empty repository to %s: %w", repoSpec.Ref, err))
 		}
 		return nil
 	}()
 	if err != nil {
-		cmd = exec.Command(gitProgram, "fetch", "origin")
-		cmd.Stdout = &out
-		cmd.Stderr = &out
-		cmd.Dir = repoSpec.Dir
-		if err = cmd.Run(); err != nil {
-			return errors.WrapPrefixf(err, "trouble fetching origin, "+
-				"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials")
+		err := runGitExec(ctx, repoSpec.Dir, "fetch", "origin")
+		if err != nil {
+			return errors.E(op, errors.Git, fmt.Errorf("trouble fetching origin, "+
+				"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials: %w", err))
 		}
-		cmd = exec.Command(gitProgram, "reset", "--hard", repoSpec.Ref)
-		cmd.Stdout = &out
-		cmd.Stderr = &out
-		cmd.Dir = repoSpec.Dir
-		if err = cmd.Run(); err != nil {
-			return errors.WrapPrefixf(
-				err, "trouble hard resetting empty repository to %s, "+
-					"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials", repoSpec.Ref)
+
+		err = runGitExec(ctx, repoSpec.Dir, "reset", "--hard", repoSpec.Ref)
+		if err != nil {
+			return errors.E(op, errors.Git, fmt.Errorf("trouble hard resetting empty repository to %s, "+
+				"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials: %w", repoSpec.Ref, err))
 		}
 	}
 
-	cmd = exec.Command(gitProgram, "submodule", "update", "--init", "--recursive")
-	cmd.Stdout = &out
-	cmd.Dir = repoSpec.Dir
-	err = cmd.Run()
+	err = runGitExec(ctx, repoSpec.Dir, "submodule", "update", "--init", "--recursive")
 	if err != nil {
-		return errors.WrapPrefixf(err, "trouble fetching submodules for %s, "+
-			"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials", repoSpec.Ref)
+		return errors.E(op, errors.Git, fmt.Errorf("trouble fetching submodules for %s, "+
+			"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials: %w", repoSpec.Ref, err))
 	}
 
 	return nil
+}
+
+func runGitExec(ctx context.Context, dir string, args ...string) error {
+	const op errors.Op = "fetch.runGitExec"
+	gitProgram, err := exec.LookPath("git")
+	if err != nil {
+		return errors.E(op, errors.Git,
+			fmt.Errorf("no 'git' program on path: %w", err))
+	}
+
+	var outBuf bytes.Buffer
+	var errBuf bytes.Buffer
+
+	cmd := exec.CommandContext(ctx, gitProgram, args...)
+	cmd.Dir = dir
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	err = cmd.Run()
+	if err != nil {
+		return &GitExecError{
+			Args:   args,
+			Err:    err,
+			StdErr: errBuf.String(),
+			StdOut: outBuf.String(),
+		}
+	}
+	return nil
+}
+
+type GitExecError struct {
+	Args   []string
+	Err    error
+	StdErr string
+	StdOut string
+}
+
+func (e *GitExecError) Error() string {
+	b := new(strings.Builder)
+	b.WriteString(e.Err.Error())
+	b.WriteString(": ")
+	b.WriteString(e.StdErr)
+	return b.String()
 }

--- a/internal/util/fetch/fetch_test.go
+++ b/internal/util/fetch/fetch_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
+	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
 	. "github.com/GoogleContainerTools/kpt/internal/util/fetch"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
@@ -76,8 +77,11 @@ func TestCommand_Run_failNoKptfile(t *testing.T) {
 
 	err = Command{
 		Pkg: createPackage(t, pkgPath),
-	}.Run()
-	assert.EqualError(t, err, "no Kptfile found")
+	}.Run(fake.CtxWithNilPrinter())
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+	assert.Contains(t, err.Error(), "no Kptfile found")
 }
 
 // TestCommand_Run_failEmptyRepo verifies that Command fail if not repo is provided.
@@ -92,8 +96,11 @@ func TestCommand_Run_failNoGit(t *testing.T) {
 
 	err = Command{
 		Pkg: createPackage(t, w.FullPackagePath()),
-	}.Run()
-	assert.EqualError(t, err, "kptfile upstream doesn't have git information")
+	}.Run(fake.CtxWithNilPrinter())
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+	assert.Contains(t, err.Error(), "kptfile upstream doesn't have git information")
 }
 
 // TestCommand_Run_failEmptyRepo verifies that Command fail if not repo is provided.
@@ -112,8 +119,11 @@ func TestCommand_Run_failEmptyRepo(t *testing.T) {
 
 	err = Command{
 		Pkg: createPackage(t, w.FullPackagePath()),
-	}.Run()
-	assert.EqualError(t, err, "must specify repo")
+	}.Run(fake.CtxWithNilPrinter())
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+	assert.Contains(t, err.Error(), "must specify repo")
 }
 
 // TestCommand_Run_failEmptyRepo verifies that Command fail if not repo is provided.
@@ -132,8 +142,11 @@ func TestCommand_Run_failNoRevision(t *testing.T) {
 
 	err = Command{
 		Pkg: createPackage(t, w.FullPackagePath()),
-	}.Run()
-	assert.EqualError(t, err, "must specify ref")
+	}.Run(fake.CtxWithNilPrinter())
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+	assert.Contains(t, err.Error(), "must specify ref")
 }
 
 // TestCommand_Run verifies that Command will clone the HEAD of the master branch.
@@ -156,7 +169,7 @@ func TestCommand_Run(t *testing.T) {
 	absPath := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	err = Command{
 		Pkg: createPackage(t, w.FullPackagePath()),
-	}.Run()
+	}.Run(fake.CtxWithNilPrinter())
 	assert.NoError(t, err)
 
 	// verify the cloned contents matches the repository
@@ -218,7 +231,7 @@ func TestCommand_Run_subdir(t *testing.T) {
 	absPath := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	err = Command{
 		Pkg: createPackage(t, w.FullPackagePath()),
-	}.Run()
+	}.Run(fake.CtxWithNilPrinter())
 	assert.NoError(t, err)
 
 	// verify the cloned contents matches the repository
@@ -296,7 +309,7 @@ func TestCommand_Run_branch(t *testing.T) {
 
 	err = Command{
 		Pkg: createPackage(t, w.FullPackagePath()),
-	}.Run()
+	}.Run(fake.CtxWithNilPrinter())
 	assert.NoError(t, err)
 
 	// verify the cloned contents matches the repository
@@ -377,7 +390,7 @@ func TestCommand_Run_tag(t *testing.T) {
 
 	err = Command{
 		Pkg: createPackage(t, w.FullPackagePath()),
-	}.Run()
+	}.Run(fake.CtxWithNilPrinter())
 	assert.NoError(t, err)
 
 	// verify the cloned contents matches the repository
@@ -431,7 +444,7 @@ func TestCommand_Run_failInvalidRepo(t *testing.T) {
 
 	err = Command{
 		Pkg: createPackage(t, w.FullPackagePath()),
-	}.Run()
+	}.Run(fake.CtxWithNilPrinter())
 	if !assert.Error(t, err) {
 		t.FailNow()
 	}
@@ -455,7 +468,7 @@ func TestCommand_Run_failInvalidBranch(t *testing.T) {
 
 	err = Command{
 		Pkg: createPackage(t, w.FullPackagePath()),
-	}.Run()
+	}.Run(fake.CtxWithNilPrinter())
 	if !assert.Error(t, err) {
 		t.FailNow()
 	}
@@ -482,7 +495,7 @@ func TestCommand_Run_failInvalidTag(t *testing.T) {
 
 	err = Command{
 		Pkg: createPackage(t, w.FullPackagePath()),
-	}.Run()
+	}.Run(fake.CtxWithNilPrinter())
 	if !assert.Error(t, err) {
 		t.FailNow()
 	}

--- a/internal/util/get/example_test.go
+++ b/internal/util/get/example_test.go
@@ -17,16 +17,16 @@ package get_test
 import (
 	"path/filepath"
 
-	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
-
+	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
 	"github.com/GoogleContainerTools/kpt/internal/util/get"
+	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 )
 
 func ExampleCommand() {
 	err := get.Command{Git: &kptfilev1alpha2.Git{
 		Repo: "https://github.com/example-org/example-repo",
 		Ref:  "v1.0",
-	}}.Run()
+	}}.Run(fake.CtxWithNilPrinter())
 	if err != nil {
 		// handle error
 	}
@@ -36,7 +36,7 @@ func ExampleCommand_branch() {
 	err := get.Command{Git: &kptfilev1alpha2.Git{
 		Repo: "https://github.com/example-org/example-repo",
 		Ref:  "refs/heads/v1.0",
-	}}.Run()
+	}}.Run(fake.CtxWithNilPrinter())
 	if err != nil {
 		// handle error
 	}
@@ -46,7 +46,7 @@ func ExampleCommand_tag() {
 	err := get.Command{Git: &kptfilev1alpha2.Git{
 		Repo: "https://github.com/example-org/example-repo",
 		Ref:  "refs/tags/v1.0",
-	}}.Run()
+	}}.Run(fake.CtxWithNilPrinter())
 	if err != nil {
 		// handle error
 	}
@@ -56,7 +56,7 @@ func ExampleCommand_commit() {
 	err := get.Command{Git: &kptfilev1alpha2.Git{
 		Repo: "https://github.com/example-org/example-repo",
 		Ref:  "8186bef8e5c0621bf80fa8106bd595aae8b62884",
-	}}.Run()
+	}}.Run(fake.CtxWithNilPrinter())
 	if err != nil {
 		// handle error
 	}
@@ -69,7 +69,7 @@ func ExampleCommand_subdir() {
 			Ref:       "v1.0",
 			Directory: filepath.Join("path", "to", "package"),
 		},
-	}.Run()
+	}.Run(fake.CtxWithNilPrinter())
 	if err != nil {
 		// handle error
 	}
@@ -81,7 +81,7 @@ func ExampleCommand_destination() {
 			Repo: "https://github.com/example-org/example-repo",
 			Ref:  "v1.0",
 		},
-		Destination: "destination-dir"}.Run()
+		Destination: "destination-dir"}.Run(fake.CtxWithNilPrinter())
 	if err != nil {
 		// handle error
 	}

--- a/internal/util/get/get_test.go
+++ b/internal/util/get/get_test.go
@@ -15,11 +15,11 @@
 package get_test
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
 	"github.com/GoogleContainerTools/kpt/internal/testutil/pkgbuilder"
 	. "github.com/GoogleContainerTools/kpt/internal/util/get"
@@ -37,8 +37,11 @@ func TestCommand_Run_failEmptyRepo(t *testing.T) {
 
 	err := Command{
 		Destination: w.WorkspaceDirectory,
-	}.Run()
-	assert.EqualError(t, err, "must specify git repo information")
+	}.Run(fake.CtxWithNilPrinter())
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+	assert.Contains(t, err.Error(), "must specify git repo information")
 }
 
 // TestCommand_Run_failEmptyRepo verifies that Command fail if not repo is provided.
@@ -51,8 +54,11 @@ func TestCommand_Run_failNoRevision(t *testing.T) {
 			Repo: "foo",
 		},
 		Destination: w.WorkspaceDirectory,
-	}.Run()
-	assert.EqualError(t, err, "must specify ref")
+	}.Run(fake.CtxWithNilPrinter())
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+	assert.Contains(t, err.Error(), "must specify ref")
 }
 
 // TestCommand_Run verifies that Command will clone the HEAD of the master branch.
@@ -74,7 +80,7 @@ func TestCommand_Run(t *testing.T) {
 		Ref:       "master",
 		Directory: "/",
 	},
-		Destination: absPath}.Run()
+		Destination: absPath}.Run(fake.CtxWithNilPrinter())
 	assert.NoError(t, err)
 
 	// verify the cloned contents matches the repository
@@ -133,7 +139,7 @@ func TestCommand_Run_subdir(t *testing.T) {
 	err := Command{Git: &kptfilev1alpha2.Git{
 		Repo: g.RepoDirectory, Ref: "refs/heads/master", Directory: subdir},
 		Destination: absPath,
-	}.Run()
+	}.Run(fake.CtxWithNilPrinter())
 	assert.NoError(t, err)
 
 	// verify the cloned contents matches the repository
@@ -194,7 +200,7 @@ func TestCommand_Run_destination(t *testing.T) {
 			Directory: "/",
 		},
 		Destination: absPath,
-	}.Run()
+	}.Run(fake.CtxWithNilPrinter())
 	assert.NoError(t, err)
 
 	// verify the cloned contents matches the repository
@@ -258,7 +264,7 @@ func TestCommand_Run_subdirAndDestination(t *testing.T) {
 			Directory: subdir,
 		},
 		Destination: absPath,
-	}.Run()
+	}.Run(fake.CtxWithNilPrinter())
 	assert.NoError(t, err)
 
 	// verify the cloned contents matches the repository
@@ -338,7 +344,7 @@ func TestCommand_Run_branch(t *testing.T) {
 			Directory: "/",
 		},
 		Destination: absPath,
-	}.Run()
+	}.Run(fake.CtxWithNilPrinter())
 	assert.NoError(t, err)
 
 	// verify the cloned contents matches the repository
@@ -421,7 +427,7 @@ func TestCommand_Run_tag(t *testing.T) {
 			Directory: "/",
 		},
 		Destination: absPath,
-	}.Run()
+	}.Run(fake.CtxWithNilPrinter())
 	assert.NoError(t, err)
 
 	// verify the cloned contents matches the repository
@@ -562,7 +568,7 @@ func TestCommand_Run_ref(t *testing.T) {
 					Directory: tc.directory,
 				},
 				Destination: absPath,
-			}.Run()
+			}.Run(fake.CtxWithNilPrinter())
 			assert.NoError(t, err)
 
 			expectedPath := tc.expected.ExpandPkgWithName(t, repos[testutil.Upstream].RepoName, testutil.ToReposInfo(repos))
@@ -591,7 +597,7 @@ func TestCommand_Run_failExistingDir(t *testing.T) {
 			Directory: "/",
 		},
 		Destination: absPath,
-	}.Run()
+	}.Run(fake.CtxWithNilPrinter())
 	assert.NoError(t, err)
 
 	// verify the KptFile contains the expected values
@@ -645,8 +651,11 @@ func TestCommand_Run_failExistingDir(t *testing.T) {
 			Directory: "/",
 		},
 		Destination: absPath,
-	}.Run()
-	assert.EqualError(t, err, fmt.Sprintf("destination directory %s already exists", absPath))
+	}.Run(fake.CtxWithNilPrinter())
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+	assert.Contains(t, err.Error(), "destination directory already exists")
 
 	// verify files are unchanged
 	g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset1), absPath)
@@ -699,7 +708,7 @@ func TestCommand_Run_nonexistingParentDir(t *testing.T) {
 			Directory: "/",
 		},
 		Destination: absPath,
-	}.Run()
+	}.Run(fake.CtxWithNilPrinter())
 	assert.NoError(t, err)
 	g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset1), absPath)
 }
@@ -719,7 +728,7 @@ func TestCommand_Run_failInvalidRepo(t *testing.T) {
 			Ref:       "refs/heads/master",
 		},
 		Destination: absPath,
-	}.Run()
+	}.Run(fake.CtxWithNilPrinter())
 	if !assert.Error(t, err) {
 		t.FailNow()
 	}
@@ -743,7 +752,7 @@ func TestCommand_Run_failInvalidBranch(t *testing.T) {
 			Ref:       "refs/heads/foo",
 		},
 		Destination: absPath,
-	}.Run()
+	}.Run(fake.CtxWithNilPrinter())
 	if !assert.Error(t, err) {
 		t.FailNow()
 	}
@@ -769,7 +778,7 @@ func TestCommand_Run_failInvalidTag(t *testing.T) {
 			Ref:       "refs/tags/foo",
 		},
 		Destination: filepath.Join(w.WorkspaceDirectory, g.RepoDirectory),
-	}.Run()
+	}.Run(fake.CtxWithNilPrinter())
 	if !assert.Error(t, err) {
 		t.FailNow()
 	}
@@ -1289,7 +1298,7 @@ func TestCommand_Run_subpackages(t *testing.T) {
 				},
 				Destination:    destinationDir,
 				UpdateStrategy: tc.updateStrategy,
-			}.Run()
+			}.Run(fake.CtxWithNilPrinter())
 
 			if tc.expectedErrMsg != "" {
 				if !assert.Error(t, err) {
@@ -1359,7 +1368,7 @@ func TestCommand_Run_symlinks(t *testing.T) {
 			Ref:       "master",
 		},
 		Destination: destinationDir,
-	}.Run()
+	}.Run(fake.CtxWithNilPrinter())
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/internal/util/git/git.go
+++ b/internal/util/git/git.go
@@ -16,10 +16,13 @@
 package git
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/GoogleContainerTools/kpt/internal/errors"
 )
 
 // RepoSpec specifies a git repository and a branch and path therein.
@@ -76,13 +79,14 @@ func isAWSHost(host string) bool {
 // lookupCommit looks up the sha of the current commit on the repo at the
 // provided path.
 func LookupCommit(repoPath string) (string, error) {
+	const op errors.Op = "git.LookupCommit"
 	cmd := exec.Command("git", "rev-parse", "--verify", "HEAD")
 	cmd.Dir = repoPath
 	cmd.Env = os.Environ()
 	cmd.Stderr = os.Stderr
 	b, err := cmd.Output()
 	if err != nil {
-		return "", err
+		return "", errors.E(op, errors.Git, fmt.Errorf("unable to look up commit: %w", err))
 	}
 	commit := strings.TrimSpace(string(b))
 	return commit, nil

--- a/internal/util/update/common.go
+++ b/internal/util/update/common.go
@@ -17,20 +17,23 @@ package update
 import (
 	"reflect"
 
+	"github.com/GoogleContainerTools/kpt/internal/errors"
+	"github.com/GoogleContainerTools/kpt/internal/types"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
 )
 
 // PkgHasUpdatedUpstream checks if the the local package has different
 // upstream information than origin.
 func PkgHasUpdatedUpstream(local, origin string) (bool, error) {
+	const op errors.Op = "update.PkgHasUpdatedUpstream"
 	originKf, err := kptfileutil.ReadFile(origin)
 	if err != nil {
-		return false, err
+		return false, errors.E(op, types.UniquePath(local), err)
 	}
 
 	localKf, err := kptfileutil.ReadFile(local)
 	if err != nil {
-		return false, err
+		return false, errors.E(op, types.UniquePath(local), err)
 	}
 
 	// If the upstream information in local has changed from origin, it


### PR DESCRIPTION
This updates the main code paths used for `kpt pkg get` and `kpt pkg update` to use the `internal/errors` package. It also improves the output during get/update to provide users with information about progress.

Some patters I see on how to use the `errors` package:
 * `Class` will mostly be used on errors returned from libraries outside of kpt. At a higher level, an error can be due to a number of different reasons, so it is hard to find a `Class` that matches.
 * Using the common error pattern `fmt.Errorf("something: %w", err)` is useful for errors returned from libraries. We should avoid doing this if the error returned is already of the `internal/errors.Error` type, since it will break the error hierarchy.
   * A challenge here is that something we want to add additional context to errors and the current structure doesn't allow us to do that while keeping the hierarchy.
 * UniquePath is something we should add only at the level where we are operating on a package. So low-level errors probably won't have this information.