### PR TITLE
Add --strategy flag to kpt pkg get command

### DIFF
--- a/internal/cmdcomplete/complete.go
+++ b/internal/cmdcomplete/complete.go
@@ -18,7 +18,7 @@ package cmdcomplete
 import (
 	"strings"
 
-	"github.com/GoogleContainerTools/kpt/internal/util/update"
+	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 	"github.com/posener/complete/v2"
 	"github.com/posener/complete/v2/predict"
 	"github.com/spf13/cobra"
@@ -60,7 +60,7 @@ func Complete(cmd *cobra.Command, skipHelp bool, visitFlags VisitFlags) *complet
 			visitFlags(cmd, flag, cc)
 		}
 		if flag.Name == "strategy" {
-			cc.Flags[flag.Name] = predict.Options(predict.OptValues(update.StrategiesAsStrings()...))
+			cc.Flags[flag.Name] = predict.Options(predict.OptValues(kptfilev1alpha2.UpdateStrategiesAsStrings()...))
 			return
 		}
 		if flag.Name == "pattern" {

--- a/internal/cmdget/cmdget.go
+++ b/internal/cmdget/cmdget.go
@@ -17,14 +17,15 @@ package cmdget
 
 import (
 	"fmt"
+	"strings"
 
 	docs "github.com/GoogleContainerTools/kpt/internal/docs/generated/pkgdocs"
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/get"
 	"github.com/GoogleContainerTools/kpt/internal/util/parse"
+	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 	"github.com/spf13/cobra"
-	"sigs.k8s.io/kustomize/kyaml/kio/filters"
 )
 
 // NewRunner returns a command runner
@@ -42,11 +43,9 @@ func NewRunner(parent string) *Runner {
 	}
 	cmdutil.FixDocs("kpt", parent, c)
 	r.Command = c
-	c.Flags().StringVar(&r.FilenamePattern, "pattern", filters.DefaultFilenamePattern,
-		`Pattern to use for writing files.  
-May contain the following formatting verbs
-%n: metadata.name, %s: metadata.namespace, %k: kind
-`)
+	c.Flags().StringVar(&r.strategy, "strategy", string(kptfilev1alpha2.ResourceMerge),
+		"update strategy that should be used when updating this package -- must be one of: "+
+			strings.Join(kptfilev1alpha2.UpdateStrategiesAsStrings(), ","))
 	return r
 }
 
@@ -56,9 +55,9 @@ func NewCommand(parent string) *cobra.Command {
 
 // Runner contains the run function
 type Runner struct {
-	Get             get.Command
-	Command         *cobra.Command
-	FilenamePattern string
+	Get      get.Command
+	Command  *cobra.Command
+	strategy string
 }
 
 func (r *Runner) preRunE(_ *cobra.Command, args []string) error {
@@ -72,12 +71,16 @@ func (r *Runner) preRunE(_ *cobra.Command, args []string) error {
 
 	r.Get.Git = &t.Git
 	p, err := pkg.New(t.Destination)
-
 	if err != nil {
 		return err
 	}
-
 	r.Get.Destination = string(p.UniquePath)
+
+	strategy, err := kptfilev1alpha2.ToUpdateStrategy(r.strategy)
+	if err != nil {
+		return err
+	}
+	r.Get.UpdateStrategy = strategy
 	return nil
 }
 

--- a/internal/cmdupdate/cmdupdate.go
+++ b/internal/cmdupdate/cmdupdate.go
@@ -48,8 +48,9 @@ func NewRunner(parent string) *Runner {
 	c.Flags().StringVarP(&r.Update.Repo, "repo", "r", "",
 		"git repo url for updating contents.  defaults to the repo the package was fetched from.")
 	c.Flags().StringVar(&r.strategy, "strategy", string(kptfilev1alpha2.ResourceMerge),
-		"update strategy for preserving changes to the local package -- must be one of: "+
-			strings.Join(update.StrategiesAsStrings(), ","))
+		"the update strategy that will be used when updating the package. This will change "+
+			"the default strategy for the package -- must be one of: "+
+			strings.Join(kptfilev1alpha2.UpdateStrategiesAsStrings(), ","))
 	c.Flags().BoolVar(&r.Update.DryRun, "dry-run", false,
 		"print the git patch rather than merging it.")
 	c.Flags().BoolVar(&r.Update.Verbose, "verbose", false,

--- a/internal/util/get/get.go
+++ b/internal/util/get/get.go
@@ -41,6 +41,11 @@ type Command struct {
 
 	// Name is the name to give the package.  Defaults to the destination.
 	Name string
+
+	// UpdateStrategy is the strategy that will be configured in the package
+	// Kptfile. This determines how changes will be merged when updating the
+	// package.
+	UpdateStrategy kptfilev1alpha2.UpdateStrategyType
 }
 
 // Run runs the Command.
@@ -69,7 +74,7 @@ func (c Command) Run() error {
 	kf.Upstream = &kptfilev1alpha2.Upstream{
 		Type:           kptfilev1alpha2.GitOrigin,
 		Git:            c.Git,
-		UpdateStrategy: kptfilev1alpha2.ResourceMerge,
+		UpdateStrategy: c.UpdateStrategy,
 	}
 
 	err = kptfileutil.WriteFile(c.Destination, kf)
@@ -151,6 +156,11 @@ func (c *Command) DefaultValues() error {
 	// default the name to the destination name
 	if len(c.Name) == 0 {
 		c.Name = filepath.Base(c.Destination)
+	}
+
+	// default the update strategy to resource-merge
+	if len(c.UpdateStrategy) == 0 {
+		c.UpdateStrategy = kptfilev1alpha2.ResourceMerge
 	}
 
 	return nil

--- a/internal/util/update/update.go
+++ b/internal/util/update/update.go
@@ -80,20 +80,6 @@ var strategies = map[kptfilev1alpha2.UpdateStrategyType]func() Updater{
 	kptfilev1alpha2.ResourceMerge:      func() Updater { return ResourceMergeUpdater{} },
 }
 
-var Strategies = []kptfilev1alpha2.UpdateStrategyType{
-	kptfilev1alpha2.FastForward,
-	kptfilev1alpha2.ForceDeleteReplace,
-	kptfilev1alpha2.ResourceMerge,
-}
-
-func StrategiesAsStrings() []string {
-	var strs []string
-	for _, s := range Strategies {
-		strs = append(strs, string(s))
-	}
-	return strs
-}
-
 // Command updates the contents of a local package to a different version.
 type Command struct {
 	// Pkg captures information about the package that should be updated.

--- a/internal/util/update/update_test.go
+++ b/internal/util/update/update_test.go
@@ -42,8 +42,8 @@ const (
 // - Modify upstream with new content
 // - Update the local package to fetch the upstream content
 func TestCommand_Run_noRefChanges(t *testing.T) {
-	for i := range Strategies {
-		strategy := Strategies[i]
+	for i := range kptfilev1alpha2.UpdateStrategies {
+		strategy := kptfilev1alpha2.UpdateStrategies[i]
 		t.Run(string(strategy), func(t *testing.T) {
 			// Setup the test upstream and local packages
 			g := &testutil.TestSetupManager{
@@ -91,8 +91,8 @@ func TestCommand_Run_noRefChanges(t *testing.T) {
 }
 
 func TestCommand_Run_subDir(t *testing.T) {
-	for i := range Strategies {
-		strategy := Strategies[i]
+	for i := range kptfilev1alpha2.UpdateStrategies {
+		strategy := kptfilev1alpha2.UpdateStrategies[i]
 		t.Run(string(strategy), func(t *testing.T) {
 			// Setup the test upstream and local packages
 			g := &testutil.TestSetupManager{
@@ -203,8 +203,8 @@ func TestCommand_Run_noChanges(t *testing.T) {
 }
 
 func TestCommand_Run_noCommit(t *testing.T) {
-	for i := range Strategies {
-		strategy := Strategies[i]
+	for i := range kptfilev1alpha2.UpdateStrategies {
+		strategy := kptfilev1alpha2.UpdateStrategies[i]
 		t.Run(string(strategy), func(t *testing.T) {
 			// Setup the test upstream and local packages
 			g := &testutil.TestSetupManager{
@@ -250,8 +250,8 @@ func TestCommand_Run_noCommit(t *testing.T) {
 }
 
 func TestCommand_Run_noAdd(t *testing.T) {
-	for i := range Strategies {
-		strategy := Strategies[i]
+	for i := range kptfilev1alpha2.UpdateStrategies {
+		strategy := kptfilev1alpha2.UpdateStrategies[i]
 		t.Run(string(strategy), func(t *testing.T) {
 			// Setup the test upstream and local packages
 			g := &testutil.TestSetupManager{
@@ -486,8 +486,8 @@ func TestCommand_Run_localPackageChanges(t *testing.T) {
 // TestCommand_Run_toBranchRef verifies the package contents are set to the contents of the branch
 // it was updated to.
 func TestCommand_Run_toBranchRef(t *testing.T) {
-	for i := range Strategies {
-		strategy := Strategies[i]
+	for i := range kptfilev1alpha2.UpdateStrategies {
+		strategy := kptfilev1alpha2.UpdateStrategies[i]
 		t.Run(string(strategy), func(t *testing.T) {
 			// Setup the test upstream and local packages
 			g := &testutil.TestSetupManager{
@@ -547,8 +547,8 @@ func TestCommand_Run_toBranchRef(t *testing.T) {
 // TestCommand_Run_toTagRef verifies the package contents are set to the contents of the tag
 // it was updated to.
 func TestCommand_Run_toTagRef(t *testing.T) {
-	for i := range Strategies {
-		strategy := Strategies[i]
+	for i := range kptfilev1alpha2.UpdateStrategies {
+		strategy := kptfilev1alpha2.UpdateStrategies[i]
 		t.Run(string(strategy), func(t *testing.T) {
 			// Setup the test upstream and local packages
 			g := &testutil.TestSetupManager{
@@ -663,8 +663,8 @@ func TestCommand_ResourceMerge_NonKRMUpdates(t *testing.T) {
 
 // TestCommand_Run_failInvalidPath verifies Run fails if the path is invalid
 func TestCommand_Run_failInvalidPath(t *testing.T) {
-	for i := range Strategies {
-		strategy := Strategies[i]
+	for i := range kptfilev1alpha2.UpdateStrategies {
+		strategy := kptfilev1alpha2.UpdateStrategies[i]
 		t.Run(string(strategy), func(t *testing.T) {
 			path := filepath.Join("fake", "path")
 			err := Command{
@@ -680,8 +680,8 @@ func TestCommand_Run_failInvalidPath(t *testing.T) {
 
 // TestCommand_Run_failInvalidRef verifies Run fails if the ref is invalid
 func TestCommand_Run_failInvalidRef(t *testing.T) {
-	for i := range Strategies {
-		strategy := Strategies[i]
+	for i := range kptfilev1alpha2.UpdateStrategies {
+		strategy := kptfilev1alpha2.UpdateStrategies[i]
 		t.Run(string(strategy), func(t *testing.T) {
 			g := &testutil.TestSetupManager{
 				T: t,

--- a/pkg/api/kptfile/v1alpha2/types.go
+++ b/pkg/api/kptfile/v1alpha2/types.go
@@ -66,6 +66,22 @@ const (
 // UpdateStrategyType defines the strategy for updating a package from upstream.
 type UpdateStrategyType string
 
+// ToUpdateStrategy takes a string representing an update strategy and will
+// return the strategy as an UpdateStrategyType. If the provided string does
+// not match any known update strategies, an error will be returned.
+func ToUpdateStrategy(strategy string) (UpdateStrategyType, error) {
+	switch strategy {
+	case string(ResourceMerge):
+		return ResourceMerge, nil
+	case string(FastForward):
+		return FastForward, nil
+	case string(ForceDeleteReplace):
+		return ForceDeleteReplace, nil
+	default:
+		return "", fmt.Errorf("unknown update strategy %q", strategy)
+	}
+}
+
 const (
 	// ResourceMerge performs a structural schema-aware comparison and
 	// merges the changes into the local package.
@@ -76,6 +92,22 @@ const (
 	// ForceDeleteReplace wipes all local changes to the package.
 	ForceDeleteReplace UpdateStrategyType = "force-delete-replace"
 )
+
+// UpdateStrategies is a slice with all the supported update strategies.
+var UpdateStrategies = []UpdateStrategyType{
+	ResourceMerge,
+	FastForward,
+	ForceDeleteReplace,
+}
+
+// UpdateStrategiesAsStrings returns a list of update strategies as strings.
+func UpdateStrategiesAsStrings() []string {
+	var strs []string
+	for _, s := range UpdateStrategies {
+		strs = append(strs, string(s))
+	}
+	return strs
+}
 
 // Upstream is a user-specified upstream locator for a package.
 type Upstream struct {


### PR DESCRIPTION
This allows users to specify the update strategy when fetching a package. The strategy will be added to the Kptfile and used for any future updates unless users explicitly provides a strategy when using the update command.

Fixes: https://github.com/GoogleContainerTools/kpt/issues/1732