### PR TITLE
Include Kptfiles and function configs in tree cmd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,9 @@ require (
 	github.com/posener/complete/v2 v2.0.1-alpha.12
 	github.com/spf13/cobra v1.1.1
 	github.com/spf13/pflag v1.0.5
-	github.com/stretchr/testify v1.6.1
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
+	github.com/stretchr/testify v1.7.0
+	github.com/xlab/treeprint v1.1.0
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 	gotest.tools v2.2.0+incompatible
 	k8s.io/apimachinery v0.20.4
 	k8s.io/cli-runtime v0.20.4

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/xlab/treeprint v1.1.0
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	gotest.tools v2.2.0+incompatible
 	k8s.io/apimachinery v0.20.4
 	k8s.io/cli-runtime v0.20.4

--- a/go.sum
+++ b/go.sum
@@ -515,6 +515,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tidwall/pretty v1.0.0 h1:HsD+QiTn7sK6flMKIvNmpqz1qrpP3Ps6jOKIKMooyg4=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
@@ -527,6 +529,8 @@ github.com/vektah/gqlparser v1.1.2/go.mod h1:1ycwN7Ij5njmMkPPAOaRFY4rET2Enx7IkVv
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca h1:1CFlNzQhALwjS9mBAUkycX616GzgsuYUOCHA5+HSlXI=
 github.com/xlab/treeprint v0.0.0-20181112141820-a009c3971eca/go.mod h1:ce1O1j6UtZfjr22oyGxGLbauSBp2YVXpARAosm7dHBg=
+github.com/xlab/treeprint v1.1.0 h1:G/1DjNkPpfZCFt9CSh6b5/nY4VimlbHF3Rh4obvtzDk=
+github.com/xlab/treeprint v1.1.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=

--- a/thirdparty/cmdconfig/commands/cmdtree/cmdtree.go
+++ b/thirdparty/cmdconfig/commands/cmdtree/cmdtree.go
@@ -59,9 +59,8 @@ func (r *TreeRunner) runE(c *cobra.Command, args []string) error {
 		Inputs:  []kio.Reader{input},
 		Filters: fltrs,
 		Outputs: []kio.Writer{TreeWriter{
-			Root:            root,
-			Writer:          c.OutOrStdout(),
-			OpenAPIFileName: kptfilev1alpha2.KptFileName,
+			Root:   root,
+			Writer: c.OutOrStdout(),
 		}},
 	}.Execute())
 }

--- a/thirdparty/cmdconfig/commands/cmdtree/cmdtree.go
+++ b/thirdparty/cmdconfig/commands/cmdtree/cmdtree.go
@@ -5,7 +5,6 @@ package cmdtree
 
 import (
 	"path/filepath"
-	"strings"
 
 	"github.com/GoogleContainerTools/kpt/internal/docs/generated/pkgdocs"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
@@ -13,7 +12,6 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/filters"
-	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 func GetTreeRunner(name string) *TreeRunner {
@@ -27,26 +25,6 @@ func GetTreeRunner(name string) *TreeRunner {
 		Args:    cobra.MaximumNArgs(1),
 	}
 
-	// TODO(pwittrock): Figure out if these are the right things to expose, and consider making it
-	// a list of options instead of individual flags
-	c.Flags().BoolVar(&r.name, "name", false, "print name field")
-	c.Flags().BoolVar(&r.resources, "resources", false, "print resources field")
-	c.Flags().BoolVar(&r.ports, "ports", false, "print ports field")
-	c.Flags().BoolVar(&r.images, "image", false, "print image field")
-	c.Flags().BoolVar(&r.replicas, "replicas", false, "print replicas field")
-	c.Flags().BoolVar(&r.args, "args", false, "print args field")
-	c.Flags().BoolVar(&r.cmd, "command", false, "print command field")
-	c.Flags().BoolVar(&r.env, "env", false, "print env field")
-	c.Flags().BoolVar(&r.all, "all", false, "print all field infos")
-	c.Flags().StringSliceVar(&r.fields, "field", []string{}, "print field")
-	c.Flags().BoolVar(&r.includeLocal, "include-local", false,
-		"if true, include local-config in the output.")
-	c.Flags().BoolVar(&r.excludeNonLocal, "exclude-non-local", false,
-		"if true, exclude non-local-config in the output.")
-	c.Flags().StringVar(&r.structure, "graph-structure", "",
-		"Graph structure to use for printing the tree.  may be any of: "+
-			strings.Join(kio.GraphStructures, ","))
-
 	r.Command = c
 	return r
 }
@@ -57,20 +35,7 @@ func NewCommand(name string) *cobra.Command {
 
 // TreeRunner contains the run function
 type TreeRunner struct {
-	Command         *cobra.Command
-	name            bool
-	resources       bool
-	ports           bool
-	images          bool
-	replicas        bool
-	all             bool
-	env             bool
-	args            bool
-	cmd             bool
-	fields          []string
-	includeLocal    bool
-	excludeNonLocal bool
-	structure       string
+	Command *cobra.Command
 }
 
 func (r *TreeRunner) runE(c *cobra.Command, args []string) error {
@@ -83,107 +48,24 @@ func (r *TreeRunner) runE(c *cobra.Command, args []string) error {
 		input = &kio.ByteReader{Reader: c.InOrStdin()}
 	} else {
 		root = filepath.Clean(args[0])
-		input = kio.LocalPackageReader{PackagePath: args[0]}
+		input = kio.LocalPackageReader{PackagePath: args[0], MatchFilesGlob: r.getMatchFilesGlob()}
 	}
 
-	var fields []kio.TreeWriterField
-	for _, field := range r.fields {
-		path, err := runner.ParseFieldPath(field)
-		if err != nil {
-			return err
-		}
-		fields = append(fields, newField(path...))
-	}
-
-	if r.name || (r.all && !c.Flag("name").Changed) {
-		fields = append(fields,
-			newField("spec", "containers", "[name=.*]", "name"),
-			newField("spec", "template", "spec", "containers", "[name=.*]", "name"),
-		)
-	}
-	if r.images || (r.all && !c.Flag("image").Changed) {
-		fields = append(fields,
-			newField("spec", "containers", "[name=.*]", "image"),
-			newField("spec", "template", "spec", "containers", "[name=.*]", "image"),
-		)
-	}
-
-	if r.cmd || (r.all && !c.Flag("command").Changed) {
-		fields = append(fields,
-			newField("spec", "containers", "[name=.*]", "command"),
-			newField("spec", "template", "spec", "containers", "[name=.*]", "command"),
-		)
-	}
-	if r.args || (r.all && !c.Flag("args").Changed) {
-		fields = append(fields,
-			newField("spec", "containers", "[name=.*]", "args"),
-			newField("spec", "template", "spec", "containers", "[name=.*]", "args"),
-		)
-	}
-	if r.env || (r.all && !c.Flag("env").Changed) {
-		fields = append(fields,
-			newField("spec", "containers", "[name=.*]", "env"),
-			newField("spec", "template", "spec", "containers", "[name=.*]", "env"),
-		)
-	}
-
-	if r.replicas || (r.all && !c.Flag("replicas").Changed) {
-		fields = append(fields,
-			newField("spec", "replicas"),
-		)
-	}
-	if r.resources || (r.all && !c.Flag("resources").Changed) {
-		fields = append(fields,
-			newField("spec", "containers", "[name=.*]", "resources"),
-			newField("spec", "template", "spec", "containers", "[name=.*]", "resources"),
-		)
-	}
-	if r.ports || (r.all && !c.Flag("ports").Changed) {
-		fields = append(fields,
-			newField("spec", "containers", "[name=.*]", "ports"),
-			newField("spec", "template", "spec", "containers", "[name=.*]", "ports"),
-			newField("spec", "ports"),
-		)
-	}
-
-	// show reconcilers in tree
 	fltrs := []kio.Filter{&filters.IsLocalConfig{
-		IncludeLocalConfig:    r.includeLocal,
-		ExcludeNonLocalConfig: r.excludeNonLocal,
+		IncludeLocalConfig: true,
 	}}
 
 	return runner.HandleError(c, kio.Pipeline{
 		Inputs:  []kio.Reader{input},
 		Filters: fltrs,
-		Outputs: []kio.Writer{kio.TreeWriter{
+		Outputs: []kio.Writer{TreeWriter{
 			Root:            root,
 			Writer:          c.OutOrStdout(),
-			Fields:          fields,
-			Structure:       kio.TreeStructure(r.structure),
 			OpenAPIFileName: kptfilev1alpha2.KptFileName,
 		}},
 	}.Execute())
 }
 
-func newField(val ...string) kio.TreeWriterField {
-	if strings.HasPrefix(strings.Join(val, "."), "spec.template.spec.containers") {
-		return kio.TreeWriterField{
-			Name:        "spec.template.spec.containers",
-			PathMatcher: yaml.PathMatcher{Path: val, StripComments: true},
-			SubName:     val[len(val)-1],
-		}
-	}
-
-	if strings.HasPrefix(strings.Join(val, "."), "spec.containers") {
-		return kio.TreeWriterField{
-			Name:        "spec.containers",
-			PathMatcher: yaml.PathMatcher{Path: val, StripComments: true},
-			SubName:     val[len(val)-1],
-		}
-	}
-
-	return kio.TreeWriterField{
-		Name:        strings.Join(val, "."),
-		PathMatcher: yaml.PathMatcher{Path: val, StripComments: true},
-	}
+func (r *TreeRunner) getMatchFilesGlob() []string {
+	return append([]string{kptfilev1alpha2.KptFileName}, kio.DefaultMatch...)
 }

--- a/thirdparty/cmdconfig/commands/cmdtree/cmdtree_test.go
+++ b/thirdparty/cmdconfig/commands/cmdtree/cmdtree_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestTreeCommandDefaultCurDir_files(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-tree-test")
+	d, err := ioutil.TempDir("", "tree-test")
 	defer os.RemoveAll(d)
 	if !assert.NoError(t, err) {
 		return
@@ -84,6 +84,7 @@ spec:
 	}
 
 	if !assert.Equal(t, `.
+├── [f1.yaml]  Abstraction foo
 ├── [f1.yaml]  Deployment foo
 ├── [f1.yaml]  Service foo
 └── [f2.yaml]  Deployment bar
@@ -92,9 +93,8 @@ spec:
 	}
 }
 
-// TestCmd_files verifies fmt reads the files and filters them
 func TestTreeCommand_files(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-tree-test")
+	d, err := ioutil.TempDir("", "tree-test")
 	defer os.RemoveAll(d)
 	if !assert.NoError(t, err) {
 		return
@@ -159,6 +159,7 @@ spec:
 	}
 
 	if !assert.Equal(t, fmt.Sprintf(`%s
+├── [f1.yaml]  Abstraction foo
 ├── [f1.yaml]  Deployment foo
 ├── [f1.yaml]  Service foo
 └── [f2.yaml]  Deployment bar
@@ -168,7 +169,7 @@ spec:
 }
 
 func TestTreeCommand_Kustomization(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-tree-test")
+	d, err := ioutil.TempDir("", "tree-test")
 	defer os.RemoveAll(d)
 	if !assert.NoError(t, err) {
 		return
@@ -214,7 +215,7 @@ resources:
 }
 
 func TestTreeCommand_subpkgs(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-tree-test")
+	d, err := ioutil.TempDir("", "tree-test")
 	defer os.RemoveAll(d)
 	if !assert.NoError(t, err) {
 		t.FailNow()
@@ -275,7 +276,7 @@ spec:
 	}
 
 	err = ioutil.WriteFile(filepath.Join(d, "Kptfile"), []byte(`apiVersion: kpt.dev/v1alpha1
-kind: Krmfile
+kind: Kptfile
 metadata:
   name: mainpkg
 openAPI:
@@ -285,7 +286,7 @@ openAPI:
 		return
 	}
 	err = ioutil.WriteFile(filepath.Join(d, "subpkg", "Kptfile"), []byte(`apiVersion: kpt.dev/v1alpha1
-kind: Krmfile
+kind: Kptfile
 metadata:
   name: subpkg
 openAPI:
@@ -304,10 +305,13 @@ openAPI:
 		return
 	}
 
-	if !assert.Equal(t, fmt.Sprintf(`%s
+	if !assert.Equal(t, fmt.Sprintf(`PKG: %s
+├── [Kptfile]  Kptfile mainpkg
+├── [f1.yaml]  Abstraction foo
 ├── [f1.yaml]  Deployment foo
 ├── [f1.yaml]  Service foo
-└── Pkg: subpkg
+└── PKG: subpkg
+    ├── [Kptfile]  Kptfile subpkg
     └── [f2.yaml]  Deployment bar
 `, d), b.String()) {
 		return
@@ -421,152 +425,6 @@ spec:
 └── bar-package
     └── [f2.yaml]  Deployment bar
 `, b.String()) {
-		return
-	}
-}
-
-func TestTreeCommand_includeReconcilers(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustomize-tree-test")
-	defer os.RemoveAll(d)
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	err = ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
-kind: Deployment
-metadata:
-  labels:
-    app: nginx2
-  name: foo
-  annotations:
-    app: nginx2
-spec:
-  replicas: 1
----
-kind: Service
-metadata:
-  name: foo
-  annotations:
-    app: nginx
-spec:
-  selector:
-    app: nginx
-`), 0600)
-	if !assert.NoError(t, err) {
-		return
-	}
-	err = ioutil.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`
-apiVersion: gcr.io/example/reconciler:v1
-kind: Abstraction
-metadata:
-  name: foo
-spec:
-  replicas: 1
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app: nginx
-  name: bar
-  annotations:
-    app: nginx
-spec:
-  replicas: 3
-`), 0600)
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	// fmt the files
-	b := &bytes.Buffer{}
-	r := GetTreeRunner("")
-	r.Command.SetArgs([]string{d, "--include-local"})
-	r.Command.SetOut(b)
-	if !assert.NoError(t, r.Command.Execute()) {
-		return
-	}
-
-	if !assert.Equal(t, fmt.Sprintf(`%s
-├── [f1.yaml]  Deployment foo
-├── [f1.yaml]  Service foo
-├── [f2.yaml]  Deployment bar
-└── [f2.yaml]  Abstraction foo
-`, d), b.String()) {
-		return
-	}
-}
-
-func TestTreeCommand_excludeNonReconcilers(t *testing.T) {
-	d, err := ioutil.TempDir("", "kustmoize-tree-test")
-	defer os.RemoveAll(d)
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	err = ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
-kind: Deployment
-metadata:
-  labels:
-    app: nginx2
-  name: foo
-  annotations:
-    app: nginx2
-spec:
-  replicas: 1
----
-kind: Service
-metadata:
-  name: foo
-  annotations:
-    app: nginx
-spec:
-  selector:
-    app: nginx
-`), 0600)
-	if !assert.NoError(t, err) {
-		return
-	}
-	err = ioutil.WriteFile(filepath.Join(d, "f2.yaml"), []byte(`
-apiVersion: v1
-kind: Abstraction
-metadata:
-  name: foo
-  configFn:
-    container:
-      image: gcr.io/example/reconciler:v1
-  annotations:
-    config.kubernetes.io/local-config: "true"
-spec:
-  replicas: 1
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  labels:
-    app: nginx
-  name: bar
-  annotations:
-    app: nginx
-spec:
-  replicas: 3
-`), 0600)
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	// fmt the files
-	b := &bytes.Buffer{}
-	r := GetTreeRunner("")
-	r.Command.SetArgs([]string{d, "--include-local", "--exclude-non-local"})
-	r.Command.SetOut(b)
-	if !assert.NoError(t, r.Command.Execute()) {
-		return
-	}
-
-	if !assert.Equal(t, fmt.Sprintf(`%s
-└── [f2.yaml]  Abstraction foo
-`, d), b.String()) {
 		return
 	}
 }

--- a/thirdparty/cmdconfig/commands/cmdtree/tree.go
+++ b/thirdparty/cmdconfig/commands/cmdtree/tree.go
@@ -1,0 +1,522 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package cmdtree
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/xlab/treeprint"
+	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+type TreeStructure string
+
+const (
+	// TreeStructurePackage configures TreeWriter to generate the tree structure off of the
+	// Resources packages.
+	TreeStructurePackage TreeStructure = "directory"
+
+	// TreeStructureOwners configures TreeWriter to generate the tree structure off of the
+	// Resource owners.
+	TreeStructureGraph TreeStructure = "owners"
+
+	PkgPrefix = "PKG: "
+)
+
+var GraphStructures = []string{string(TreeStructureGraph), string(TreeStructurePackage)}
+
+// TreeWriter prints the package structured as a tree.
+// TODO(pwittrock): test this package better.  it is lower-risk since it is only
+// used for printing rather than updating or editing.
+type TreeWriter struct {
+	Writer          io.Writer
+	Root            string
+	Fields          []TreeWriterField
+	Structure       TreeStructure
+	OpenAPIFileName string
+}
+
+// TreeWriterField configures a Resource field to be included in the tree
+type TreeWriterField struct {
+	yaml.PathMatcher
+	Name    string
+	SubName string
+}
+
+func (p TreeWriter) packageStructure(nodes []*yaml.RNode) error {
+	indexByPackage := p.index(nodes)
+
+	// create the new tree
+	tree := treeprint.New()
+	tree.SetValue(p.Root)
+
+	// add each package to the tree
+	treeIndex := map[string]treeprint.Tree{}
+	keys := p.sort(indexByPackage)
+	for _, pkg := range keys {
+		// create a branch for this package -- search for the parent package and create
+		// the branch under it -- requires that the keys are sorted
+		branch := tree
+		for parent, subTree := range treeIndex {
+			if strings.HasPrefix(pkg, parent) {
+				// found a package whose path is a prefix to our own, use this
+				// package if a closer one isn't found
+				branch = subTree
+				// don't break, continue searching for more closely related ancestors
+			}
+		}
+
+		// create a new branch for the package
+		createOk := pkg != "." // special edge case logic for tree on current working dir
+		if createOk {
+			branch = branch.AddBranch(branchName(p.Root, pkg, p.OpenAPIFileName))
+		}
+
+		// cache the branch for this package
+		treeIndex[pkg] = branch
+
+		// print each resource in the package
+		for i := range indexByPackage[pkg] {
+			var err error
+			if _, err = p.doResource(indexByPackage[pkg][i], "", branch); err != nil {
+				return err
+			}
+		}
+	}
+
+	out := tree.String()
+	_, err := os.Stat(filepath.Join(p.Root, p.OpenAPIFileName))
+	if !os.IsNotExist(err) {
+		out = PkgPrefix + out
+	}
+
+	_, err = io.WriteString(p.Writer, out)
+	return err
+}
+
+// branchName takes the root directory and relative path to the directory
+// and returns the branch name
+func branchName(root, dirRelPath, openAPIFileName string) string {
+	name := filepath.Base(dirRelPath)
+	_, err := os.Stat(filepath.Join(root, dirRelPath, openAPIFileName))
+	if !os.IsNotExist(err) {
+		// add Pkg: prefix indicating that it is a separate package as it has
+		// openAPIFile
+		return PkgPrefix + name
+	}
+	return name
+}
+
+// Write writes the ascii tree to p.Writer
+func (p TreeWriter) Write(nodes []*yaml.RNode) error {
+	switch p.Structure {
+	case TreeStructurePackage:
+		return p.packageStructure(nodes)
+	case TreeStructureGraph:
+		return p.graphStructure(nodes)
+	}
+
+	// If any resource has an owner reference, default to the graph structure. Otherwise, use package structure.
+	for _, node := range nodes {
+		if owners, _ := node.Pipe(yaml.Lookup("metadata", "ownerReferences")); owners != nil {
+			return p.graphStructure(nodes)
+		}
+	}
+	return p.packageStructure(nodes)
+}
+
+// node wraps a tree node, and any children nodes
+type node struct {
+	p TreeWriter
+	*yaml.RNode
+	children []*node
+}
+
+func (a node) Len() int      { return len(a.children) }
+func (a node) Swap(i, j int) { a.children[i], a.children[j] = a.children[j], a.children[i] }
+func (a node) Less(i, j int) bool {
+	return compareNodes(a.children[i].RNode, a.children[j].RNode)
+}
+
+// Tree adds this node to the root
+func (a node) Tree(root treeprint.Tree) error {
+	sort.Sort(a)
+	branch := root
+	var err error
+
+	// generate a node for the Resource
+	if a.RNode != nil {
+		branch, err = a.p.doResource(a.RNode, "Resource", root)
+		if err != nil {
+			return err
+		}
+	}
+
+	// attach children to the branch
+	for _, n := range a.children {
+		if err := n.Tree(branch); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// graphStructure writes the tree using owners for structure
+func (p TreeWriter) graphStructure(nodes []*yaml.RNode) error {
+	resourceToOwner := map[string]*node{}
+	root := &node{}
+	// index each of the nodes by their owner
+	for _, n := range nodes {
+		ownerVal, err := ownerToString(n)
+		if err != nil {
+			return err
+		}
+		var owner *node
+		if ownerVal == "" {
+			// no owner -- attach to the root
+			owner = root
+		} else {
+			// owner found -- attach to the owner
+			var found bool
+			owner, found = resourceToOwner[ownerVal]
+			if !found {
+				// initialize the owner if not found
+				resourceToOwner[ownerVal] = &node{p: p}
+				owner = resourceToOwner[ownerVal]
+			}
+		}
+
+		nodeVal, err := nodeToString(n)
+		if err != nil {
+			return err
+		}
+		val, found := resourceToOwner[nodeVal]
+		if !found {
+			// initialize the node if not found -- may have already been initialized if it
+			// is the owner of another node
+			resourceToOwner[nodeVal] = &node{p: p}
+			val = resourceToOwner[nodeVal]
+		}
+		val.RNode = n
+		owner.children = append(owner.children, val)
+	}
+
+	for k, v := range resourceToOwner {
+		if v.RNode == nil {
+			return fmt.Errorf(
+				"owner '%s' not found in input, but found as an owner of input objects", k)
+		}
+	}
+
+	// print the tree
+	tree := treeprint.New()
+	if err := root.Tree(tree); err != nil {
+		return err
+	}
+
+	_, err := io.WriteString(p.Writer, tree.String())
+	return err
+}
+
+// nodeToString generates a string to identify the node -- matches ownerToString format
+func nodeToString(node *yaml.RNode) (string, error) {
+	meta, err := node.GetMeta()
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s %s/%s", meta.Kind, meta.Namespace, meta.Name), nil
+}
+
+// ownerToString generate a string to identify the owner -- matches nodeToString format
+func ownerToString(node *yaml.RNode) (string, error) {
+	meta, err := node.GetMeta()
+	if err != nil {
+		return "", err
+	}
+	namespace := meta.Namespace
+
+	owners, err := node.Pipe(yaml.Lookup("metadata", "ownerReferences"))
+	if err != nil {
+		return "", err
+	}
+	if owners == nil {
+		return "", nil
+	}
+
+	elements, err := owners.Elements()
+	if err != nil {
+		return "", err
+	}
+	if len(elements) == 0 {
+		return "", err
+	}
+	owner := elements[0]
+	var kind, name string
+
+	if value := owner.Field("kind"); !value.IsNilOrEmpty() {
+		kind = value.Value.YNode().Value
+	}
+	if value := owner.Field("name"); !value.IsNilOrEmpty() {
+		name = value.Value.YNode().Value
+	}
+
+	return fmt.Sprintf("%s %s/%s", kind, namespace, name), nil
+}
+
+// index indexes the Resources by their package
+func (p TreeWriter) index(nodes []*yaml.RNode) map[string][]*yaml.RNode {
+	// index the ResourceNodes by package
+	indexByPackage := map[string][]*yaml.RNode{}
+	for i := range nodes {
+		meta, err := nodes[i].GetMeta()
+		if err != nil || meta.Kind == "" {
+			// not a resource
+			continue
+		}
+		pkg := filepath.Dir(meta.Annotations[kioutil.PathAnnotation])
+		indexByPackage[pkg] = append(indexByPackage[pkg], nodes[i])
+	}
+	return indexByPackage
+}
+
+func compareNodes(i, j *yaml.RNode) bool {
+	metai, _ := i.GetMeta()
+	metaj, _ := j.GetMeta()
+	pi := metai.Annotations[kioutil.PathAnnotation]
+	pj := metaj.Annotations[kioutil.PathAnnotation]
+
+	// compare file names
+	if filepath.Base(pi) != filepath.Base(pj) {
+		return filepath.Base(pi) < filepath.Base(pj)
+	}
+
+	// compare namespace
+	if metai.Namespace != metaj.Namespace {
+		return metai.Namespace < metaj.Namespace
+	}
+
+	// compare name
+	if metai.Name != metaj.Name {
+		return metai.Name < metaj.Name
+	}
+
+	// compare kind
+	if metai.Kind != metaj.Kind {
+		return metai.Kind < metaj.Kind
+	}
+
+	// compare apiVersion
+	if metai.APIVersion != metaj.APIVersion {
+		return metai.APIVersion < metaj.APIVersion
+	}
+	return true
+}
+
+// sort sorts the Resources in the index in display order and returns the ordered
+// keys for the index
+//
+// Packages are sorted by package name
+// Resources within a package are sorted by: [filename, namespace, name, kind, apiVersion]
+func (p TreeWriter) sort(indexByPackage map[string][]*yaml.RNode) []string {
+	var keys []string
+	for k := range indexByPackage {
+		pkgNodes := indexByPackage[k]
+		sort.Slice(pkgNodes, func(i, j int) bool { return compareNodes(pkgNodes[i], pkgNodes[j]) })
+		keys = append(keys, k)
+	}
+
+	// return the package names sorted lexicographically
+	sort.Strings(keys)
+	return keys
+}
+
+func (p TreeWriter) doResource(leaf *yaml.RNode, metaString string, branch treeprint.Tree) (treeprint.Tree, error) {
+	meta, _ := leaf.GetMeta()
+	if metaString == "" {
+		path := meta.Annotations[kioutil.PathAnnotation]
+		path = filepath.Base(path)
+		metaString = path
+	}
+
+	value := fmt.Sprintf("%s %s", meta.Kind, meta.Name)
+	if len(meta.Namespace) > 0 {
+		value = fmt.Sprintf("%s %s/%s", meta.Kind, meta.Namespace, meta.Name)
+	}
+
+	fields, err := p.getFields(leaf)
+	if err != nil {
+		return nil, err
+	}
+
+	n := branch.AddMetaBranch(metaString, value)
+	for i := range fields {
+		field := fields[i]
+
+		// do leaf node
+		if len(field.matchingElementsAndFields) == 0 {
+			n.AddNode(fmt.Sprintf("%s: %s", field.name, field.value))
+			continue
+		}
+
+		// do nested nodes
+		b := n.AddBranch(field.name)
+		for j := range field.matchingElementsAndFields {
+			elem := field.matchingElementsAndFields[j]
+			b := b.AddBranch(elem.name)
+			for k := range elem.matchingElementsAndFields {
+				field := elem.matchingElementsAndFields[k]
+				b.AddNode(fmt.Sprintf("%s: %s", field.name, field.value))
+			}
+		}
+	}
+
+	return n, nil
+}
+
+// getFields looks up p.Fields from leaf and structures them into treeFields.
+// TODO(pwittrock): simplify this function
+func (p TreeWriter) getFields(leaf *yaml.RNode) (treeFields, error) {
+	fieldsByName := map[string]*treeField{}
+
+	// index nested and non-nested fields
+	for i := range p.Fields {
+		f := p.Fields[i]
+		seq, err := leaf.Pipe(&f)
+		if err != nil {
+			return nil, err
+		}
+		if seq == nil {
+			continue
+		}
+
+		if fieldsByName[f.Name] == nil {
+			fieldsByName[f.Name] = &treeField{name: f.Name}
+		}
+
+		// non-nested field -- add directly to the treeFields list
+		if f.SubName == "" {
+			// non-nested field -- only 1 element
+			val, err := yaml.String(seq.Content()[0], yaml.Trim, yaml.Flow)
+			if err != nil {
+				return nil, err
+			}
+			fieldsByName[f.Name].value = val
+			continue
+		}
+
+		// nested-field -- create a parent elem, and index by the 'match' value
+		if fieldsByName[f.Name].subFieldByMatch == nil {
+			fieldsByName[f.Name].subFieldByMatch = map[string]treeFields{}
+		}
+		index := fieldsByName[f.Name].subFieldByMatch
+		for j := range seq.Content() {
+			elem := seq.Content()[j]
+			matches := f.Matches[elem]
+			str, err := yaml.String(elem, yaml.Trim, yaml.Flow)
+			if err != nil {
+				return nil, err
+			}
+
+			// map the field by the name of the element
+			// index the subfields by the matching element so we can put all the fields for the
+			// same element under the same branch
+			matchKey := strings.Join(matches, "/")
+			index[matchKey] = append(index[matchKey], &treeField{name: f.SubName, value: str})
+		}
+	}
+
+	// iterate over collection of all queried fields in the Resource
+	for _, field := range fieldsByName {
+		// iterate over collection of elements under the field -- indexed by element name
+		for match, subFields := range field.subFieldByMatch {
+			// create a new element for this collection of fields
+			// note: we will convert name to an index later, but keep the match for sorting
+			elem := &treeField{name: match}
+			field.matchingElementsAndFields = append(field.matchingElementsAndFields, elem)
+
+			// iterate over collection of queried fields for the element
+			for i := range subFields {
+				// add to the list of fields for this element
+				elem.matchingElementsAndFields = append(elem.matchingElementsAndFields, subFields[i])
+			}
+		}
+		// clear this cached data
+		field.subFieldByMatch = nil
+	}
+
+	// put the fields in a list so they are ordered
+	fieldList := treeFields{}
+	for _, v := range fieldsByName {
+		fieldList = append(fieldList, v)
+	}
+
+	// sort the fields
+	sort.Sort(fieldList)
+	for i := range fieldList {
+		field := fieldList[i]
+		// sort the elements under this field
+		sort.Sort(field.matchingElementsAndFields)
+
+		for i := range field.matchingElementsAndFields {
+			element := field.matchingElementsAndFields[i]
+			// sort the elements under a list field by their name
+			sort.Sort(element.matchingElementsAndFields)
+			// set the name of the element to its index
+			element.name = fmt.Sprintf("%d", i)
+		}
+	}
+
+	return fieldList, nil
+}
+
+// treeField wraps a field node
+type treeField struct {
+	// name is the name of the node
+	name string
+
+	// value is the value of the node -- may be empty
+	value string
+
+	// matchingElementsAndFields is a slice of fields that go under this as a branch
+	matchingElementsAndFields treeFields
+
+	// subFieldByMatch caches matchingElementsAndFields indexed by the name of the matching elem
+	subFieldByMatch map[string]treeFields
+}
+
+// treeFields wraps a slice of treeField so they can be sorted
+type treeFields []*treeField
+
+func (nodes treeFields) Len() int { return len(nodes) }
+
+func (nodes treeFields) Less(i, j int) bool {
+	iIndex, iFound := yaml.FieldOrder[nodes[i].name]
+	jIndex, jFound := yaml.FieldOrder[nodes[j].name]
+	if iFound && jFound {
+		return iIndex < jIndex
+	}
+	if iFound {
+		return true
+	}
+	if jFound {
+		return false
+	}
+
+	if nodes[i].name != nodes[j].name {
+		return nodes[i].name < nodes[j].name
+	}
+	if nodes[i].value != nodes[j].value {
+		return nodes[i].value < nodes[j].value
+	}
+	return false
+}
+
+func (nodes treeFields) Swap(i, j int) { nodes[i], nodes[j] = nodes[j], nodes[i] }

--- a/thirdparty/cmdconfig/commands/cmdtree/tree.go
+++ b/thirdparty/cmdconfig/commands/cmdtree/tree.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 
+	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 	"github.com/xlab/treeprint"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
@@ -36,11 +37,10 @@ var GraphStructures = []string{string(TreeStructureGraph), string(TreeStructureP
 // TODO(pwittrock): test this package better.  it is lower-risk since it is only
 // used for printing rather than updating or editing.
 type TreeWriter struct {
-	Writer          io.Writer
-	Root            string
-	Fields          []TreeWriterField
-	Structure       TreeStructure
-	OpenAPIFileName string
+	Writer    io.Writer
+	Root      string
+	Fields    []TreeWriterField
+	Structure TreeStructure
 }
 
 // TreeWriterField configures a Resource field to be included in the tree
@@ -76,7 +76,7 @@ func (p TreeWriter) packageStructure(nodes []*yaml.RNode) error {
 		// create a new branch for the package
 		createOk := pkg != "." // special edge case logic for tree on current working dir
 		if createOk {
-			branch = branch.AddBranch(branchName(p.Root, pkg, p.OpenAPIFileName))
+			branch = branch.AddBranch(branchName(p.Root, pkg))
 		}
 
 		// cache the branch for this package
@@ -92,7 +92,7 @@ func (p TreeWriter) packageStructure(nodes []*yaml.RNode) error {
 	}
 
 	out := tree.String()
-	_, err := os.Stat(filepath.Join(p.Root, p.OpenAPIFileName))
+	_, err := os.Stat(filepath.Join(p.Root, kptfilev1alpha2.KptFileName))
 	if !os.IsNotExist(err) {
 		out = PkgPrefix + out
 	}
@@ -103,12 +103,12 @@ func (p TreeWriter) packageStructure(nodes []*yaml.RNode) error {
 
 // branchName takes the root directory and relative path to the directory
 // and returns the branch name
-func branchName(root, dirRelPath, openAPIFileName string) string {
+func branchName(root, dirRelPath string) string {
 	name := filepath.Base(dirRelPath)
-	_, err := os.Stat(filepath.Join(root, dirRelPath, openAPIFileName))
+	_, err := os.Stat(filepath.Join(root, dirRelPath, kptfilev1alpha2.KptFileName))
 	if !os.IsNotExist(err) {
 		// add Pkg: prefix indicating that it is a separate package as it has
-		// openAPIFile
+		// Kptfile
 		return PkgPrefix + name
 	}
 	return name


### PR DESCRIPTION
This PR is to cleanup tree command. There are many flags which might not be used at all. We should be aggressive in cleaning up such flags and add them in future if there is a need. Or else we will be stuck with them forever. This PR also includes Kptfile and function configs as part of tree command output. Copies over the implementation of tree command to kpt from kustomize.

