### PR TITLE
Makefile target to flush kpt fn cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,13 @@ test-docker:
 # target to run e2e tests for "kpt fn render" command
 test-fn-render:
 	go test -v --tags=docker --run=TestFnRender ./e2e/
-	
+
+# target to flush kpt-fn cache
+flush-fn-cache:
+	for fn in set-namespace set-label set-annotation starlark; do \
+		docker image rm gcr.io/kpt-fn/$$fn:unstable ; \
+	done
+
 vet:
 	go vet ./...
 


### PR DESCRIPTION
This PR adds a Makefile target to flush kpt-fn cache.

Note: This is a quick fix. The logic can be improved by querying `docker image list` and grabbing all functions that contains `kpt-fn` and issue remove.

