### PR TITLE
return non-zero exit code in case of error

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,12 +36,18 @@ import (
 
 func main() {
 	var logFlags flag.FlagSet
+	var err error
 
 	ctx := context.Background()
 
 	cmd := run.GetMain(ctx)
 	logs.InitLogs()
-	defer logs.FlushLogs()
+	defer func() {
+		logs.FlushLogs()
+		if err != nil {
+			os.Exit(1)
+		}
+	}()
 
 	// Enable commandline flags for klog.
 	// logging will help in collecting debugging information from users
@@ -53,9 +59,9 @@ func main() {
 	_ = cmd.Flags().Set("logtostderr", "false")
 	_ = cmd.Flags().Set("alsologtostderr", "false")
 
-	if err := cmd.Execute(); err != nil {
+	err = cmd.Execute()
+	if err != nil {
 		handleErr(cmd, err)
-		os.Exit(1)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
@@ -54,6 +55,7 @@ func main() {
 
 	if err := cmd.Execute(); err != nil {
 		handleErr(cmd, err)
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
`kpt` will return non-zero (1) exit code if it encounters error in running any command.