### PR TITLE
Fix migrate command and add e2e tests

### DIFF
--- a/commands/initcmd.go
+++ b/commands/initcmd.go
@@ -77,12 +77,14 @@ func (io *KptInitOptions) Run(args []string) error {
 		randomSuffix := common.RandomStr(time.Now().UTC().UnixNano())
 		io.name = fmt.Sprintf("%s-%s", defaultInventoryName, randomSuffix)
 	}
-	// Set the init options inventory id label.
-	id, err := generateID(io.name, io.namespace, time.Now())
-	if err != nil {
-		return err
+	// Set the init options inventory id label, if not already set.
+	if io.inventoryID == "" {
+		id, err := generateID(io.name, io.namespace, time.Now())
+		if err != nil {
+			return err
+		}
+		io.inventoryID = id
 	}
-	io.inventoryID = id
 	// Finally, update these values in the Inventory section of the Kptfile.
 	return io.updateKptfile()
 }

--- a/commands/initcmd_test.go
+++ b/commands/initcmd_test.go
@@ -22,36 +22,35 @@ var (
 )
 
 var kptFile = `
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1alph2
 kind: Kptfile
 metadata:
   name: test1
 upstreamLock:
   type: git
   gitLock:
-    commit: 786b898857bd7e9647c229d5f39b0be4de86c915
     repo: git@github.com:seans3/blueprint-helloworld
     directory: /
     ref: master
 `
 
+const testInventoryID = "SSSSSSSSSS-RRRRR"
+
 var kptFileWithInventory = `
-apiVersion: kpt.dev/v1alpha1
+apiVersion: kpt.dev/v1alpha2
 kind: Kptfile
 metadata:
   name: test1
 upstreamLock:
   type: git
   gitLock:
-    commit: 786b898857bd7e9647c229d5f39b0be4de86c915
     repo: git@github.com:seans3/blueprint-helloworld
     directory: /
     ref: master
 inventory:
     name: foo
     namespace: test-namespace
-    inventoryID: SSSSSSSSSS-RRRRR
-`
+    inventoryID: ` + testInventoryID + "\n"
 
 var testTime = time.Unix(5555555, 66666666)
 

--- a/commands/migratecmd.go
+++ b/commands/migratecmd.go
@@ -121,10 +121,6 @@ func (mr *MigrateRunner) Run(reader io.Reader, args []string) error {
 	if err := mr.applyCRD(); err != nil {
 		return err
 	}
-	// Update the Kptfile with the resource group values (e.g. namespace, name, id).
-	if err := mr.updateKptfile(args); err != nil {
-		return err
-	}
 	// Retrieve the current ConfigMap inventory objects.
 	cmInvObj, err := mr.retrieveConfigMapInv(bytes.NewReader(stdinBytes), args)
 	if err != nil {
@@ -134,6 +130,12 @@ func (mr *MigrateRunner) Run(reader io.Reader, args []string) error {
 			return nil
 		}
 		klog.V(4).Infof("error retrieving ConfigMap inventory object: %s", err)
+		return err
+	}
+	cmInventoryID := cmInvObj.ID()
+	klog.V(4).Infof("previous inventoryID: %s", cmInventoryID)
+	// Update the Kptfile with the resource group values (e.g. namespace, name, id).
+	if err := mr.updateKptfile(args, cmInventoryID); err != nil {
 		return err
 	}
 	cmObjs, err := mr.retrieveInvObjs(cmInvObj)
@@ -179,9 +181,11 @@ func (mr *MigrateRunner) applyCRD() error {
 }
 
 // updateKptfile installs the "inventory" fields in the Kptfile.
-func (mr *MigrateRunner) updateKptfile(args []string) error {
+func (mr *MigrateRunner) updateKptfile(args []string, prevID string) error {
 	fmt.Fprint(mr.ioStreams.Out, "  updating Kptfile inventory values...")
 	if !mr.dryRun {
+		// Set inventory ID from previous inventory object.
+		mr.initOptions.inventoryID = prevID
 		if err := mr.initOptions.Run(args); err != nil {
 			if _, exists := err.(*InvExistsError); exists {
 				fmt.Fprint(mr.ioStreams.Out, "values already exist...")
@@ -212,6 +216,8 @@ func (mr *MigrateRunner) retrieveConfigMapInv(reader io.Reader, args []string) (
 		if _, ok := err.(inventory.NoInventoryObjError); ok { //nolint
 			fmt.Fprintln(mr.ioStreams.Out, "no ConfigMap inventory...completed")
 		}
+	} else {
+		fmt.Fprintf(mr.ioStreams.Out, "success (inventory-id: %s)\n", cmInv.ID())
 	}
 	return cmInv, err
 }
@@ -220,6 +226,7 @@ func (mr *MigrateRunner) retrieveConfigMapInv(reader io.Reader, args []string) (
 // inventory object by querying the inventory object in the cluster,
 // or an error if one occurred.
 func (mr *MigrateRunner) retrieveInvObjs(invObj inventory.InventoryInfo) ([]object.ObjMetadata, error) {
+	fmt.Fprint(mr.ioStreams.Out, "  retrieve ConfigMap inventory objs...")
 	cmInvClient, err := mr.cmProvider.InventoryClient()
 	if err != nil {
 		return nil, err
@@ -242,6 +249,10 @@ func (mr *MigrateRunner) migrateObjs(cmObjs []object.ObjMetadata, reader io.Read
 	fmt.Fprint(mr.ioStreams.Out, "  migrate inventory to ResourceGroup...")
 	if len(cmObjs) == 0 {
 		fmt.Fprint(mr.ioStreams.Out, "no inventory objects found\n")
+		return nil
+	}
+	if mr.dryRun {
+		fmt.Fprintln(mr.ioStreams.Out, "success")
 		return nil
 	}
 	rgReader, err := mr.rgLoader.ManifestReader(reader, args[0])
@@ -278,6 +289,9 @@ func (mr *MigrateRunner) deleteConfigMapInv(invObj inventory.InventoryInfo) erro
 	if err != nil {
 		return err
 	}
+	if mr.dryRun {
+		cmInvClient.SetDryRunStrategy(common.DryRunClient)
+	}
 	if err = cmInvClient.DeleteInventoryObj(invObj); err != nil {
 		return err
 	}
@@ -299,10 +313,12 @@ func (mr *MigrateRunner) deleteConfigMapFile() error {
 		}
 		if len(cmFilename) > 0 {
 			fmt.Fprintf(mr.ioStreams.Out, "deleting inventory template file: %s...", cmFilename)
-			err = os.Remove(cmFilename)
-			if err != nil {
-				fmt.Fprint(mr.ioStreams.Out, "failed\n")
-				return err
+			if !mr.dryRun {
+				err = os.Remove(cmFilename)
+				if err != nil {
+					fmt.Fprint(mr.ioStreams.Out, "failed\n")
+					return err
+				}
 			}
 			fmt.Fprint(mr.ioStreams.Out, "success\n")
 		}

--- a/commands/migratecmd_test.go
+++ b/commands/migratecmd_test.go
@@ -147,7 +147,7 @@ func TestKptMigrate_updateKptfile(t *testing.T) {
 			rgLoader := live.NewResourceGroupManifestLoader(tf)
 			migrateRunner := GetMigrateRunner(cmProvider, rgProvider, cmLoader, rgLoader, ioStreams)
 			migrateRunner.dryRun = tc.dryRun
-			err = migrateRunner.updateKptfile([]string{dir})
+			err = migrateRunner.updateKptfile([]string{dir}, testInventoryID)
 			// Check if there should be an error
 			if tc.isError {
 				if err == nil {
@@ -164,8 +164,8 @@ func TestKptMigrate_updateKptfile(t *testing.T) {
 				if len(kf.Inventory.Name) == 0 {
 					t.Errorf("inventory name not set in Kptfile")
 				}
-				if len(kf.Inventory.InventoryID) == 0 {
-					t.Errorf("inventory id not set in Kptfile")
+				if kf.Inventory.InventoryID != testInventoryID {
+					t.Errorf("inventory id not set in Kptfile: %s", kf.Inventory.InventoryID)
 				}
 			} else if kf.Inventory != nil {
 				t.Errorf("inventory shouldn't be set during dryrun")

--- a/e2e/live/testdata/template-rg-namespace.yaml
+++ b/e2e/live/testdata/template-rg-namespace.yaml
@@ -1,0 +1,48 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# NOTE: auto-generated. Some fields should NOT be modified.
+# Date: 2020-11-19 12:50:49 PST
+#
+# Contains the "inventory object" template ConfigMap.
+# When this object is applied, it is handled specially,
+# storing the metadata of all the other objects applied.
+# This object and its stored inventory is subsequently
+# used to calculate the set of objects to automatically
+# delete (prune), when an object is omitted from further
+# applies. When applied, this "inventory object" is also
+# used to identify the entire set of objects to delete.
+#
+# NOTE: The name of this inventory template file
+# does NOT have any impact on group-related functionality
+# such as deletion or pruning.
+#
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  # DANGER: Do not change the inventory object namespace.
+  # Changing the namespace will cause a loss of continuity
+  # with previously applied grouped objects. Set deletion
+  # and pruning functionality will be impaired.
+  namespace: test-rg-namespace
+  # NOTE: The name of the inventory object does NOT have
+  # any impact on group-related functionality such as
+  # deletion or pruning.
+  name: inventory-26306433
+  labels:
+    # DANGER: Do not change the value of this label.
+    # Changing this value will cause a loss of continuity
+    # with previously applied grouped objects. Set deletion
+    # and pruning functionality will be impaired.
+    cli-utils.sigs.k8s.io/inventory-id: 46d8946c-c1fa-4e1d-9357-b37fb9bae25f

--- a/go.sum
+++ b/go.sum
@@ -901,7 +901,6 @@ sigs.k8s.io/controller-runtime v0.6.0 h1:Fzna3DY7c4BIP6KwfSlrfnj20DJ+SeMBK8HSFvO
 sigs.k8s.io/controller-runtime v0.6.0/go.mod h1:CpYf5pdNY/B352A1TFLAS2JVSlnGQ5O2cftPHndTroo=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
-sigs.k8s.io/kustomize/kyaml v0.10.16 h1:4rn0PTEK4STOA5kbpz72oGskjpKYlmwru4YRgVQFv+c=
 sigs.k8s.io/kustomize/kyaml v0.10.16/go.mod h1:mlQFagmkm1P+W4lZJbJ/yaxMd8PqMRSC4cPcfUVt5Hg=
 sigs.k8s.io/kustomize/kyaml v0.10.17 h1:4zrV0ym5AYa0e512q7K3Wp1u7mzoWW0xR3UHJcGWGIg=
 sigs.k8s.io/kustomize/kyaml v0.10.17/go.mod h1:mlQFagmkm1P+W4lZJbJ/yaxMd8PqMRSC4cPcfUVt5Hg=

--- a/package-examples/helloworld-kustomize/resources/deploy.yaml
+++ b/package-examples/helloworld-kustomize/resources/deploy.yaml
@@ -1,3 +1,17 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
* Fixes migrate command on `next` branch by transferring `owning-inventory` annotation from `ConfigMap` inventory to `ResourceGroup` inventory.
* Adds e2e tests for migrate command.
* Updates some `Kptfile` in tests to `v1alpha2`.