### PR TITLE
Pipeline changes cause diff

### DIFF
--- a/internal/util/diff/pkgdiff_test.go
+++ b/internal/util/diff/pkgdiff_test.go
@@ -66,13 +66,11 @@ func TestPkgDiff(t *testing.T) {
 			name: "different pipelines in Kptfile is a diff",
 			pkg1: pkgbuilder.NewRootPkg().
 				WithKptfile(pkgbuilder.NewKptfile().
-					WithPipeline(pkgbuilder.NewFunction("gcr.io/kpt-dev/foo:latest")).
-					WithUpstream("github.com/GoogleContainerTools/kpt", "/", "master", "resource-merge")).
+					WithPipeline(pkgbuilder.NewFunction("gcr.io/kpt-dev/foo:latest"))).
 				WithResource(pkgbuilder.DeploymentResource),
 			pkg2: pkgbuilder.NewRootPkg().
 				WithKptfile(pkgbuilder.NewKptfile().
-					WithPipeline(pkgbuilder.NewFunction("gcr.io/kpt-dev/bar:latest")).
-					WithUpstream("github.com/GoogleContainerTools/kpt", "/", "kpt/v1", "resource-merge")).
+					WithPipeline(pkgbuilder.NewFunction("gcr.io/kpt-dev/buzz:latest"))).
 				WithResource(pkgbuilder.DeploymentResource),
 			diff: toStringSet("Kptfile"),
 		},

--- a/internal/util/diff/pkgdiff_test.go
+++ b/internal/util/diff/pkgdiff_test.go
@@ -63,6 +63,20 @@ func TestPkgDiff(t *testing.T) {
 			diff: toStringSet(),
 		},
 		{
+			name: "different pipelines in Kptfile is a diff",
+			pkg1: pkgbuilder.NewRootPkg().
+				WithKptfile(pkgbuilder.NewKptfile().
+					WithPipeline(pkgbuilder.NewFunction("gcr.io/kpt-dev/foo:latest")).
+					WithUpstream("github.com/GoogleContainerTools/kpt", "/", "master", "resource-merge")).
+				WithResource(pkgbuilder.DeploymentResource),
+			pkg2: pkgbuilder.NewRootPkg().
+				WithKptfile(pkgbuilder.NewKptfile().
+					WithPipeline(pkgbuilder.NewFunction("gcr.io/kpt-dev/bar:latest")).
+					WithUpstream("github.com/GoogleContainerTools/kpt", "/", "kpt/v1", "resource-merge")).
+				WithResource(pkgbuilder.DeploymentResource),
+			diff: toStringSet("Kptfile"),
+		},
+		{
 			name: "subpackages are not included",
 			pkg1: pkgbuilder.NewRootPkg().
 				WithKptfile().


### PR DESCRIPTION
Part of #1776

Adds test coverage to confirm that Kptfile changes outside of the `upstream` field are detected and flagged as a diff.