### PR TITLE
Extend support for git cache to all strategies

### DIFF
--- a/internal/cmddiff/cmddiff_test.go
+++ b/internal/cmddiff/cmddiff_test.go
@@ -15,6 +15,7 @@
 package cmddiff_test
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -24,6 +25,10 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMain(m *testing.M) {
+	os.Exit(testutil.ConfigureTestKptCache(m))
+}
 
 func TestCmdInvalidDiffType(t *testing.T) {
 	runner := cmddiff.NewRunner(fake.CtxWithNilPrinter(), "")

--- a/internal/cmdget/cmdget.go
+++ b/internal/cmdget/cmdget.go
@@ -71,7 +71,7 @@ func (r *Runner) preRunE(_ *cobra.Command, args []string) error {
 	if len(args) == 1 {
 		args = append(args, pkg.CurDir)
 	}
-	t, err := parse.GitParseArgs(args)
+	t, err := parse.GitParseArgs(r.ctx, args)
 	if err != nil {
 		return errors.E(op, err)
 	}

--- a/internal/cmdget/cmdget_test.go
+++ b/internal/cmdget/cmdget_test.go
@@ -15,14 +15,13 @@
 package cmdget_test
 
 import (
-	"io/ioutil"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/GoogleContainerTools/kpt/internal/cmdget"
-	"github.com/GoogleContainerTools/kpt/internal/gitutil"
 	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
@@ -30,6 +29,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
+
+func TestMain(m *testing.M) {
+	os.Exit(testutil.ConfigureTestKptCache(m))
+}
 
 // TestCmd_execute tests that get is correctly invoked.
 func TestCmd_execute(t *testing.T) {
@@ -157,7 +160,7 @@ func TestCmd_fail(t *testing.T) {
 	if !assert.Error(t, err) {
 		return
 	}
-	assert.Contains(t, err.Error(), "failed to lookup master(or main) branch")
+	assert.Contains(t, err.Error(), "'/real/dir' does not appear to be a git repository")
 }
 
 // NoOpRunE is a noop function to replace the run function of a command.  Useful for testing argument parsing.
@@ -190,40 +193,37 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
 
 	failRun := NoOpFailRunE{t: t}.runE
-	gitutil.DefaultRef = func(repo string) (string, error) {
-		return "master", nil
-	}
 
 	testCases := map[string]struct {
-		argsFunc    func(dir string) []string
+		argsFunc    func(repo, dir string) []string
 		runE        func(*cobra.Command, []string) error
-		validations func(dir string, r *cmdget.Runner, err error)
+		validations func(repo, dir string, r *cmdget.Runner, err error)
 	}{
 		"must have at least 1 arg": {
-			argsFunc: func(dir string) []string {
+			argsFunc: func(repo, _ string) []string {
 				return []string{}
 			},
 			runE: failRun,
-			validations: func(_ string, r *cmdget.Runner, err error) {
+			validations: func(_, _ string, r *cmdget.Runner, err error) {
 				assert.EqualError(t, err, "requires at least 1 arg(s), only received 0")
 			},
 		},
 		"must provide unambiguous repo, dir and version": {
-			argsFunc: func(dir string) []string {
+			argsFunc: func(repo, _ string) []string {
 				return []string{"foo", "bar", "baz"}
 			},
 			runE: failRun,
-			validations: func(_ string, r *cmdget.Runner, err error) {
+			validations: func(_, _ string, r *cmdget.Runner, err error) {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), "ambiguous repo/dir@version specify '.git' in argument")
 			},
 		},
 		"repo arg is split up correctly into ref and repo": {
-			argsFunc: func(dir string) []string {
+			argsFunc: func(repo, _ string) []string {
 				return []string{"something://foo.git/@master", "./"}
 			},
 			runE: NoOpRunE,
-			validations: func(_ string, r *cmdget.Runner, err error) {
+			validations: func(_, _ string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
 				assert.Equal(t, "master", r.Get.Git.Ref)
 				assert.Equal(t, "something://foo", r.Get.Git.Repo)
@@ -231,136 +231,136 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 			},
 		},
 		"repo arg is split up correctly into ref, directory and repo": {
-			argsFunc: func(dir string) []string {
-				return []string{"file://foo.git/blueprints/java", "."}
+			argsFunc: func(repo, _ string) []string {
+				return []string{fmt.Sprintf("file://%s.git/blueprints/java", repo), "."}
 			},
 			runE: NoOpRunE,
-			validations: func(_ string, r *cmdget.Runner, err error) {
+			validations: func(repo, _ string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "file://foo", r.Get.Git.Repo)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
 				assert.Equal(t, "master", r.Get.Git.Ref)
 				assert.Equal(t, "/blueprints/java", r.Get.Git.Directory)
 				assert.Equal(t, filepath.Join(pathPrefix, w.WorkspaceDirectory, "java"), r.Get.Destination)
 			},
 		},
 		"current working dir -- should use package name": {
-			argsFunc: func(dir string) []string {
-				return []string{"https://foo.git/blueprints/java", "foo/../bar/../"}
+			argsFunc: func(repo, _ string) []string {
+				return []string{fmt.Sprintf("file://%s.git/blueprints/java", repo), "foo/../bar/../"}
 			},
 			runE: NoOpRunE,
-			validations: func(_ string, r *cmdget.Runner, err error) {
+			validations: func(repo, _ string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://foo", r.Get.Git.Repo)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
 				assert.Equal(t, "master", r.Get.Git.Ref)
 				assert.Equal(t, "/blueprints/java", r.Get.Git.Directory)
 				assert.Equal(t, filepath.Join(pathPrefix, w.WorkspaceDirectory, "java"), r.Get.Destination)
 			},
 		},
 		"clean relative path": {
-			argsFunc: func(dir string) []string {
-				return []string{"https://foo.git/blueprints/java", "./foo/../bar/../baz"}
+			argsFunc: func(repo, _ string) []string {
+				return []string{fmt.Sprintf("file://%s.git/blueprints/java", repo), "./foo/../bar/../baz"}
 			},
 			runE: NoOpRunE,
-			validations: func(_ string, r *cmdget.Runner, err error) {
+			validations: func(repo, _ string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://foo", r.Get.Git.Repo)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
 				assert.Equal(t, "master", r.Get.Git.Ref)
 				assert.Equal(t, "/blueprints/java", r.Get.Git.Directory)
 				assert.Equal(t, filepath.Join(pathPrefix, w.WorkspaceDirectory, "baz"), r.Get.Destination)
 			},
 		},
 		"clean absolute path": {
-			argsFunc: func(dir string) []string {
-				return []string{"https://foo.git/blueprints/java", "/foo/../bar/../baz"}
+			argsFunc: func(repo, _ string) []string {
+				return []string{fmt.Sprintf("file://%s.git/blueprints/java", repo), "/foo/../bar/../baz"}
 			},
 			runE: NoOpRunE,
-			validations: func(_ string, r *cmdget.Runner, err error) {
+			validations: func(repo, _ string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://foo", r.Get.Git.Repo)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
 				assert.Equal(t, "master", r.Get.Git.Ref)
 				assert.Equal(t, "/blueprints/java", r.Get.Git.Directory)
 				assert.Equal(t, "/baz", r.Get.Destination)
 			},
 		},
 		"provide an absolute destination directory": {
-			argsFunc: func(dir string) []string {
-				return []string{"https://foo.git", filepath.Join(dir, "package", "my-app")}
+			argsFunc: func(repo, dir string) []string {
+				return []string{fmt.Sprintf("file://%s.git", repo), filepath.Join(dir, "my-app")}
 			},
 			runE: NoOpRunE,
-			validations: func(dir string, r *cmdget.Runner, err error) {
+			validations: func(repo, dir string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://foo", r.Get.Git.Repo)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
 				assert.Equal(t, "master", r.Get.Git.Ref)
-				assert.Equal(t, filepath.Join(dir, "package", "my-app"), r.Get.Destination)
+				assert.Equal(t, filepath.Join(dir, "my-app"), r.Get.Destination)
 			},
 		},
 		"package in a subdirectory": {
-			argsFunc: func(dir string) []string {
-				return []string{"https://github.com/foo/bar.git/baz", filepath.Join(dir, "package", "my-app")}
+			argsFunc: func(repo, dir string) []string {
+				return []string{fmt.Sprintf("file://%s.git/baz", repo), filepath.Join(dir, "my-app")}
 			},
 			runE: NoOpRunE,
-			validations: func(dir string, r *cmdget.Runner, err error) {
+			validations: func(repo, dir string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://github.com/foo/bar", r.Get.Git.Repo)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
 				assert.Equal(t, "/baz", r.Get.Git.Directory)
 				assert.Equal(t, "master", r.Get.Git.Ref)
-				assert.Equal(t, filepath.Join(dir, "package", "my-app"), r.Get.Destination)
+				assert.Equal(t, filepath.Join(dir, "my-app"), r.Get.Destination)
 			},
 		},
 		"package in a subdirectory at a specific ref": {
-			argsFunc: func(dir string) []string {
-				return []string{"https://github.com/foo/bar.git/baz@v1", filepath.Join(dir, "package", "my-app")}
+			argsFunc: func(repo, dir string) []string {
+				return []string{fmt.Sprintf("file://%s.git/baz@v1", repo), filepath.Join(dir, "my-app")}
 			},
 			runE: NoOpRunE,
-			validations: func(dir string, r *cmdget.Runner, err error) {
+			validations: func(repo, dir string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://github.com/foo/bar", r.Get.Git.Repo)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
 				assert.Equal(t, "/baz", r.Get.Git.Directory)
 				assert.Equal(t, "v1", r.Get.Git.Ref)
-				assert.Equal(t, filepath.Join(dir, "package", "my-app"), r.Get.Destination)
+				assert.Equal(t, filepath.Join(dir, "my-app"), r.Get.Destination)
 			},
 		},
 		"provided directory already exists": {
-			argsFunc: func(dir string) []string {
-				return []string{"https://foo.git", filepath.Join(dir, "package")}
+			argsFunc: func(repo, dir string) []string {
+				return []string{fmt.Sprintf("file://%s.git", repo), filepath.Join(dir, "package")}
 			},
 			runE: NoOpRunE,
-			validations: func(dir string, r *cmdget.Runner, err error) {
+			validations: func(repo, dir string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://foo", r.Get.Git.Repo)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
 				assert.Equal(t, "master", r.Get.Git.Ref)
-				assert.Equal(t, filepath.Join(dir, "package", "foo"), r.Get.Destination)
+				assert.Equal(t, filepath.Join(dir, "package"), r.Get.Destination)
 			},
 		},
 		"invalid repo": {
-			argsFunc: func(dir string) []string {
+			argsFunc: func(repo, dir string) []string {
 				return []string{"/", filepath.Join(dir, "package", "my-app")}
 			},
 			runE: failRun,
-			validations: func(dir string, r *cmdget.Runner, err error) {
+			validations: func(repo, dir string, r *cmdget.Runner, err error) {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), "specify '.git'")
 			},
 		},
 		"valid strategy provided": {
-			argsFunc: func(dir string) []string {
-				return []string{"https://foo.git", filepath.Join(dir, "package"), "--strategy=fast-forward"}
+			argsFunc: func(repo, dir string) []string {
+				return []string{fmt.Sprintf("file://%s.git", repo), filepath.Join(dir, "package"), "--strategy=fast-forward"}
 			},
 			runE: NoOpRunE,
-			validations: func(dir string, r *cmdget.Runner, err error) {
+			validations: func(repo, dir string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "https://foo", r.Get.Git.Repo)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
 				assert.Equal(t, "master", r.Get.Git.Ref)
-				assert.Equal(t, filepath.Join(dir, "package", "foo"), r.Get.Destination)
+				assert.Equal(t, filepath.Join(dir, "package"), r.Get.Destination)
 				assert.Equal(t, kptfilev1alpha2.FastForward, r.Get.UpdateStrategy)
 			},
 		},
 		"invalid strategy provided": {
-			argsFunc: func(dir string) []string {
-				return []string{"https://foo.git", filepath.Join(dir, "package"), "--strategy=does-not-exist"}
+			argsFunc: func(repo, dir string) []string {
+				return []string{fmt.Sprintf("file://%s.git", repo), filepath.Join(dir, "package"), "--strategy=does-not-exist"}
 			},
 			runE: failRun,
-			validations: func(dir string, r *cmdget.Runner, err error) {
+			validations: func(repo, dir string, r *cmdget.Runner, err error) {
 				assert.Error(t, err)
 				assert.Contains(t, err.Error(), "unknown update strategy \"does-not-exist\"")
 			},
@@ -369,19 +369,19 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
-			d, err := ioutil.TempDir("", "kpt")
-			assert.NoError(t, err)
-			defer os.RemoveAll(d)
-			err = os.Mkdir(filepath.Join(d, "package"), 0700)
-			assert.NoError(t, err)
+			g, w, clean := testutil.SetupRepoAndWorkspace(t, testutil.Content{
+				Data:   testutil.Dataset1,
+				Branch: "master",
+			})
+			defer clean()
 
 			r := cmdget.NewRunner(fake.CtxWithNilPrinter(), "kpt")
 			r.Command.SilenceErrors = true
 			r.Command.SilenceUsage = true
 			r.Command.RunE = tc.runE
-			r.Command.SetArgs(tc.argsFunc(d))
-			err = r.Command.Execute()
-			tc.validations(d, r, err)
+			r.Command.SetArgs(tc.argsFunc(g.RepoDirectory, w.WorkspaceDirectory))
+			err := r.Command.Execute()
+			tc.validations(g.RepoDirectory, w.WorkspaceDirectory, r, err)
 		})
 	}
 }

--- a/internal/cmdinit/cmdinit_test.go
+++ b/internal/cmdinit/cmdinit_test.go
@@ -22,11 +22,14 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/kpt/internal/cmdinit"
-	"github.com/GoogleContainerTools/kpt/internal/gitutil"
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/man"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMain(m *testing.M) {
+	os.Exit(testutil.ConfigureTestKptCache(m))
+}
 
 // TestCmd verifies the directory is initialized
 func TestCmd(t *testing.T) {
@@ -162,64 +165,5 @@ func TestCmd_failNotExists(t *testing.T) {
 	err = r.Command.Execute()
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "does not exist")
-	}
-}
-
-func TestGitUtil_DefaultRef(t *testing.T) {
-	// set up git repo with both main and master branches
-	g, _, clean := testutil.SetupRepoAndWorkspace(t, testutil.Content{
-		Data:   testutil.Dataset1,
-		Branch: "master",
-	})
-	defer clean()
-
-	// check if master is picked as default if both main and master branches exist
-	defaultRef, err := gitutil.DefaultRef("file://" + g.RepoDirectory)
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	if !assert.Equal(t, "master", defaultRef) {
-		t.FailNow()
-	}
-	if !assert.Equal(t, "master", defaultRef) {
-		t.FailNow()
-	}
-
-	err = g.CheckoutBranch("main", true)
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-
-	// delete master branch and check if main is selected as default
-	err = g.DeleteBranch("master")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-
-	defaultRef, err = gitutil.DefaultRef("file://" + g.RepoDirectory)
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	if !assert.Equal(t, "main", defaultRef) {
-		t.FailNow()
-	}
-
-	err = g.CheckoutBranch("master", true)
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-
-	// delete main branch and check if master is selected as default
-	err = g.DeleteBranch("main")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-
-	defaultRef, err = gitutil.DefaultRef("file://" + g.RepoDirectory)
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	if !assert.Equal(t, "master", defaultRef) {
-		t.FailNow()
 	}
 }

--- a/internal/cmdupdate/cmdupdate_test.go
+++ b/internal/cmdupdate/cmdupdate_test.go
@@ -15,6 +15,7 @@
 package cmdupdate_test
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -31,6 +32,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
+
+func TestMain(m *testing.M) {
+	os.Exit(testutil.ConfigureTestKptCache(m))
+}
 
 // TestCmd_execute verifies that update is correctly invoked.
 func TestCmd_execute(t *testing.T) {
@@ -54,11 +59,16 @@ func TestCmd_execute(t *testing.T) {
 	if !g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset1), dest) {
 		return
 	}
-	gitRunner := gitutil.NewLocalGitRunner(w.WorkspaceDirectory)
-	if !assert.NoError(t, gitRunner.Run("add", ".")) {
+	gitRunner, err := gitutil.NewLocalGitRunner(w.WorkspaceDirectory)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	_, err = gitRunner.Run(context.Background(), "add", ".")
+	if !assert.NoError(t, err) {
 		return
 	}
-	if !assert.NoError(t, gitRunner.Run("commit", "-m", "commit local package -- ds1")) {
+	_, err = gitRunner.Run(context.Background(), "commit", "-m", "commit local package -- ds1")
+	if !assert.NoError(t, err) {
 		return
 	}
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -42,6 +42,9 @@ type Error struct {
 	// Fn is the kpt function being run either as part of "fn render" or "fn eval"
 	Fn Fn
 
+	// Repo is the git repo used for get, update or diff
+	Repo Repo
+
 	// Class refers to class of errors
 	Class Class
 
@@ -72,6 +75,12 @@ func (e *Error) Error() string {
 		pad(b, ": ")
 		b.WriteString("fn ")
 		b.WriteString(string(e.Fn))
+	}
+
+	if e.Repo != "" {
+		pad(b, ": ")
+		b.WriteString("repo ")
+		b.WriteString(string(e.Repo))
 	}
 
 	if e.Class != 0 {
@@ -118,6 +127,9 @@ type Op string
 
 // Fn describes the kpt function associated with the error.
 type Fn string
+
+// Repo describes the repo associated with the error.
+type Repo string
 
 // Class describes the class of errors encountered.
 type Class int
@@ -169,6 +181,8 @@ func E(args ...interface{}) error {
 			e.Op = a
 		case Fn:
 			e.Fn = a
+		case Repo:
+			e.Repo = a
 		case Class:
 			e.Class = a
 		case *Error:
@@ -196,6 +210,10 @@ func E(args ...interface{}) error {
 
 	if e.Fn == wrappedErr.Fn {
 		wrappedErr.Fn = ""
+	}
+
+	if e.Repo == wrappedErr.Repo {
+		wrappedErr.Repo = ""
 	}
 
 	if e.Class == wrappedErr.Class {

--- a/internal/gitutil/gitutil.go
+++ b/internal/gitutil/gitutil.go
@@ -15,14 +15,17 @@
 package gitutil
 
 import (
+	"bufio"
 	"bytes"
-	"crypto/sha256"
-	"encoding/base64"
+	"context"
+	"crypto/md5"
+	"encoding/base32"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/GoogleContainerTools/kpt/internal/errors"
@@ -32,144 +35,270 @@ import (
 // for remote repos.  Defaults to UserHomeDir/.kpt/repos if unspecified.
 const RepoCacheDirEnv = "KPT_CACHE_DIR"
 
-// DefaultRef returns the DefaultRef to "master" if master branch exists in
-// remote repository, falls back to "main" if master branch doesn't exist
-// Making it a var so that it can be overridden for local testing
-var DefaultRef = func(repo string) (string, error) {
-	const op errors.Op = "gitutil.DefaultRef"
-	masterRef := "master"
-	mainRef := "main"
-	masterExists, err := branchExists(repo, masterRef)
+// NewLocalGitRunner returns a new GitLocalRunner for a local package.
+func NewLocalGitRunner(pkg string) (*GitLocalRunner, error) {
+	const op errors.Op = "gitutil.NewLocalGitRunner"
+	p, err := exec.LookPath("git")
 	if err != nil {
-		return "", errors.E(op, errors.Git, err)
-	}
-	mainExists, err := branchExists(repo, mainRef)
-	if err != nil {
-		return "", errors.E(op, errors.Git, err)
-	}
-	if masterExists {
-		return masterRef, nil
-	} else if mainExists {
-		return mainRef, nil
-	}
-	return masterRef, nil
-}
-
-// BranchExists checks if branch is present in the input repo
-func branchExists(repo, branch string) (bool, error) {
-	const op errors.Op = "gitutil.branchExists"
-	gitProgram, err := exec.LookPath("git")
-	if err != nil {
-		return false, errors.E(op, errors.Git,
+		return nil, errors.E(op, errors.Git,
 			fmt.Errorf("no 'git' program on path: %w", err))
 	}
-	stdOut := bytes.Buffer{}
-	stdErr := bytes.Buffer{}
-	cmd := exec.Command(gitProgram, "ls-remote", repo, branch)
-	cmd.Stderr = &stdErr
-	cmd.Stdout = &stdOut
-	err = cmd.Run()
-	if err != nil {
-		// stdErr contains the error message for os related errors, git permission errors
-		// and if repo doesn't exist
-		return false, errors.E(op, errors.Git,
-			fmt.Errorf("failed to lookup master(or main) branch %v: %s", err, strings.TrimSpace(stdErr.String())))
-	}
-	// stdOut contains the branch information if the branch is present in remote repo
-	// stdOut is empty if the repo doesn't have the input branch
-	if strings.TrimSpace(stdOut.String()) != "" {
-		return true, nil
-	}
-	return false, nil
+
+	return &GitLocalRunner{
+		gitPath: p,
+		Dir:     pkg,
+	}, nil
 }
 
-// NewUpstreamGitRunner returns a new GitRunner for an upstream package.
-//
-// The upstream package repo will be fetched to a local cache directory under $HOME/.kpt
-// and hard reset to origin/main.
-// The refs will also be fetched so they are available locally.
-func NewUpstreamGitRunner(uri, dir string, required []string, optional []string) (*GitRunner, error) {
-	const op errors.Op = "gitutil.NewUpstreamGitRunner"
-	g := &GitRunner{}
+// GitLocalRunner runs git commands in a local git repo.
+type GitLocalRunner struct {
+	// Path to the git executable.
+	gitPath string
 
-	// make sure the repo is fetched
-	cacheDir, err := g.cacheRepo(uri, dir, required, optional)
-	if err != nil {
-		return nil, errors.E(op, err)
-	}
-	g.RepoDir = cacheDir
-	g.Dir = filepath.Join(cacheDir, dir)
-	return g, nil
-}
-
-// NewLocalGitRunner returns a new GitRunner for a local package.
-func NewLocalGitRunner(pkg string) *GitRunner {
-	return &GitRunner{Dir: pkg}
-}
-
-// GitRunner runs git commands in a git repo.
-type GitRunner struct {
 	// Dir is the directory the commands are run in.
 	Dir string
+}
 
-	// RepoDir is the directory of the git repo containing the package
-	RepoDir string
-
-	// Stderr is where the git command Stderr is written
-	Stderr *bytes.Buffer
-
-	// Stdin is where the git command Stdin is read from
-	Stdin *bytes.Buffer
-
-	// Stdout is where the git command Stdout is written
-	Stdout *bytes.Buffer
-
-	// Verbose prints verbose command information
-	Verbose bool
+type RunResult struct {
+	Stdout string
+	Stderr string
 }
 
 // Run runs a git command.
 // Omit the 'git' part of the command.
-func (g *GitRunner) Run(args ...string) error {
-	const op errors.Op = "gitutil.Run"
-	p, err := exec.LookPath("git")
-	if err != nil {
-		return errors.E(op, errors.Git,
-			fmt.Errorf("no 'git' program on path: %w", err))
-	}
+// The first return value contains the output to Stdout and Stderr when
+// running the command.
+func (g *GitLocalRunner) Run(ctx context.Context, args ...string) (RunResult, error) {
+	return g.run(ctx, false, args...)
+}
 
-	cmd := exec.Command(p, args...)
+// RunVerbose runs a git command.
+// Omit the 'git' part of the command.
+// The first return value contains the output to Stdout and Stderr when
+// running the command.
+func (g *GitLocalRunner) RunVerbose(ctx context.Context, args ...string) (RunResult, error) {
+	return g.run(ctx, true, args...)
+}
+
+// run runs a git command.
+// Omit the 'git' part of the command.
+// The first return value contains the output to Stdout and Stderr when
+// running the command.
+func (g *GitLocalRunner) run(ctx context.Context, verbose bool, args ...string) (RunResult, error) {
+	const op errors.Op = "gitutil.run"
+
+	cmd := exec.CommandContext(ctx, g.gitPath, args...)
 	cmd.Dir = g.Dir
 	cmd.Env = os.Environ()
 
-	g.Stdout = &bytes.Buffer{}
-	g.Stderr = &bytes.Buffer{}
-	if g.Verbose {
-		// print the command
-		fmt.Println(cmd.Args)
-		cmd.Stdout = io.MultiWriter(g.Stdout, os.Stdout)
-		cmd.Stdout = io.MultiWriter(g.Stderr, os.Stderr)
+	cmdStdout := &bytes.Buffer{}
+	cmdStderr := &bytes.Buffer{}
+	if verbose {
+		cmd.Stdout = io.MultiWriter(cmdStdout, os.Stdout)
+		cmd.Stderr = io.MultiWriter(cmdStderr, os.Stderr)
 	} else {
-		cmd.Stdout = g.Stdout
-		cmd.Stderr = g.Stderr
+		cmd.Stdout = cmdStdout
+		cmd.Stderr = cmdStderr
 	}
 
-	if g.Stdin != nil {
-		cmd.Stdin = g.Stdin
-	}
-	err = cmd.Run()
+	err := cmd.Run()
 	if err != nil {
-		return errors.E(op, errors.Git, err)
+		return RunResult{}, errors.E(op, errors.Git, &GitExecError{
+			Args:   args,
+			Err:    err,
+			StdOut: cmdStdout.String(),
+			StdErr: cmdStderr.String(),
+		})
 	}
+	return RunResult{
+		Stdout: cmdStdout.String(),
+		Stderr: cmdStderr.String(),
+	}, nil
+}
+
+type GitExecError struct {
+	Args   []string
+	Err    error
+	StdErr string
+	StdOut string
+}
+
+func (e *GitExecError) Error() string {
+	b := new(strings.Builder)
+	b.WriteString(e.Err.Error())
+	b.WriteString(": ")
+	b.WriteString(e.StdErr)
+	return b.String()
+}
+
+// NewGitUpstreamRepo returns a new GitUpstreamRepo for an upstream package.
+func NewGitUpstreamRepo(ctx context.Context, uri string) (*GitUpstreamRepo, error) {
+	const op errors.Op = "gitutil.NewGitUpstreamRepo"
+
+	g := &GitUpstreamRepo{
+		URI: uri,
+	}
+	if err := g.updateRefs(ctx); err != nil {
+		return nil, errors.E(op, errors.Repo(uri), err)
+	}
+	return g, nil
+}
+
+// GitUpstreamRepo runs git commands in a local git repo.
+type GitUpstreamRepo struct {
+	URI string
+
+	// Heads contains all head refs in the upstream repo as well as the
+	// each of the are referencing.
+	Heads map[string]string
+
+	// Tags contains all tag refs in the upstream repo as well as the
+	// each of the are referencing.
+	Tags map[string]string
+}
+
+// updateRefs fetches all refs from the upstream git repo, parses the results
+// and caches all refs and the commit they reference. Not that this doesn't
+// download any objects, only refs.
+func (gur *GitUpstreamRepo) updateRefs(ctx context.Context) error {
+	const op errors.Op = "gitutil.updateRefs"
+	repoCacheDir, err := gur.cacheRepo(ctx, gur.URI, []string{}, []string{})
+	if err != nil {
+		return errors.E(op, errors.Repo(gur.URI), err)
+	}
+
+	gitRunner, err := NewLocalGitRunner(repoCacheDir)
+	if err != nil {
+		return errors.E(op, errors.Repo(gur.URI), err)
+	}
+
+	rr, err := gitRunner.Run(ctx, "ls-remote", "--heads", "--tags", "--refs", "origin")
+	if err != nil {
+		// TODO: This should only fail if we can't connect to the repo. We should
+		// consider exposing the error message from git to the user here.
+		return errors.E(op, errors.Repo(gur.URI), err)
+	}
+
+	heads := make(map[string]string)
+	tags := make(map[string]string)
+
+	re := regexp.MustCompile(`^([a-z0-9]+)\s+refs/(heads|tags)/(.+)$`)
+	scanner := bufio.NewScanner(bytes.NewBufferString(rr.Stdout))
+	for scanner.Scan() {
+		txt := scanner.Text()
+		res := re.FindStringSubmatch(txt)
+		if len(res) == 0 {
+			continue
+		}
+		switch res[2] {
+		case "heads":
+			heads[res[3]] = res[1]
+		case "tags":
+			tags[res[3]] = res[1]
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return errors.E(op, errors.Repo(gur.URI), errors.Git,
+			fmt.Errorf("error parsing response from git: %w", err))
+	}
+	gur.Heads = heads
+	gur.Tags = tags
 	return nil
 }
 
-// getRepoDir returns the cache directory name for a remote repo
-func (g *GitRunner) getRepoDir(uri string) string {
-	return base64.URLEncoding.EncodeToString(sha256.New().Sum([]byte(uri)))[:32]
+// GetRepo fetches all the provided refs and the objects. It will fetch it
+// to the cache repo and returns the path to the local git clone in the cache
+// directory.
+func (gur *GitUpstreamRepo) GetRepo(ctx context.Context, refs []string) (string, error) {
+	const op errors.Op = "gitutil.GetRepo"
+	dir, err := gur.cacheRepo(ctx, gur.URI, refs, []string{})
+	if err != nil {
+		return "", errors.E(op, errors.Repo(gur.URI), err)
+	}
+	return dir, nil
 }
 
-func (g *GitRunner) getRepoCacheDir() (string, error) {
+// GetDefaultBranch returns the name of the branch pointed to by the
+// HEAD symref. This is the default branch of the repository.
+func (gur *GitUpstreamRepo) GetDefaultBranch(ctx context.Context) (string, error) {
+	const op errors.Op = "gitutil.GetDefaultBranch"
+	cacheRepo, err := gur.cacheRepo(ctx, gur.URI, []string{}, []string{})
+	if err != nil {
+		return "", errors.E(op, errors.Repo(gur.URI), err)
+	}
+
+	gitRunner, err := NewLocalGitRunner(cacheRepo)
+	if err != nil {
+		return "", errors.E(op, errors.Repo(gur.URI), err)
+	}
+
+	rr, err := gitRunner.Run(ctx, "ls-remote", "--symref", "origin", "HEAD")
+	if err != nil {
+		return "", errors.E(op, errors.Repo(gur.URI), err)
+	}
+	if rr.Stdout == "" {
+		return "", errors.E(op, errors.Repo(gur.URI),
+			fmt.Errorf("unable to detect default branch in repo"))
+	}
+
+	re := regexp.MustCompile(`ref: refs/heads/([^\s/]+)\s*HEAD`)
+	match := re.FindStringSubmatch(rr.Stdout)
+	if len(match) != 2 {
+		return "", errors.E(op, errors.Repo(gur.URI), errors.Git,
+			fmt.Errorf("unexpected response from git when determining default branch: %s", rr.Stdout))
+	}
+	return match[1], nil
+}
+
+// ResolveBranch resolves the branch to a commit SHA. This happens based on the
+// cached information about refs in the upstream repo. If the branch doesn't exist
+// in the upstream repo, the last return value will be false.
+func (gur *GitUpstreamRepo) ResolveBranch(branch string) (string, bool) {
+	if strings.HasPrefix(branch, "refs/heads/") {
+		branch = strings.TrimPrefix(branch, "refs/heads/")
+	}
+	for head, commit := range gur.Heads {
+		if head == branch {
+			return commit, true
+		}
+	}
+	return "", false
+}
+
+// ResolveTag resolves the tag to a commit SHA. This happens based on the
+// cached information about refs in the upstream repo. If the tag doesn't exist
+// in the upstream repo, the last return value will be false.
+func (gur *GitUpstreamRepo) ResolveTag(tag string) (string, bool) {
+	if strings.HasPrefix(tag, "refs/tags/") {
+		tag = strings.TrimPrefix(tag, "refs/tags/")
+	}
+	for t, commit := range gur.Tags {
+		if t == tag {
+			return commit, true
+		}
+	}
+	return "", false
+}
+
+// ResolveRef resolves the ref (either tag or branch) to a commit SHA. If the
+// ref doesn't exist in the upstream repo, the last return value will be false.
+func (gur *GitUpstreamRepo) ResolveRef(ref string) (string, bool) {
+	commit, found := gur.ResolveBranch(ref)
+	if found {
+		return commit, true
+	}
+	return gur.ResolveTag(ref)
+}
+
+// getRepoDir returns the cache directory name for a remote repo
+// This takes the md5 hash of the repo uri and then base32 encodes it to make
+// sure it doesn't contain characters that isn't legal in directory names.
+func (gur *GitUpstreamRepo) getRepoDir(uri string) string {
+	return strings.ToLower(base32.StdEncoding.EncodeToString(md5.New().Sum([]byte(uri))))
+}
+
+// getRepoCacheDir
+func (gur *GitUpstreamRepo) getRepoCacheDir() (string, error) {
 	const op errors.Op = "gitutil.getRepoCacheDir"
 	var err error
 	dir := os.Getenv(RepoCacheDirEnv)
@@ -180,36 +309,38 @@ func (g *GitRunner) getRepoCacheDir() (string, error) {
 	// cache location unspecified, use UserHomeDir/.kpt/repos
 	dir, err = os.UserHomeDir()
 	if err != nil {
-		return "", errors.E(op, fmt.Errorf(
-			"failed to clone repo: trouble resolving cache directory: %w", err))
+		return "", errors.E(op, errors.IO, fmt.Errorf(
+			"error looking up user home dir: %w", err))
 	}
 	return filepath.Join(dir, ".kpt", "repos"), nil
 }
 
 // cacheRepo fetches a remote repo to a cache location, and fetches the provided refs.
-func (g *GitRunner) cacheRepo(uri, dir string,
-	requiredRefs []string, optionalRefs []string) (string, error) {
+func (gur *GitUpstreamRepo) cacheRepo(ctx context.Context, uri string, requiredRefs []string, optionalRefs []string) (string, error) {
 	const op errors.Op = "gitutil.cacheRepo"
-	kptCacheDir, err := g.getRepoCacheDir()
+	kptCacheDir, err := gur.getRepoCacheDir()
 	if err != nil {
 		return "", errors.E(op, err)
 	}
 	if err := os.MkdirAll(kptCacheDir, 0700); err != nil {
 		return "", errors.E(op, errors.IO, fmt.Errorf(
-			"failed to clone repo: trouble creating cache directory: %w", err))
+			"error creating cache directory for repo: %w", err))
 	}
 
 	// create the repo directory if it doesn't exist yet
-	gitRunner := GitRunner{Dir: kptCacheDir}
-	uriSha := g.getRepoDir(uri)
+	gitRunner, err := NewLocalGitRunner(kptCacheDir)
+	if err != nil {
+		return "", errors.E(op, errors.Repo(uri), err)
+	}
+	uriSha := gur.getRepoDir(uri)
 	repoCacheDir := filepath.Join(kptCacheDir, uriSha)
 	if _, err := os.Stat(repoCacheDir); os.IsNotExist(err) {
-		if err := gitRunner.Run("init", uriSha); err != nil {
-			return "", errors.E(op, errors.Git, fmt.Errorf("failed to clone repo: trouble running init: %w", err))
+		if _, err := gitRunner.Run(ctx, "init", uriSha); err != nil {
+			return "", errors.E(op, errors.Git, fmt.Errorf("error running `git init`: %w", err))
 		}
 		gitRunner.Dir = repoCacheDir
-		if err = gitRunner.Run("remote", "add", "origin", uri); err != nil {
-			return "", errors.E(op, errors.Git, fmt.Errorf("failed to clone repo: trouble adding origin: %w", err))
+		if _, err = gitRunner.Run(ctx, "remote", "add", "origin", uri); err != nil {
+			return "", errors.E(op, errors.Git, fmt.Errorf("error adding origin remote: %w", err))
 		}
 	} else {
 		gitRunner.Dir = repoCacheDir
@@ -218,59 +349,37 @@ func (g *GitRunner) cacheRepo(uri, dir string,
 	// fetch the specified refs
 	triedFallback := false
 	for _, s := range requiredRefs {
-		if err = gitRunner.Run("fetch", "origin", s); err != nil {
+		if _, err := gitRunner.Run(ctx, "fetch", "origin", "--depth=1", s); err != nil {
 			if !triedFallback { // only fallback to fetch origin once
-				// fallback on fetching the origin -- some versions of git have an issue
-				// with fetching the first commit by sha.
-				if err = gitRunner.Run("fetch", "origin"); err != nil {
+				// fallback on fetching the origin. If the user provided a short sha,
+				// we need to fetch all objects in order to resolve it into the full
+				// sha.
+				// TODO: See if there is a way to resolve a short sha into a complete
+				// sha without fetching. Haven't found one so far...
+				if _, retryErr := gitRunner.Run(ctx, "fetch", "origin"); retryErr != nil {
+					// We are using the original error here.
 					return "", errors.E(op, errors.Git, fmt.Errorf(
-						"failed to clone git repo: trouble fetching origin, "+
-							"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials: %w", err))
+						"error running `git fetch` for origin: %w", err))
 				}
 				triedFallback = true
 			}
 			// verify we got the commit
-			if err = gitRunner.Run("show", s); err != nil {
+			if _, err = gitRunner.Run(ctx, "show", s); err != nil {
 				return "", errors.E(op, errors.Git, fmt.Errorf(
-					"failed to clone git repo: trouble fetching origin %s, "+
-						"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials: %w", s, err))
+					"error verifying results from fetch: %w", err))
 			}
 		}
 	}
 
 	var found bool
 	for _, s := range optionalRefs {
-		if err := gitRunner.Run("fetch", "origin", s); err == nil {
+		if _, err := gitRunner.Run(ctx, "fetch", "origin", s); err == nil {
 			found = true
 		}
 	}
-	if !found {
-		return "", errors.E(op, errors.Git, fmt.Errorf("failed to clone git repo: unable to find any matching refs: %s, "+
-			"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials",
+	if !found && len(optionalRefs) > 0 {
+		return "", errors.E(op, errors.Git, fmt.Errorf("unable to find any refs %s",
 			strings.Join(optionalRefs, ",")))
 	}
-
-	if err = gitRunner.Run("fetch", "origin"); err != nil {
-		return "", errors.E(op, errors.Git, fmt.Errorf("failed to clone git repo: trouble fetching origin, "+
-			"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials: %w", err))
-	}
-
-	defaultRef, err := DefaultRef(uri)
-	if err != nil {
-		return "", errors.E(op, errors.Git, fmt.Errorf("please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials: %w", err))
-	}
-
-	// reset the repo state
-	if err = gitRunner.Run("checkout", defaultRef); err != nil {
-		return "", errors.E(op, errors.Git, fmt.Errorf("failed to clone repo: trouble checking out %s, "+
-			"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials: %w", defaultRef, err))
-	}
-
-	// TODO: make this safe for concurrent operations
-	if err = gitRunner.Run("reset", "--hard", "origin/"+defaultRef); err != nil {
-		return "", errors.E(op, errors.Git, fmt.Errorf("failed to clone repo: trouble reset to %s, "+
-			"please run 'git clone <REPO>; stat <DIR/SUBDIR>' to verify credentials: %w", defaultRef, err))
-	}
-	gitRunner.Dir = filepath.Join(repoCacheDir, dir)
 	return repoCacheDir, nil
 }

--- a/internal/gitutil/gitutil_test.go
+++ b/internal/gitutil/gitutil_test.go
@@ -1,0 +1,453 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitutil_test
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/GoogleContainerTools/kpt/internal/errors"
+	. "github.com/GoogleContainerTools/kpt/internal/gitutil"
+	"github.com/GoogleContainerTools/kpt/internal/testutil"
+	"github.com/GoogleContainerTools/kpt/internal/testutil/pkgbuilder"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMain(m *testing.M) {
+	os.Exit(testutil.ConfigureTestKptCache(m))
+}
+
+func TestLocalGitRunner(t *testing.T) {
+	testCases := map[string]struct {
+		args           []string
+		expectedStdout string
+		expectedErr    *GitExecError
+	}{
+		"successful command with output to stdout": {
+			args:           []string{"branch", "--show-current"},
+			expectedStdout: "main",
+		},
+		"failed command with output to stderr": {
+			args: []string{"checkout", "does-not-exist"},
+			expectedErr: &GitExecError{
+				StdOut: "",
+				StdErr: "error: pathspec 'does-not-exist' did not match any file(s) known to git",
+			},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			dir, err := ioutil.TempDir("", "kpt-test")
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			runner, err := NewLocalGitRunner(dir)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			_, err = runner.Run(context.Background(), "init", "--initial-branch=main")
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			rr, err := runner.Run(context.Background(), tc.args...)
+			if tc.expectedErr != nil {
+				var gitExecError *GitExecError
+				if !errors.As(err, &gitExecError) {
+					t.Error("expected error of type *GitExecError")
+					t.FailNow()
+				}
+				assert.Equal(t, tc.expectedErr.StdOut, strings.TrimSpace(gitExecError.StdOut))
+				assert.Equal(t, tc.expectedErr.StdErr, strings.TrimSpace(gitExecError.StdErr))
+				return
+			}
+
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			assert.Equal(t, tc.expectedStdout, strings.TrimSpace(rr.Stdout))
+		})
+	}
+}
+
+func TestNewGitUpstreamRepo_noRepo(t *testing.T) {
+	dir, err := ioutil.TempDir("", "kpt-test")
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	_, err = NewGitUpstreamRepo(context.Background(), dir)
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+	assert.Contains(t, err.Error(), "does not appear to be a git repository")
+}
+
+func TestNewGitUpstreamRepo_noRefs(t *testing.T) {
+	dir, err := ioutil.TempDir("", "kpt-test")
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	runner, err := NewLocalGitRunner(dir)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	_, err = runner.Run(context.Background(), "init", "--bare")
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	gur, err := NewGitUpstreamRepo(context.Background(), dir)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	assert.Equal(t, 0, len(gur.Heads))
+	assert.Equal(t, 0, len(gur.Tags))
+}
+
+func TestNewGitUpstreamRepo(t *testing.T) {
+	testCases := map[string]struct {
+		repoContent   []testutil.Content
+		expectedHeads []string
+		expectedTags  []string
+	}{
+		"single branch, no tags": {
+			repoContent: []testutil.Content{
+				{
+					Pkg: pkgbuilder.NewRootPkg().
+						WithResource(pkgbuilder.DeploymentResource),
+					Branch: "master",
+				},
+			},
+			expectedHeads: []string{"master"},
+			expectedTags:  []string{},
+		},
+		"multiple tags and branches": {
+			repoContent: []testutil.Content{
+				{
+					Pkg: pkgbuilder.NewRootPkg().
+						WithResource(pkgbuilder.DeploymentResource),
+					Branch: "master",
+					Tag:    "v1",
+				},
+				{
+					Pkg: pkgbuilder.NewRootPkg().
+						WithResource(pkgbuilder.DeploymentResource),
+					Branch:       "main",
+					CreateBranch: true,
+					Tag:          "v2",
+				},
+			},
+			expectedHeads: []string{"main", "master"},
+			expectedTags:  []string{"v1", "v2"},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			repoContent := map[string][]testutil.Content{
+				testutil.Upstream: tc.repoContent,
+			}
+			g, _, clean := testutil.SetupReposAndWorkspace(t, repoContent)
+			defer clean()
+			if !assert.NoError(t, testutil.UpdateRepos(t, g, repoContent)) {
+				t.FailNow()
+			}
+
+			gur, err := NewGitUpstreamRepo(context.Background(), g[testutil.Upstream].RepoDirectory)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			assert.EqualValues(t, tc.expectedHeads, toKeys(gur.Heads))
+			assert.EqualValues(t, tc.expectedTags, toKeys(gur.Tags))
+		})
+	}
+}
+
+func TestGitUpstreamRepo_GetDefaultBranch_noRefs(t *testing.T) {
+	dir, err := ioutil.TempDir("", "kpt-test")
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	runner, err := NewLocalGitRunner(dir)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	_, err = runner.Run(context.Background(), "init", "--bare")
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	gur, err := NewGitUpstreamRepo(context.Background(), dir)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	_, err = gur.GetDefaultBranch(context.Background())
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+	assert.Contains(t, err.Error(), "unable to detect default branch in repo")
+}
+
+func TestGitUpstreamRepo_GetDefaultBranch(t *testing.T) {
+	testCases := map[string]struct {
+		repoContent []testutil.Content
+		expectedRef string
+	}{
+		"selects the default branch if it is the only one available": {
+			repoContent: []testutil.Content{
+				{
+					Data:   testutil.Dataset1,
+					Branch: "main",
+				},
+			},
+			expectedRef: "main",
+		},
+		"selects the default branch if there are multiple branches": {
+			repoContent: []testutil.Content{
+				{
+					Data:   testutil.Dataset1,
+					Branch: "foo",
+				},
+				{
+					Data:   testutil.Dataset2,
+					Branch: "main",
+				},
+				{
+					Data:   testutil.Dataset3,
+					Branch: "master",
+				},
+			},
+			expectedRef: "foo",
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			g, _, clean := testutil.SetupReposAndWorkspace(t, map[string][]testutil.Content{
+				testutil.Upstream: tc.repoContent,
+			})
+			defer clean()
+
+			gur, err := NewGitUpstreamRepo(context.Background(), g[testutil.Upstream].RepoDirectory)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			defaultRef, err := gur.GetDefaultBranch(context.Background())
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			if !assert.Equal(t, tc.expectedRef, defaultRef) {
+				t.FailNow()
+			}
+		})
+	}
+}
+
+func TestGitUpstreamRepo_GetRepo(t *testing.T) {
+	testCases := map[string]struct {
+		repoContent []testutil.Content
+		refsFunc    func(*testing.T, string) []string
+	}{
+		"get branch": {
+			repoContent: []testutil.Content{
+				{
+					Pkg: pkgbuilder.NewRootPkg().
+						WithResource(pkgbuilder.DeploymentResource),
+					Branch: "foo",
+				},
+			},
+			refsFunc: func(*testing.T, string) []string {
+				return []string{"foo"}
+			},
+		},
+		// TODO: We should test both lightweight tags and annotated tags.
+		"get tag": {
+			repoContent: []testutil.Content{
+				{
+					Pkg: pkgbuilder.NewRootPkg().
+						WithResource(pkgbuilder.DeploymentResource),
+					Branch: "foo",
+					Tag:    "abc/123",
+				},
+			},
+			refsFunc: func(*testing.T, string) []string {
+				return []string{"abc/123"}
+			},
+		},
+		"get commit": {
+			repoContent: []testutil.Content{
+				{
+					Pkg: pkgbuilder.NewRootPkg().
+						WithResource(pkgbuilder.DeploymentResource),
+					Branch: "foo",
+					Tag:    "abc/123",
+				},
+			},
+			refsFunc: func(t *testing.T, upstreamPath string) []string {
+				runner, err := NewLocalGitRunner(upstreamPath)
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+				rr, err := runner.Run(context.Background(), "show-ref", "-s", "abc/123")
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+				return []string{strings.TrimSpace(rr.Stdout)}
+			},
+		},
+		"get short commit": {
+			repoContent: []testutil.Content{
+				{
+					Pkg: pkgbuilder.NewRootPkg().
+						WithResource(pkgbuilder.DeploymentResource),
+					Branch: "foo",
+					Tag:    "abc/123",
+				},
+			},
+			refsFunc: func(t *testing.T, upstreamPath string) []string {
+				runner, err := NewLocalGitRunner(upstreamPath)
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+				rr, err := runner.Run(context.Background(), "show-ref", "-s", "abc/123")
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+				sha := strings.TrimSpace(rr.Stdout)
+				rr, err = runner.Run(context.Background(), "rev-parse", "--short", sha)
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+				return []string{strings.TrimSpace(rr.Stdout)}
+			},
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			g, _, clean := testutil.SetupReposAndWorkspace(t, map[string][]testutil.Content{
+				testutil.Upstream: tc.repoContent,
+			})
+			defer clean()
+
+			gur, err := NewGitUpstreamRepo(context.Background(), g[testutil.Upstream].RepoDirectory)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			refs := tc.refsFunc(t, g[testutil.Upstream].RepoDirectory)
+			dir, err := gur.GetRepo(context.Background(), refs)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			runner, err := NewLocalGitRunner(dir)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			for _, r := range refs {
+				sha, found := gur.ResolveRef(r)
+				if !found {
+					// Assume the ref is a commit...
+					sha = r
+				}
+				_, err := runner.Run(context.Background(), "reset", "--hard", sha)
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// Verify that we can fetch two different version of the same ref into the
+// same cached repo.
+func TestGitUpstreamRepo_GetRepo_multipleUpdates(t *testing.T) {
+	branchName := "kpt-test"
+	repoContent := map[string][]testutil.Content{
+		testutil.Upstream: {
+			{
+				Pkg: pkgbuilder.NewRootPkg().
+					WithResource(pkgbuilder.DeploymentResource),
+				Branch: branchName,
+			},
+			{
+				Pkg: pkgbuilder.NewRootPkg().
+					WithResource(pkgbuilder.ConfigMapResource),
+				Branch: branchName,
+			},
+		},
+	}
+	g, _, clean := testutil.SetupReposAndWorkspace(t, repoContent)
+	defer clean()
+
+	firstRepoDir := getRepoAndVerify(t, g[testutil.Upstream].RepoDirectory, branchName)
+	_, err := os.Stat(filepath.Join(firstRepoDir, "deployment.yaml"))
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	if !assert.NoError(t, testutil.UpdateRepos(t, g, repoContent)) {
+		t.FailNow()
+	}
+
+	secondRepoDir := getRepoAndVerify(t, g[testutil.Upstream].RepoDirectory, branchName)
+	_, err = os.Stat(filepath.Join(secondRepoDir, "configmap.yaml"))
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	assert.Equal(t, firstRepoDir, secondRepoDir)
+}
+
+func getRepoAndVerify(t *testing.T, repo, branchName string) string {
+	gur, err := NewGitUpstreamRepo(context.Background(), repo)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	dir, err := gur.GetRepo(context.Background(), []string{branchName})
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	runner, err := NewLocalGitRunner(dir)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	sha, _ := gur.ResolveBranch(branchName)
+	_, err = runner.Run(context.Background(), "reset", "--hard", sha)
+	assert.NoError(t, err)
+
+	return dir
+}
+
+func toKeys(m map[string]string) []string {
+	keys := make([]string, 0)
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/testutil/setup_manager.go
+++ b/internal/testutil/setup_manager.go
@@ -15,6 +15,7 @@
 package testutil
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -107,11 +108,16 @@ func (g *TestSetupManager) Init() bool {
 		}}.Run(fake.CtxWithNilPrinter())) {
 		return false
 	}
-	localGit := gitutil.NewLocalGitRunner(g.LocalWorkspace.WorkspaceDirectory)
-	if !assert.NoError(g.T, localGit.Run("add", ".")) {
+	localGit, err := gitutil.NewLocalGitRunner(g.LocalWorkspace.WorkspaceDirectory)
+	if !assert.NoError(g.T, err) {
 		return false
 	}
-	if !assert.NoError(g.T, localGit.Run("commit", "-m", "add files")) {
+	_, err = localGit.Run(context.Background(), "add", ".")
+	if !assert.NoError(g.T, err) {
+		return false
+	}
+	_, err = localGit.Run(context.Background(), "commit", "-m", "add files")
+	if !assert.NoError(g.T, err) {
 		return false
 	}
 

--- a/internal/util/diff/diff.go
+++ b/internal/util/diff/diff.go
@@ -136,7 +136,11 @@ func (c *Command) Run(ctx context.Context) error {
 	var upstreamTargetPkg string
 
 	if c.Ref == "" {
-		c.Ref, err = gitutil.DefaultRef(kptFile.UpstreamLock.GitLock.Repo)
+		gur, err := gitutil.NewGitUpstreamRepo(ctx, kptFile.UpstreamLock.GitLock.Repo)
+		if err != nil {
+			return err
+		}
+		c.Ref, err = gur.GetDefaultBranch(ctx)
 		if err != nil {
 			return err
 		}

--- a/internal/util/fetch/fetch_test.go
+++ b/internal/util/fetch/fetch_test.go
@@ -29,6 +29,10 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
+func TestMain(m *testing.M) {
+	os.Exit(testutil.ConfigureTestKptCache(m))
+}
+
 func setupWorkspace(t *testing.T) (*testutil.TestGitRepo, *testutil.TestWorkspace, func()) {
 	g, w, clean := testutil.SetupRepoAndWorkspace(t, testutil.Content{
 		Data:   testutil.Dataset1,
@@ -448,7 +452,7 @@ func TestCommand_Run_failInvalidRepo(t *testing.T) {
 	if !assert.Error(t, err) {
 		t.FailNow()
 	}
-	if !assert.Contains(t, err.Error(), "failed to lookup master(or main) branch") {
+	if !assert.Contains(t, err.Error(), "'foo' does not appear to be a git repository") {
 		t.FailNow()
 	}
 }

--- a/internal/util/get/get_test.go
+++ b/internal/util/get/get_test.go
@@ -30,6 +30,10 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
+func TestMain(m *testing.M) {
+	os.Exit(testutil.ConfigureTestKptCache(m))
+}
+
 // TestCommand_Run_failEmptyRepo verifies that Command fail if not repo is provided.
 func TestCommand_Run_failEmptyRepo(t *testing.T) {
 	_, w, clean := testutil.SetupRepoAndWorkspace(t, testutil.Content{})
@@ -732,7 +736,7 @@ func TestCommand_Run_failInvalidRepo(t *testing.T) {
 	if !assert.Error(t, err) {
 		t.FailNow()
 	}
-	if !assert.Contains(t, err.Error(), "failed to lookup master(or main) branch") {
+	if !assert.Contains(t, err.Error(), "'foo' does not appear to be a git repository") {
 		t.FailNow()
 	}
 }

--- a/internal/util/git/git.go
+++ b/internal/util/git/git.go
@@ -37,6 +37,9 @@ type RepoSpec struct {
 	// Dir where the orgRepo is cloned to.
 	Dir string
 
+	// Commit is the commit for the version that was added to Dir.
+	Commit string
+
 	// Relative path in the repository, and in the cloneDir,
 	// to a Kustomization.
 	Path string

--- a/internal/util/parse/parse.go
+++ b/internal/util/parse/parse.go
@@ -15,6 +15,7 @@
 package parse
 
 import (
+	"context"
 	"os"
 	"path"
 	"path/filepath"
@@ -30,7 +31,7 @@ type Target struct {
 	Destination string
 }
 
-func GitParseArgs(args []string) (Target, error) {
+func GitParseArgs(ctx context.Context, args []string) (Target, error) {
 	g := Target{}
 	if args[0] == "-" {
 		return g, nil
@@ -52,7 +53,11 @@ func GitParseArgs(args []string) (Target, error) {
 			dir = parts[1]
 		}
 		if version == "" {
-			defaultRef, err := gitutil.DefaultRef(repo)
+			gur, err := gitutil.NewGitUpstreamRepo(ctx, repo)
+			if err != nil {
+				return g, err
+			}
+			defaultRef, err := gur.GetDefaultBranch(ctx)
 			if err != nil {
 				return g, err
 			}
@@ -81,7 +86,11 @@ func GitParseArgs(args []string) (Target, error) {
 		return g, err
 	}
 	if version == "" {
-		defaultRef, err := gitutil.DefaultRef(repo)
+		gur, err := gitutil.NewGitUpstreamRepo(ctx, repo)
+		if err != nil {
+			return g, err
+		}
+		defaultRef, err := gur.GetDefaultBranch(ctx)
 		if err != nil {
 			return g, err
 		}

--- a/internal/util/update/update.go
+++ b/internal/util/update/update.go
@@ -124,11 +124,16 @@ func (u Command) Run(ctx context.Context) error {
 	}
 
 	// require package is checked into git before trying to update it
-	g := gitutil.NewLocalGitRunner(u.Pkg.UniquePath.String())
-	if err := g.Run("status", "-s"); err != nil {
+	g, err := gitutil.NewLocalGitRunner(u.Pkg.UniquePath.String())
+	if err != nil {
+		return err
+	}
+
+	rr, err := g.Run(ctx, "status", "-s")
+	if err != nil {
 		return errors.E(op, u.Pkg.UniquePath, err)
 	}
-	if strings.TrimSpace(g.Stdout.String()) != "" {
+	if strings.TrimSpace(rr.Stdout) != "" {
 		return errors.E(op, u.Pkg.UniquePath, fmt.Errorf("package must be committed "+
 			"to git before attempting to update"))
 	}

--- a/internal/util/update/update_test.go
+++ b/internal/util/update/update_test.go
@@ -17,6 +17,7 @@ package update_test
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"reflect"
 	"testing"
@@ -37,6 +38,10 @@ import (
 const (
 	kptRepo = "github.com/GoogleContainerTools/kpt"
 )
+
+func TestMain(m *testing.M) {
+	os.Exit(testutil.ConfigureTestKptCache(m))
+}
 
 // TestCommand_Run_noRefChanges updates a package without specifying a new ref.
 // - Get a package using  a branch ref

--- a/pkg/kptfile/kptfileutil/util.go
+++ b/pkg/kptfile/kptfileutil/util.go
@@ -221,12 +221,6 @@ func UpdateUpstreamLockFromGit(path string, spec *git.RepoSpec) error {
 		return errors.E(op, types.UniquePath(path), err)
 	}
 
-	// find the git commit sha that we cloned the package at so we can write it to the KptFile
-	commit, err := git.LookupCommit(spec.AbsPath())
-	if err != nil {
-		return errors.E(op, types.UniquePath(spec.AbsPath()), err)
-	}
-
 	// populate the cloneFrom values so we know where the package came from
 	kpgfile.UpstreamLock = &kptfilev1alpha2.UpstreamLock{
 		Type: kptfilev1alpha2.GitOrigin,
@@ -234,7 +228,7 @@ func UpdateUpstreamLockFromGit(path string, spec *git.RepoSpec) error {
 			Repo:      spec.OrgRepo,
 			Directory: spec.Path,
 			Ref:       spec.Ref,
-			Commit:    commit,
+			Commit:    spec.Commit,
 		},
 	}
 	err = WriteFile(path, kpgfile)


### PR DESCRIPTION
This makes several improvements to how kpt uses git during `get` and `update`:
 * Leverage the cache dir to avoid having to fetch all refs and objects for a repo every time.
 * Fetch refs and the commit their pointing at as the first request to the upstream git repo:
   * Allows us to check for existence of package tags without trying to fetch the ref (and its objects) and therefore avoid what is now duplicated effort if the package ref doesn't exist and we have to fall back to the repo-level ref.
   * Since we will always have the commit SHA for every ref, we can always do `git reset --hard` to check out the specific commit. This means we can avoid creating any local refs (i.e. do `git checkout`).
   * The `git ls-remote` command we use to fetch refs has few failure scenarios if we can talk to the repo. So an error from this command almost certainly means we can't talk to the repo (so auth issues, doesn't exist...).

Some consequences of this change:
 * We no longer fetch git submodules. I think this a case that is unlikely to be used much (and if I'm wrong, we can add support for this later) and we already provide subpackages to handle this kind of cases.
 * This doesn't yet have a way to automatically clean up the kpt cache. Probably not a huge concern for now, but we should see if there is a good way automatically prune.

Fixes: https://github.com/GoogleContainerTools/kpt/issues/1618, https://github.com/GoogleContainerTools/kpt/issues/1376, https://github.com/GoogleContainerTools/kpt/issues/1527, https://github.com/GoogleContainerTools/kpt/issues/1079