### PR TITLE
re-enabling verify samples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,5 +105,4 @@ site-check:
 	./scripts/check-site.sh
 
 site-verify-examples:
-	@echo TODO: re-enable after sample update
-	# ./scripts/verifyExamples.sh
+	./scripts/verifyExamples.sh

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -2978,8 +2978,8 @@
       "dev": true
     },
     "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
     },

--- a/site/reference/README.md
+++ b/site/reference/README.md
@@ -38,7 +38,7 @@ The following are examples of running each kpt command group.
 
 ```shell
 # get a package
-$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/helloworld-set@v0.5.0 helloworld
+$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/helloworld-set@next helloworld
 fetching package /package-examples/helloworld-set from \
   https://github.com/GoogleContainerTools/kpt to helloworld
 ```

--- a/site/reference/fn/export/README.md
+++ b/site/reference/fn/export/README.md
@@ -27,7 +27,7 @@ cd $TEST_HOME
 <!-- @fetchPackage @verifyExamples-->
 ```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
-kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.5.0 DIR/
+kpt pkg get $SRC_REPO/package-examples/helloworld-set@next DIR/
 ```
 
 {{% /hide %}}

--- a/site/reference/fn/source/README.md
+++ b/site/reference/fn/source/README.md
@@ -26,7 +26,7 @@ cd $TEST_HOME
 <!-- @fetchPackage @verifyExamples-->
 ```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
-kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.5.0 DIR/
+kpt pkg get $SRC_REPO/package-examples/helloworld-set@next DIR/
 ```
 
 {{% /hide %}}

--- a/site/reference/live/apply/README.md
+++ b/site/reference/live/apply/README.md
@@ -241,6 +241,11 @@ kpt pkg get $SRC_REPO/package-examples/helloworld-set@next my-dir
 kind delete cluster && kind create cluster
 ```
 
+<!-- @installResourceGroup @verifyExamples-->
+```
+kpt live install-resource-group
+```
+
 <!-- @initCluster @verifyExamples-->
 ```
 kpt live init my-dir

--- a/site/reference/live/apply/README.md
+++ b/site/reference/live/apply/README.md
@@ -233,7 +233,7 @@ cd $TEST_HOME
 <!-- @fetchPackage @verifyExamples-->
 ```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
-kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.5.0 my-dir
+kpt pkg get $SRC_REPO/package-examples/helloworld-set@next my-dir
 ```
 
 <!-- @createKindCluster @verifyExamples-->

--- a/site/reference/live/destroy/README.md
+++ b/site/reference/live/destroy/README.md
@@ -27,7 +27,7 @@ cd $TEST_HOME
 <!-- @fetchPackage @verifyExamples-->
 ```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
-kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.5.0 my-dir
+kpt pkg get $SRC_REPO/package-examples/helloworld-set@next my-dir
 ```
 
 <!-- @createKindCluster @verifyExamples-->

--- a/site/reference/live/destroy/README.md
+++ b/site/reference/live/destroy/README.md
@@ -35,6 +35,11 @@ kpt pkg get $SRC_REPO/package-examples/helloworld-set@next my-dir
 kind delete cluster && kind create cluster
 ```
 
+<!-- @installResourceGroup @verifyExamples-->
+```
+kpt live install-resource-group
+```
+
 <!-- @initCluster @verifyExamples-->
 ```
 kpt live init my-dir

--- a/site/reference/live/init/README.md
+++ b/site/reference/live/init/README.md
@@ -32,7 +32,7 @@ cd $TEST_HOME
 <!-- @fetchPackage @verifyExamples-->
 ```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
-kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.5.0 my-dir
+kpt pkg get $SRC_REPO/package-examples/helloworld-set@next my-dir
 ```
 
 <!-- @createKindCluster @verifyExamples-->

--- a/site/reference/live/init/README.md
+++ b/site/reference/live/init/README.md
@@ -39,6 +39,12 @@ kpt pkg get $SRC_REPO/package-examples/helloworld-set@next my-dir
 ```
 kind delete cluster && kind create cluster
 ```
+
+<!-- @installResourceGroup @verifyExamples-->
+```
+kpt live install-resource-group
+```
+
 {{% /hide %}}
 
 <!--mdtogo:Examples-->

--- a/site/reference/live/init/README.md
+++ b/site/reference/live/init/README.md
@@ -53,7 +53,8 @@ kpt live init my-dir/
 
 <!-- @removeInventoryTemplate @verifyExamples-->
 ```shell
-rm my-dir/inventory-template.yaml
+rm -r my-dir
+kpt pkg get $SRC_REPO/package-examples/helloworld-set@next my-dir
 ```
 
 {{% /hide %}}

--- a/site/reference/live/preview/README.md
+++ b/site/reference/live/preview/README.md
@@ -31,7 +31,7 @@ cd $TEST_HOME
 <!-- @fetchPackage @verifyExamples-->
 ```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
-kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.5.0 my-dir
+kpt pkg get $SRC_REPO/package-examples/helloworld-set@next my-dir
 ```
 
 <!-- @createKindCluster @verifyExamples-->

--- a/site/reference/live/preview/README.md
+++ b/site/reference/live/preview/README.md
@@ -39,6 +39,11 @@ kpt pkg get $SRC_REPO/package-examples/helloworld-set@next my-dir
 kind delete cluster && kind create cluster
 ```
 
+<!-- @installResourceGroup @verifyExamples-->
+```
+kpt live install-resource-group
+```
+
 <!-- @initCluster @verifyExamples-->
 ```
 kpt live init my-dir

--- a/site/reference/live/status/README.md
+++ b/site/reference/live/status/README.md
@@ -37,6 +37,11 @@ kpt pkg get $SRC_REPO/package-examples/helloworld-set@next my-app
 kind delete cluster && kind create cluster
 ```
 
+<!-- @installResourceGroup @verifyExamples-->
+```
+kpt live install-resource-group
+```
+
 <!-- @initCluster @verifyExamples-->
 ```
 kpt live init my-app

--- a/site/reference/live/status/README.md
+++ b/site/reference/live/status/README.md
@@ -29,7 +29,7 @@ cd $TEST_HOME
 <!-- @fetchPackage @verifyExamples-->
 ```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
-kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.5.0 my-app
+kpt pkg get $SRC_REPO/package-examples/helloworld-set@next my-app
 ```
 
 <!-- @createKindCluster @verifyExamples-->

--- a/site/reference/pkg/README.md
+++ b/site/reference/pkg/README.md
@@ -36,7 +36,7 @@ $ git init
 
 # get the package
 $ export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
-$ kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.3.0 helloworld
+$ kpt pkg get $SRC_REPO/package-examples/helloworld-set@next helloworld
 
 # add helloworld to your workspace
 $ git add .

--- a/site/reference/pkg/diff/README.md
+++ b/site/reference/pkg/diff/README.md
@@ -33,7 +33,7 @@ cd $TEST_HOME
 <!-- @fetchPackage @verifyExamples-->
 ```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
-kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.5.0 hello-world
+kpt pkg get $SRC_REPO/package-examples/helloworld-set@next hello-world
 cd hello-world
 ```
 

--- a/site/reference/pkg/tree/README.md
+++ b/site/reference/pkg/tree/README.md
@@ -50,54 +50,12 @@ cd my-dir
 kpt pkg tree
 ```
 
-<!-- @pkgTree @verifyExamples-->
-```shell
-# print replicas, container name, and container image and fields for Resources
-kpt pkg tree --replicas --image --name
-```
-
-<!-- @pkgTree @verifyExamples-->
-```shell
-# print all common Resource fields
-kpt pkg tree --all
-```
-
-<!-- @pkgTree @verifyExamples-->
-```shell
-# print the "foo"" annotation
-kpt pkg tree --field "metadata.annotations.foo"
-```
-
-<!-- @pkgTree @verifyStaleExamples-->
-```shell
-# print the status of resources piped from kubectl output with status.condition 
-type of "Completed"
-kubectl get all -o yaml | kpt pkg tree - \
-  --field="status.conditions[type=Completed].status"
-```
-
-<!-- @pkgTree @verifyStaleExamples-->
-```shell
-# print live Resources from a cluster using owners for graph structure
-kubectl get all -o yaml | kpt pkg tree --replicas --name --image
-```
-
-<!-- @pkgTree @verifyStaleExamples-->
-```shell
-# print live Resources with status condition fields
-kubectl get all -o yaml | kpt pkg tree \
-  --name --image --replicas \
-  --field="status.conditions[type=Completed].status" \
-  --field="status.conditions[type=Complete].status" \
-  --field="status.conditions[type=Ready].status" \
-  --field="status.conditions[type=ContainersReady].status"
-```
 <!--mdtogo-->
 
 ### Synopsis
 <!--mdtogo:Long-->
 ```
-kpt pkg tree [DIR | -] [flags]
+kpt pkg tree [DIR | -]
 ```
 
 #### Args
@@ -110,31 +68,6 @@ DIR:
 #### Flags
 
 ```
---args:
-  if true, print the container args field
 
---command:
-  if true, print the container command field
-
---env:
-  if true, print the container env field
-
---field:
-  dot-separated path to a field to print
-
---image:
-  if true, print the container image fields
-
---name:
-  if true, print the container name fields
-
---ports:
-  if true, print the container port fields
-
---replicas:
-  if true, print the replica field
-
---resources:
-  if true, print the resource reservations
 ```
 <!--mdtogo-->

--- a/site/reference/pkg/tree/README.md
+++ b/site/reference/pkg/tree/README.md
@@ -37,7 +37,7 @@ cd $TEST_HOME
 <!-- @fetchPackage @verifyExamples-->
 ```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
-kpt pkg get $SRC_REPO/package-examples/helloworld-set@v0.5.0 my-dir
+kpt pkg get $SRC_REPO/package-examples/helloworld-set@next my-dir
 cd my-dir
 ```
 


### PR DESCRIPTION
## Description
This re-enables the verify samples check.

Note to the reviewers, this there is a check on several pages that are going to be re-written.  Updating the reference documents is out of scope of this PR.  This is just re-enablement of the check that will aid us in the content we produce for reference docs.

## Testing done

```sh
 ~/src/kpt » make site-verify-examples
....
I0419 17:09:24.352260   58541 scanner.go:55] stream stdOut: done reading
I0419 17:09:24.352394   58541 subshell.go:193] Run:  Waiting for shell to end.
I0419 17:09:24.352429   58541 subshell.go:196] Run:  Wait completed.
I0419 17:09:24.352437   58541 subshell.go:295] Run:  Shell done.
I0419 17:09:24.352447   58541 scanner.go:78] buffScanner: stdOut closed normally
I0419 17:09:24.352450   58541 scanner.go:78] buffScanner: stdErr closed normally
I0419 17:09:24.352487   58541 subshell.go:84] accum stdOut closed.
I0419 17:09:24.352498   58541 subshell.go:84] accum stdErr closed.
Success

```
