### PR TITLE
Ensures ResourceGroup CRD applied before preview/apply on next branch

### DIFF
--- a/commands/livecmd.go
+++ b/commands/livecmd.go
@@ -33,10 +33,6 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/provider"
 )
 
-// resourceGroupEnv is an environment variable which hides code to implement
-// the ResourceGroup inventory object and migrating to ResourceGroup inventory.
-const resourceGroupEnv = "RESOURCE_GROUP_INVENTORY"
-
 func GetLiveCommand(name string, f util.Factory) *cobra.Command {
 	liveCmd := &cobra.Command{
 		Use:   "live",

--- a/internal/cmdliveinit/cmdliveinit.go
+++ b/internal/cmdliveinit/cmdliveinit.go
@@ -58,8 +58,9 @@ func NewKptInitOptions(f cmdutil.Factory, ioStreams genericclioptions.IOStreams)
 // Complete fills in fields for KptInitOptions based on the passed "args".
 func (io *KptInitOptions) Run(args []string) error {
 	// Set the init options directory.
-	if len(args) != 1 {
-		return fmt.Errorf("need one 'directory' arg; have %d", len(args))
+	if len(args) == 0 {
+		// default to the current working directory
+		args = append(args, ".")
 	}
 	dir, err := config.NormalizeDir(args[0])
 	if err != nil {


### PR DESCRIPTION
* Ensures the `ResourceGroup` CRD is applied before the `preview` or `apply` commands are run. Fixes: https://github.com/GoogleContainerTools/kpt/issues/1787
* Fixes `apply` and `init` commands to default to current directory if there are no args (apply currently hangs): Fixes https://github.com/GoogleContainerTools/kpt/issues/1786
* TODO: Resolve duplicate RESTMapper reset code here and in `cli-utils`