### PR TITLE
Remove unused flags for the update command

### DIFF
--- a/commands/livecmd.go
+++ b/commands/livecmd.go
@@ -18,8 +18,8 @@ import (
 	"os"
 
 	"github.com/GoogleContainerTools/kpt/internal/cmdfetchk8sschema"
-	"github.com/GoogleContainerTools/kpt/internal/docs/generated/livedocs"
 	"github.com/GoogleContainerTools/kpt/internal/cmdliveinit"
+	"github.com/GoogleContainerTools/kpt/internal/docs/generated/livedocs"
 	"github.com/GoogleContainerTools/kpt/pkg/live"
 	"github.com/GoogleContainerTools/kpt/thirdparty/cli-utils/destroy"
 	"github.com/GoogleContainerTools/kpt/thirdparty/cli-utils/diff"

--- a/internal/cmdupdate/cmdupdate.go
+++ b/internal/cmdupdate/cmdupdate.go
@@ -48,16 +48,10 @@ func NewRunner(ctx context.Context, parent string) *Runner {
 		SuggestFor: []string{"rebase", "replace"},
 	}
 
-	c.Flags().StringVarP(&r.Update.Repo, "repo", "r", "",
-		"git repo url for updating contents.  defaults to the repo the package was fetched from.")
 	c.Flags().StringVar(&r.strategy, "strategy", string(kptfilev1alpha2.ResourceMerge),
 		"the update strategy that will be used when updating the package. This will change "+
 			"the default strategy for the package -- must be one of: "+
 			strings.Join(kptfilev1alpha2.UpdateStrategiesAsStrings(), ","))
-	c.Flags().BoolVar(&r.Update.DryRun, "dry-run", false,
-		"print the git patch rather than merging it.")
-	c.Flags().BoolVar(&r.Update.Verbose, "verbose", false,
-		"print verbose logging information.")
 	cmdutil.FixDocs("kpt", parent, c)
 	r.Command = c
 	return r

--- a/internal/util/update/update_test.go
+++ b/internal/util/update/update_test.go
@@ -703,41 +703,6 @@ func TestCommand_Run_failInvalidPath(t *testing.T) {
 	}
 }
 
-// TestCommand_Run_failInvalidRepo verifies Run fails if the repo is invalid
-func TestCommand_Run_failInvalidRepo(t *testing.T) {
-	g := &testutil.TestSetupManager{
-		T: t,
-		ReposChanges: map[string][]testutil.Content{
-			testutil.Upstream: {
-				{
-					Data:   testutil.Dataset1,
-					Branch: "master",
-				},
-				{
-					Data: testutil.Dataset2,
-				},
-			},
-		},
-	}
-	defer g.Clean()
-	if !g.Init() {
-		return
-	}
-
-	err := Command{
-		Pkg:  pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
-		Repo: "fake",
-	}.Run(fake.CtxWithNilPrinter())
-	if !assert.Error(t, err) {
-		t.FailNow()
-	}
-	assert.Contains(t, err.Error(), "'fake' does not appear to be a git repository")
-
-	if !g.AssertLocalDataEquals(testutil.Dataset1) {
-		return
-	}
-}
-
 // TestCommand_Run_failInvalidRef verifies Run fails if the ref is invalid
 func TestCommand_Run_failInvalidRef(t *testing.T) {
 	for i := range kptfilev1alpha2.UpdateStrategies {


### PR DESCRIPTION
This removes some unused flags from the `kpt pkg update` command:

 * repo: This would allow users to update from a different repo than the package was originally forked from. This is a difficult situation for merge and unlikely to be used much. 
 * dry-run: This was only used for the git-merge-patch strategy which we no longer support. We could consider a dry-run flag, but currently users can accomplish this easily by just doing the actual update and then remove the changes with git.
 * verbose: If we want to have more output, we should do it either using the klog library or have a solution that works across all kpt commands.
