### PR TITLE
Update quick start guide to include `search-replace` and `kpt update` functionality 

### DIFF
--- a/package-examples/nginx/Kptfile
+++ b/package-examples/nginx/Kptfile
@@ -5,5 +5,3 @@ metadata:
 pipeline:
   validators:
   - image: gcr.io/kpt-fn/kubeval:v0.1
-    configMap:
-      strict: "true"

--- a/package-examples/nginx/deployment.yaml
+++ b/package-examples/nginx/deployment.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -27,7 +26,7 @@ spec:
         app: nginx
     spec:
       containers:
-      - name: nginx
-        image: nginx:1.14.1
-        ports:
-        - containerPort: 80
+        - name: nginx
+          image: nginx:1.14.1
+          ports:
+            - containerPort: 80

--- a/package-examples/nginx/deployment.yaml
+++ b/package-examples/nginx/deployment.yaml
@@ -28,6 +28,6 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:1.14.2
+        image: nginx:1.14.1
         ports:
         - containerPort: 80

--- a/package-examples/nginx/svc.yaml
+++ b/package-examples/nginx/svc.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: Service
 metadata:
@@ -23,4 +22,4 @@ spec:
   selector:
     app: nginx
   ports:
-  - port: 80
+    - port: 80

--- a/site/book/01-getting-started/02-quickstart.md
+++ b/site/book/01-getting-started/02-quickstart.md
@@ -12,7 +12,7 @@ $ kpt pkg get https://github.com/GoogleContainerTools/kpt/package-examples/nginx
 $ cd nginx
 ```
 
-Commit the local package to `git`:
+Commit the local package to git:
 
 ```shell
 git init; git add .; git commit -am "nginx package"
@@ -51,7 +51,7 @@ Often, you want to automatically mutate and/or validate resources in a package.
 `kpt fn` commands enable you to execute programs called _kpt functions_.
 
 For example, you can automatically search and replace all the occurrences of `app` name on resources
-in the package using [path expressions]:
+in the package using path expressions:
 
 ```shell
 $ kpt fn eval --image gcr.io/kpt-fn/search-replace:v0.1 -- 'by-path=spec.**.app' 'put-value=my-nginx'
@@ -119,7 +119,7 @@ Subsequently, there might be updates to the remote `nginx` package which you wan
 A typical `git rebase` might lead to merge conflicts in this scenario. `kpt pkg update` is schema-aware
 and intelligently merges local changes with upstream updates.
 
-Commit your local changes to `git` before update:
+Commit your local changes to git before update:
 
 ```shell
 git add .; git commit -am "customized nginx package"

--- a/site/book/01-getting-started/02-quickstart.md
+++ b/site/book/01-getting-started/02-quickstart.md
@@ -52,9 +52,8 @@ $ kpt fn eval --image gcr.io/kpt-fn/search-replace:v0.1 -- by-value=80 put-value
 
 `eval` command can be used for one-time _imperative_ operations. For operations that need to be
 performed repeatedly, there is a _declarative_ way to define a pipeline of functions as part of the
-package (in the `Kptfile`).
-
-For example, you can declare `set-namespace` function and new desired value in the `pipeline` section of `Kptfile`:
+package (in the `Kptfile`). For example, you can declare `set-namespace` function and new desired value
+in the `pipeline` section of `Kptfile`. This function will set the `namespace` on all the resources in the package.
 
 ```shell
 pipeline:

--- a/site/book/01-getting-started/02-quickstart.md
+++ b/site/book/01-getting-started/02-quickstart.md
@@ -8,7 +8,7 @@ configuration using the underlying Git version control system.
 First, let's fetch the _kpt package_ from Git to your local filesystem:
 
 ```shell
-$ kpt pkg get https://github.com/GoogleContainerTools/kpt/package-examples/nginx@v0.1
+$ kpt pkg get https://github.com/GoogleContainerTools/kpt/package-examples/nginx@v0.2
 $ cd nginx
 ```
 
@@ -126,7 +126,7 @@ git add .; git commit -am "customized nginx package"
 ```
 
 ```shell
-$ kpt pkg update @v0.2
+$ kpt pkg update @v0.3
 ```
 
 You can observe that the changes you have made are intact, along with the new changes from

--- a/site/book/01-getting-started/02-quickstart.md
+++ b/site/book/01-getting-started/02-quickstart.md
@@ -12,6 +12,12 @@ $ kpt pkg get https://github.com/GoogleContainerTools/kpt/package-examples/nginx
 $ cd nginx
 ```
 
+Commit the local package to `git`:
+
+```shell
+git init; git add .; git commit -am "nginx package"
+```
+
 `kpt pkg` commands provide the functionality for working with packages on Git and on your local
 filesystem.
 
@@ -74,9 +80,9 @@ $ kpt fn render
 In this case, the author of the `nginx` package has already declared a function (`kubeval`) that
 validates the resources using their OpenAPI schema.
 
-In general, regardless of the how you choose to customize the package — whether by manually editing
+In general, regardless of how you choose to customize the package — whether by manually editing
 it or running imperative functions — you need to _render_ the package before applying it the
-cluster. This ensure all the functions declared in the package are executed and the package is ready
+cluster. This ensures all the functions declared in the package are executed, and the package is ready
 to be applied to the cluster.
 
 ## Apply the Package
@@ -107,24 +113,24 @@ $ kpt live apply --reconcile-timeout=15m
 
 This waits for the resources to be reconciled on the cluster by monitoring their status.
 
-## Fetch updates
+## Update the package
 
-On Day n, there might be updates to the remote `nginx` package which you want to rebase your local package against.
-A typical `git rebase` might lead to merge conflicts in this scenario. `kpt pkg update` is semantic-aware
+Subsequently, there might be updates to the remote `nginx` package which you want to rebase your local package against.
+A typical `git rebase` might lead to merge conflicts in this scenario. `kpt pkg update` is schema-aware
 and intelligently merges local changes with upstream updates.
 
-First, commit your local changes to `git` before update
+Commit your local changes to `git` before update:
 
 ```shell
-git init; git add .; git commit -am "my-nginx"
+git add .; git commit -am "customized nginx package"
 ```
 
 ```shell
 $ kpt pkg update @v0.2
 ```
 
-You can observe that the changes you have made are in-tact along with the new changes from
-upstream(image version updated in `Deployment` resource) are fetched on to local.
+You can observe that the changes you have made are intact, along with the new changes from
+upstream(image version updated in `Deployment` resource) are fetched onto the local package.
 
 Apply the updated resources to the cluster:
 

--- a/site/book/01-getting-started/02-quickstart.md
+++ b/site/book/01-getting-started/02-quickstart.md
@@ -52,15 +52,15 @@ $ kpt fn eval --image gcr.io/kpt-fn/search-replace:v0.1 -- by-value=80 put-value
 
 `eval` command can be used for one-time _imperative_ operations. For operations that need to be
 performed repeatedly, there is a _declarative_ way to define a pipeline of functions as part of the
-package (in the `Kptfile`). For example, you can declare `set-namespace` function and new desired value
-in the `pipeline` section of `Kptfile`. This function will set the `namespace` on all the resources in the package.
+package (in the `Kptfile`). For example, you can declare `set-label` function in the `pipeline`
+section of `Kptfile`. This function will set the `label` on all the resources in the package.
 
 ```shell
 pipeline:
   mutators:
-  - image: gcr.io/kpt-fn/set-namespace:v0.1
-    configMap:
-      namespace: my-space
+    - image: gcr.io/kpt-fn/set-label:v0.1
+      configMap:
+        env: dev
 ```
 
 This pipeline is executed using the `render` command:
@@ -90,12 +90,6 @@ $ kpt live init
 This adds some metadata to the `Kptfile` required to keep track of changes made to the state of the
 cluster. For example, if a resource is deleted from the package in the future, it will be pruned
 from the cluster.
-
-Create the namespace with name `my-space`
-
-```sh
-$ kubectl create ns my-space
-```
 
 You can preview the changes that will be made to the cluster:
 

--- a/site/book/01-getting-started/02-quickstart.md
+++ b/site/book/01-getting-started/02-quickstart.md
@@ -12,12 +12,6 @@ $ kpt pkg get https://github.com/GoogleContainerTools/kpt/package-examples/nginx
 $ cd nginx
 ```
 
-Commit the local package to git:
-
-```shell
-git init; git add .; git commit -am "Pristine nginx package"
-```
-
 `kpt pkg` commands provide the functionality for working with packages on Git and on your local
 filesystem.
 
@@ -34,6 +28,12 @@ PKG: nginx
 As you can see, this package contains 3 resources in 3 files. There is a special file named
 `Kptfile` which is used by the kpt tool itself and is not deployed to the cluster. Later chapters
 will explain the `Kptfile` in detail.
+
+Initialize a local Git repo and commit the forked copy of the package:
+
+```shell
+git init; git add .; git commit -am "Pristine nginx package"
+```
 
 ## Customize the package
 
@@ -77,7 +77,7 @@ pipeline:
 
 This function will ensure that the label `env: dev` is added to all the resources in the package.
 
-This pipeline is executed using the `render` command:
+The pipeline is executed using the `render` command:
 
 ```shell
 $ kpt fn render
@@ -121,7 +121,7 @@ This waits for the resources to be reconciled on the cluster by monitoring their
 
 ## Update the package
 
-Subsequently, there might be updates to the upstream `nginx` you may be interested in. You want to merge
+At some point, there will be a new version of the upstream `nginx` package, and you want to merge
 the upstream changes with changes to your local package.
 
 First, commit your local changes:

--- a/site/book/01-getting-started/02-quickstart.md
+++ b/site/book/01-getting-started/02-quickstart.md
@@ -35,7 +35,7 @@ At this point, you typically want to customize the package. With kpt, you can us
 approaches depending on your use case.
 
 You may want to manually edit the files. For example, modify the value of `spec.replicas`
-in the `Deployment` resource using your favorite editor:
+in `deployment.yaml` using your favorite editor:
 
 ```shell
 $ vim deployment.yaml
@@ -44,21 +44,33 @@ $ vim deployment.yaml
 Often, you want to automatically mutate and/or validate resources in a package.
 `kpt fn` commands enable you to execute programs called _kpt functions_.
 
-For example, you can automatically set a label with key `env` on all the resources in the package:
+For example, you can automatically search and replace the existing `port` value on all the resources in the package:
 
 ```shell
-$ kpt fn eval --image gcr.io/kpt-fn/set-label:v0.1 -- env=dev
+$ kpt fn eval --image gcr.io/kpt-fn/search-replace:v0.1 -- by-value=80 put-value=8080
 ```
 
 `eval` command can be used for one-time _imperative_ operations. For operations that need to be
 performed repeatedly, there is a _declarative_ way to define a pipeline of functions as part of the
-package (in the `Kptfile`). This pipeline is executed using the `render` command:
+package (in the `Kptfile`).
+
+For example, you can declare `set-namespace` function and new desired value in the `pipeline` section of `Kptfile`:
+
+```shell
+pipeline:
+  mutators:
+  - image: gcr.io/kpt-fn/set-namespace:v0.1
+    configMap:
+      namespace: my-space
+```
+
+This pipeline is executed using the `render` command:
 
 ```shell
 $ kpt fn render
 ```
 
-In this case, the author of the Nginx package has already declared a function (`kubeval`) that
+In this case, the author of the `nginx` package has already declared a function (`kubeval`) that
 validates the resources using their OpenAPI schema.
 
 In general, regardless of the how you choose to customize the package — whether by manually editing
@@ -79,6 +91,12 @@ $ kpt live init
 This adds some metadata to the `Kptfile` required to keep track of changes made to the state of the
 cluster. For example, if a resource is deleted from the package in the future, it will be pruned
 from the cluster.
+
+Create the namespace with name `my-space`
+
+```sh
+$ kubectl create ns my-space
+```
 
 You can preview the changes that will be made to the cluster:
 

--- a/site/book/01-getting-started/02-quickstart.md
+++ b/site/book/01-getting-started/02-quickstart.md
@@ -15,7 +15,7 @@ $ cd nginx
 Commit the local package to git:
 
 ```shell
-git init; git add .; git commit -am "nginx package"
+git init; git add .; git commit -am "Pristine nginx package"
 ```
 
 `kpt pkg` commands provide the functionality for working with packages on Git and on your local
@@ -55,6 +55,12 @@ in the package using path expressions:
 
 ```shell
 $ kpt fn eval --image gcr.io/kpt-fn/search-replace:v0.1 -- 'by-path=spec.**.app' 'put-value=my-nginx'
+```
+
+To see what changes were made to the local package:
+
+```shell
+$ git diff
 ```
 
 `eval` command can be used for one-time _imperative_ operations. For operations that need to be
@@ -115,22 +121,22 @@ This waits for the resources to be reconciled on the cluster by monitoring their
 
 ## Update the package
 
-Subsequently, there might be updates to the remote `nginx` package which you want to rebase your local package against.
-A typical `git rebase` might lead to merge conflicts in this scenario. `kpt pkg update` is schema-aware
-and intelligently merges local changes with upstream updates.
+Subsequently, there might be updates to the upstream `nginx` you may be interested in. You want to merge
+the upstream changes with changes to your local package.
 
-Commit your local changes to git before update:
+First, commit your local changes:
 
 ```shell
-git add .; git commit -am "customized nginx package"
+git add .; git commit -am "My customizations"
 ```
+
+Then update to version `v0.3`:
 
 ```shell
 $ kpt pkg update @v0.3
 ```
 
-You can observe that the changes you have made are intact, along with the new changes from
-upstream(image version updated in `Deployment` resource) are fetched onto the local package.
+This merges the upstream changes with your local changes using a schema-aware merge strategy.
 
 Apply the updated resources to the cluster:
 

--- a/site/book/01-getting-started/02-quickstart.md
+++ b/site/book/01-getting-started/02-quickstart.md
@@ -49,8 +49,7 @@ $ vim deployment.yaml
 
 Often, you want to automatically mutate and/or validate resources in a package.
 `kpt fn` commands enable you to execute programs called _kpt functions_.
-
-For example, you can automatically search and replace all the occurrences of `app` name on resources
+For instance, you can automatically search and replace all the occurrences of `app` name on resources
 in the package using path expressions:
 
 ```shell
@@ -65,9 +64,8 @@ $ git diff
 
 `eval` command can be used for one-time _imperative_ operations. For operations that need to be
 performed repeatedly, there is a _declarative_ way to define a pipeline of functions as part of the
-package (in the `Kptfile`). For example, you might want organize resources in the package using a label `env`.
-To achieve that, you can declare `set-label` function in the `pipeline` section of `Kptfile`.
-This function will ensure that the label `env: dev` is added to all the resources in the package.
+package (in the `Kptfile`). For example, you might want label all resources in the package.
+To achieve that, you can declare `set-label` function in the `pipeline` section of `Kptfile`:
 
 ```shell
 pipeline:
@@ -76,6 +74,8 @@ pipeline:
       configMap:
         env: dev
 ```
+
+This function will ensure that the label `env: dev` is added to all the resources in the package.
 
 This pipeline is executed using the `render` command:
 


### PR DESCRIPTION
This PR does the following:
Updates quick start guide to include `search-replace` and `kpt update` functionality, as they are more relevant. 
Removes `strict: "true"` option from `nginx` package as it is more prone to fail and is unnecessary. 
Updates `nginx` image version to `1.14.1` so that the subsequent version will be updated to `1.14.2`.
Fixes the indentation in `nginx` package so that there are no unwanted diffs.