### PR TITLE
Format output of render command

### DIFF
--- a/e2e/testdata/fn-render/basicpipeline/.expected/diff.patch
+++ b/e2e/testdata/fn-render/basicpipeline/.expected/diff.patch
@@ -1,15 +1,14 @@
 diff --git a/resources.yaml b/resources.yaml
-index 7a494c9..c77c357 100644
+index 7a494c9..a9dd224 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -14,13 +14,26 @@
- apiVersion: apps/v1
+@@ -15,12 +15,25 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
-+  labels:
-+    tier: backend
    name: nginx-deployment
 +  namespace: staging
++  labels:
++    tier: backend
  spec:
    replicas: 3
 +  selector:
@@ -23,9 +22,9 @@ index 7a494c9..c77c357 100644
  apiVersion: custom.io/v1
  kind: Custom
  metadata:
-+  labels:
-+    tier: backend
    name: custom
 +  namespace: staging
++  labels:
++    tier: backend
  spec:
    image: nginx:1.2.3

--- a/e2e/testdata/fn-render/fnconfig/.expected/diff.patch
+++ b/e2e/testdata/fn-render/fnconfig/.expected/diff.patch
@@ -1,16 +1,15 @@
 diff --git a/db/resources.yaml b/db/resources.yaml
-index ac1fd96..a6c12c6 100644
+index ac1fd96..49fa8df 100644
 --- a/db/resources.yaml
 +++ b/db/resources.yaml
-@@ -14,6 +14,19 @@
- apiVersion: apps/v1
+@@ -15,5 +15,18 @@ apiVersion: apps/v1
  kind: StatefulSet
  metadata:
+   name: db
++  namespace: staging
 +  labels:
 +    app: backend
 +    tier: db
-   name: db
-+  namespace: staging
  spec:
    replicas: 3
 +  selector:
@@ -23,17 +22,16 @@ index ac1fd96..a6c12c6 100644
 +        app: backend
 +        tier: db
 diff --git a/resources.yaml b/resources.yaml
-index 7a494c9..5b8e411 100644
+index 7a494c9..ac4edf8 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -14,13 +14,26 @@
- apiVersion: apps/v1
+@@ -15,12 +15,25 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
-+  labels:
-+    tier: db
    name: nginx-deployment
 +  namespace: staging
++  labels:
++    tier: db
  spec:
    replicas: 3
 +  selector:
@@ -47,9 +45,9 @@ index 7a494c9..5b8e411 100644
  apiVersion: custom.io/v1
  kind: Custom
  metadata:
-+  labels:
-+    tier: db
    name: custom
 +  namespace: staging
++  labels:
++    tier: db
  spec:
    image: nginx:1.2.3

--- a/e2e/testdata/fn-render/generator/.expected/diff.patch
+++ b/e2e/testdata/fn-render/generator/.expected/diff.patch
@@ -1,17 +1,17 @@
 diff --git a/db/deployment_httpbin.yaml b/db/deployment_httpbin.yaml
 new file mode 100644
-index 0000000..2bf91c8
+index 0000000..0932111
 --- /dev/null
 +++ b/db/deployment_httpbin.yaml
 @@ -0,0 +1,25 @@
 +apiVersion: apps/v1
 +kind: Deployment
 +metadata:
++  name: httpbin
++  namespace: staging
 +  labels:
 +    app: backend
 +    tier: db
-+  name: httpbin
-+  namespace: staging
 +spec:
 +  replicas: 4
 +  selector:
@@ -25,23 +25,22 @@ index 0000000..2bf91c8
 +        tier: db
 +    spec:
 +      containers:
-+        - image: kennethreitz/httpbin
-+          name: httpbin
++        - name: httpbin
++          image: kennethreitz/httpbin
 +          ports:
 +            - containerPort: 9876
 diff --git a/db/resources.yaml b/db/resources.yaml
-index ac1fd96..a6c12c6 100644
+index ac1fd96..49fa8df 100644
 --- a/db/resources.yaml
 +++ b/db/resources.yaml
-@@ -14,6 +14,19 @@
- apiVersion: apps/v1
+@@ -15,5 +15,18 @@ apiVersion: apps/v1
  kind: StatefulSet
  metadata:
+   name: db
++  namespace: staging
 +  labels:
 +    app: backend
 +    tier: db
-   name: db
-+  namespace: staging
  spec:
    replicas: 3
 +  selector:
@@ -54,17 +53,16 @@ index ac1fd96..a6c12c6 100644
 +        app: backend
 +        tier: db
 diff --git a/resources.yaml b/resources.yaml
-index 7a494c9..5b8e411 100644
+index 7a494c9..ac4edf8 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -14,13 +14,26 @@
- apiVersion: apps/v1
+@@ -15,12 +15,25 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
-+  labels:
-+    tier: db
    name: nginx-deployment
 +  namespace: staging
++  labels:
++    tier: db
  spec:
    replicas: 3
 +  selector:
@@ -78,9 +76,9 @@ index 7a494c9..5b8e411 100644
  apiVersion: custom.io/v1
  kind: Custom
  metadata:
-+  labels:
-+    tier: db
    name: custom
 +  namespace: staging
++  labels:
++    tier: db
  spec:
    image: nginx:1.2.3

--- a/e2e/testdata/fn-render/inline-fnconfig/.expected/diff.patch
+++ b/e2e/testdata/fn-render/inline-fnconfig/.expected/diff.patch
@@ -1,15 +1,14 @@
 diff --git a/resources.yaml b/resources.yaml
-index 7a494c9..c77c357 100644
+index 7a494c9..a9dd224 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -14,13 +14,26 @@
- apiVersion: apps/v1
+@@ -15,12 +15,25 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
-+  labels:
-+    tier: backend
    name: nginx-deployment
 +  namespace: staging
++  labels:
++    tier: backend
  spec:
    replicas: 3
 +  selector:
@@ -23,9 +22,9 @@ index 7a494c9..c77c357 100644
  apiVersion: custom.io/v1
  kind: Custom
  metadata:
-+  labels:
-+    tier: backend
    name: custom
 +  namespace: staging
++  labels:
++    tier: backend
  spec:
    image: nginx:1.2.3

--- a/e2e/testdata/fn-render/resource-deletion/.expected/diff.patch
+++ b/e2e/testdata/fn-render/resource-deletion/.expected/diff.patch
@@ -42,17 +42,16 @@ index 0ef5d14..0000000
 -      - image: kennethreitz/httpbin
 -        name: httpbin
 diff --git a/resources.yaml b/resources.yaml
-index 7a494c9..c77c357 100644
+index 7a494c9..a9dd224 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -14,13 +14,26 @@
- apiVersion: apps/v1
+@@ -15,12 +15,25 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
-+  labels:
-+    tier: backend
    name: nginx-deployment
 +  namespace: staging
++  labels:
++    tier: backend
  spec:
    replicas: 3
 +  selector:
@@ -66,9 +65,9 @@ index 7a494c9..c77c357 100644
  apiVersion: custom.io/v1
  kind: Custom
  metadata:
-+  labels:
-+    tier: backend
    name: custom
 +  namespace: staging
++  labels:
++    tier: backend
  spec:
    image: nginx:1.2.3

--- a/e2e/testdata/fn-render/resource-has-pkgname-prefix/.expected/diff.patch
+++ b/e2e/testdata/fn-render/resource-has-pkgname-prefix/.expected/diff.patch
@@ -1,84 +1,74 @@
 diff --git a/mysql/mysql-deployment.yaml b/mysql/mysql-deployment.yaml
-index eb6a122..b9e519d 100644
+index eb6a122..1fecfa4 100644
 --- a/mysql/mysql-deployment.yaml
 +++ b/mysql/mysql-deployment.yaml
-@@ -14,32 +14,36 @@
- apiVersion: v1
- kind: Service
- metadata:
--  name: wordpress-mysql
-+  annotations:
+@@ -18,14 +18,16 @@ metadata:
+   labels:
+     app: wordpress
+   annotations:
+-    projectId: 'PROJECT_ID' # kpt-set: ${gcloud.core.project}
+-    teamname: 'YOURTEAM' # kpt-set: ${teamname}
 +    abc: def
 +    foo: bar
 +    projectId: PROJECT_ID # kpt-set: ${gcloud.core.project}
 +    teamname: YOURTEAM # kpt-set: ${teamname}
-   labels:
-     app: wordpress
--  annotations:
--    projectId: 'PROJECT_ID' # kpt-set: ${gcloud.core.project}
--    teamname: 'YOURTEAM' # kpt-set: ${teamname}
-+  name: wordpress-mysql
  spec:
-+  clusterIP: None
-   ports:
+-  ports:
 -  - port: 3306
-+    - port: 3306
    selector:
      app: wordpress
      tier: mysql
--  clusterIP: None
++  ports:
++    - port: 3306
+   clusterIP: None
  ---
  apiVersion: v1
- kind: PersistentVolumeClaim
- metadata:
--  name: mysql-pv-claim
-+  annotations:
+@@ -35,14 +37,16 @@ metadata:
+   labels:
+     app: wordpress
+   annotations:
+-    projectId: 'PROJECT_ID' # kpt-set: ${gcloud.core.project}
+-    teamname: 'YOURTEAM' # kpt-set: ${teamname}
 +    abc: def
 +    foo: bar
 +    projectId: PROJECT_ID # kpt-set: ${gcloud.core.project}
 +    teamname: YOURTEAM # kpt-set: ${teamname}
-   labels:
-     app: wordpress
--  annotations:
--    projectId: 'PROJECT_ID' # kpt-set: ${gcloud.core.project}
--    teamname: 'YOURTEAM' # kpt-set: ${teamname}
-+  name: mysql-pv-claim
  spec:
-   accessModes:
+-  accessModes:
 -  - ReadWriteOnce
-+    - ReadWriteOnce
    resources:
      requests:
        storage: 20Gi
-@@ -47,12 +51,14 @@ spec:
++  accessModes:
++    - ReadWriteOnce
+ ---
  apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
  kind: Deployment
- metadata:
--  name: wordpress-mysql
-+  annotations:
+@@ -51,37 +55,42 @@ metadata:
+   labels:
+     app: wordpress
+   annotations:
+-    projectId: 'PROJECT_ID' # kpt-set: ${gcloud.core.project}
+-    teamname: 'YOURTEAM' # kpt-set: ${teamname}
 +    abc: def
 +    foo: bar
 +    projectId: PROJECT_ID # kpt-set: ${gcloud.core.project}
 +    teamname: YOURTEAM # kpt-set: ${teamname}
-   labels:
-     app: wordpress
--  annotations:
--    projectId: 'PROJECT_ID' # kpt-set: ${gcloud.core.project}
--    teamname: 'YOURTEAM' # kpt-set: ${teamname}
-+  name: wordpress-mysql
  spec:
    selector:
      matchLabels:
-@@ -62,26 +68,29 @@ spec:
-     type: Recreate
+       app: wordpress
+       tier: mysql
+-  strategy:
+-    type: Recreate
    template:
      metadata:
-+      annotations:
-+        abc: def
-+        foo: bar
        labels:
          app: wordpress
          tier: mysql
++      annotations:
++        abc: def
++        foo: bar
      spec:
        containers:
 -      - image: mysql:5.6 # kpt-set: ${ms-image}:${ms-tag}
@@ -91,23 +81,24 @@ index eb6a122..b9e519d 100644
 -              key: password
 -        ports:
 -        - containerPort: 3306
-+        - env:
-+            - name: MYSQL_ROOT_PASSWORD
-+              valueFrom:
-+                secretKeyRef:
-+                  key: password
-+                  name: mysql-pass
-+          image: mysql:5.6 # kpt-set: ${ms-image}:${ms-tag}
-           name: mysql
+-          name: mysql
 -        volumeMounts:
 -        - name: mysql-persistent-storage
 -          mountPath: /var/lib/mysql
++        - name: mysql
++          image: mysql:5.6 # kpt-set: ${ms-image}:${ms-tag}
 +          ports:
-+            - containerPort: 3306
-+              name: mysql
++            - name: mysql
++              containerPort: 3306
++          env:
++            - name: MYSQL_ROOT_PASSWORD
++              valueFrom:
++                secretKeyRef:
++                  name: mysql-pass
++                  key: password
 +          volumeMounts:
-+            - mountPath: /var/lib/mysql
-+              name: mysql-persistent-storage
++            - name: mysql-persistent-storage
++              mountPath: /var/lib/mysql
        volumes:
 -      - name: mysql-persistent-storage
 -        persistentVolumeClaim:
@@ -115,85 +106,77 @@ index eb6a122..b9e519d 100644
 +        - name: mysql-persistent-storage
 +          persistentVolumeClaim:
 +            claimName: mysql-pv-claim
++  strategy:
++    type: Recreate
 diff --git a/wordpress-deployment.yaml b/wordpress-deployment.yaml
-index a300019..83e1463 100644
+index 693b8d4..3cbda32 100644
 --- a/wordpress-deployment.yaml
 +++ b/wordpress-deployment.yaml
-@@ -9,18 +9,19 @@
- # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- # See the License for the specific language governing permissions and
- # limitations under the License.
--apiVersion: v1 
-+apiVersion: v1
- kind: Service
- metadata:
--  name: wordpress
-+  annotations:
+@@ -16,15 +16,16 @@ metadata:
+   labels:
+     app: wordpress
+   annotations:
+-    projectId: 'PROJECT_ID' # kpt-set: ${gcloud.core.project}
+-    teamname: 'YOURTEAM' # kpt-set: ${teamname}
 +    abc: def
 +    projectId: PROJECT_ID # kpt-set: ${gcloud.core.project}
 +    teamname: YOURTEAM # kpt-set: ${teamname}
-   labels:
-     app: wordpress
--  annotations:
--    projectId: 'PROJECT_ID' # kpt-set: ${gcloud.core.project}
--    teamname: 'YOURTEAM' # kpt-set: ${teamname}
-+  name: wordpress
  spec:
-   ports:
+-  ports:
 -  - port: 80
-+    - port: 80
++  type: LoadBalancer
    selector:
      app: wordpress
      tier: frontend
-@@ -29,15 +30,16 @@ spec:
+-  type: LoadBalancer
++  ports:
++    - port: 80
+ ---
  apiVersion: v1
  kind: PersistentVolumeClaim
- metadata:
--  name: wp-pv-claim
-+  annotations:
+@@ -33,14 +34,15 @@ metadata:
+   labels:
+     app: wordpress
+   annotations:
+-    projectId: 'PROJECT_ID' # kpt-set: ${gcloud.core.project}
+-    teamname: 'YOURTEAM' # kpt-set: ${teamname}
 +    abc: def
 +    projectId: PROJECT_ID # kpt-set: ${gcloud.core.project}
 +    teamname: YOURTEAM # kpt-set: ${teamname}
-   labels:
-     app: wordpress
--  annotations:
--    projectId: 'PROJECT_ID' # kpt-set: ${gcloud.core.project}
--    teamname: 'YOURTEAM' # kpt-set: ${teamname}
-+  name: wp-pv-claim
  spec:
-   accessModes:
+-  accessModes:
 -  - ReadWriteOnce
-+    - ReadWriteOnce
    resources:
      requests:
        storage: 20Gi
-@@ -45,12 +47,13 @@ spec:
++  accessModes:
++    - ReadWriteOnce
+ ---
  apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
  kind: Deployment
- metadata:
--  name: wordpress
-+  annotations:
+@@ -49,39 +51,42 @@ metadata:
+   labels:
+     app: wordpress
+   annotations:
+-    projectId: 'PROJECT_ID' # kpt-set: ${gcloud.core.project}
+-    teamname: 'YOURTEAM' # kpt-set: ${teamname}
 +    abc: def
 +    projectId: PROJECT_ID # kpt-set: ${gcloud.core.project}
 +    teamname: YOURTEAM # kpt-set: ${teamname}
-   labels:
-     app: wordpress
--  annotations:
--    projectId: 'PROJECT_ID' # kpt-set: ${gcloud.core.project}
--    teamname: 'YOURTEAM' # kpt-set: ${teamname}
-+  name: wordpress
  spec:
    selector:
      matchLabels:
-@@ -60,28 +63,30 @@ spec:
-     type: Recreate
+       app: wordpress
+       tier: frontend
+-  strategy:
+-    type: Recreate
    template:
      metadata:
-+      annotations:
-+        abc: def
        labels:
          app: wordpress
          tier: frontend
++      annotations:
++        abc: def
      spec:
        containers:
 -      - image: wordpress:4.8-apache # kpt-set: ${wp-image}:${wp-tag}
@@ -208,25 +191,26 @@ index a300019..83e1463 100644
 -              key: password
 -        ports:
 -        - containerPort: 80
-+        - env:
+-          name: wordpress
+-        volumeMounts:
+-        - name: wordpress-persistent-storage
+-          mountPath: /var/www/html
++        - name: wordpress
++          image: wordpress:4.8-apache # kpt-set: ${wp-image}:${wp-tag}
++          ports:
++            - name: wordpress
++              containerPort: 80
++          env:
 +            - name: WORDPRESS_DB_HOST
 +              value: wordpress-mysql
 +            - name: WORDPRESS_DB_PASSWORD
 +              valueFrom:
 +                secretKeyRef:
-+                  key: password
 +                  name: mysql-pass
-+          image: wordpress:4.8-apache # kpt-set: ${wp-image}:${wp-tag}
-           name: wordpress
--        volumeMounts:
--        - name: wordpress-persistent-storage
--          mountPath: /var/www/html
-+          ports:
-+            - containerPort: 80
-+              name: wordpress
++                  key: password
 +          volumeMounts:
-+            - mountPath: /var/www/html
-+              name: wordpress-persistent-storage
++            - name: wordpress-persistent-storage
++              mountPath: /var/www/html
        volumes:
 -      - name: wordpress-persistent-storage
 -        persistentVolumeClaim:
@@ -234,3 +218,5 @@ index a300019..83e1463 100644
 +        - name: wordpress-persistent-storage
 +          persistentVolumeClaim:
 +            claimName: wp-pv-claim
++  strategy:
++    type: Recreate

--- a/e2e/testdata/fn-render/resource-has-pkgname-prefix/wordpress-deployment.yaml
+++ b/e2e/testdata/fn-render/resource-has-pkgname-prefix/wordpress-deployment.yaml
@@ -9,7 +9,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: v1 
+apiVersion: v1
 kind: Service
 metadata:
   name: wordpress

--- a/e2e/testdata/fn-render/subpkg-resource-deletion/.expected/diff.patch
+++ b/e2e/testdata/fn-render/subpkg-resource-deletion/.expected/diff.patch
@@ -1,5 +1,5 @@
 diff --git a/db/resources.yaml b/db/resources.yaml
-index 3aca276..adf2fec 100644
+index 3aca276..9dabb18 100644
 --- a/db/resources.yaml
 +++ b/db/resources.yaml
 @@ -1,27 +1,10 @@
@@ -27,11 +27,11 @@ index 3aca276..adf2fec 100644
  apiVersion: custom.io/v1
  kind: Custom
  metadata:
+   name: custom
++  namespace: staging
 +  labels:
 +    app: backend
 +    tier: backend
-   name: custom
-+  namespace: staging
  spec:
    image: nginx:1.2.3
 diff --git a/deployment_httpbin.yaml b/deployment_httpbin.yaml
@@ -78,17 +78,16 @@ index 0ef5d14..0000000
 -      - image: kennethreitz/httpbin
 -        name: httpbin
 diff --git a/resources.yaml b/resources.yaml
-index 6590f6c..725ad34 100644
+index 6590f6c..b5b54e0 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -14,6 +14,16 @@
- apiVersion: apps/v1
+@@ -15,5 +15,15 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
-+  labels:
-+    tier: backend
    name: nginx-deployment
 +  namespace: staging
++  labels:
++    tier: backend
  spec:
    replicas: 3
 +  selector:

--- a/e2e/testdata/fn-render/subpkgs/.expected/diff.patch
+++ b/e2e/testdata/fn-render/subpkgs/.expected/diff.patch
@@ -1,16 +1,15 @@
 diff --git a/db/resources.yaml b/db/resources.yaml
-index ac1fd96..a6c12c6 100644
+index ac1fd96..49fa8df 100644
 --- a/db/resources.yaml
 +++ b/db/resources.yaml
-@@ -14,6 +14,19 @@
- apiVersion: apps/v1
+@@ -15,5 +15,18 @@ apiVersion: apps/v1
  kind: StatefulSet
  metadata:
+   name: db
++  namespace: staging
 +  labels:
 +    app: backend
 +    tier: db
-   name: db
-+  namespace: staging
  spec:
    replicas: 3
 +  selector:
@@ -23,17 +22,16 @@ index ac1fd96..a6c12c6 100644
 +        app: backend
 +        tier: db
 diff --git a/resources.yaml b/resources.yaml
-index 7a494c9..5b8e411 100644
+index 7a494c9..ac4edf8 100644
 --- a/resources.yaml
 +++ b/resources.yaml
-@@ -14,13 +14,26 @@
- apiVersion: apps/v1
+@@ -15,12 +15,25 @@ apiVersion: apps/v1
  kind: Deployment
  metadata:
-+  labels:
-+    tier: db
    name: nginx-deployment
 +  namespace: staging
++  labels:
++    tier: db
  spec:
    replicas: 3
 +  selector:
@@ -47,9 +45,9 @@ index 7a494c9..5b8e411 100644
  apiVersion: custom.io/v1
  kind: Custom
  metadata:
-+  labels:
-+    tier: db
    name: custom
 +  namespace: staging
++  labels:
++    tier: db
  spec:
    image: nginx:1.2.3

--- a/internal/cmdrender/executor.go
+++ b/internal/cmdrender/executor.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/types"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/kio/filters"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 	"sigs.k8s.io/kustomize/kyaml/sets"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
@@ -66,6 +67,13 @@ func (e *Executor) Execute(ctx context.Context) error {
 	}
 
 	pkgWriter := &kio.LocalPackageReadWriter{PackagePath: string(root.pkg.UniquePath)}
+
+	// format resources before writing
+	_, err = filters.FormatFilter{UseSchema: true}.Filter(resources)
+	if err != nil {
+		return err
+	}
+
 	err = pkgWriter.Write(resources)
 	if err != nil {
 		return fmt.Errorf("failed to save resources: %w", err)


### PR DESCRIPTION
This PR adds format step for render command before writing the resources. Field ordering follows the ordering defined in the source Kubernetes [resource definitions](https://github.com/kubernetes-sigs/kustomize/blob/master/kyaml/openapi/kubernetesapi/v1204/swagger.json), falling back on lexicographical sorting for unrecognized fields.

Also updates e2e tests where the output is not formatted.