### PR TITLE
Resolve errors to user-facing messages at the top level

### DIFF
--- a/internal/errors/resolver/resolver.go
+++ b/internal/errors/resolver/resolver.go
@@ -1,0 +1,66 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolver
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+)
+
+// errorResolvers is the list of known resolvers for kpt errors.
+var errorResolvers []ErrorResolver
+
+// AddErrorResolver adds the provided error resolver to the list of resolvers
+// which will be used to resolve errors.
+func AddErrorResolver(er ErrorResolver) {
+	errorResolvers = append(errorResolvers, er)
+}
+
+// ResolveError attempts to resolve the provided error into a descriptive
+// string which will be displayed to the user. If the last return value is false,
+// the error could not be resolved.
+func ResolveError(err error) (string, bool) {
+	for _, resolver := range errorResolvers {
+		msg, found := resolver.Resolve(err)
+		if found {
+			return msg, true
+		}
+	}
+	return "", false
+}
+
+// ExecuteTemplate takes the provided template string and data, and renders
+// the template. If something goes wrong, it panics.
+func ExecuteTemplate(text string, data interface{}) (string, bool) {
+	tmpl, tmplErr := template.New("kpterror").Parse(text)
+	if tmplErr != nil {
+		panic(fmt.Errorf("error creating template: %w", tmplErr))
+	}
+
+	var b bytes.Buffer
+	execErr := tmpl.Execute(&b, data)
+	if execErr != nil {
+		panic(fmt.Errorf("error executing template: %w", execErr))
+	}
+	return strings.TrimSpace(b.String()), true
+}
+
+// ErrorResolver is an interface that allows kpt to resolve an error into
+// an error message suitable for the end user.
+type ErrorResolver interface {
+	Resolve(err error) (string, bool)
+}

--- a/internal/errors/resolver/resolvers.go
+++ b/internal/errors/resolver/resolvers.go
@@ -1,0 +1,93 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolver
+
+import (
+	goerrors "errors"
+	"fmt"
+	"strings"
+
+	"github.com/GoogleContainerTools/kpt/internal/gitutil"
+)
+
+//nolint:gochecknoinits
+func init() {
+	AddErrorResolver(&gitExecErrorResolver{})
+}
+
+const (
+	genericGitExecError = `
+Error executing git command {{ printf "%q " .gitcmd }}
+{{- if gt (len .repo) 0 -}}
+against repo {{ printf "%q " .repo }}
+{{- end }}
+{{- if gt (len .ref) 0 -}}
+for reference {{ printf "%q " .ref }}
+{{- end }}
+
+{{- if gt (len .stdout) 0 }}
+{{ printf "\nStdOut:" }}
+{{ printf "%s" .stdout }}
+{{- end }}
+
+{{- if gt (len .stderr) 0 }}
+{{ printf "\nStdErr:" }}
+{{ printf "%s" .stderr }}
+{{- end }}
+`
+
+	unknownRefGitExecError = `
+Unknown ref {{ printf "%q" .ref }}. Please verify that the reference exists in upstream repo {{ printf "%q" .repo }}.
+
+{{- if gt (len .stdout) 0 }}
+{{ printf "\nStdOut:" }}
+{{ printf "%s" .stdout }}
+{{- end }}
+
+{{- if gt (len .stderr) 0 }}
+{{ printf "\nStdErr:" }}
+{{ printf "%s" .stderr }}
+{{- end }}
+`
+)
+
+// gitExecErrorResolver is an implementation of the ErrorResolver interface
+// that can produce error messages for errors of the gitutil.GitExecError type.
+type gitExecErrorResolver struct{}
+
+func (*gitExecErrorResolver) Resolve(err error) (string, bool) {
+	var gitExecErr *gitutil.GitExecError
+	if !goerrors.As(err, &gitExecErr) {
+		return "", false
+	}
+	fullCommand := fmt.Sprintf("git %s %s", gitExecErr.Command,
+		strings.Join(gitExecErr.Args, " "))
+	tmplArgs := map[string]interface{}{
+		"gitcmd": fullCommand,
+		"repo":   gitExecErr.Repo,
+		"ref":    gitExecErr.Ref,
+		"stdout": gitExecErr.StdOut,
+		"stderr": gitExecErr.StdErr,
+	}
+	switch {
+	// TODO(mortent): Checking the content of the output at this level seems a bit awkward. We might
+	// consider doing this the the gitutil package and use some kind of error code to signal
+	// the different error cases to higher levels in the stack.
+	case strings.Contains(gitExecErr.StdErr, " unknown revision or path not in the working tree"):
+		return ExecuteTemplate(unknownRefGitExecError, tmplArgs)
+	default:
+		return ExecuteTemplate(genericGitExecError, tmplArgs)
+	}
+}

--- a/internal/errors/resolver/resolvers.go
+++ b/internal/errors/resolver/resolvers.go
@@ -29,7 +29,7 @@ func init() {
 
 const (
 	genericGitExecError = `
-Error executing git command {{ printf "%q " .gitcmd }}
+Error: Failed to execute git command {{ printf "%q " .gitcmd }}
 {{- if gt (len .repo) 0 -}}
 against repo {{ printf "%q " .repo }}
 {{- end }}
@@ -37,27 +37,31 @@ against repo {{ printf "%q " .repo }}
 for reference {{ printf "%q " .ref }}
 {{- end }}
 
+{{- if or (gt (len .stdout) 0) (gt (len .stderr) 0)}}
+{{ printf "\nDetails:" }}
+{{- end }}
+
 {{- if gt (len .stdout) 0 }}
-{{ printf "\nStdOut:" }}
 {{ printf "%s" .stdout }}
 {{- end }}
 
 {{- if gt (len .stderr) 0 }}
-{{ printf "\nStdErr:" }}
 {{ printf "%s" .stderr }}
 {{- end }}
 `
 
 	unknownRefGitExecError = `
-Unknown ref {{ printf "%q" .ref }}. Please verify that the reference exists in upstream repo {{ printf "%q" .repo }}.
+Error: Unknown ref {{ printf "%q" .ref }}. Please verify that the reference exists in upstream repo {{ printf "%q" .repo }}.
+
+{{- if or (gt (len .stdout) 0) (gt (len .stderr) 0)}}
+{{ printf "\nDetails:" }}
+{{- end }}
 
 {{- if gt (len .stdout) 0 }}
-{{ printf "\nStdOut:" }}
 {{ printf "%s" .stdout }}
 {{- end }}
 
 {{- if gt (len .stderr) 0 }}
-{{ printf "\nStdErr:" }}
 {{ printf "%s" .stderr }}
 {{- end }}
 `

--- a/internal/gitutil/gitutil_test.go
+++ b/internal/gitutil/gitutil_test.go
@@ -36,16 +36,19 @@ func TestMain(m *testing.M) {
 
 func TestLocalGitRunner(t *testing.T) {
 	testCases := map[string]struct {
+		command        string
 		args           []string
 		expectedStdout string
 		expectedErr    *GitExecError
 	}{
 		"successful command with output to stdout": {
-			args:           []string{"branch", "--show-current"},
+			command:        "branch",
+			args:           []string{"--show-current"},
 			expectedStdout: "main",
 		},
 		"failed command with output to stderr": {
-			args: []string{"checkout", "does-not-exist"},
+			command: "checkout",
+			args:    []string{"does-not-exist"},
 			expectedErr: &GitExecError{
 				StdOut: "",
 				StdErr: "error: pathspec 'does-not-exist' did not match any file(s) known to git",
@@ -69,7 +72,7 @@ func TestLocalGitRunner(t *testing.T) {
 				t.FailNow()
 			}
 
-			rr, err := runner.Run(context.Background(), tc.args...)
+			rr, err := runner.Run(context.Background(), tc.command, tc.args...)
 			if tc.expectedErr != nil {
 				var gitExecError *GitExecError
 				if !errors.As(err, &gitExecError) {

--- a/internal/util/fetch/fetch.go
+++ b/internal/util/fetch/fetch.go
@@ -169,6 +169,10 @@ func ClonerUsingGitExec(ctx context.Context, repoSpec *git.RepoSpec) error {
 	// sure that any changes in the local worktree are cleaned out.
 	_, err = gitRunner.Run(ctx, "reset", "--hard", commit)
 	if err != nil {
+		gitutil.AmendGitExecError(err, func(e *gitutil.GitExecError) {
+			e.Repo = repoSpec.CloneSpec()
+			e.Ref = commit
+		})
 		return errors.E(op, errors.Git, errors.Repo(repoSpec.CloneSpec()), err)
 	}
 


### PR DESCRIPTION
This is a POC for how we can keep the general error handling solution (which prints the trace to the user) with a way to have better actionable and informative errors for "expected" error situations. This solution allows us to handle errors at the cobra level (so avoid printing of error message scattered through the codebase), provide clear error messages when possible, and fall back to the full trace for errors that we "don't expect". 