### PR TITLE
Output message for kpt live init on next branch

### DIFF
--- a/commands/migratecmd.go
+++ b/commands/migratecmd.go
@@ -187,6 +187,7 @@ func (mr *MigrateRunner) updateKptfile(args []string, prevID string) error {
 	if !mr.dryRun {
 		// Set inventory ID from previous inventory object.
 		mr.initOptions.InventoryID = prevID
+		mr.initOptions.Quiet = true
 		if err := mr.initOptions.Run(args); err != nil {
 			if _, exists := err.(*cmdliveinit.InvExistsError); exists {
 				fmt.Fprint(mr.ioStreams.Out, "values already exist...")

--- a/e2e/live/end-to-end-test.sh
+++ b/e2e/live/end-to-end-test.sh
@@ -429,13 +429,33 @@ printResult
 echo "Testing init for Kptfile/ResourceGroup"
 echo "kpt live init e2e/live/testdata/rg-test-case-1a"
 cp -f e2e/live/testdata/Kptfile e2e/live/testdata/rg-test-case-1a
-${BIN_DIR}/kpt live init e2e/live/testdata/rg-test-case-1a
+${BIN_DIR}/kpt live init e2e/live/testdata/rg-test-case-1a > $OUTPUT_DIR/status
+assertContains "initializing Kptfile inventory info (namespace: rg-test-namespace)...success"
 # Difference in Kptfile should have inventory data
 diff e2e/live/testdata/Kptfile e2e/live/testdata/rg-test-case-1a/Kptfile > $OUTPUT_DIR/status 2>&1
 assertContains "inventory:"
 assertContains "namespace: rg-test-namespace"
 assertContains "name: inventory-"
 assertContains "inventoryID:"
+printResult
+
+echo "Testing init Kptfile/ResourceGroup already initialized"
+echo "kpt live init e2e/live/testdata/rg-test-case-1a"
+${BIN_DIR}/kpt live init e2e/live/testdata/rg-test-case-1a > $OUTPUT_DIR/status 2>&1
+assertContains "initializing Kptfile inventory info (namespace: rg-test-namespace)...failed"
+assertContains "error: ResourceGroup configuration has already been created."
+printResult
+
+echo "Testing init force Kptfile/ResourceGroup"
+echo "kpt live init --force e2e/live/testdata/rg-test-case-1a"
+${BIN_DIR}/kpt live init --force e2e/live/testdata/rg-test-case-1a > $OUTPUT_DIR/status 2>&1
+assertContains "initializing Kptfile inventory info (namespace: rg-test-namespace)...success"
+printResult
+
+echo "Testing init quiet Kptfile/ResourceGroup"
+echo "kpt live init --quiet e2e/live/testdata/rg-test-case-1a"
+${BIN_DIR}/kpt live init --quiet e2e/live/testdata/rg-test-case-1a > $OUTPUT_DIR/status 2>&1
+assertNotContains "initializing Kptfile inventory info"
 printResult
 
 # Test: Basic kpt live preview


### PR DESCRIPTION
* Output messaging during `kpt live init` (makes `next` branch similar to `master` branch).
* Adds `--quiet` flag to `kpt live init` (to make it equivalent to the `master` branch).
* Adds `end-to-end.sh` tests to validate functionality.
* Fixes: https://github.com/GoogleContainerTools/kpt/issues/1800
```
$ kpt live init e2e/live/testdata/rg-test-case-1a
initializing Kptfile inventory info (namespace: rg-test-namespace)...success

$ kpt live init e2e/live/testdata/rg-test-case-1a
initializing Kptfile inventory info (namespace: rg-test-namespace)...failed
error: ResourceGroup configuration has already been created. Changing
them after a package has been applied to the cluster can lead to
undesired results. Use the --force flag to suppress this error.
```
