### PR TITLE
Fix typo in `info.emails`

### DIFF
--- a/package-examples/wordpress/Kptfile
+++ b/package-examples/wordpress/Kptfile
@@ -3,9 +3,8 @@ kind: Kptfile
 metadata:
   name: wordpress
 info:
-  site: https://github.com/GoogleContainerTools/kpt
   description: This is an example wordpress package with mysql subpackage
-  email:
+  emails:
   - kpt-team@google.com
 pipeline:
   mutators:


### PR DESCRIPTION
This illustrates the need for validation prior to publishing. `Render` needs to provide this guarantees since it preceeds `Publish`: https://kpt.dev/book/02-concepts/02-package-lifecycle