### PR TITLE
Rename the GitLock field on UpstreamLock to Git

### DIFF
--- a/commands/migratecmd_test.go
+++ b/commands/migratecmd_test.go
@@ -349,7 +349,7 @@ metadata:
   name: test1
 upstreamLock:
   type: git
-  gitLock:
+  git:
     repo: git@github.com:seans3/blueprint-helloworld
     directory: /
     ref: master
@@ -367,7 +367,7 @@ metadata:
   name: test1
 upstreamLock:
   type: git
-  gitLock:
+  git:
     repo: git@github.com:seans3/blueprint-helloworld
     directory: /
     ref: master

--- a/internal/cmdget/cmdget_test.go
+++ b/internal/cmdget/cmdget_test.go
@@ -78,7 +78,7 @@ func TestCmd_execute(t *testing.T) {
 		},
 		UpstreamLock: &kptfilev1alpha2.UpstreamLock{
 			Type: kptfilev1alpha2.GitOrigin,
-			GitLock: &kptfilev1alpha2.GitLock{
+			Git: &kptfilev1alpha2.GitLock{
 				Directory: "/",
 				Repo:      "file://" + g.RepoDirectory,
 				Ref:       "master",
@@ -136,7 +136,7 @@ func TestCmdMainBranch_execute(t *testing.T) {
 		},
 		UpstreamLock: &kptfilev1alpha2.UpstreamLock{
 			Type: kptfilev1alpha2.GitOrigin,
-			GitLock: &kptfilev1alpha2.GitLock{
+			Git: &kptfilev1alpha2.GitLock{
 				Directory: "/",
 				Repo:      "file://" + g.RepoDirectory,
 				Ref:       "main",

--- a/internal/cmdliveinit/cmdliveinit_test.go
+++ b/internal/cmdliveinit/cmdliveinit_test.go
@@ -29,7 +29,7 @@ metadata:
   name: test1
 upstreamLock:
   type: git
-  gitLock:
+  git:
     repo: git@github.com:seans3/blueprint-helloworld
     directory: /
     ref: master
@@ -44,7 +44,7 @@ metadata:
   name: test1
 upstreamLock:
   type: git
-  gitLock:
+  git:
     repo: git@github.com:seans3/blueprint-helloworld
     directory: /
     ref: master

--- a/internal/cmdupdate/cmdupdate_test.go
+++ b/internal/cmdupdate/cmdupdate_test.go
@@ -117,7 +117,7 @@ func TestCmd_execute(t *testing.T) {
 		},
 		UpstreamLock: &kptfilev1alpha2.UpstreamLock{
 			Type: kptfilev1alpha2.GitOrigin,
-			GitLock: &kptfilev1alpha2.GitLock{
+			Git: &kptfilev1alpha2.GitLock{
 				Repo:      "file://" + g.RepoDirectory,
 				Ref:       "master",
 				Directory: "/",

--- a/internal/testutil/pkgbuilder/builder.go
+++ b/internal/testutil/pkgbuilder/builder.go
@@ -516,7 +516,7 @@ upstream:
 {{- if .Pkg.Kptfile.UpstreamLock }}
 upstreamLock:
   type: git
-  gitLock:
+  git:
     commit: {{.Pkg.Kptfile.UpstreamLock.Commit}}
     directory: {{.Pkg.Kptfile.UpstreamLock.Dir}}
     ref: {{.Pkg.Kptfile.UpstreamLock.Ref}}

--- a/internal/testutil/setup_manager.go
+++ b/internal/testutil/setup_manager.go
@@ -208,7 +208,7 @@ func (g *TestSetupManager) AssertKptfile(name, commit, ref string, strategy kptf
 		},
 		UpstreamLock: &kptfilev1alpha2.UpstreamLock{
 			Type: "git",
-			GitLock: &kptfilev1alpha2.GitLock{
+			Git: &kptfilev1alpha2.GitLock{
 				Directory: g.GetSubDirectory,
 				Repo:      g.Repos[Upstream].RepoDirectory,
 				Ref:       ref,

--- a/internal/util/diff/diff.go
+++ b/internal/util/diff/diff.go
@@ -121,9 +121,9 @@ func (c *Command) Run(ctx context.Context) error {
 	}
 
 	// get the upstreamPkg at current version
-	upstreamPkg, err := c.PkgGetter.GetPkg(ctx, kptFile.UpstreamLock.GitLock.Repo,
-		kptFile.UpstreamLock.GitLock.Directory,
-		kptFile.UpstreamLock.GitLock.Commit)
+	upstreamPkg, err := c.PkgGetter.GetPkg(ctx, kptFile.UpstreamLock.Git.Repo,
+		kptFile.UpstreamLock.Git.Directory,
+		kptFile.UpstreamLock.Git.Commit)
 	if err != nil {
 		return err
 	}
@@ -136,7 +136,7 @@ func (c *Command) Run(ctx context.Context) error {
 	var upstreamTargetPkg string
 
 	if c.Ref == "" {
-		gur, err := gitutil.NewGitUpstreamRepo(ctx, kptFile.UpstreamLock.GitLock.Repo)
+		gur, err := gitutil.NewGitUpstreamRepo(ctx, kptFile.UpstreamLock.Git.Repo)
 		if err != nil {
 			return err
 		}
@@ -150,8 +150,8 @@ func (c *Command) Run(ctx context.Context) error {
 		c.DiffType == DiffTypeCombined ||
 		c.DiffType == DiffType3Way {
 		// get the upstream pkg at the target version
-		upstreamTargetPkg, err = c.PkgGetter.GetPkg(ctx, kptFile.UpstreamLock.GitLock.Repo,
-			kptFile.UpstreamLock.GitLock.Directory,
+		upstreamTargetPkg, err = c.PkgGetter.GetPkg(ctx, kptFile.UpstreamLock.Git.Repo,
+			kptFile.UpstreamLock.Git.Directory,
 			c.Ref)
 		if err != nil {
 			return err

--- a/internal/util/fetch/fetch_test.go
+++ b/internal/util/fetch/fetch_test.go
@@ -204,7 +204,7 @@ func TestCommand_Run(t *testing.T) {
 		},
 		UpstreamLock: &kptfilev1alpha2.UpstreamLock{
 			Type: "git",
-			GitLock: &kptfilev1alpha2.GitLock{
+			Git: &kptfilev1alpha2.GitLock{
 				Directory: "/",
 				Repo:      "file://" + g.RepoDirectory,
 				Ref:       "master",
@@ -266,7 +266,7 @@ func TestCommand_Run_subdir(t *testing.T) {
 		},
 		UpstreamLock: &kptfilev1alpha2.UpstreamLock{
 			Type: kptfilev1alpha2.GitOrigin,
-			GitLock: &kptfilev1alpha2.GitLock{
+			Git: &kptfilev1alpha2.GitLock{
 				Commit:    commit,
 				Directory: subdir,
 				Ref:       "refs/heads/master",
@@ -342,7 +342,7 @@ func TestCommand_Run_branch(t *testing.T) {
 		},
 		UpstreamLock: &kptfilev1alpha2.UpstreamLock{
 			Type: kptfilev1alpha2.GitOrigin,
-			GitLock: &kptfilev1alpha2.GitLock{
+			Git: &kptfilev1alpha2.GitLock{
 				Directory: "/",
 				Repo:      g.RepoDirectory,
 				Ref:       "refs/heads/exp",
@@ -423,7 +423,7 @@ func TestCommand_Run_tag(t *testing.T) {
 		},
 		UpstreamLock: &kptfilev1alpha2.UpstreamLock{
 			Type: "git",
-			GitLock: &kptfilev1alpha2.GitLock{
+			Git: &kptfilev1alpha2.GitLock{
 				Directory: "/",
 				Repo:      g.RepoDirectory,
 				Ref:       "refs/tags/v2",

--- a/internal/util/get/get_test.go
+++ b/internal/util/get/get_test.go
@@ -106,7 +106,7 @@ func TestCommand_Run(t *testing.T) {
 		},
 		UpstreamLock: &kptfilev1alpha2.UpstreamLock{
 			Type: kptfilev1alpha2.GitOrigin,
-			GitLock: &kptfilev1alpha2.GitLock{
+			Git: &kptfilev1alpha2.GitLock{
 				Directory: "/",
 				Repo:      "file://" + g.RepoDirectory,
 				Ref:       "master",
@@ -165,7 +165,7 @@ func TestCommand_Run_subdir(t *testing.T) {
 		},
 		UpstreamLock: &kptfilev1alpha2.UpstreamLock{
 			Type: "git",
-			GitLock: &kptfilev1alpha2.GitLock{
+			Git: &kptfilev1alpha2.GitLock{
 				Commit:    commit,
 				Directory: subdir,
 				Ref:       "refs/heads/master",
@@ -226,7 +226,7 @@ func TestCommand_Run_destination(t *testing.T) {
 		},
 		UpstreamLock: &kptfilev1alpha2.UpstreamLock{
 			Type: kptfilev1alpha2.GitOrigin,
-			GitLock: &kptfilev1alpha2.GitLock{
+			Git: &kptfilev1alpha2.GitLock{
 				Directory: "/",
 				Repo:      g.RepoDirectory,
 				Ref:       "master",
@@ -290,7 +290,7 @@ func TestCommand_Run_subdirAndDestination(t *testing.T) {
 		},
 		UpstreamLock: &kptfilev1alpha2.UpstreamLock{
 			Type: kptfilev1alpha2.GitOrigin,
-			GitLock: &kptfilev1alpha2.GitLock{
+			Git: &kptfilev1alpha2.GitLock{
 				Commit:    commit,
 				Directory: subdir,
 				Ref:       "master",
@@ -368,7 +368,7 @@ func TestCommand_Run_branch(t *testing.T) {
 		},
 		UpstreamLock: &kptfilev1alpha2.UpstreamLock{
 			Type: kptfilev1alpha2.GitOrigin,
-			GitLock: &kptfilev1alpha2.GitLock{
+			Git: &kptfilev1alpha2.GitLock{
 				Directory: "/",
 				Repo:      g.RepoDirectory,
 				Ref:       "refs/heads/exp",
@@ -451,7 +451,7 @@ func TestCommand_Run_tag(t *testing.T) {
 		},
 		UpstreamLock: &kptfilev1alpha2.UpstreamLock{
 			Type: kptfilev1alpha2.GitOrigin,
-			GitLock: &kptfilev1alpha2.GitLock{
+			Git: &kptfilev1alpha2.GitLock{
 				Directory: "/",
 				Repo:      g.RepoDirectory,
 				Ref:       "refs/tags/v2",
@@ -623,7 +623,7 @@ func TestCommand_Run_failExistingDir(t *testing.T) {
 		},
 		UpstreamLock: &kptfilev1alpha2.UpstreamLock{
 			Type: kptfilev1alpha2.GitOrigin,
-			GitLock: &kptfilev1alpha2.GitLock{
+			Git: &kptfilev1alpha2.GitLock{
 				Directory: "/",
 				Repo:      g.RepoDirectory,
 				Ref:       "master",
@@ -676,7 +676,7 @@ func TestCommand_Run_failExistingDir(t *testing.T) {
 		},
 		UpstreamLock: &kptfilev1alpha2.UpstreamLock{
 			Type: kptfilev1alpha2.GitOrigin,
-			GitLock: &kptfilev1alpha2.GitLock{
+			Git: &kptfilev1alpha2.GitLock{
 				Directory: "/",
 				Repo:      g.RepoDirectory,
 				Ref:       "master",

--- a/internal/util/update/update.go
+++ b/internal/util/update/update.go
@@ -209,7 +209,7 @@ func (u Command) updateRootPackage(ctx context.Context, p *pkg.Pkg) error {
 
 	var origin repoClone
 	if kf.UpstreamLock != nil {
-		gLock := kf.UpstreamLock.GitLock
+		gLock := kf.UpstreamLock.Git
 		originRepoSpec := &git.RepoSpec{OrgRepo: gLock.Repo, Path: gLock.Directory, Ref: gLock.Commit}
 		if err := fetch.ClonerUsingGitExec(ctx, originRepoSpec); err != nil {
 			return errors.E(op, p.UniquePath, err)

--- a/internal/util/update/update_test.go
+++ b/internal/util/update/update_test.go
@@ -351,7 +351,7 @@ func TestCommand_Run_localPackageChanges(t *testing.T) {
 				if err != nil {
 					return "", err
 				}
-				return f.UpstreamLock.GitLock.Commit, nil
+				return f.UpstreamLock.Git.Commit, nil
 			},
 		},
 		"update using force-delete-replace strategy with local changes": {

--- a/pkg/api/kptfile/v1alpha2/types.go
+++ b/pkg/api/kptfile/v1alpha2/types.go
@@ -140,8 +140,8 @@ type UpstreamLock struct {
 	// Type is the type of origin.
 	Type OriginType `yaml:"type,omitempty"`
 
-	// GitLock is the resolved locator for a package on Git.
-	GitLock *GitLock `yaml:"gitLock,omitempty"`
+	// Git is the resolved locator for a package on Git.
+	Git *GitLock `yaml:"git,omitempty"`
 }
 
 // GitLock is the resolved locator for a package on Git.

--- a/pkg/kptfile/kptfileutil/util.go
+++ b/pkg/kptfile/kptfileutil/util.go
@@ -224,7 +224,7 @@ func UpdateUpstreamLockFromGit(path string, spec *git.RepoSpec) error {
 	// populate the cloneFrom values so we know where the package came from
 	kpgfile.UpstreamLock = &kptfilev1alpha2.UpstreamLock{
 		Type: kptfilev1alpha2.GitOrigin,
-		GitLock: &kptfilev1alpha2.GitLock{
+		Git: &kptfilev1alpha2.GitLock{
 			Repo:      spec.OrgRepo,
 			Directory: spec.Path,
 			Ref:       spec.Ref,
@@ -291,11 +291,11 @@ func merge(localKf, updatedKf, originalKf kptfilev1alpha2.KptFile) (kptfilev1alp
 	if localKf.UpstreamLock != nil {
 		mergedKf.UpstreamLock = &kptfilev1alpha2.UpstreamLock{
 			Type: localKf.UpstreamLock.Type,
-			GitLock: &kptfilev1alpha2.GitLock{
-				Commit:    localKf.UpstreamLock.GitLock.Commit,
-				Directory: localKf.UpstreamLock.GitLock.Directory,
-				Repo:      localKf.UpstreamLock.GitLock.Repo,
-				Ref:       localKf.UpstreamLock.GitLock.Ref,
+			Git: &kptfilev1alpha2.GitLock{
+				Commit:    localKf.UpstreamLock.Git.Commit,
+				Directory: localKf.UpstreamLock.Git.Directory,
+				Repo:      localKf.UpstreamLock.Git.Repo,
+				Ref:       localKf.UpstreamLock.Git.Ref,
 			},
 		}
 	}
@@ -318,11 +318,11 @@ func updateUpstreamAndUpstreamLock(localKf, updatedKf kptfilev1alpha2.KptFile) k
 	if updatedKf.UpstreamLock != nil {
 		localKf.UpstreamLock = &kptfilev1alpha2.UpstreamLock{
 			Type: updatedKf.UpstreamLock.Type,
-			GitLock: &kptfilev1alpha2.GitLock{
-				Commit:    updatedKf.UpstreamLock.GitLock.Commit,
-				Directory: updatedKf.UpstreamLock.GitLock.Directory,
-				Repo:      updatedKf.UpstreamLock.GitLock.Repo,
-				Ref:       updatedKf.UpstreamLock.GitLock.Ref,
+			Git: &kptfilev1alpha2.GitLock{
+				Commit:    updatedKf.UpstreamLock.Git.Commit,
+				Directory: updatedKf.UpstreamLock.Git.Directory,
+				Repo:      updatedKf.UpstreamLock.Git.Repo,
+				Ref:       updatedKf.UpstreamLock.Git.Ref,
 			},
 		}
 	}

--- a/pkg/kptfile/kptfileutil/util_test.go
+++ b/pkg/kptfile/kptfileutil/util_test.go
@@ -72,7 +72,7 @@ metadata:
   name: cockroachdb
 upstreamLock:
   type: git
-  gitLock:
+  git:
     commit: dd7adeb5492cca4c24169cecee023dbe632e5167
     directory: staging/cockroachdb
     ref: refs/heads/owners-update
@@ -95,7 +95,7 @@ upstreamLock:
 		},
 		UpstreamLock: &kptfilev1alpha2.UpstreamLock{
 			Type: "git",
-			GitLock: &kptfilev1alpha2.GitLock{
+			Git: &kptfilev1alpha2.GitLock{
 				Commit:    "dd7adeb5492cca4c24169cecee023dbe632e5167",
 				Directory: "staging/cockroachdb",
 				Ref:       "refs/heads/owners-update",
@@ -267,7 +267,7 @@ upstream:
     ref: v2
 upstreamLock:
   type: git
-  gitLock:
+  git:
     repo: github.com/GoogleContainerTools/kpt
     directory: /
     ref: v2
@@ -293,7 +293,7 @@ upstream:
     ref: v2
 upstreamLock:
   type: git
-  gitLock:
+  git:
     repo: github.com/GoogleContainerTools/kpt
     directory: /
     ref: v2

--- a/pkg/live/rgpath_test.go
+++ b/pkg/live/rgpath_test.go
@@ -31,7 +31,7 @@ metadata:
   name: test1
 upstreamLock:
   type: git
-  gitLock:
+  git:
     commit: 786b898857bd7e9647c229d5f39b0be4de86c915
     repo: git@github.com:seans3/blueprint-helloworld
     directory: /
@@ -49,7 +49,7 @@ metadata:
   name: test1
 upstreamLock:
   type: git
-  gitLock:
+  git:
     commit: 786b898857bd7e9647c229d5f39b0be4de86c915
     repo: git@github.com:seans3/blueprint-helloworld
     directory: /
@@ -65,7 +65,7 @@ metadata:
   name: test1
 upstreamLock:
   type: git
-  gitLock:
+  git:
     commit: 786b898857bd7e9647c229d5f39b0be4de86c915
     repo: git@github.com:seans3/blueprint-helloworld
     directory: /


### PR DESCRIPTION
This PR renames the `GitLock` property on `UpstreamLock` in the Kptfile to `Git`.

Fixes: https://github.com/GoogleContainerTools/kpt/issues/1836
