### PR TITLE
Move error handling for kpt live commands into kpt error resolver

### DIFF
--- a/internal/errors/resolver/git.go
+++ b/internal/errors/resolver/git.go
@@ -73,10 +73,10 @@ Error: Unknown ref {{ printf "%q" .ref }}. Please verify that the reference exis
 // that can produce error messages for errors of the gitutil.GitExecError type.
 type gitExecErrorResolver struct{}
 
-func (*gitExecErrorResolver) Resolve(err error) (ResolvedErr, bool) {
+func (*gitExecErrorResolver) Resolve(err error) (ResolvedResult, bool) {
 	var gitExecErr *gitutil.GitExecError
 	if !goerrors.As(err, &gitExecErr) {
-		return ResolvedErr{}, false
+		return ResolvedResult{}, false
 	}
 	fullCommand := fmt.Sprintf("git %s %s", gitExecErr.Command,
 		strings.Join(gitExecErr.Args, " "))
@@ -97,7 +97,7 @@ func (*gitExecErrorResolver) Resolve(err error) (ResolvedErr, bool) {
 	default:
 		msg = ExecuteTemplate(genericGitExecError, tmplArgs)
 	}
-	return ResolvedErr{
+	return ResolvedResult{
 		Message:  msg,
 		ExitCode: 1,
 	}, true
@@ -107,14 +107,17 @@ func (*gitExecErrorResolver) Resolve(err error) (ResolvedErr, bool) {
 // that can produce error messages for errors of the FnExecError type.
 type fnExecErrorResolver struct{}
 
-func (*fnExecErrorResolver) Resolve(err error) (string, bool) {
+func (*fnExecErrorResolver) Resolve(err error) (ResolvedResult, bool) {
 	kioErr := errors.UnwrapKioError(err)
 
 	var fnErr *errors.FnExecError
 	if !goerrors.As(kioErr, &fnErr) {
-		return "", false
+		return ResolvedResult{}, false
 	}
 	// TODO: write complete details to a file
 
-	return fnErr.String(), true
+	return ResolvedResult{
+		Message: fnErr.String(),
+		ExitCode: 1,
+	}, true
 }

--- a/internal/errors/resolver/live.go
+++ b/internal/errors/resolver/live.go
@@ -40,7 +40,7 @@ The package should have one and only one inventory object template.
 `
 	//nolint:lll
 	timeoutError = `
-Error: Timeout after {{printf "%.0f" .err.Timeout.Seconds}} seconds waiting for {{printf "%d" (len .err.TimedOutResources)}} out of {{printf "%d" (len .err.Identifiers)}} resources to reach condition {{ .err.Condition}}:
+Error: Timeout after {{printf "%.0f" .err.Timeout.Seconds}} seconds waiting for {{printf "%d" (len .err.TimedOutResources)}} out of {{printf "%d" (len .err.Identifiers)}} resources to reach condition {{ .err.Condition}}:{{ printf "\n" }}
 
 {{- range .err.TimedOutResources}}
 {{printf "%s/%s %s %s" .Identifier.GroupKind.Kind .Identifier.Name .Status .Message }}
@@ -54,25 +54,25 @@ Error: Timeout after {{printf "%.0f" .err.Timeout.Seconds}} seconds waiting for 
 // that can resolve error types used in the live functionality.
 type liveErrorResolver struct{}
 
-func (*liveErrorResolver) Resolve(err error) (ResolvedErr, bool) {
+func (*liveErrorResolver) Resolve(err error) (ResolvedResult, bool) {
 	tmplArgs := map[string]interface{}{
 		"err": err,
 	}
 	switch err.(type) {
 	case *inventory.NoInventoryObjError:
-		return ResolvedErr{
+		return ResolvedResult{
 			Message: ExecuteTemplate(noInventoryObjError, tmplArgs),
 		}, true
 	case *inventory.MultipleInventoryObjError:
-		return ResolvedErr{
+		return ResolvedResult{
 			Message: ExecuteTemplate(multipleInventoryObjError, tmplArgs),
 		}, true
 	case *taskrunner.TimeoutError:
-		return ResolvedErr{
+		return ResolvedResult{
 			Message:  ExecuteTemplate(timeoutError, tmplArgs),
 			ExitCode: TimeoutErrorExitCode,
 		}, true
 	default:
-		return ResolvedErr{}, false
+		return ResolvedResult{}, false
 	}
 }

--- a/internal/errors/resolver/live.go
+++ b/internal/errors/resolver/live.go
@@ -1,0 +1,78 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolver
+
+import (
+	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
+	"sigs.k8s.io/cli-utils/pkg/inventory"
+)
+
+//nolint:gochecknoinits
+func init() {
+	AddErrorResolver(&liveErrorResolver{})
+}
+
+const (
+	noInventoryObjError = `
+Error: Package uninitialized. Please run "kpt live init" command.
+
+The package needs to be initialized to generate the template
+which will store state for resource sets. This state is
+necessary to perform functionality such as deleting an entire
+package or automatically deleting omitted resources (pruning).
+`
+	multipleInventoryObjError = `
+Error: Package has multiple inventory object templates.
+
+The package should have one and only one inventory object template.
+`
+	//nolint:lll
+	timeoutError = `
+Error: Timeout after {{printf "%.0f" .err.Timeout.Seconds}} seconds waiting for {{printf "%d" (len .err.TimedOutResources)}} out of {{printf "%d" (len .err.Identifiers)}} resources to reach condition {{ .err.Condition}}:
+
+{{- range .err.TimedOutResources}}
+{{printf "%s/%s %s %s" .Identifier.GroupKind.Kind .Identifier.Name .Status .Message }}
+{{- end}}
+`
+
+	TimeoutErrorExitCode = 3
+)
+
+// liveErrorResolver is an implementation of the ErrorResolver interface
+// that can resolve error types used in the live functionality.
+type liveErrorResolver struct{}
+
+func (*liveErrorResolver) Resolve(err error) (ResolvedErr, bool) {
+	tmplArgs := map[string]interface{}{
+		"err": err,
+	}
+	switch err.(type) {
+	case *inventory.NoInventoryObjError:
+		return ResolvedErr{
+			Message: ExecuteTemplate(noInventoryObjError, tmplArgs),
+		}, true
+	case *inventory.MultipleInventoryObjError:
+		return ResolvedErr{
+			Message: ExecuteTemplate(multipleInventoryObjError, tmplArgs),
+		}, true
+	case *taskrunner.TimeoutError:
+		return ResolvedErr{
+			Message:  ExecuteTemplate(timeoutError, tmplArgs),
+			ExitCode: TimeoutErrorExitCode,
+		}, true
+	default:
+		return ResolvedErr{}, false
+	}
+}

--- a/internal/errors/resolver/resolver.go
+++ b/internal/errors/resolver/resolver.go
@@ -33,14 +33,14 @@ func AddErrorResolver(er ErrorResolver) {
 // ResolveError attempts to resolve the provided error into a descriptive
 // string which will be displayed to the user. If the last return value is false,
 // the error could not be resolved.
-func ResolveError(err error) (ResolvedErr, bool) {
+func ResolveError(err error) (ResolvedResult, bool) {
 	for _, resolver := range errorResolvers {
 		msg, found := resolver.Resolve(err)
 		if found {
 			return msg, true
 		}
 	}
-	return ResolvedErr{}, false
+	return ResolvedResult{}, false
 }
 
 // ExecuteTemplate takes the provided template string and data, and renders
@@ -59,7 +59,7 @@ func ExecuteTemplate(text string, data interface{}) string {
 	return strings.TrimSpace(b.String())
 }
 
-type ResolvedErr struct {
+type ResolvedResult struct {
 	Message  string
 	ExitCode int
 }
@@ -67,5 +67,5 @@ type ResolvedErr struct {
 // ErrorResolver is an interface that allows kpt to resolve an error into
 // an error message suitable for the end user.
 type ErrorResolver interface {
-	Resolve(err error) (ResolvedErr, bool)
+	Resolve(err error) (ResolvedResult, bool)
 }

--- a/internal/errors/resolver/resolver.go
+++ b/internal/errors/resolver/resolver.go
@@ -33,19 +33,19 @@ func AddErrorResolver(er ErrorResolver) {
 // ResolveError attempts to resolve the provided error into a descriptive
 // string which will be displayed to the user. If the last return value is false,
 // the error could not be resolved.
-func ResolveError(err error) (string, bool) {
+func ResolveError(err error) (ResolvedErr, bool) {
 	for _, resolver := range errorResolvers {
 		msg, found := resolver.Resolve(err)
 		if found {
 			return msg, true
 		}
 	}
-	return "", false
+	return ResolvedErr{}, false
 }
 
 // ExecuteTemplate takes the provided template string and data, and renders
 // the template. If something goes wrong, it panics.
-func ExecuteTemplate(text string, data interface{}) (string, bool) {
+func ExecuteTemplate(text string, data interface{}) string {
 	tmpl, tmplErr := template.New("kpterror").Parse(text)
 	if tmplErr != nil {
 		panic(fmt.Errorf("error creating template: %w", tmplErr))
@@ -56,11 +56,16 @@ func ExecuteTemplate(text string, data interface{}) (string, bool) {
 	if execErr != nil {
 		panic(fmt.Errorf("error executing template: %w", execErr))
 	}
-	return strings.TrimSpace(b.String()), true
+	return strings.TrimSpace(b.String())
+}
+
+type ResolvedErr struct {
+	Message  string
+	ExitCode int
 }
 
 // ErrorResolver is an interface that allows kpt to resolve an error into
 // an error message suitable for the end user.
 type ErrorResolver interface {
-	Resolve(err error) (string, bool)
+	Resolve(err error) (ResolvedErr, bool)
 }

--- a/main.go
+++ b/main.go
@@ -75,8 +75,8 @@ func runMain() int {
 func handleErr(cmd *cobra.Command, err error) int {
 	// First attempt to see if we can resolve the error into a specific
 	// error message.
-	re, found := resolver.ResolveError(err)
-	if found {
+	re, resolved := resolver.ResolveError(err)
+	if resolved {
 		fmt.Fprintf(cmd.ErrOrStderr(), "\n%s \n", re.Message)
 		return re.ExitCode
 	}

--- a/thirdparty/cli-utils/printers/table/printer.go
+++ b/thirdparty/cli-utils/printers/table/printer.go
@@ -138,7 +138,6 @@ func (t *Printer) runPrintLoop(coll *ResourceStateCollector, stop chan struct{})
 				ticker.Stop()
 				latestState := coll.LatestState()
 				linesPrinted = baseTablePrinter.PrintTable(latestState, linesPrinted)
-				_, _ = fmt.Fprint(t.IOStreams.Out, "\n")
 				return
 			case <-ticker.C:
 				latestState := coll.LatestState()


### PR DESCRIPTION
This combines the new error resolver in kpt with the similar solution in cli-utils. With this change, we use one way to handle errors from both git and live.
This also expands the ErrorResolver somewhat by letting the resolver also determine the exit code for an error.
