### PR TITLE
Add additional tests for `kpt pkg update`

### DIFF
--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -319,6 +319,12 @@ func (g *TestGitRepo) ReplaceData(data string) error {
 	return replaceData(g.RepoDirectory, data)
 }
 
+// CustomUpdate executes the provided update function and passes in the
+// path to the directory of the repository.
+func (g *TestGitRepo) CustomUpdate(f func(string) error) error {
+	return f(g.RepoDirectory)
+}
+
 // SetupTestGitRepo initializes a new git repository and populates it with data from a source
 func (g *TestGitRepo) SetupTestGitRepo(name string, data []Content, repos map[string]*TestGitRepo) error {
 	defaultBranch := "main"
@@ -773,6 +779,12 @@ func (w *TestWorkspace) CheckoutBranch(branch string, create bool) error {
 // ReplaceData replaces the data with a new source
 func (w *TestWorkspace) ReplaceData(data string) error {
 	return replaceData(filepath.Join(w.WorkspaceDirectory, w.PackageDir), data)
+}
+
+// CustomUpdate executes the provided update function and passes in the
+// path to the directory of the repository.
+func (w *TestWorkspace) CustomUpdate(f func(string) error) error {
+	return f(w.WorkspaceDirectory)
 }
 
 // Commit performs a git commit

--- a/internal/util/get/get_test.go
+++ b/internal/util/get/get_test.go
@@ -1351,21 +1351,19 @@ func TestCommand_Run_symlinks(t *testing.T) {
 							WithKptfile().
 							WithResource(pkgbuilder.ConfigMapResource),
 					),
+				UpdateFunc: func(path string) error {
+					// Create symlink in the upstream repo.
+					return os.Symlink(filepath.Join(path, "subpkg"),
+						filepath.Join(path, "subpkg-sym"))
+				},
 			},
 		},
 	})
 	defer clean()
 	upstreamRepo := repos[testutil.Upstream]
 
-	// Create a symlink in the upstream repo
-	err := os.Symlink(filepath.Join(upstreamRepo.RepoDirectory, "subpkg"),
-		filepath.Join(upstreamRepo.RepoDirectory, "subpkg-sym"))
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-
 	destinationDir := filepath.Join(w.WorkspaceDirectory, upstreamRepo.RepoName)
-	err = Command{
+	err := Command{
 		Git: &kptfilev1alpha2.Git{
 			Repo:      upstreamRepo.RepoDirectory,
 			Directory: "/",

--- a/internal/util/update/update_test.go
+++ b/internal/util/update/update_test.go
@@ -815,6 +815,67 @@ func TestCommand_Run_failInvalidRef(t *testing.T) {
 	}
 }
 
+func TestCommand_Run_manualChange(t *testing.T) {
+	g := &testutil.TestSetupManager{
+		T: t,
+		ReposChanges: map[string][]testutil.Content{
+			testutil.Upstream: {
+				{
+					Pkg: pkgbuilder.NewRootPkg().
+						WithResource(pkgbuilder.DeploymentResource),
+					Branch: masterBranch,
+					Tag:    "v1",
+				},
+				{
+					Pkg: pkgbuilder.NewRootPkg().
+						WithResource(pkgbuilder.ConfigMapResource),
+					Tag: "v2",
+				},
+				{
+					Pkg: pkgbuilder.NewRootPkg().
+						WithResource(pkgbuilder.SecretResource),
+					Tag: "v3",
+				},
+			},
+		},
+		GetRef: "v1",
+		LocalChanges: []testutil.Content{
+			{
+				Pkg: pkgbuilder.NewRootPkg().
+					WithKptfile(
+						pkgbuilder.NewKptfile().
+							WithUpstreamRef(testutil.Upstream, "/", "v3", "resource-merge").
+							WithUpstreamLockRef(testutil.Upstream, "/", "v1", 0),
+					).
+					WithResource(pkgbuilder.DeploymentResource),
+			},
+		},
+	}
+	defer g.Clean()
+	if !g.Init() {
+		return
+	}
+
+	err := Command{
+		Pkg: pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
+	}.Run(fake.CtxWithNilPrinter())
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	expLocal := pkgbuilder.NewRootPkg().
+		WithKptfile(
+			pkgbuilder.NewKptfile().
+				WithUpstreamRef(testutil.Upstream, "/", "v3", "resource-merge").
+				WithUpstreamLockRef(testutil.Upstream, "/", "v3", 2),
+		).
+		WithResource(pkgbuilder.SecretResource)
+	expectedPath := expLocal.ExpandPkgWithName(t,
+		g.LocalWorkspace.PackageDir, testutil.ToReposInfo(g.Repos))
+
+	testutil.KptfileAwarePkgEqual(t, expectedPath, g.LocalWorkspace.FullPackagePath())
+}
+
 func TestCommand_Run_badStrategy(t *testing.T) {
 	strategy := kptfilev1alpha2.UpdateStrategyType("foo")
 


### PR DESCRIPTION
Adds two additional tests:
- Verifies that a user can update the `Upstream` section of the Kptfile manually and then use the `kpt pkg update` command to actually update the package.
- Tests handling of symlinks during update. It also addresses a problem with the test for symlinks with `kpt pkg get`.
