### PR TITLE
Extract container runtime & fn error resolver

### DIFF
--- a/internal/cmdrender/pipeline_function.go
+++ b/internal/cmdrender/pipeline_function.go
@@ -23,8 +23,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/GoogleContainerTools/kpt/internal/cmdrender/runtime"
 	"github.com/GoogleContainerTools/kpt/internal/errors"
+	"github.com/GoogleContainerTools/kpt/internal/fnruntime"
 	"github.com/GoogleContainerTools/kpt/internal/types"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
@@ -40,13 +40,13 @@ func newFnRunner(ctx context.Context, f *kptfilev1alpha2.Function, pkgPath types
 		return nil, err
 	}
 
-	cfn := &runtime.ContainerFn{
+	cfn := &fnruntime.ContainerFn{
 		Path:  pkgPath,
 		Image: f.Image,
 		Ctx:   ctx,
 	}
 
-	cfnw := &runtime.ContainerFnWrapper{
+	cfnw := &fnruntime.ContainerFnWrapper{
 		Fn: cfn,
 	}
 

--- a/internal/errors/resolver/fn.go
+++ b/internal/errors/resolver/fn.go
@@ -1,0 +1,45 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolver
+
+import (
+	goerrors "errors"
+
+	"github.com/GoogleContainerTools/kpt/internal/errors"
+)
+
+//nolint:gochecknoinits
+func init() {
+	AddErrorResolver(&fnExecErrorResolver{})
+}
+
+// gitExecErrorResolver is an implementation of the ErrorResolver interface
+// that can produce error messages for errors of the FnExecError type.
+type fnExecErrorResolver struct{}
+
+func (*fnExecErrorResolver) Resolve(err error) (ResolvedResult, bool) {
+	kioErr := errors.UnwrapKioError(err)
+
+	var fnErr *errors.FnExecError
+	if !goerrors.As(kioErr, &fnErr) {
+		return ResolvedResult{}, false
+	}
+	// TODO: write complete details to a file
+
+	return ResolvedResult{
+		Message:  fnErr.String(),
+		ExitCode: 1,
+	}, true
+}

--- a/internal/errors/resolver/git.go
+++ b/internal/errors/resolver/git.go
@@ -19,14 +19,12 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/gitutil"
 )
 
 //nolint:gochecknoinits
 func init() {
 	AddErrorResolver(&gitExecErrorResolver{})
-	AddErrorResolver(&fnExecErrorResolver{})
 }
 
 const (
@@ -99,25 +97,6 @@ func (*gitExecErrorResolver) Resolve(err error) (ResolvedResult, bool) {
 	}
 	return ResolvedResult{
 		Message:  msg,
-		ExitCode: 1,
-	}, true
-}
-
-// gitExecErrorResolver is an implementation of the ErrorResolver interface
-// that can produce error messages for errors of the FnExecError type.
-type fnExecErrorResolver struct{}
-
-func (*fnExecErrorResolver) Resolve(err error) (ResolvedResult, bool) {
-	kioErr := errors.UnwrapKioError(err)
-
-	var fnErr *errors.FnExecError
-	if !goerrors.As(kioErr, &fnErr) {
-		return ResolvedResult{}, false
-	}
-	// TODO: write complete details to a file
-
-	return ResolvedResult{
-		Message:  fnErr.String(),
 		ExitCode: 1,
 	}, true
 }

--- a/internal/fnruntime/container.go
+++ b/internal/fnruntime/container.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package runtime
+package fnruntime
 
 import (
 	"bytes"

--- a/internal/fnruntime/container_test.go
+++ b/internal/fnruntime/container_test.go
@@ -14,14 +14,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package runtime_test
+package fnruntime_test
 
 import (
 	"bytes"
 	"context"
 	"testing"
 
-	"github.com/GoogleContainerTools/kpt/internal/cmdrender/runtime"
+	"github.com/GoogleContainerTools/kpt/internal/fnruntime"
 	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"github.com/stretchr/testify/assert"
 )
@@ -50,7 +50,7 @@ func TestContainerFn(t *testing.T) {
 		ctx := context.Background()
 		t.Run(tt.name, func(t *testing.T) {
 			outBuff, errBuff := &bytes.Buffer{}, &bytes.Buffer{}
-			instance := runtime.ContainerFn{
+			instance := fnruntime.ContainerFn{
 				Ctx:   printer.WithContext(ctx, printer.New(outBuff, errBuff)),
 				Image: tt.image,
 			}


### PR DESCRIPTION
Extract container runtime to a separate package from `cmdrender`. This can make the dependency from `fn eval` less ambiguous. `fn eval` will share the representation layer with `fn render` and the representation layer is in container runtime.

Also move function error resolver to a separate file from `git.go`.

#1861 
