### PR TITLE
Unwrap kpt errors to prevent printing stacktrace

### DIFF
--- a/e2e/testdata/fn-render/missing-fnconfig/.expected/config.yaml
+++ b/e2e/testdata/fn-render/missing-fnconfig/.expected/config.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 exitCode: 1
-stdErr: 'fn gcr.io/kpt-fn/set-label:unstable: missing function config "labelconfig1.yaml"'
+stdErr: 'Error: missing function config "labelconfig1.yaml"'
 stdOut: |
   [RUNNING] "gcr.io/kpt-fn/set-label:unstable"
   [PASS] "gcr.io/kpt-fn/set-label:unstable"

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -248,3 +248,20 @@ func UnwrapKioError(err error) error {
 	}
 	return kioErr.Err
 }
+
+// UnwrapErrors unwraps any *Error errors in the chain and returns
+// the first error it finds that is of a different type. If no such error
+// can be found, the last return value will be false.
+//nolint
+func UnwrapErrors(err error) (error, bool) {
+	for {
+		if err == nil {
+			return nil, false
+		}
+		e, ok := err.(*Error)
+		if !ok {
+			return err, true
+		}
+		err = e.Err
+	}
+}

--- a/internal/util/cmdutil/cmdutil.go
+++ b/internal/util/cmdutil/cmdutil.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	"github.com/GoogleContainerTools/kpt/internal/errors"
-	goerrors "github.com/go-errors/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -40,13 +39,12 @@ func FixDocs(old, new string, c *cobra.Command) {
 	c.Example = strings.ReplaceAll(c.Example, old, new)
 }
 
-func PrintErrorStacktrace(err error) {
+func PrintErrorStacktrace() bool {
 	e := os.Getenv(StackTraceOnErrors)
 	if StackOnError || e == trueString || e == "1" {
-		if err, ok := err.(*goerrors.Error); ok {
-			fmt.Fprintf(os.Stderr, "%s", err.Stack())
-		}
+		return true
 	}
+	return false
 }
 
 // StackOnError if true, will print a stack trace on failure.

--- a/internal/util/parse/parse.go
+++ b/internal/util/parse/parse.go
@@ -162,7 +162,7 @@ func getDest(v, repo, subdir string) (string, error) {
 		parent := filepath.Dir(v)
 		if _, err := os.Stat(parent); os.IsNotExist(err) {
 			// error -- fetch to directory where parent does not exist
-			return "", errors.Errorf("parent directory %s does not exist", parent)
+			return "", errors.Errorf("parent directory %q does not exist", parent)
 		}
 		// fetch to a specific directory -- don't default the name
 		return v, nil
@@ -180,7 +180,7 @@ func getDest(v, repo, subdir string) (string, error) {
 
 	// make sure the destination directory does not yet exist yet
 	if _, err := os.Stat(v); !os.IsNotExist(err) {
-		return "", errors.Errorf("destination directory %s already exists", v)
+		return "", errors.Errorf("destination directory %q already exists", v)
 	}
 	return v, nil
 }


### PR DESCRIPTION
This PR updates the printing behavior in `main.go` to unwrap any `*error.Error` errors in the hierarchy to avoid printing the stacktrace. This essentially means we just take the error message from the first non-kpterror we find and print it to stderr. This resolves the issue where we show the stacktrace to users. The stacktrace can be included by either using the `--stack-trace` flag or setting the `COBRA_STACK_TRACE_ON_ERRORS` env variable (we might want to revisit the name).

With this change the output described in https://github.com/GoogleContainerTools/kpt/issues/1852 becomes will now be:
```
$ kpt pkg get https://github.com/GoogleContainerTools/kpt/package-examples/nginx@next
Error: destination directory "nginx" already exists
```