### PR TITLE
Align UX of packaging with the hydration UX

### DIFF
--- a/internal/cmdget/cmdget.go
+++ b/internal/cmdget/cmdget.go
@@ -22,7 +22,6 @@ import (
 	docs "github.com/GoogleContainerTools/kpt/internal/docs/generated/pkgdocs"
 	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
-	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"github.com/GoogleContainerTools/kpt/internal/types"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/get"
@@ -93,9 +92,6 @@ func (r *Runner) preRunE(_ *cobra.Command, args []string) error {
 
 func (r *Runner) runE(c *cobra.Command, _ []string) error {
 	const op errors.Op = "cmdget.runE"
-	pr := printer.FromContextOrDie(r.ctx)
-	pr.Printf("Fetching package %q from %q into %q\n",
-		strings.TrimPrefix(r.Get.Git.Directory, "/"), r.Get.Git.Repo, r.Get.Destination)
 	if err := r.Get.Run(r.ctx); err != nil {
 		return errors.E(op, types.UniquePath(r.Get.Destination), err)
 	}

--- a/internal/cmdget/cmdget.go
+++ b/internal/cmdget/cmdget.go
@@ -17,12 +17,12 @@ package cmdget
 
 import (
 	"context"
-	"fmt"
 	"strings"
 
 	docs "github.com/GoogleContainerTools/kpt/internal/docs/generated/pkgdocs"
 	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
+	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"github.com/GoogleContainerTools/kpt/internal/types"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/get"
@@ -93,8 +93,9 @@ func (r *Runner) preRunE(_ *cobra.Command, args []string) error {
 
 func (r *Runner) runE(c *cobra.Command, _ []string) error {
 	const op errors.Op = "cmdget.runE"
-	fmt.Fprintf(c.OutOrStdout(), "fetching package %s from %s to %s\n",
-		r.Get.Git.Directory, r.Get.Git.Repo, r.Get.Destination)
+	pr := printer.FromContextOrDie(r.ctx)
+	pr.Printf("Fetching package %q from %q into %q\n",
+		strings.TrimPrefix(r.Get.Git.Directory, "/"), r.Get.Git.Repo, r.Get.Destination)
 	if err := r.Get.Run(r.ctx); err != nil {
 		return errors.E(op, types.UniquePath(r.Get.Destination), err)
 	}

--- a/internal/cmdupdate/cmdupdate.go
+++ b/internal/cmdupdate/cmdupdate.go
@@ -25,6 +25,7 @@ import (
 	docs "github.com/GoogleContainerTools/kpt/internal/docs/generated/pkgdocs"
 	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
+	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"github.com/GoogleContainerTools/kpt/internal/types"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/update"
@@ -111,13 +112,9 @@ func (r *Runner) preRunE(_ *cobra.Command, args []string) error {
 
 func (r *Runner) runE(c *cobra.Command, _ []string) error {
 	const op errors.Op = "cmdupdate.runE"
-	if len(r.Update.Ref) > 0 {
-		fmt.Fprintf(c.ErrOrStderr(), "updating package %s to %s\n",
-			r.Update.Pkg.UniquePath, r.Update.Ref)
-	} else {
-		fmt.Fprintf(c.ErrOrStderr(), "updating package %s\n",
-			r.Update.Pkg.UniquePath)
-	}
+	pr := printer.FromContextOrDie(r.ctx)
+	pr.Printf("Updating package in %q\n",
+		r.Update.Pkg.UniquePath.String())
 	if err := r.Update.Run(r.ctx); err != nil {
 		return errors.E(op, r.Update.Pkg.UniquePath, err)
 	}

--- a/internal/cmdupdate/cmdupdate.go
+++ b/internal/cmdupdate/cmdupdate.go
@@ -25,7 +25,6 @@ import (
 	docs "github.com/GoogleContainerTools/kpt/internal/docs/generated/pkgdocs"
 	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
-	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"github.com/GoogleContainerTools/kpt/internal/types"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/update"
@@ -112,9 +111,6 @@ func (r *Runner) preRunE(_ *cobra.Command, args []string) error {
 
 func (r *Runner) runE(c *cobra.Command, _ []string) error {
 	const op errors.Op = "cmdupdate.runE"
-	pr := printer.FromContextOrDie(r.ctx)
-	pr.Printf("Updating package in %q\n",
-		r.Update.Pkg.UniquePath.String())
 	if err := r.Update.Run(r.ctx); err != nil {
 		return errors.E(op, r.Update.Pkg.UniquePath, err)
 	}

--- a/internal/printer/fake/fake.go
+++ b/internal/printer/fake/fake.go
@@ -17,12 +17,15 @@ package fake
 import (
 	"context"
 
+	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	"github.com/GoogleContainerTools/kpt/internal/printer"
 )
 
 // NilPrinter implements the printer.Printer interface and just ignores
 // all print calls.
 type NilPrinter struct{}
+
+func (np *NilPrinter) PrintPackage(*pkg.Pkg, bool) {}
 
 func (np *NilPrinter) OptPrintf(*printer.Options, string, ...interface{}) {}
 

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -104,7 +104,7 @@ func (pr *printer) PrintPackage(p *pkg.Pkg, leadingNewline bool) {
 	if leadingNewline {
 		fmt.Fprint(pr.outStream, "\n")
 	}
-	fmt.Fprintf(pr.outStream, "Package %q:\n\n", p.DisplayPath)
+	fmt.Fprintf(pr.outStream, "Package %q:\n", p.DisplayPath)
 }
 
 // Printf is the wrapper over fmt.Printf that displays the output.

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	"github.com/GoogleContainerTools/kpt/internal/types"
 )
 
@@ -31,6 +32,7 @@ var TruncateOutput bool
 // The main intention, at the moment, is to abstract away printing
 // output in the CLI so that we can evolve the kpt CLI UX.
 type Printer interface {
+	PrintPackage(pkg *pkg.Pkg, leadingNewline bool)
 	Printf(format string, args ...interface{})
 	OptPrintf(opt *Options, format string, args ...interface{})
 }
@@ -97,6 +99,13 @@ type contextKey int
 // arbitrary.  If this package defined other context keys, they would have
 // different integer values.
 const printerKey contextKey = 0
+
+func (pr *printer) PrintPackage(p *pkg.Pkg, leadingNewline bool) {
+	if leadingNewline {
+		fmt.Fprint(pr.outStream, "\n")
+	}
+	fmt.Fprintf(pr.outStream, "Package %q:\n\n", p.DisplayPath)
+}
 
 // Printf is the wrapper over fmt.Printf that displays the output.
 func (pr *printer) Printf(format string, args ...interface{}) {

--- a/internal/util/fetch/fetch.go
+++ b/internal/util/fetch/fetch.go
@@ -97,8 +97,8 @@ func (c Command) validate(kf *kptfilev1alpha2.KptFile) error {
 // of the Kptfile of the package.
 func cloneAndCopy(ctx context.Context, r *git.RepoSpec, dest string) error {
 	const op errors.Op = "fetch.cloneAndCopy"
-	p := printer.FromContextOrDie(ctx)
-	p.Printf("cloning %s@%s\n", r.OrgRepo, r.Ref)
+	pr := printer.FromContextOrDie(ctx)
+
 	err := ClonerUsingGitExec(ctx, r)
 	if err != nil {
 		return errors.E(op, errors.Git, types.UniquePath(dest), err)
@@ -106,7 +106,7 @@ func cloneAndCopy(ctx context.Context, r *git.RepoSpec, dest string) error {
 	defer os.RemoveAll(r.Dir)
 
 	sourcePath := filepath.Join(r.Dir, r.Path)
-	p.Printf("copying %q to %s\n", r.Path, dest)
+	pr.Printf("Adding package %q\n", strings.TrimPrefix(r.Path, "/"))
 	if err := pkgutil.CopyPackageWithSubpackages(sourcePath, dest); err != nil {
 		return errors.E(op, types.UniquePath(dest), err)
 	}

--- a/internal/util/fetch/fetch.go
+++ b/internal/util/fetch/fetch.go
@@ -106,7 +106,7 @@ func cloneAndCopy(ctx context.Context, r *git.RepoSpec, dest string) error {
 	defer os.RemoveAll(r.Dir)
 
 	sourcePath := filepath.Join(r.Dir, r.Path)
-	pr.Printf("Adding package %q\n", strings.TrimPrefix(r.Path, "/"))
+	pr.Printf("Adding package %q.\n", strings.TrimPrefix(r.Path, "/"))
 	if err := pkgutil.CopyPackageWithSubpackages(sourcePath, dest); err != nil {
 		return errors.E(op, types.UniquePath(dest), err)
 	}

--- a/internal/util/get/get.go
+++ b/internal/util/get/get.go
@@ -113,16 +113,16 @@ func (c Command) fetchPackages(ctx context.Context, rootPkg *pkg.Pkg) error {
 	for s.Len() > 0 {
 		p := s.Pop()
 
+		pr.Printf("\n")
+		pr.OptPrintf(printer.NewOpt().PkgDisplay(p.DisplayPath), "\n")
+
 		kf, err := p.Kptfile()
 		if err != nil {
 			return errors.E(op, p.UniquePath, err)
 		}
 
 		if kf.Upstream != nil && kf.UpstreamLock == nil {
-			if rootPkg.UniquePath != p.UniquePath {
-				pr.Printf("fetching subpackage %s from %s to %s\n",
-					kf.Upstream.Git.Directory, kf.Upstream.Git.Repo, p.UniquePath)
-			}
+			pr.Printf("Fetching %s@%s\n", kf.Upstream.Git.Repo, kf.Upstream.Git.Ref)
 			err := (&fetch.Command{
 				Pkg: p,
 			}).Run(ctx)

--- a/internal/util/get/get.go
+++ b/internal/util/get/get.go
@@ -113,7 +113,6 @@ func (c Command) fetchPackages(ctx context.Context, rootPkg *pkg.Pkg) error {
 
 	for s.Len() > 0 {
 		p := s.Pop()
-		packageCount += 1
 
 		kf, err := p.Kptfile()
 		if err != nil {
@@ -121,6 +120,7 @@ func (c Command) fetchPackages(ctx context.Context, rootPkg *pkg.Pkg) error {
 		}
 
 		if kf.Upstream != nil && kf.UpstreamLock == nil {
+			packageCount += 1
 			pr.PrintPackage(p, !(p == rootPkg))
 			pr.Printf("Fetching %s@%s.\n", kf.Upstream.Git.Repo, kf.Upstream.Git.Ref)
 			err := (&fetch.Command{

--- a/internal/util/update/update.go
+++ b/internal/util/update/update.go
@@ -133,6 +133,10 @@ func (u Command) Run(ctx context.Context) error {
 	for s.Len() > 0 {
 		p := s.Pop()
 
+		pr := printer.FromContextOrDie(ctx)
+		pr.Printf("\n")
+		pr.OptPrintf(printer.NewOpt().PkgDisplay(p.DisplayPath), "\n")
+
 		if err := u.updateRootPackage(ctx, p); err != nil {
 			return errors.E(op, p.UniquePath, err)
 		}
@@ -191,17 +195,15 @@ func (u Command) updateRootPackage(ctx context.Context, p *pkg.Pkg) error {
 		return errors.E(op, p.UniquePath, err)
 	}
 
+	pr := printer.FromContextOrDie(ctx)
+
 	if kf.Upstream == nil || kf.Upstream.Git == nil {
 		return nil
 	}
 
 	g := kf.Upstream.Git
-
-	pr := printer.FromContextOrDie(ctx)
-	pr.Printf("updating package %s from %s/%s@%s\n",
-		filepath.Base(p.UniquePath.String()), g.Repo, g.Directory, g.Ref)
-
 	updated := &git.RepoSpec{OrgRepo: g.Repo, Path: g.Directory, Ref: g.Ref}
+	pr.Printf("Fetching upstream from %s@%s\n", kf.Upstream.Git.Repo, kf.Upstream.Git.Ref)
 	if err := fetch.ClonerUsingGitExec(ctx, updated); err != nil {
 		return errors.E(op, p.UniquePath, err)
 	}
@@ -211,6 +213,7 @@ func (u Command) updateRootPackage(ctx context.Context, p *pkg.Pkg) error {
 	if kf.UpstreamLock != nil {
 		gLock := kf.UpstreamLock.Git
 		originRepoSpec := &git.RepoSpec{OrgRepo: gLock.Repo, Path: gLock.Directory, Ref: gLock.Commit}
+		pr.Printf("Fetching origin from %s@%s\n", kf.Upstream.Git.Repo, kf.Upstream.Git.Ref)
 		if err := fetch.ClonerUsingGitExec(ctx, originRepoSpec); err != nil {
 			return errors.E(op, p.UniquePath, err)
 		}
@@ -235,11 +238,9 @@ func (u Command) updateRootPackage(ctx context.Context, p *pkg.Pkg) error {
 		isRoot := false
 		if relPath == "." {
 			isRoot = true
-		} else {
-			pr.Printf("updating subpackage %s\n", relPath)
 		}
 
-		if err := u.updatePackage(relPath, localPath, updatedPath, originPath, isRoot); err != nil {
+		if err := u.updatePackage(ctx, relPath, localPath, updatedPath, originPath, isRoot); err != nil {
 			return errors.E(op, p.UniquePath, err)
 		}
 
@@ -265,8 +266,10 @@ func (u Command) updateRootPackage(ctx context.Context, p *pkg.Pkg) error {
 // The last parameter tells if this package is the root, i.e. the package
 // from which we got the information about upstream and origin.
 //nolint:gocyclo
-func (u Command) updatePackage(subPkgPath, localPath, updatedPath, originPath string, isRootPkg bool) error {
+func (u Command) updatePackage(ctx context.Context, subPkgPath, localPath, updatedPath, originPath string, isRootPkg bool) error {
 	const op errors.Op = "update.updatePackage"
+	pr := printer.FromContextOrDie(ctx)
+
 	localExists, err := pkg.IsPackageDir(localPath)
 	if err != nil {
 		return errors.E(op, types.UniquePath(localPath), err)
@@ -296,6 +299,7 @@ func (u Command) updatePackage(subPkgPath, localPath, updatedPath, originPath st
 	// Check if subpackage has been added both in upstream and in local. We
 	// can't make a sane merge here, so we treat it as an error.
 	case !originExists && localExists && updatedExists:
+		pr.Printf("Package %q added in both local and upstream\n", packageName(localPath))
 		return errors.E(op, types.UniquePath(localPath),
 			fmt.Errorf("subpackage %q added in both upstream and local", subPkgPath))
 
@@ -303,6 +307,7 @@ func (u Command) updatePackage(subPkgPath, localPath, updatedPath, originPath st
 	// contains any unfetched subpackages, those will be handled when we traverse
 	// the package hierarchy and that package is the root.
 	case !originExists && !localExists && updatedExists:
+		pr.Printf("Adding package %q from upstream\n", packageName(localPath))
 		if err := pkgutil.CopyPackage(updatedPath, localPath, !isRootPkg); err != nil {
 			return errors.E(op, types.UniquePath(localPath), err)
 		}
@@ -319,7 +324,8 @@ func (u Command) updatePackage(subPkgPath, localPath, updatedPath, originPath st
 	// In this case we assume the user knows what they are doing, so
 	// we don't re-add the updated package from upstream.
 	case originExists && !localExists && updatedExists:
-		break
+		pr.Printf("Ignoring package %q in upstream since it is deleted from local\n", packageName(localPath))
+
 	// Package deleted from upstream
 	case originExists && localExists && !updatedExists:
 		// Check the diff. If there are local changes, we keep the subpackage.
@@ -328,20 +334,24 @@ func (u Command) updatePackage(subPkgPath, localPath, updatedPath, originPath st
 			return errors.E(op, types.UniquePath(localPath), err)
 		}
 		if diff.Len() == 0 {
+			pr.Printf("Deleting package %q from local since it is removed in upstream\n", packageName(localPath))
 			if err := os.RemoveAll(localPath); err != nil {
 				return errors.E(op, types.UniquePath(localPath), err)
 			}
+		} else {
+			pr.Printf("Package %q deleted from upstream, but keeping local since it has changes\n", packageName(localPath))
 		}
 	default:
-		if err := u.mergePackage(localPath, updatedPath, originPath, subPkgPath, isRootPkg); err != nil {
+		if err := u.mergePackage(ctx, localPath, updatedPath, originPath, subPkgPath, isRootPkg); err != nil {
 			return errors.E(op, types.UniquePath(localPath), err)
 		}
 	}
 	return nil
 }
 
-func (u Command) mergePackage(localPath, updatedPath, originPath, relPath string, isRootPkg bool) error {
+func (u Command) mergePackage(ctx context.Context, localPath, updatedPath, originPath, relPath string, isRootPkg bool) error {
 	const op errors.Op = "update.mergePackage"
+	pr := printer.FromContextOrDie(ctx)
 	updatedUnfetched, err := pkg.IsPackageUnfetched(updatedPath)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) || !isRootPkg {
@@ -389,6 +399,7 @@ func (u Command) mergePackage(localPath, updatedPath, originPath, relPath string
 		return errors.E(op, types.UniquePath(localPath),
 			fmt.Errorf("unrecognized update strategy %s", u.Strategy))
 	}
+	pr.Printf("Updating package %q with strategy %q\n", packageName(localPath), pkgKf.Upstream.UpdateStrategy)
 	if err := updater().Update(UpdateOptions{
 		RelPackagePath: relPath,
 		LocalPath:      localPath,
@@ -399,4 +410,8 @@ func (u Command) mergePackage(localPath, updatedPath, originPath, relPath string
 		return errors.E(op, types.UniquePath(localPath), err)
 	}
 	return nil
+}
+
+func packageName(path string) string {
+	return filepath.Base(path)
 }


### PR DESCRIPTION
This changes the output during `kpt pkg get` and `kpt pkg update` to be more aligned with the output from running the hydration pipeline. 

Fetching a composite package:
```
$ kpt pkg get git@github.com:mortent/kpt-composite-packages.git/kafka
Package "kafka":

Fetching git@github.com:mortent/kpt-composite-packages@main.
From github.com:mortent/kpt-composite-packages
 * branch            main       -> FETCH_HEAD
Adding package "kafka".

Package "kafka/zookeeper2":

Fetching https://github.com/mortent/kpt-packages@master.
From https://github.com/mortent/kpt-packages
 * branch            master     -> FETCH_HEAD
Adding package "zookeeper".

Package "kafka/zookeeper2/zookeeper-networkpolicy":

Fetching https://github.com/mortent/kpt-packages@master.
From https://github.com/mortent/kpt-packages
 * branch            master     -> FETCH_HEAD
Adding package "zookeeper-networkpolicy".

Package "kafka/zookeeper1":

Fetching https://github.com/mortent/kpt-packages@master.
From https://github.com/mortent/kpt-packages
 * branch            master     -> FETCH_HEAD
Adding package "zookeeper".

Package "kafka/zookeeper1/zookeeper-networkpolicy":

Fetching https://github.com/mortent/kpt-packages@master.
From https://github.com/mortent/kpt-packages
 * branch            master     -> FETCH_HEAD
Adding package "zookeeper-networkpolicy".

Fetched 5 package(s).
```

Updating same package:
```
$ kpt pkg update kafka
Package "kafka":

Fetching upstream from git@github.com:mortent/kpt-composite-packages@main.
From github.com:mortent/kpt-composite-packages
 * branch            main       -> FETCH_HEAD
Fetching origin from git@github.com:mortent/kpt-composite-packages@main.
From github.com:mortent/kpt-composite-packages
 * branch            22c9011801e190ce6cbfd7ae929b2ade6327a13b -> FETCH_HEAD

Package "kafka/zookeeper2":

Fetching upstream from https://github.com/mortent/kpt-packages@master.
From https://github.com/mortent/kpt-packages
 * branch            master     -> FETCH_HEAD
Fetching origin from https://github.com/mortent/kpt-packages@master.
From https://github.com/mortent/kpt-packages
 * branch            a0f76dcbe81d7ccd58511862db26a4f104c597d2 -> FETCH_HEAD
Updating package "zookeeper2" with strategy "resource-merge".

Package "kafka/zookeeper2/zookeeper-networkpolicy":

Fetching upstream from https://github.com/mortent/kpt-packages@master.
From https://github.com/mortent/kpt-packages
 * branch            master     -> FETCH_HEAD
Fetching origin from https://github.com/mortent/kpt-packages@master.
From https://github.com/mortent/kpt-packages
 * branch            a0f76dcbe81d7ccd58511862db26a4f104c597d2 -> FETCH_HEAD
Updating package "zookeeper-networkpolicy" with strategy "resource-merge".

Package "kafka/zookeeper1":

Fetching upstream from https://github.com/mortent/kpt-packages@master.
From https://github.com/mortent/kpt-packages
 * branch            master     -> FETCH_HEAD
Fetching origin from https://github.com/mortent/kpt-packages@master.
From https://github.com/mortent/kpt-packages
 * branch            a0f76dcbe81d7ccd58511862db26a4f104c597d2 -> FETCH_HEAD
Updating package "zookeeper1" with strategy "resource-merge".

Package "kafka/zookeeper1/zookeeper-networkpolicy":

Fetching upstream from https://github.com/mortent/kpt-packages@master.
From https://github.com/mortent/kpt-packages
 * branch            master     -> FETCH_HEAD
Fetching origin from https://github.com/mortent/kpt-packages@master.
From https://github.com/mortent/kpt-packages
 * branch            a0f76dcbe81d7ccd58511862db26a4f104c597d2 -> FETCH_HEAD
Updating package "zookeeper-networkpolicy" with strategy "resource-merge".

Updated 5 package(s).
```
