### PR TITLE
Improve error messages to users for kpt pkg update

### DIFF
--- a/internal/cmdupdate/cmdupdate_test.go
+++ b/internal/cmdupdate/cmdupdate_test.go
@@ -168,7 +168,7 @@ func TestCmd_failUnCommitted(t *testing.T) {
 	if !assert.Error(t, err) {
 		return
 	}
-	assert.Contains(t, err.Error(), "package must be committed to git before attempting to update")
+	assert.Contains(t, err.Error(), "contains uncommitted changes")
 
 	if !g.AssertEqual(t, filepath.Join(g.DatasetDirectory, testutil.Dataset1), dest) {
 		return

--- a/internal/errors/resolver/update.go
+++ b/internal/errors/resolver/update.go
@@ -1,0 +1,66 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolver
+
+import (
+	"github.com/GoogleContainerTools/kpt/internal/errors"
+	"github.com/GoogleContainerTools/kpt/internal/util/update"
+)
+
+//nolint:gochecknoinits
+func init() {
+	AddErrorResolver(&updateErrorResolver{})
+}
+
+var (
+	//nolint:lll
+	pkgNotGitRepo = `
+Package {{ printf "%q" .repo }} is not within a git repository. Please initialize a repository using 'git init' and then commit the changes using 'git commit -a -m "<commit message>"'.
+`
+
+	pkgRepoDirty = `
+Package {{ printf "%q" .repo }} contains uncommitted changes. Please commit the changes using 'git commit -a -m "<commit message>"'.
+`
+)
+
+// updateErrorResolver is an implementation of the ErrorResolver interface
+// to resolve update errors.
+type updateErrorResolver struct{}
+
+func (*updateErrorResolver) Resolve(err error) (ResolvedResult, bool) {
+	var msg string
+
+	var pkgNotGitRepoError *update.PkgNotGitRepoError
+	if errors.As(err, &pkgNotGitRepoError) {
+		msg = ExecuteTemplate(pkgNotGitRepo, map[string]interface{}{
+			"repo": pkgNotGitRepoError.Path,
+		})
+	}
+
+	var pkgRepoDirtyError *update.PkgRepoDirtyError
+	if errors.As(err, &pkgRepoDirtyError) {
+		msg = ExecuteTemplate(pkgRepoDirty, map[string]interface{}{
+			"repo": pkgRepoDirtyError.Path,
+		})
+	}
+
+	if msg != "" {
+		return ResolvedResult{
+			Message:  msg,
+			ExitCode: 1,
+		}, true
+	}
+	return ResolvedResult{}, false
+}

--- a/internal/errors/resolver/update.go
+++ b/internal/errors/resolver/update.go
@@ -27,11 +27,11 @@ func init() {
 var (
 	//nolint:lll
 	pkgNotGitRepo = `
-Package {{ printf "%q" .repo }} is not within a git repository. Please initialize a repository using 'git init' and then commit the changes using 'git commit -a -m "<commit message>"'.
+Package {{ printf "%q" .repo }} is not within a git repository. Please initialize a repository using 'git init' and then commit the changes using 'git commit -m "<commit message>"'.
 `
 
 	pkgRepoDirty = `
-Package {{ printf "%q" .repo }} contains uncommitted changes. Please commit the changes using 'git commit -a -m "<commit message>"'.
+Package {{ printf "%q" .repo }} contains uncommitted changes. Please commit the changes using 'git commit -m "<commit message>"'.
 `
 )
 

--- a/internal/util/update/update_test.go
+++ b/internal/util/update/update_test.go
@@ -248,7 +248,7 @@ func TestCommand_Run_noCommit(t *testing.T) {
 			if !assert.Error(t, err) {
 				return
 			}
-			assert.Contains(t, err.Error(), "package must be committed to git before attempting to update")
+			assert.Contains(t, err.Error(), "contains uncommitted changes")
 
 			if !g.AssertLocalDataEquals(testutil.Dataset3) {
 				return
@@ -295,9 +295,45 @@ func TestCommand_Run_noAdd(t *testing.T) {
 			if !assert.Error(t, err) {
 				return
 			}
-			assert.Contains(t, err.Error(), "package must be committed to git before attempting to update")
+			assert.Contains(t, err.Error(), "contains uncommitted changes")
 		})
 	}
+}
+
+func TestCommand_Run_noGitRepo(t *testing.T) {
+	d, err := ioutil.TempDir("", "kpt-noGitRepo-test")
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	defer os.RemoveAll(d)
+
+	kf := kptfileutil.DefaultKptfile(filepath.Base(d))
+	kf.Upstream = &kptfilev1alpha2.Upstream{
+		Type: kptfilev1alpha2.GitOrigin,
+		Git: &kptfilev1alpha2.Git{
+			Repo:      "https://github.com/GoogleContainerTools/kpt",
+			Directory: "/",
+			Ref:       "main",
+		},
+		UpdateStrategy: kptfilev1alpha2.ResourceMerge,
+	}
+	kf.UpstreamLock = &kptfilev1alpha2.UpstreamLock{
+		Type: kptfilev1alpha2.GitOrigin,
+		Git: &kptfilev1alpha2.GitLock{
+			Repo:      "https://github.com/GoogleContainerTools/kpt",
+			Directory: "/",
+			Ref:       "main",
+			Commit:    "abc123",
+		},
+	}
+
+	err = Command{
+		Pkg: pkgtest.CreatePkgOrFail(t, d),
+	}.Run(fake.CtxWithNilPrinter())
+	if !assert.Error(t, err) {
+		return
+	}
+	assert.Contains(t, err.Error(), "is not a git repository")
 }
 
 func TestCommand_Run_localPackageChanges(t *testing.T) {


### PR DESCRIPTION
This PR updates the error message shown to users when the local package is either not in a git repository, or the git repository has uncommitted files.

Output when no git repo:
```
$ kpt pkg update kafka
updating package /Users/<user>/kafka
Package "/Users/<user>/kafka" is not within a git repository. Please initialize a repository using 'git init' and then commit the changes using 'git commit -m "<commit message>"'. 
```

Output when repo has uncommitted files:
```
$ kpt pkg update kafka
updating package /Users/<user>/kafka
Package "/Users/<user>/kafka" contains uncommitted changes. Please commit the changes using 'git commit -m "<commit message>"'. 
```

Fixes: https://github.com/GoogleContainerTools/kpt/issues/1852