### PR TITLE
Update wordpress example with formatted resources

### DIFF
--- a/package-examples/wordpress/deployment/deployment.yaml
+++ b/package-examples/wordpress/deployment/deployment.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: wordpress

--- a/package-examples/wordpress/deployment/deployment.yaml
+++ b/package-examples/wordpress/deployment/deployment.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
 kind: Deployment
 metadata:
@@ -23,8 +22,6 @@ spec:
     matchLabels:
       app: wordpress
       tier: frontend
-  strategy:
-    type: Recreate
   template:
     metadata:
       labels:
@@ -32,8 +29,11 @@ spec:
         tier: frontend
     spec:
       containers:
-        - image: wordpress:4.8-apache # {"$kpt-set":"image-tag"}
-          name: wordpress
+        - name: wordpress
+          image: wordpress:4.8-apache # kpt-set: ${wp-image}:${wp-tag}
+          ports:
+            - name: wordpress
+              containerPort: 80
           env:
             - name: WORDPRESS_DB_HOST
               value: wordpress-mysql
@@ -42,9 +42,6 @@ spec:
                 secretKeyRef:
                   name: mysql-pass
                   key: password
-          ports:
-            - containerPort: 80
-              name: wordpress
           volumeMounts:
             - name: wordpress-persistent-storage
               mountPath: /var/www/html
@@ -52,3 +49,5 @@ spec:
         - name: wordpress-persistent-storage
           persistentVolumeClaim:
             claimName: wp-pv-claim
+  strategy:
+    type: Recreate

--- a/package-examples/wordpress/deployment/volume.yaml
+++ b/package-examples/wordpress/deployment/volume.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -19,8 +18,8 @@ metadata:
   labels:
     app: wordpress
 spec:
-  accessModes:
-    - ReadWriteOnce
   resources:
     requests:
       storage: 20Gi
+  accessModes:
+    - ReadWriteOnce

--- a/package-examples/wordpress/mysql/deployment.yaml
+++ b/package-examples/wordpress/mysql/deployment.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: Service
 metadata:
@@ -19,11 +18,11 @@ metadata:
   labels:
     app: wordpress
 spec:
-  ports:
-  - port: 3306
   selector:
     app: wordpress
     tier: mysql
+  ports:
+    - port: 3306
   clusterIP: None
 ---
 apiVersion: v1
@@ -33,11 +32,11 @@ metadata:
   labels:
     app: wordpress
 spec:
-  accessModes:
-  - ReadWriteOnce
   resources:
     requests:
       storage: 20Gi
+  accessModes:
+    - ReadWriteOnce
 ---
 apiVersion: apps/v1 # for versions before 1.9.0 use apps/v1beta2
 kind: Deployment
@@ -50,8 +49,6 @@ spec:
     matchLabels:
       app: wordpress
       tier: mysql
-  strategy:
-    type: Recreate
   template:
     metadata:
       labels:
@@ -59,21 +56,23 @@ spec:
         tier: mysql
     spec:
       containers:
-      - image: mysql:5.6 # kpt-set: ${ms-image}:${ms-tag}
-        name: mysql
-        env:
-        - name: MYSQL_ROOT_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: mysql-pass
-              key: password
-        ports:
-        - containerPort: 3306
-          name: mysql
-        volumeMounts:
-        - name: mysql-persistent-storage
-          mountPath: /var/lib/mysql
+        - name: mysql
+          image: mysql:5.6 # kpt-set: ${ms-image}:${ms-tag}
+          ports:
+            - name: mysql
+              containerPort: 3306
+          env:
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mysql-pass
+                  key: password
+          volumeMounts:
+            - name: mysql-persistent-storage
+              mountPath: /var/lib/mysql
       volumes:
-      - name: mysql-persistent-storage
-        persistentVolumeClaim:
-          claimName: mysql-pv-claim
+        - name: mysql-persistent-storage
+          persistentVolumeClaim:
+            claimName: mysql-pv-claim
+  strategy:
+    type: Recreate

--- a/package-examples/wordpress/service.yaml
+++ b/package-examples/wordpress/service.yaml
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 apiVersion: v1
 kind: Service
 metadata:
@@ -19,9 +18,9 @@ metadata:
   labels:
     app: wordpress
 spec:
-  ports:
-    - port: 80
+  type: LoadBalancer
   selector:
     app: wordpress
     tier: frontend
-  type: LoadBalancer
+  ports:
+    - port: 80


### PR DESCRIPTION
As `render` command formats the resources, updating the wordpress example so that users don't get confused by formatting diffs. Also updated image-tag setter references.