### PR TITLE
make eval to use kpt container & exec runtime

### DIFF
--- a/e2e/testdata/fn-eval/missing-fn-config/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/missing-fn-config/.expected/config.yaml
@@ -15,4 +15,4 @@
 testType: eval
 exitCode: 1
 image: gcr.io/kpt-fn/set-namespace:v0.1
-stdErr: "failed to configure function: input namespace cannot be emptyerror: exit status 1"
+stdErr: "failed to configure function: input namespace cannot be empty"

--- a/e2e/testdata/fn-eval/missing-fn-image/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/missing-fn-image/.expected/config.yaml
@@ -17,5 +17,4 @@ exitCode: 1
 image: gcr.io/kpt-fn/dne # non-existing image
 args:
   namespace: staging
-stdErr: "Failed to fetch \"latest\" from request \"/v2/kpt-fn/dne/manifests/latest\""
-
+stdErr: 'failed to check function image existence: function image "gcr.io/kpt-fn/dne" doesn''t exist'

--- a/internal/fnruntime/exec.go
+++ b/internal/fnruntime/exec.go
@@ -1,0 +1,73 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fnruntime
+
+import (
+	"bytes"
+	"context"
+	goerrors "errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"time"
+
+	"github.com/GoogleContainerTools/kpt/internal/errors"
+	"github.com/GoogleContainerTools/kpt/internal/printer"
+)
+
+type ExecFn struct {
+	// Path is the os specific path to the executable
+	// file. It can be relative or absolute.
+	Path string
+	// Args are the arguments to the executable
+	Args []string
+	// Container function will be killed after this timeour.
+	// The default value is 5 minutes.
+	Timeout time.Duration
+}
+
+// Run runs the executable file which reads the input from r and
+// writes the output to w.
+func (f *ExecFn) Run(r io.Reader, w io.Writer) error {
+	// setup exec run timeout
+	timeout := defaultTimeout
+	if f.Timeout != 0 {
+		timeout = f.Timeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, f.Path, f.Args...)
+
+	errSink := bytes.Buffer{}
+	cmd.Stdin = r
+	cmd.Stdout = w
+	cmd.Stderr = &errSink
+
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if goerrors.As(err, &exitErr) {
+			return &errors.FnExecError{
+				OriginalErr:    exitErr,
+				ExitCode:       exitErr.ExitCode(),
+				Stderr:         errSink.String(),
+				TruncateOutput: printer.TruncateOutput,
+			}
+		}
+		return fmt.Errorf("unexpected function error: %w", err)
+	}
+
+	return nil
+}

--- a/thirdparty/kyaml/runfn/runfn.go
+++ b/thirdparty/kyaml/runfn/runfn.go
@@ -16,14 +16,13 @@ import (
 	"sync/atomic"
 
 	"sigs.k8s.io/kustomize/kyaml/errors"
-	"sigs.k8s.io/kustomize/kyaml/fn/runtime/container"
 	"sigs.k8s.io/kustomize/kyaml/fn/runtime/exec"
 	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
-	"sigs.k8s.io/kustomize/kyaml/fn/runtime/starlark"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 
+	"github.com/GoogleContainerTools/kpt/internal/fnruntime"
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	"github.com/GoogleContainerTools/kpt/internal/types"
 	"github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
@@ -218,26 +217,7 @@ func (r RunFns) runFunctions(
 		Outputs:               outputs,
 		ContinueOnEmptyResult: r.ContinueOnEmptyResult,
 	}
-	if r.LogSteps {
-		err = pipeline.ExecuteWithCallback(func(op kio.Filter) {
-			var identifier string
-
-			switch filter := op.(type) {
-			case *container.Filter:
-				identifier = filter.Image
-			case *exec.Filter:
-				identifier = filter.Path
-			case *starlark.Filter:
-				identifier = filter.String()
-			default:
-				identifier = "unknown-type function"
-			}
-
-			_, _ = fmt.Fprintf(r.LogWriter, "Running %s\n", identifier)
-		})
-	} else {
-		err = pipeline.Execute()
-	}
+	err = pipeline.Execute()
 	if err != nil {
 		return err
 	}
@@ -446,19 +426,25 @@ func (r *RunFns) defaultFnFilterProvider(spec runtimeutil.FunctionSpec, fnConfig
 		if err != nil {
 			return nil, err
 		}
-		c := container.NewContainer(
-			runtimeutil.ContainerSpec{
-				Image:         spec.Container.Image,
-				Network:       spec.Container.Network,
-				StorageMounts: r.StorageMounts,
-				Env:           spec.Container.Env,
+		c := &fnruntime.ContainerFn{
+			Path:          r.uniquePath,
+			Image:         spec.Container.Image,
+			UIDGID:        uidgid,
+			StorageMounts: r.StorageMounts,
+			Env:           r.Env,
+			Perm: fnruntime.ContainerFnPermission{
+				AllowNetwork: spec.Container.Network,
+				// mounts are always from CLI flags so we allow
+				// them by default for eval
+				AllowMount: true,
 			},
-			uidgid,
-		)
-		cf := &c
-		cf.Exec.FunctionConfig = fnConfig
-		cf.Exec.ResultsFile = resultsFile
-		cf.Exec.DeferFailure = spec.DeferFailure
+		}
+		cf := &runtimeutil.FunctionFilter{
+			Run:            c.Run,
+			FunctionConfig: fnConfig,
+			DeferFailure:   spec.DeferFailure,
+			ResultsFile:    resultsFile,
+		}
 		return cf, nil
 	}
 

--- a/thirdparty/kyaml/runfn/runfn_test.go
+++ b/thirdparty/kyaml/runfn/runfn_test.go
@@ -11,15 +11,14 @@ import (
 	"os/user"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"testing"
 
+	"github.com/GoogleContainerTools/kpt/internal/fnruntime"
 	"github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 	"github.com/stretchr/testify/assert"
 
 	"sigs.k8s.io/kustomize/kyaml/copyutil"
 	"sigs.k8s.io/kustomize/kyaml/errors"
-	"sigs.k8s.io/kustomize/kyaml/fn/runtime/container"
 	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/filters"
@@ -85,10 +84,15 @@ kind:
 		return
 	}
 	filter, _ := instance.functionFilterProvider(spec, api, currentUser)
-	c := container.NewContainer(runtimeutil.ContainerSpec{Image: "example.com:version"}, "nobody")
-	cf := &c
-	cf.Exec.FunctionConfig = api
-	assert.Equal(t, cf, filter)
+	c := fnruntime.ContainerFn{
+		Image:  "example.com:version",
+		UIDGID: "nobody",
+	}
+	cf := &runtimeutil.FunctionFilter{
+		Run:            c.Run,
+		FunctionConfig: api,
+	}
+	assert.Equal(t, fmt.Sprint(cf), fmt.Sprint(filter))
 }
 
 func TestRunFns_initAsCurrentUser(t *testing.T) {
@@ -115,10 +119,15 @@ kind:
 		return
 	}
 	filter, _ := instance.functionFilterProvider(spec, api, currentUser)
-	c := container.NewContainer(runtimeutil.ContainerSpec{Image: "example.com:version"}, "1:2")
-	cf := &c
-	cf.Exec.FunctionConfig = api
-	assert.Equal(t, cf, filter)
+	c := fnruntime.ContainerFn{
+		Image:  "example.com:version",
+		UIDGID: "1:2",
+	}
+	cf := &runtimeutil.FunctionFilter{
+		Run:            c.Run,
+		FunctionConfig: api,
+	}
+	assert.Equal(t, fmt.Sprint(cf), fmt.Sprint(filter))
 }
 
 func TestRunFns_Execute__initDefault(t *testing.T) {
@@ -188,130 +197,6 @@ func TestRunFns_Execute__initDefault(t *testing.T) {
 			(&tt.instance).functionFilterProvider = nil
 			if !assert.Equal(t, tt.expected, tt.instance) {
 				t.FailNow()
-			}
-		})
-	}
-}
-
-// TestRunFns_getFilters tests how filters are found and sorted
-func TestRunFns_getFilters(t *testing.T) {
-	type f struct {
-		// string value of function
-		value string
-	}
-	var tests = []struct {
-		// function files to write
-		in []f
-		// images to be run in a specific order
-		out []string
-
-		// images to be run in a specific order -- computed from directory path
-		outFn func(string) []string
-
-		// expected Error
-		error string
-
-		// name of the test
-		name string
-	}{
-		{name: "no function spec",
-			in: []f{
-				{
-					value: `
-foo: bar
-`,
-				},
-			},
-		},
-
-		// Test
-		//
-		//
-		{name: "defer_failure",
-			in: []f{
-				{
-					value: `
-apiVersion: example.com/v1alpha1
-kind: ExampleFunction
-metadata:
-  annotations:
-    config.kubernetes.io/function: |
-      deferFailure: true
-      container:
-        image: gcr.io/example.com/image:v1.0.0
-    config.kubernetes.io/local-config: "true"
-`,
-				},
-			},
-			out: []string{"gcr.io/example.com/image:v1.0.0 deferFailure: true"},
-		},
-
-		// Test
-		//
-		//
-		{name: "explicit functions",
-			in: []f{
-				{
-					value: `
-metadata:
-  annotations:
-    config.kubernetes.io/function: |
-      container:
-        image: c
-`,
-				},
-			},
-			out: []string{"c"},
-		},
-	}
-
-	for i := range tests {
-		tt := tests[i]
-		t.Run(tt.name, func(t *testing.T) {
-			// setup the test directory
-			d := setupTest(t)
-			defer os.RemoveAll(d)
-
-			var parsedFns []*yaml.RNode
-			var err error
-			for _, f := range tt.in {
-				parsedFns = append(parsedFns, yaml.MustParse(f.value))
-			}
-
-			// init the instance
-			r := &RunFns{
-				Functions: parsedFns,
-				Path:      d,
-			}
-			assert.NoError(t, r.init())
-
-			// get the filters which would be run
-			var results []string
-			_, fltrs, _, err := r.getNodesAndFilters()
-
-			if tt.error != "" {
-				if !assert.EqualError(t, err, tt.error) {
-					t.FailNow()
-				}
-				return
-			}
-
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
-			for _, f := range fltrs {
-				results = append(results, strings.TrimSpace(fmt.Sprintf("%v", f)))
-			}
-
-			// compare the actual ordering to the expected ordering
-			if tt.outFn != nil {
-				if !assert.Equal(t, tt.outFn(d), results) {
-					t.FailNow()
-				}
-			} else {
-				if !assert.Equal(t, tt.out, results) {
-					t.FailNow()
-				}
 			}
 		})
 	}
@@ -401,98 +286,6 @@ metadata:
 			}
 
 			assert.Equal(t, test.expectedImages, images)
-		})
-	}
-}
-
-func TestRunFns_network(t *testing.T) {
-	tests := []struct {
-		name          string
-		input         string
-		network       bool
-		expectNetwork bool
-		error         string
-	}{
-		{
-			name: "imperative false, declarative false",
-			input: `
-metadata:
-  annotations:
-    config.kubernetes.io/function: |
-      container:
-        image: a
-        network: false
-`,
-			network:       false,
-			expectNetwork: false,
-		},
-		{
-			name: "imperative true, declarative false",
-			input: `
-metadata:
-  annotations:
-    config.kubernetes.io/function: |
-      container:
-        image: a
-        network: false
-`,
-			network:       true,
-			expectNetwork: false,
-		},
-		{
-			name: "imperative true, declarative true",
-			input: `
-metadata:
-  annotations:
-    config.kubernetes.io/function: |
-      container:
-        image: a
-        network: true
-`,
-			network:       true,
-			expectNetwork: true,
-		},
-		{
-			name: "imperative false, declarative true",
-			input: `
-metadata:
-  annotations:
-    config.kubernetes.io/function: |
-      container:
-        image: a
-        network: true
-`,
-			network: false,
-			error:   "network required but not enabled with --network",
-		},
-	}
-
-	for i := range tests {
-		tt := tests[i]
-		fn := yaml.MustParse(tt.input)
-		t.Run(tt.name, func(t *testing.T) {
-			// init the instance
-			r := &RunFns{
-				Functions: []*yaml.RNode{fn},
-				Network:   tt.network,
-			}
-			assert.NoError(t, r.init())
-
-			_, fltrs, _, err := r.getNodesAndFilters()
-			if tt.error != "" {
-				if !assert.EqualError(t, err, tt.error) {
-					t.FailNow()
-				}
-				return
-			}
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
-
-			fltr := fltrs[0].(*container.Filter)
-			if !assert.Equal(t, tt.expectNetwork, fltr.Network) {
-				t.FailNow()
-			}
 		})
 	}
 }
@@ -818,36 +611,6 @@ func TestCmd_Execute_setInput(t *testing.T) {
 		t.FailNow()
 	}
 	assert.Contains(t, string(b), "kind: StatefulSet")
-}
-
-// TestCmd_Execute_enableLogSteps tests the execution of a filter with LogSteps enabled.
-func TestCmd_Execute_enableLogSteps(t *testing.T) {
-	dir := setupTest(t)
-	defer os.RemoveAll(dir)
-
-	fn, err := yaml.Parse(ValueReplacerYAMLData)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	logs := &bytes.Buffer{}
-	instance := RunFns{
-		Path:                   dir,
-		functionFilterProvider: getFilterProvider(t),
-		LogSteps:               true,
-		LogWriter:              logs,
-		Functions:              []*yaml.RNode{fn},
-	}
-	if !assert.NoError(t, instance.Execute()) {
-		t.FailNow()
-	}
-	b, err := ioutil.ReadFile(
-		filepath.Join(dir, "java", "java-deployment.resource.yaml"))
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	assert.Contains(t, string(b), "kind: StatefulSet")
-	assert.Equal(t, "Running unknown-type function\n", logs.String())
 }
 
 func getGeneratorFilterProvider(t *testing.T) func(runtimeutil.FunctionSpec, *yaml.RNode, currentUserFunc) (kio.Filter, error) {


### PR DESCRIPTION
`fn eval` is using container and exec runtime from kyaml. These runtimes are [hardcoding](https://github.com/kubernetes-sigs/kustomize/blob/master/kyaml/fn/runtime/exec/exec.go#L34) the command error outputs to `os.Stderr` so we cannot get the stderr output from the runtime.

One alternative is refactoring the kyaml implementation to accept a writer for stderr. However, given we have had our own [container runtime](https://github.com/GoogleContainerTools/kpt/blob/next/internal/fnruntime/container.go) in kpt and is used by `render`. It's better to make `eval` and `render` to use the same runtime.

This PR is modifying the container runtime in kpt to support the functionalities required by `fn eval` and adding an exec runtime for `fn eval`.