### PR TITLE
Add functions catalog back to sidebar.

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -35,6 +35,7 @@
           placeholder: "Search",
           paths: "auto",
         },
+        externalLinkTarget: "_self",
         loadSidebar: "sidebar.md",
         alias: {
           "/*.*/sidebar.md": "/sidebar.md",

--- a/site/sidebar.md
+++ b/site/sidebar.md
@@ -47,5 +47,6 @@
         - [init](reference/live/init/)
         - [preview](reference/live/preview/)
         - [status](reference/live/status/)
+- [Functions Catalog](https://catalog.kpt.dev/ ':crossorgin')
 - [FAQ](faq/)
 - [Contact](contact/)


### PR DESCRIPTION
Opens the catalog in the same window with behavior similar to pub.dev at https://dart.dev/guides/packages 
Demo at https://kpt-dev-ee2a9--fn-sidebar-9ucyyfi3.web.app 
Catalog styling bugs and link behavior will be a different PR addressing https://github.com/GoogleContainerTools/kpt/issues/1825