### PR TITLE
Structured result support

### DIFF
--- a/internal/cmdrender/cmd.go
+++ b/internal/cmdrender/cmd.go
@@ -36,6 +36,8 @@ func NewRunner(ctx context.Context, parent string) *Runner {
 		RunE:    r.runE,
 		PreRunE: r.preRunE,
 	}
+	c.Flags().StringVar(&r.resultsDirPath, "results-dir", "",
+		"path to the directory to save function results")
 	cmdutil.FixDocs("kpt", parent, c)
 	r.Command = c
 	return r
@@ -47,9 +49,10 @@ func NewCommand(ctx context.Context, parent string) *cobra.Command {
 
 // Runner contains the run function pipeline run command
 type Runner struct {
-	pkgPath string
-	Command *cobra.Command
-	ctx     context.Context
+	pkgPath        string
+	resultsDirPath string
+	Command        *cobra.Command
+	ctx            context.Context
 }
 
 func (r *Runner) preRunE(c *cobra.Command, args []string) error {
@@ -75,7 +78,8 @@ func (r *Runner) runE(c *cobra.Command, _ []string) error {
 		return err
 	}
 	executor := Executor{
-		PkgPath: r.pkgPath,
+		PkgPath:        r.pkgPath,
+		ResultsDirPath: r.resultsDirPath,
 	}
 	if err = executor.Execute(r.ctx); err != nil {
 		return err

--- a/internal/cmdrender/executor.go
+++ b/internal/cmdrender/executor.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/GoogleContainerTools/kpt/internal/errors"
+	"github.com/GoogleContainerTools/kpt/internal/fnruntime"
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"github.com/GoogleContainerTools/kpt/internal/types"
@@ -402,7 +403,7 @@ func (pn *pkgNode) runValidators(ctx context.Context, hctx *hydrationContext, in
 
 	for i := range pl.Validators {
 		fn := pl.Validators[i]
-		validator, err := newFunctionRunner(ctx, hctx, &fn, pn.pkg.UniquePath)
+		validator, err := fnruntime.NewFunctionRunner(ctx, &fn, pn.pkg.UniquePath, hctx.fnResults)
 		if err != nil {
 			return err
 		}
@@ -456,7 +457,7 @@ func fnChain(ctx context.Context, hctx *hydrationContext, pkgPath types.UniquePa
 	var runners []kio.Filter
 	for i := range fns {
 		fn := fns[i]
-		r, err := newFunctionRunner(ctx, hctx, &fn, pkgPath)
+		r, err := fnruntime.NewFunctionRunner(ctx, &fn, pkgPath, hctx.fnResults)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cmdrender/executor.go
+++ b/internal/cmdrender/executor.go
@@ -402,7 +402,7 @@ func (pn *pkgNode) runValidators(ctx context.Context, hctx *hydrationContext, in
 
 	for i := range pl.Validators {
 		fn := pl.Validators[i]
-		validator, err := newFnRunner(ctx, hctx, &fn, pn.pkg.UniquePath)
+		validator, err := newFunctionRunner(ctx, hctx, &fn, pn.pkg.UniquePath)
 		if err != nil {
 			return err
 		}
@@ -456,7 +456,7 @@ func fnChain(ctx context.Context, hctx *hydrationContext, pkgPath types.UniquePa
 	var runners []kio.Filter
 	for i := range fns {
 		fn := fns[i]
-		r, err := newFnRunner(ctx, hctx, &fn, pkgPath)
+		r, err := newFunctionRunner(ctx, hctx, &fn, pkgPath)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cmdrender/executor.go
+++ b/internal/cmdrender/executor.go
@@ -17,6 +17,7 @@ package cmdrender
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -26,6 +27,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"github.com/GoogleContainerTools/kpt/internal/types"
+	fnresultv1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/fnresult/v1alpha2"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/filters"
@@ -36,13 +38,25 @@ import (
 
 // Executor hydrates a given pkg.
 type Executor struct {
-	PkgPath string
+	PkgPath        string
+	ResultsDirPath string
+
 	Printer printer.Printer
 }
 
 // Execute runs a pipeline.
 func (e *Executor) Execute(ctx context.Context) error {
 	const op errors.Op = "fn.render"
+
+	if e.ResultsDirPath != "" {
+		// TODO(droot): ensure the specified directory exists
+		if _, err := os.Stat(e.ResultsDirPath); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("results-dir %q must exist", e.ResultsDirPath)
+			}
+			return fmt.Errorf("results-dir %q check failed: %w", e.ResultsDirPath, err)
+		}
+	}
 
 	pr := printer.FromContextOrDie(ctx)
 
@@ -53,12 +67,23 @@ func (e *Executor) Execute(ctx context.Context) error {
 
 	// initialize hydration context
 	hctx := &hydrationContext{
-		root: root,
-		pkgs: map[types.UniquePath]*pkgNode{},
+		root:      root,
+		pkgs:      map[types.UniquePath]*pkgNode{},
+		fnResults: &fnresultv1alpha2.ResultList{},
 	}
 
 	resources, err := hydrate(ctx, root, hctx)
 	if err != nil {
+		if e.ResultsDirPath == "" {
+			return nil
+		}
+
+		resultFile, resultErr := e.saveResults(hctx)
+		if resultErr != nil {
+			return fmt.Errorf("failed to save function results: %w", resultErr)
+		}
+
+		pr.Printf("Results saved successfully at %q.\n", resultFile)
 		return errors.E(op, root.pkg.UniquePath, err)
 	}
 
@@ -84,8 +109,39 @@ func (e *Executor) Execute(ctx context.Context) error {
 	}
 
 	pr.Printf("Successfully executed %d function(s) in %d package(s).\n", hctx.executedFunctionCnt, len(hctx.pkgs))
-	// TODO: Output the complete result file path here
+
+	if e.ResultsDirPath == "" {
+		return nil
+	}
+
+	resultFile, err := e.saveResults(hctx)
+	if err != nil {
+		return fmt.Errorf("failed to save function results: %w", err)
+	}
+
+	pr.Printf("Results saved successfully at %q.\n", resultFile)
+
 	return nil
+}
+
+// saveResults saves results gathered from running the pipeline at specified dir.
+func (e *Executor) saveResults(hctx *hydrationContext) (string, error) {
+	if e.ResultsDirPath == "" {
+		return "", nil
+	}
+	filePath := filepath.Join(e.ResultsDirPath, "results.yaml")
+
+	content, err := yaml.Marshal(hctx.fnResults)
+	if err != nil {
+		return "", err
+	}
+
+	err = ioutil.WriteFile(filePath, content, 0744)
+	if err != nil {
+		return "", err
+	}
+
+	return filePath, nil
 }
 
 // hydrationContext contains bits to track state of a package hydration.
@@ -110,6 +166,10 @@ type hydrationContext struct {
 
 	// executedFunctionCnt is the counter for functions that have been executed.
 	executedFunctionCnt int
+
+	// fnResults stores function results gathered
+	// during pipeline execution.
+	fnResults *fnresultv1alpha2.ResultList
 }
 
 //
@@ -314,7 +374,7 @@ func (pn *pkgNode) runMutators(ctx context.Context, hctx *hydrationContext, inpu
 		return input, nil
 	}
 
-	mutators, err := fnChain(ctx, pn.pkg.UniquePath, pl.Mutators)
+	mutators, err := fnChain(ctx, pn.pkg.UniquePath, pl.Mutators, hctx.fnResults)
 	if err != nil {
 		return nil, err
 	}
@@ -356,7 +416,7 @@ func (pn *pkgNode) runValidators(ctx context.Context, hctx *hydrationContext, in
 
 	for i := range pl.Validators {
 		fn := pl.Validators[i]
-		validator, err := newFnRunner(ctx, &fn, pn.pkg.UniquePath)
+		validator, err := newFnRunner(ctx, &fn, pn.pkg.UniquePath, hctx.fnResults)
 		if err != nil {
 			return err
 		}
@@ -406,11 +466,11 @@ func adjustRelPath(resources []*yaml.RNode, relPath string) ([]*yaml.RNode, erro
 }
 
 // fnChain returns a slice of function runners given a list of functions defined in pipeline.
-func fnChain(ctx context.Context, pkgPath types.UniquePath, fns []kptfilev1alpha2.Function) ([]kio.Filter, error) {
+func fnChain(ctx context.Context, pkgPath types.UniquePath, fns []kptfilev1alpha2.Function, fnResults *fnresultv1alpha2.ResultList) ([]kio.Filter, error) {
 	var runners []kio.Filter
 	for i := range fns {
 		fn := fns[i]
-		r, err := newFnRunner(ctx, &fn, pkgPath)
+		r, err := newFnRunner(ctx, &fn, pkgPath, fnResults)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/cmdrender/pipeline_function.go
+++ b/internal/cmdrender/pipeline_function.go
@@ -39,7 +39,7 @@ import (
 
 // newFnRunner returns a fnRunner from the image and configs of
 // this function.
-func newFnRunner(ctx context.Context, f *kptfilev1alpha2.Function, pkgPath types.UniquePath, fnResults *v1alpha2.ResultList) (kio.Filter, error) {
+func newFnRunner(ctx context.Context, hctx *hydrationContext, f *kptfilev1alpha2.Function, pkgPath types.UniquePath) (kio.Filter, error) {
 	config, err := newFnConfig(f, pkgPath)
 	if err != nil {
 		return nil, err
@@ -54,7 +54,7 @@ func newFnRunner(ctx context.Context, f *kptfilev1alpha2.Function, pkgPath types
 	return &FunctionRunner{
 		ctx:             ctx,
 		containerRunner: cfn,
-		resultList:      fnResults,
+		fnResults:       hctx.fnResults,
 		filter: &runtimeutil.FunctionFilter{
 			Run:            cfn.Run,
 			FunctionConfig: config,
@@ -65,7 +65,7 @@ func newFnRunner(ctx context.Context, f *kptfilev1alpha2.Function, pkgPath types
 // FunctionRunner wraps FunctionFilter and implements a kio.Filter interface.
 type FunctionRunner struct {
 	ctx             context.Context
-	resultList      *v1alpha2.ResultList
+	fnResults       *v1alpha2.ResultList
 	containerRunner *fnruntime.ContainerFn
 	filter          *runtimeutil.FunctionFilter
 }
@@ -87,7 +87,7 @@ func (fnr *FunctionRunner) Filter(input []*yaml.RNode) (output []*yaml.RNode, er
 				Stderr:   fnErr.Stderr,
 				Results:  results,
 			}
-			fnr.resultList.Items = append(fnr.resultList.Items, fnResult)
+			fnr.fnResults.Items = append(fnr.fnResults.Items, fnResult)
 		}
 		return output, err
 	}

--- a/internal/cmdrender/pipeline_function.go
+++ b/internal/cmdrender/pipeline_function.go
@@ -23,11 +23,12 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/GoogleContainerTools/kpt/thirdparty/kyaml/fn/runtime/runtimeutil"
+
 	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/fnruntime"
 	"github.com/GoogleContainerTools/kpt/internal/types"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
-	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )

--- a/internal/cmdrender/pipeline_function.go
+++ b/internal/cmdrender/pipeline_function.go
@@ -81,6 +81,9 @@ func (fr *functionRunner) Filter(input []*yaml.RNode) (output []*yaml.RNode, err
 	}
 	// capture the result from running the function
 	pr.OptPrintf(printOpt, "[PASS] %q\n", fr.containerRunner.Image)
+
+	// TODO(droot): print functionResults
+
 	return output, nil
 }
 

--- a/internal/cmdrender/pipeline_function.go
+++ b/internal/cmdrender/pipeline_function.go
@@ -77,7 +77,8 @@ func (fr *functionRunner) Filter(input []*yaml.RNode) (output []*yaml.RNode, err
 	output, err = fr.do(input)
 	if err != nil {
 		pr.OptPrintf(printOpt, "[FAIL] %q\n", fr.containerRunner.Image)
-		return output, err
+		pr.OptPrintf(printOpt, "%s\n", err)
+		return output, errors.AlreadyHandledErr
 	}
 	// capture the result from running the function
 	pr.OptPrintf(printOpt, "[PASS] %q\n", fr.containerRunner.Image)

--- a/internal/errors/fnerrors.go
+++ b/internal/errors/fnerrors.go
@@ -73,3 +73,8 @@ func (fe *FnExecError) String() string {
 func (fe *FnExecError) Error() string {
 	return fe.String()
 }
+
+// AlreadyHandledErr is an error that is already handled by
+// a kpt command and nothing needs to be done by the global
+// error handler except to return a non-zero exit code.
+var AlreadyHandledErr error = fmt.Errorf("")

--- a/internal/errors/resolver/fn.go
+++ b/internal/errors/resolver/fn.go
@@ -23,6 +23,7 @@ import (
 //nolint:gochecknoinits
 func init() {
 	AddErrorResolver(&fnExecErrorResolver{})
+	AddErrorResolver(&alreadyHandledErrorResolver{})
 }
 
 // gitExecErrorResolver is an implementation of the ErrorResolver interface
@@ -42,4 +43,10 @@ func (*fnExecErrorResolver) Resolve(err error) (ResolvedResult, bool) {
 		Message:  fnErr.String(),
 		ExitCode: 1,
 	}, true
+}
+
+type alreadyHandledErrorResolver struct{}
+
+func (*alreadyHandledErrorResolver) Resolve(err error) (ResolvedResult, bool) {
+	return ResolvedResult{ExitCode: 1}, true
 }

--- a/internal/fnruntime/runner_test.go
+++ b/internal/fnruntime/runner_test.go
@@ -26,7 +26,7 @@
 
 // Package pipeline provides struct definitions for Pipeline and utility
 // methods to read and write a pipeline resource.
-package cmdrender
+package fnruntime
 
 import (
 	"io/ioutil"

--- a/thirdparty/kyaml/fn/runtime/runtimeutil/doc.go
+++ b/thirdparty/kyaml/fn/runtime/runtimeutil/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package runtimeutil contains libraries for implementing function runtimes.
+package runtimeutil

--- a/thirdparty/kyaml/fn/runtime/runtimeutil/functiontypes.go
+++ b/thirdparty/kyaml/fn/runtime/runtimeutil/functiontypes.go
@@ -1,0 +1,305 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package runtimeutil
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+const (
+	FunctionAnnotationKey    = "config.kubernetes.io/function"
+	oldFunctionAnnotationKey = "config.k8s.io/function"
+)
+
+var functionAnnotationKeys = []string{FunctionAnnotationKey, oldFunctionAnnotationKey}
+
+// ContainerNetworkName is a type for network name used in container
+type ContainerNetworkName string
+
+const (
+	NetworkNameNone ContainerNetworkName = "none"
+	NetworkNameHost ContainerNetworkName = "host"
+)
+const defaultEnvValue string = "true"
+
+// ContainerEnv defines the environment present in a container.
+type ContainerEnv struct {
+	// EnvVars is a key-value map that will be set as env in container
+	EnvVars map[string]string
+
+	// VarsToExport are only env key. Value will be the value in the host system
+	VarsToExport []string
+}
+
+// GetDockerFlags returns docker run style env flags
+func (ce *ContainerEnv) GetDockerFlags() []string {
+	envs := ce.EnvVars
+	if envs == nil {
+		envs = make(map[string]string)
+	}
+
+	flags := []string{}
+	// return in order to keep consistent among different runs
+	keys := []string{}
+	for k := range envs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
+		flags = append(flags, "-e", key+"="+envs[key])
+	}
+
+	for _, key := range ce.VarsToExport {
+		flags = append(flags, "-e", key)
+	}
+
+	return flags
+}
+
+// AddKeyValue adds a key-value pair into the envs
+func (ce *ContainerEnv) AddKeyValue(key, value string) {
+	if ce.EnvVars == nil {
+		ce.EnvVars = make(map[string]string)
+	}
+	ce.EnvVars[key] = value
+}
+
+// HasExportedKey returns true if the key is a exported key
+func (ce *ContainerEnv) HasExportedKey(key string) bool {
+	for _, k := range ce.VarsToExport {
+		if k == key {
+			return true
+		}
+	}
+	return false
+}
+
+// AddKey adds a key into the envs
+func (ce *ContainerEnv) AddKey(key string) {
+	if !ce.HasExportedKey(key) {
+		ce.VarsToExport = append(ce.VarsToExport, key)
+	}
+}
+
+// Raw returns a slice of string which represents the envs.
+// Example: [foo=bar, baz]
+func (ce *ContainerEnv) Raw() []string {
+	var ret []string
+	for k, v := range ce.EnvVars {
+		ret = append(ret, k+"="+v)
+	}
+
+	ret = append(ret, ce.VarsToExport...)
+	return ret
+}
+
+// NewContainerEnv returns a pointer to a new ContainerEnv
+func NewContainerEnv() *ContainerEnv {
+	var ce ContainerEnv
+	ce.EnvVars = make(map[string]string)
+	// default envs
+	ce.EnvVars["LOG_TO_STDERR"] = defaultEnvValue
+	ce.EnvVars["STRUCTURED_RESULTS"] = defaultEnvValue
+	return &ce
+}
+
+// NewContainerEnvFromStringSlice returns a new ContainerEnv pointer with parsing
+// input envStr. envStr example: ["foo=bar", "baz"]
+func NewContainerEnvFromStringSlice(envStr []string) *ContainerEnv {
+	ce := NewContainerEnv()
+	for _, e := range envStr {
+		parts := strings.SplitN(e, "=", 2)
+		if len(parts) == 1 {
+			ce.AddKey(e)
+		} else {
+			ce.AddKeyValue(parts[0], parts[1])
+		}
+	}
+	return ce
+}
+
+// FunctionSpec defines a spec for running a function
+type FunctionSpec struct {
+	DeferFailure bool `json:"deferFailure,omitempty" yaml:"deferFailure,omitempty"`
+
+	// Container is the spec for running a function as a container
+	Container ContainerSpec `json:"container,omitempty" yaml:"container,omitempty"`
+
+	// Starlark is the spec for running a function as a starlark script
+	Starlark StarlarkSpec `json:"starlark,omitempty" yaml:"starlark,omitempty"`
+
+	// ExecSpec is the spec for running a function as an executable
+	Exec ExecSpec `json:"exec,omitempty" yaml:"exec,omitempty"`
+
+	// Mounts are the storage or directories to mount into the container
+	StorageMounts []StorageMount `json:"mounts,omitempty" yaml:"mounts,omitempty"`
+}
+
+type ExecSpec struct {
+	Path string `json:"path,omitempty" yaml:"path,omitempty"`
+}
+
+// ContainerSpec defines a spec for running a function as a container
+type ContainerSpec struct {
+	// Image is the container image to run
+	Image string `json:"image,omitempty" yaml:"image,omitempty"`
+
+	// Network defines network specific configuration
+	Network bool `json:"network,omitempty" yaml:"network,omitempty"`
+
+	// Mounts are the storage or directories to mount into the container
+	StorageMounts []StorageMount `json:"mounts,omitempty" yaml:"mounts,omitempty"`
+
+	// Env is a slice of env string that will be exposed to container
+	Env []string `json:"envs,omitempty" yaml:"envs,omitempty"`
+}
+
+// StarlarkSpec defines how to run a function as a starlark program
+type StarlarkSpec struct {
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	// Path specifies a path to a starlark script
+	Path string `json:"path,omitempty" yaml:"path,omitempty"`
+
+	// URL specifies a url containing a starlark script
+	URL string `json:"url,omitempty" yaml:"url,omitempty"`
+}
+
+// StorageMount represents a container's mounted storage option(s)
+type StorageMount struct {
+	// Type of mount e.g. bind mount, local volume, etc.
+	MountType string `json:"type,omitempty" yaml:"type,omitempty"`
+
+	// Source for the storage to be mounted.
+	// For named volumes, this is the name of the volume.
+	// For anonymous volumes, this field is omitted (empty string).
+	// For bind mounts, this is the path to the file or directory on the host.
+	Src string `json:"src,omitempty" yaml:"src,omitempty"`
+
+	// The path where the file or directory is mounted in the container.
+	DstPath string `json:"dst,omitempty" yaml:"dst,omitempty"`
+
+	// Mount in ReadWrite mode if it's explicitly configured
+	// See https://docs.docker.com/storage/bind-mounts/#use-a-read-only-bind-mount
+	ReadWriteMode bool `json:"rw,omitempty" yaml:"rw,omitempty"`
+}
+
+func (s *StorageMount) String() string {
+	mode := ""
+	if !s.ReadWriteMode {
+		mode = ",readonly"
+	}
+	return fmt.Sprintf("type=%s,source=%s,target=%s%s", s.MountType, s.Src, s.DstPath, mode)
+}
+
+// GetFunctionSpec returns the FunctionSpec for a resource.  Returns
+// nil if the resource does not have a FunctionSpec.
+//
+// The FunctionSpec is read from the resource metadata.annotation
+// "config.kubernetes.io/function"
+func GetFunctionSpec(n *yaml.RNode) *FunctionSpec {
+	meta, err := n.GetMeta()
+	if err != nil {
+		return nil
+	}
+
+	if fn := getFunctionSpecFromAnnotation(n, meta); fn != nil {
+		fn.StorageMounts = []StorageMount{}
+		return fn
+	}
+
+	// legacy function specification for backwards compatibility
+	container := meta.Annotations["config.kubernetes.io/container"]
+	if container != "" {
+		return &FunctionSpec{Container: ContainerSpec{Image: container}}
+	}
+	return nil
+}
+
+// getFunctionSpecFromAnnotation parses the config function from an annotation
+// if it is found
+func getFunctionSpecFromAnnotation(n *yaml.RNode, meta yaml.ResourceMeta) *FunctionSpec {
+	var fs FunctionSpec
+	for _, s := range functionAnnotationKeys {
+		fn := meta.Annotations[s]
+		if fn != "" {
+			err := yaml.Unmarshal([]byte(fn), &fs)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%v\n", err)
+			}
+			return &fs
+		}
+	}
+	n, err := n.Pipe(yaml.Lookup("metadata", "configFn"))
+	if err != nil || yaml.IsMissingOrNull(n) {
+		return nil
+	}
+	s, err := n.String()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+	}
+	err = yaml.Unmarshal([]byte(s), &fs)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+	}
+	return &fs
+}
+
+func StringToStorageMount(s string) StorageMount {
+	m := make(map[string]string)
+	options := strings.Split(s, ",")
+	for _, option := range options {
+		keyVal := strings.SplitN(option, "=", 2)
+		if len(keyVal) == 2 {
+			m[keyVal[0]] = keyVal[1]
+		}
+	}
+	var sm StorageMount
+	for key, value := range m {
+		switch {
+		case key == "type":
+			sm.MountType = value
+		case key == "src" || key == "source":
+			sm.Src = value
+		case key == "dst" || key == "target":
+			sm.DstPath = value
+		case key == "rw" && value == "true":
+			sm.ReadWriteMode = true
+		}
+	}
+	return sm
+}
+
+// IsReconcilerFilter filters Resources based on whether or not they are Reconciler Resource.
+// Resources with an apiVersion starting with '*.gcr.io', 'gcr.io' or 'docker.io' are considered
+// Reconciler Resources.
+type IsReconcilerFilter struct {
+	// ExcludeReconcilers if set to true, then Reconcilers will be excluded -- e.g.
+	// Resources with a reconcile container through the apiVersion (gcr.io prefix) or
+	// through the annotations
+	ExcludeReconcilers bool `yaml:"excludeReconcilers,omitempty"`
+
+	// IncludeNonReconcilers if set to true, the NonReconciler will be included.
+	IncludeNonReconcilers bool `yaml:"includeNonReconcilers,omitempty"`
+}
+
+// Filter implements kio.Filter
+func (c *IsReconcilerFilter) Filter(inputs []*yaml.RNode) ([]*yaml.RNode, error) {
+	var out []*yaml.RNode
+	for i := range inputs {
+		isFnResource := GetFunctionSpec(inputs[i]) != nil
+		if isFnResource && !c.ExcludeReconcilers {
+			out = append(out, inputs[i])
+		}
+		if !isFnResource && c.IncludeNonReconcilers {
+			out = append(out, inputs[i])
+		}
+	}
+	return out, nil
+}

--- a/thirdparty/kyaml/fn/runtime/runtimeutil/runtimeutil.go
+++ b/thirdparty/kyaml/fn/runtime/runtimeutil/runtimeutil.go
@@ -1,0 +1,256 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package runtimeutil
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"path"
+	"strings"
+
+	"sigs.k8s.io/kustomize/kyaml/comments"
+	"sigs.k8s.io/kustomize/kyaml/errors"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
+
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+// FunctionFilter wraps another filter to be invoked in the context of a function.
+// FunctionFilter manages scoping the function, deferring failures, and saving results
+// to files.
+type FunctionFilter struct {
+	// Run implements the function.
+	Run func(reader io.Reader, writer io.Writer) error
+
+	// FunctionConfig is passed to the function through ResourceList.functionConfig.
+	FunctionConfig *yaml.RNode `yaml:"functionConfig,omitempty"`
+
+	// GlobalScope explicitly scopes the function to all input resources rather than only those
+	// resources scoped to it by path.
+	GlobalScope bool
+
+	// ResultsFile is the file to write function ResourceList.results to.
+	// If unset, results will not be written.
+	ResultsFile string
+
+	// DeferFailure will cause the Filter to return a nil error even if Run returns an error.
+	// The Run error will be available through GetExit().
+	DeferFailure bool
+
+	// results saves the results emitted from Run
+	results *yaml.RNode
+
+	// exit saves the error returned from Run
+	exit error
+
+	ids map[string]*yaml.RNode
+}
+
+// GetExit returns the error from Run
+func (c FunctionFilter) GetExit() error {
+	return c.exit
+}
+
+// functionsDirectoryName is keyword directory name for functions scoped 1 directory higher
+const functionsDirectoryName = "functions"
+
+// getFunctionScope returns the path of the directory containing the function config,
+// or its parent directory if the base directory is named "functions"
+func (c *FunctionFilter) getFunctionScope() (string, error) {
+	m, err := c.FunctionConfig.GetMeta()
+	if err != nil {
+		return "", errors.Wrap(err)
+	}
+	p, found := m.Annotations[kioutil.PathAnnotation]
+	if !found {
+		return "", nil
+	}
+
+	functionDir := path.Clean(path.Dir(p))
+
+	if path.Base(functionDir) == functionsDirectoryName {
+		// the scope of functions in a directory called "functions" is 1 level higher
+		// this is similar to how the golang "internal" directory scoping works
+		functionDir = path.Dir(functionDir)
+	}
+	return functionDir, nil
+}
+
+// scope partitions the input nodes into 2 slices.  The first slice contains only Resources
+// which are scoped under dir, and the second slice contains the Resources which are not.
+func (c *FunctionFilter) scope(dir string, nodes []*yaml.RNode) ([]*yaml.RNode, []*yaml.RNode, error) {
+	// scope container filtered Resources to Resources under that directory
+	var input, saved []*yaml.RNode
+	if c.GlobalScope {
+		return nodes, nil, nil
+	}
+
+	// global function
+	if dir == "" || dir == "." {
+		return nodes, nil, nil
+	}
+
+	// identify Resources read from directories under the function configuration
+	for i := range nodes {
+		m, err := nodes[i].GetMeta()
+		if err != nil {
+			return nil, nil, err
+		}
+		p, found := m.Annotations[kioutil.PathAnnotation]
+		if !found {
+			// this Resource isn't scoped under the function -- don't know where it came from
+			// consider it out of scope
+			saved = append(saved, nodes[i])
+			continue
+		}
+
+		resourceDir := path.Clean(path.Dir(p))
+		if path.Base(resourceDir) == functionsDirectoryName {
+			// Functions in the `functions` directory are scoped to
+			// themselves, and should see themselves as input
+			resourceDir = path.Dir(resourceDir)
+		}
+		if !strings.HasPrefix(resourceDir, dir) {
+			// this Resource doesn't fall under the function scope if it
+			// isn't in a subdirectory of where the function lives
+			saved = append(saved, nodes[i])
+			continue
+		}
+
+		// this input is scoped under the function
+		input = append(input, nodes[i])
+	}
+
+	return input, saved, nil
+}
+
+func (c *FunctionFilter) Filter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
+	in := &bytes.Buffer{}
+	out := &bytes.Buffer{}
+
+	// only process Resources scoped to this function, save the others
+	functionDir, err := c.getFunctionScope()
+	if err != nil {
+		return nil, err
+	}
+	input, saved, err := c.scope(functionDir, nodes)
+	if err != nil {
+		return nil, err
+	}
+
+	// set ids on each input so it is possible to copy comments from inputs back to outputs
+	if err := c.setIds(input); err != nil {
+		return nil, err
+	}
+
+	// write the input
+	err = kio.ByteWriter{
+		WrappingAPIVersion:    kio.ResourceListAPIVersion,
+		WrappingKind:          kio.ResourceListKind,
+		Writer:                in,
+		KeepReaderAnnotations: true,
+		FunctionConfig:        c.FunctionConfig}.Write(input)
+	if err != nil {
+		return nil, err
+	}
+
+	// capture the command stdout for the return value
+	r := &kio.ByteReader{Reader: out}
+
+	// don't exit immediately if the function fails -- write out the validation
+	c.exit = c.Run(in, out)
+
+	output, err := r.Read()
+	if err != nil {
+		return nil, err
+	}
+
+	// copy the comments from the inputs to the outputs
+	if err := c.setComments(output); err != nil {
+		return nil, err
+	}
+
+	if err := c.doResults(r); err != nil {
+		return nil, err
+	}
+
+	if c.exit != nil && !c.DeferFailure {
+		return append(output, saved...), c.exit
+	}
+
+	// annotate any generated Resources with a path and index if they don't already have one
+	if err := kioutil.DefaultPathAnnotation(functionDir, output); err != nil {
+		return nil, err
+	}
+
+	// emit both the Resources output from the function, and the out-of-scope Resources
+	// which were not provided to the function
+	return append(output, saved...), nil
+}
+
+const idAnnotation = "config.k8s.io/id"
+
+func (c *FunctionFilter) setIds(nodes []*yaml.RNode) error {
+	// set the id on each node to map inputs to outputs
+	var id int
+	c.ids = map[string]*yaml.RNode{}
+	for i := range nodes {
+		id++
+		idStr := fmt.Sprintf("%v", id)
+		err := nodes[i].PipeE(yaml.SetAnnotation(idAnnotation, idStr))
+		if err != nil {
+			return errors.Wrap(err)
+		}
+		c.ids[idStr] = nodes[i]
+	}
+	return nil
+}
+
+func (c *FunctionFilter) setComments(nodes []*yaml.RNode) error {
+	for i := range nodes {
+		node := nodes[i]
+		anID, err := node.Pipe(yaml.GetAnnotation(idAnnotation))
+		if err != nil {
+			return errors.Wrap(err)
+		}
+		if anID == nil {
+			continue
+		}
+
+		var in *yaml.RNode
+		var found bool
+		if in, found = c.ids[anID.YNode().Value]; !found {
+			continue
+		}
+		if err := comments.CopyComments(in, node); err != nil {
+			return errors.Wrap(err)
+		}
+		if err := node.PipeE(yaml.ClearAnnotation(idAnnotation)); err != nil {
+			return errors.Wrap(err)
+		}
+	}
+	return nil
+}
+
+func (c *FunctionFilter) doResults(r *kio.ByteReader) error {
+	// Write the results to a file if configured to do so
+	if c.ResultsFile != "" && r.Results != nil {
+		results, err := r.Results.String()
+		if err != nil {
+			return err
+		}
+		err = ioutil.WriteFile(c.ResultsFile, []byte(results), 0600)
+		if err != nil {
+			return err
+		}
+	}
+
+	if r.Results != nil {
+		c.results = r.Results
+	}
+	return nil
+}

--- a/thirdparty/kyaml/fn/runtime/runtimeutil/runtimeutil.go
+++ b/thirdparty/kyaml/fn/runtime/runtimeutil/runtimeutil.go
@@ -254,3 +254,7 @@ func (c *FunctionFilter) doResults(r *kio.ByteReader) error {
 	}
 	return nil
 }
+
+func (c *FunctionFilter) Result() *yaml.RNode {
+	return c.results
+}

--- a/thirdparty/kyaml/fn/runtime/runtimeutil/runtimeutil_test.go
+++ b/thirdparty/kyaml/fn/runtime/runtimeutil/runtimeutil_test.go
@@ -1,0 +1,1514 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package runtimeutil
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+type testRun struct {
+	err           error
+	expectedInput string
+	output        string
+	t             *testing.T
+}
+
+func (r testRun) run(reader io.Reader, writer io.Writer) error {
+	if r.expectedInput != "" {
+		input, err := ioutil.ReadAll(reader)
+		if !assert.NoError(r.t, err) {
+			r.t.FailNow()
+		}
+
+		// verify input matches expected
+		if !assert.Equal(r.t, r.expectedInput, string(input)) {
+			r.t.FailNow()
+		}
+	}
+
+	_, err := writer.Write([]byte(r.output))
+	if !assert.NoError(r.t, err) {
+		r.t.FailNow()
+	}
+
+	return r.err
+}
+
+func TestFunctionFilter_Filter(t *testing.T) {
+	var tests = []struct {
+		run                testRun
+		name               string
+		input              []string
+		functionConfig     string
+		expectedOutput     []string
+		expectedError      string
+		expectedSavedError string
+		expectedResults    string
+		noMakeResultsFile  bool
+		instance           FunctionFilter
+	}{
+		// verify that resources emitted from the function have a file path defaulted
+		// if none already exists
+		{
+			name: "default_file_path_annotation",
+			run: testRun{
+				output: `
+apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: deployment-foo
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: service-foo
+`,
+			},
+			expectedOutput: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-foo
+  annotations:
+    config.kubernetes.io/path: 'deployment_deployment-foo.yaml'
+`,
+				`
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-foo
+  annotations:
+    config.kubernetes.io/path: 'service_service-foo.yaml'
+`,
+			},
+		},
+
+		// verify that resources emitted from the function do not have a file path defaulted
+		// if one already exists
+		{
+			name: "no_default_file_path_annotation",
+			run: testRun{
+				output: `
+apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: deployment-foo
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: service-foo
+    annotations:
+     config.kubernetes.io/path: 'foo.yaml'
+`,
+			},
+			expectedOutput: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-foo
+  annotations:
+    config.kubernetes.io/path: 'deployment_deployment-foo.yaml'
+`,
+				`
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-foo
+  annotations:
+    config.kubernetes.io/path: 'foo.yaml'
+`,
+			},
+		},
+
+		// verify the FunctionFilter correctly writes the inputs and reads the outputs
+		// of Run
+		{
+			name: "write_read",
+			run: testRun{
+				output: `
+apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: service-foo
+    annotations:
+      config.kubernetes.io/path: 'foo.yaml'
+- apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: configmap-foo
+    annotations:
+      config.kubernetes.io/path: 'foo.yaml'
+`,
+			},
+			input: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-foo
+`,
+				`
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-foo
+`,
+			},
+			expectedOutput: []string{`
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-foo
+  annotations:
+    config.kubernetes.io/path: 'foo.yaml'
+`,
+				`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: configmap-foo
+  annotations:
+    config.kubernetes.io/path: 'foo.yaml'
+`,
+			},
+		},
+
+		// verify that the results file is written
+		//
+		{
+			name: "write_results_file",
+			run: testRun{
+				output: `apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: deployment-foo
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: service-foo
+results:
+- apiVersion: config.k8s.io/v1alpha1
+  kind: ObjectError
+  name: "some-validator"
+  items:
+  - type: error
+    message: "some message"
+    resourceRef:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: foo
+      namespace: bar
+    file:
+      path: deploy.yaml
+      index: 0
+    field:
+      path: "spec.template.spec.containers[3].resources.limits.cpu"
+      currentValue: "200"
+      suggestedValue: "2"
+`,
+			},
+			expectedOutput: []string{`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-foo
+  annotations:
+    config.kubernetes.io/path: 'deployment_deployment-foo.yaml'
+`, `
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-foo
+  annotations:
+    config.kubernetes.io/path: 'service_service-foo.yaml'
+`,
+			},
+			expectedResults: `
+- apiVersion: config.k8s.io/v1alpha1
+  kind: ObjectError
+  name: "some-validator"
+  items:
+  - type: error
+    message: "some message"
+    resourceRef:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: foo
+      namespace: bar
+    file:
+      path: deploy.yaml
+      index: 0
+    field:
+      path: "spec.template.spec.containers[3].resources.limits.cpu"
+      currentValue: "200"
+      suggestedValue: "2"
+`,
+		},
+
+		// verify that the results file is written for functions that exist non-0
+		// and the FunctionFilter returns the error
+		{
+			name:          "write_results_file_function_exit_non_0",
+			expectedError: "failed",
+			run: testRun{
+				err: fmt.Errorf("failed"),
+				output: `
+apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: deployment-foo
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: service-foo
+results:
+- apiVersion: config.k8s.io/v1alpha1
+  kind: ObjectError
+  name: "some-validator"
+  items:
+  - type: error
+    message: "some message"
+    resourceRef:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: foo
+      namespace: bar
+    file:
+      path: deploy.yaml
+      index: 0
+    field:
+      path: "spec.template.spec.containers[3].resources.limits.cpu"
+      currentValue: "200"
+      suggestedValue: "2"
+`,
+			},
+			expectedOutput: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-foo
+  annotations:
+    config.kubernetes.io/path: 'deployment_deployment-foo.yaml'
+    `, `
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-foo
+  annotations:
+    config.kubernetes.io/path: 'service_service-foo.yaml'
+    `,
+			},
+			expectedResults: `
+- apiVersion: config.k8s.io/v1alpha1
+  kind: ObjectError
+  name: "some-validator"
+  items:
+  - type: error
+    message: "some message"
+    resourceRef:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: foo
+      namespace: bar
+    file:
+      path: deploy.yaml
+      index: 0
+    field:
+      path: "spec.template.spec.containers[3].resources.limits.cpu"
+      currentValue: "200"
+      suggestedValue: "2"
+    `,
+		},
+
+		// verify that if deferFailure is set, the results file is written and the
+		// exit error is saved, but the FunctionFilter does not return an error.
+		{
+			name:               "write_results_defer_failure",
+			instance:           FunctionFilter{DeferFailure: true},
+			expectedSavedError: "failed",
+			run: testRun{
+				err: fmt.Errorf("failed"),
+				output: `
+apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: deployment-foo
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: service-foo
+results:
+- apiVersion: config.k8s.io/v1alpha1
+  kind: ObjectError
+  name: "some-validator"
+  items:
+  - type: error
+    message: "some message"
+    resourceRef:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: foo
+      namespace: bar
+    file:
+      path: deploy.yaml
+      index: 0
+    field:
+      path: "spec.template.spec.containers[3].resources.limits.cpu"
+      currentValue: "200"
+      suggestedValue: "2"`,
+			},
+			expectedOutput: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-foo
+  annotations:
+    config.kubernetes.io/path: 'deployment_deployment-foo.yaml'
+		`, `
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-foo
+  annotations:
+    config.kubernetes.io/path: 'service_service-foo.yaml'
+		`,
+			},
+			expectedResults: `
+- apiVersion: config.k8s.io/v1alpha1
+  kind: ObjectError
+  name: "some-validator"
+  items:
+  - type: error
+    message: "some message"
+    resourceRef:
+      apiVersion: apps/v1
+      kind: Deployment
+      name: foo
+      namespace: bar
+    file:
+      path: deploy.yaml
+      index: 0
+    field:
+      path: "spec.template.spec.containers[3].resources.limits.cpu"
+      currentValue: "200"
+      suggestedValue: "2"`,
+		},
+
+		{
+			name:              "write_results_bad_results_file",
+			expectedError:     "open /not/real/file:",
+			noMakeResultsFile: true,
+			run: testRun{
+				output: `
+apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: deployment-foo
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: service-foo
+results:
+- apiVersion: config.k8s.io/v1alpha1
+  name: "some-validator"
+`,
+			},
+			expectedOutput: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-foo
+  annotations:
+    config.kubernetes.io/path: 'deployment_deployment-foo.yaml'
+		`, `
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-foo
+  annotations:
+    config.kubernetes.io/path: 'service_service-foo.yaml'
+		`,
+			},
+			// these aren't written, expect an error
+			expectedResults: `
+- apiVersion: config.k8s.io/v1alpha1
+  name: "some-validator"
+`,
+		},
+
+		// verify the function only sees resources scoped to it based on the directory
+		// containing the functionConfig and the directory containing each resource.
+		// resources not provided to the function should still appear in the FunctionFilter
+		// output
+		{
+			name: "scope_resources_by_directory",
+			run: testRun{
+				expectedInput: `apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: service-foo
+    annotations:
+      config.kubernetes.io/path: 'foo/bar/s.yaml'
+      config.k8s.io/id: '1'
+functionConfig:
+  apiVersion: example.com/v1
+  kind: Example
+  metadata:
+    name: foo
+    annotations:
+      config.kubernetes.io/path: 'foo/bar.yaml'
+`,
+				output: `apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: service-foo
+    annotations:
+      config.kubernetes.io/path: 'foo/bar/s.yaml'
+      new: annotation
+      config.k8s.io/id: '1'
+functionConfig:
+  apiVersion: example.com/v1
+  kind: Example
+  metadata:
+    name: foo
+    annotations:
+      config.kubernetes.io/path: 'foo/bar.yaml'
+`,
+			},
+			functionConfig: `
+apiVersion: example.com/v1
+kind: Example
+metadata:
+  name: foo
+  annotations:
+    config.kubernetes.io/path: 'foo/bar.yaml'
+`,
+			input: []string{
+				// this should not be in scope
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-foo
+  annotations:
+    config.kubernetes.io/path: 'baz/bar/d.yaml'
+`,
+				// this should be in scope
+				`
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-foo
+  annotations:
+    config.kubernetes.io/path: 'foo/bar/s.yaml'
+`},
+			expectedOutput: []string{
+				`
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-foo
+  annotations:
+    config.kubernetes.io/path: 'foo/bar/s.yaml'
+    new: annotation
+`, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-foo
+  annotations:
+    config.kubernetes.io/path: 'baz/bar/d.yaml'
+`,
+			},
+		},
+
+		// verify functions without file path annotation are not scoped to functions
+		{
+			name: "scope_resources_by_directory_resources_missing_path",
+			run: testRun{
+				expectedInput: `apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: service-foo
+    annotations:
+      config.kubernetes.io/path: 'foo/bar/s.yaml'
+      config.k8s.io/id: '1'
+functionConfig:
+  apiVersion: example.com/v1
+  kind: Example
+  metadata:
+    name: foo
+    annotations:
+      config.kubernetes.io/path: 'foo/bar.yaml'
+`,
+				output: `apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: service-foo
+    annotations:
+      config.kubernetes.io/path: 'foo/bar/s.yaml'
+      new: annotation
+      config.k8s.io/id: '1'
+functionConfig:
+  apiVersion: example.com/v1
+  kind: Example
+  metadata:
+    name: foo
+    annotations:
+      config.kubernetes.io/path: 'foo/bar.yaml'
+`,
+			},
+			functionConfig: `
+apiVersion: example.com/v1
+kind: Example
+metadata:
+  name: foo
+  annotations:
+    config.kubernetes.io/path: 'foo/bar.yaml'
+`,
+			input: []string{
+				// this should not be in scope
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-foo
+`,
+				// this should be in scope
+				`
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-foo
+  annotations:
+    config.kubernetes.io/path: 'foo/bar/s.yaml'
+`},
+			expectedOutput: []string{
+				`
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-foo
+  annotations:
+    config.kubernetes.io/path: 'foo/bar/s.yaml'
+    new: annotation
+`, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-foo
+`,
+			},
+		},
+
+		// verify the functions can see all resources if global scope is set
+		{
+			name:     "scope_resources_global",
+			instance: FunctionFilter{GlobalScope: true},
+			run: testRun{
+				expectedInput: `apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: deployment-foo
+    annotations:
+      config.kubernetes.io/path: 'baz/bar/d.yaml'
+      config.k8s.io/id: '1'
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: service-foo
+    annotations:
+      config.kubernetes.io/path: 'foo/bar/s.yaml'
+      config.k8s.io/id: '2'
+functionConfig:
+  apiVersion: example.com/v1
+  kind: Example
+  metadata:
+    name: foo
+    annotations:
+      config.kubernetes.io/path: 'foo/bar.yaml'
+`,
+				output: `apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: deployment-foo
+    annotations:
+      config.kubernetes.io/path: 'baz/bar/d.yaml'
+      config.k8s.io/id: '1'
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: service-foo
+    annotations:
+      config.kubernetes.io/path: 'foo/bar/s.yaml'
+      new: annotation
+      config.k8s.io/id: '2'
+functionConfig:
+  apiVersion: example.com/v1
+  kind: Example
+  metadata:
+    name: foo
+    annotations:
+      config.kubernetes.io/path: 'foo/bar.yaml'
+`,
+			},
+			functionConfig: `
+apiVersion: example.com/v1
+kind: Example
+metadata:
+  name: foo
+  annotations:
+    config.kubernetes.io/path: 'foo/bar.yaml'
+`,
+			input: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-foo
+  annotations:
+    config.kubernetes.io/path: 'baz/bar/d.yaml'
+`,
+				`
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-foo
+  annotations:
+    config.kubernetes.io/path: 'foo/bar/s.yaml'
+`},
+			expectedOutput: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-foo
+  annotations:
+    config.kubernetes.io/path: 'baz/bar/d.yaml'
+`, `
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-foo
+  annotations:
+    config.kubernetes.io/path: 'foo/bar/s.yaml'
+    new: annotation
+`,
+			},
+		},
+
+		{
+			name: "scope_no_resources",
+			run: testRun{
+				expectedInput: `apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items: []
+functionConfig:
+  apiVersion: example.com/v1
+  kind: Example
+  metadata:
+    name: foo
+    annotations:
+      config.kubernetes.io/path: 'foo/bar.yaml'
+`,
+				output: `apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items: []
+functionConfig:
+  apiVersion: example.com/v1
+  kind: Example
+  metadata:
+    name: foo
+    annotations:
+      config.kubernetes.io/path: 'foo/bar.yaml'
+`,
+			},
+			functionConfig: `
+apiVersion: example.com/v1
+kind: Example
+metadata:
+  name: foo
+  annotations:
+    config.kubernetes.io/path: 'foo/bar.yaml'
+`,
+			input: []string{
+				// these should not be in scope
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-foo
+  annotations:
+    config.kubernetes.io/path: 'baz/bar/d.yaml'
+`, `
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-foo
+  annotations:
+    config.kubernetes.io/path: 'biz/bar/s.yaml'
+`},
+			expectedOutput: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-foo
+  annotations:
+    config.kubernetes.io/path: 'baz/bar/d.yaml'
+`, `
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-foo
+  annotations:
+    config.kubernetes.io/path: 'biz/bar/s.yaml'
+`,
+			},
+		},
+
+		{
+			name: "scope_functions_dir",
+			run: testRun{
+				expectedInput: `apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: service-foo
+    annotations:
+      config.kubernetes.io/path: 'foo/bar/s.yaml'
+      config.k8s.io/id: '1'
+functionConfig:
+  apiVersion: example.com/v1
+  kind: Example
+  metadata:
+    name: foo
+    annotations:
+      config.kubernetes.io/path: 'foo/functions/bar.yaml'
+`,
+				output: `apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: service-foo
+    annotations:
+      config.kubernetes.io/path: 'foo/bar/s.yaml'
+      config.k8s.io/id: '1'
+      new: annotation
+functionConfig:
+  apiVersion: example.com/v1
+  kind: Example
+  metadata:
+    name: foo
+    annotations:
+      config.kubernetes.io/path: 'foo/functions/bar.yaml'
+`,
+			},
+			functionConfig: `
+apiVersion: example.com/v1
+kind: Example
+metadata:
+  name: foo
+  annotations:
+    config.kubernetes.io/path: 'foo/functions/bar.yaml'
+`,
+			input: []string{
+				// this should not be in scope
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-foo
+  annotations:
+    config.kubernetes.io/path: 'baz/bar/d.yaml'
+`,
+				// this should be in scope
+				`
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-foo
+  annotations:
+    config.kubernetes.io/path: 'foo/bar/s.yaml'
+`},
+			expectedOutput: []string{
+				`
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-foo
+  annotations:
+    config.kubernetes.io/path: 'foo/bar/s.yaml'
+    new: annotation
+`, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-foo
+  annotations:
+    config.kubernetes.io/path: 'baz/bar/d.yaml'
+`,
+			},
+		},
+
+		{
+			name: "copy_comments",
+			run: testRun{
+				expectedInput: `apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: deployment-foo
+    annotations:
+      config.kubernetes.io/path: 'foo/b.yaml'
+      config.k8s.io/id: '1'
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: service-foo # name comment
+    annotations:
+      config.kubernetes.io/path: 'foo/a.yaml'
+      config.k8s.io/id: '2'
+functionConfig:
+  apiVersion: example.com/v1
+  kind: Example
+  metadata:
+    name: foo
+    annotations:
+      config.kubernetes.io/path: 'foo/f.yaml'
+`,
+				// delete the comment
+				output: `apiVersion: config.kubernetes.io/v1alpha1
+kind: ResourceList
+items:
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: deployment-foo
+    annotations:
+      config.kubernetes.io/path: 'foo/b.yaml'
+      config.k8s.io/id: '1'
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: service-foo
+    annotations:
+      config.kubernetes.io/path: 'foo/a.yaml'
+      config.k8s.io/id: '2'
+      new: annotation
+functionConfig:
+  apiVersion: example.com/v1
+  kind: Example
+  metadata:
+    name: foo
+    annotations:
+      config.kubernetes.io/path: 'foo/f.yaml'
+`,
+			},
+			functionConfig: `
+apiVersion: example.com/v1
+kind: Example
+metadata:
+  name: foo
+  annotations:
+    config.kubernetes.io/path: 'foo/f.yaml'
+`,
+			input: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-foo
+  annotations:
+    config.kubernetes.io/path: 'foo/b.yaml'
+`,
+				`
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-foo # name comment
+  annotations:
+    config.kubernetes.io/path: 'foo/a.yaml'
+`},
+			expectedOutput: []string{
+				`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deployment-foo
+  annotations:
+    config.kubernetes.io/path: 'foo/b.yaml'
+`, `
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-foo # name comment
+  annotations:
+    config.kubernetes.io/path: 'foo/a.yaml'
+    new: annotation
+`,
+			},
+		},
+	}
+
+	for i := range tests {
+		tt := tests[i]
+		t.Run(tt.name, func(t *testing.T) {
+			// results file setup
+			if len(tt.expectedResults) > 0 && !tt.noMakeResultsFile {
+				// expect result files to be written -- create a directory for them
+				f, err := ioutil.TempFile("", "test-kyaml-*.yaml")
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+				defer os.RemoveAll(f.Name())
+				tt.instance.ResultsFile = f.Name()
+			} else if len(tt.expectedResults) > 0 {
+				// failure case for writing to bad results location
+				tt.instance.ResultsFile = "/not/real/file"
+			}
+
+			// initialize the inputs for the FunctionFilter
+			var inputs []*yaml.RNode
+			for i := range tt.input {
+				node, err := yaml.Parse(tt.input[i])
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+				inputs = append(inputs, node)
+			}
+
+			// run the FunctionFilter
+			tt.run.t = t
+			tt.instance.Run = tt.run.run
+			if tt.functionConfig != "" {
+				fc, err := yaml.Parse(tt.functionConfig)
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+				tt.instance.FunctionConfig = fc
+			}
+			output, err := tt.instance.Filter(inputs)
+			if tt.expectedError != "" {
+				if !assert.Error(t, err) {
+					t.FailNow()
+				}
+				if !assert.Contains(t, err.Error(), tt.expectedError) {
+					t.FailNow()
+				}
+				return
+			}
+
+			// check for saved error
+			if tt.expectedSavedError != "" {
+				if !assert.EqualError(t, tt.instance.exit, tt.expectedSavedError) {
+					t.FailNow()
+				}
+			}
+
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			// verify function output
+			var actual []string
+			for i := range output {
+				s, err := output[i].String()
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+				actual = append(actual, strings.TrimSpace(s))
+			}
+			var expected []string
+			for i := range tt.expectedOutput {
+				expected = append(expected, strings.TrimSpace(tt.expectedOutput[i]))
+			}
+
+			if !assert.Equal(t, expected, actual) {
+				t.FailNow()
+			}
+
+			// verify results files
+			if len(tt.instance.ResultsFile) > 0 {
+				tt.expectedResults = strings.TrimSpace(tt.expectedResults)
+
+				results, err := tt.instance.results.String()
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+				if !assert.Equal(t, tt.expectedResults, strings.TrimSpace(results)) {
+					t.FailNow()
+				}
+
+				b, err := ioutil.ReadFile(tt.instance.ResultsFile)
+				writtenResults := strings.TrimSpace(string(b))
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+				if !assert.Equal(t, tt.expectedResults, writtenResults) {
+					t.FailNow()
+				}
+			}
+		})
+	}
+}
+
+func Test_GetFunction(t *testing.T) {
+	var tests = []struct {
+		name       string
+		resource   string
+		expectedFn string
+		missingFn  bool
+	}{
+
+		// fn annotation
+		{
+			name: "fn annotation",
+			resource: `
+apiVersion: v1beta1
+kind: Example
+metadata:
+  annotations:
+    config.kubernetes.io/function: |-
+      container:
+        image: foo:v1.0.0
+`,
+			expectedFn: `
+container:
+    image: foo:v1.0.0`,
+		},
+
+		{
+			name: "storage mounts json style",
+			resource: `
+apiVersion: v1beta1
+kind: Example
+metadata:
+  annotations:
+    config.kubernetes.io/function: |-
+      container:
+        image: foo:v1.0.0
+        mounts: [ {type: bind, src: /mount/path, dst: /local/}, {src: myvol, dst: /local/, type: volume}, {dst: /local/, type: tmpfs} ]
+`,
+			expectedFn: `
+container:
+    image: foo:v1.0.0
+    mounts:
+      - type: bind
+        src: /mount/path
+        dst: /local/
+      - type: volume
+        src: myvol
+        dst: /local/
+      - type: tmpfs
+        dst: /local/
+`,
+		},
+
+		{
+			name: "storage mounts yaml style",
+			resource: `
+apiVersion: v1beta1
+kind: Example
+metadata:
+  annotations:
+    config.kubernetes.io/function: |-
+      container:
+        image: foo:v1.0.0
+        mounts:
+        - src: /mount/path
+          type: bind
+          dst: /local/
+        - dst: /local/
+          src: myvol
+          type: volume
+        - type: tmpfs
+          dst: /local/
+`,
+			expectedFn: `
+container:
+    image: foo:v1.0.0
+    mounts:
+      - type: bind
+        src: /mount/path
+        dst: /local/
+      - type: volume
+        src: myvol
+        dst: /local/
+      - type: tmpfs
+        dst: /local/
+`,
+		},
+
+		{
+			name: "network",
+			resource: `
+apiVersion: v1beta1
+kind: Example
+metadata:
+  annotations:
+    config.kubernetes.io/function: |-
+      container:
+        image: foo:v1.0.0
+        network: true
+`,
+			expectedFn: `
+container:
+    image: foo:v1.0.0
+    network: true
+`,
+		},
+
+		{
+			name: "path",
+			resource: `
+apiVersion: v1beta1
+kind: Example
+metadata:
+  annotations:
+    config.kubernetes.io/function: |-
+      path: foo
+      container:
+        image: foo:v1.0.0
+`,
+			// path should be erased
+			expectedFn: `
+container:
+    image: foo:v1.0.0
+`,
+		},
+
+		{
+			name: "network",
+			resource: `
+apiVersion: v1beta1
+kind: Example
+metadata:
+  annotations:
+    config.kubernetes.io/function: |-
+      network: foo
+      container:
+        image: foo:v1.0.0
+`,
+			// network should be erased
+			expectedFn: `
+container:
+    image: foo:v1.0.0
+`,
+		},
+
+		// legacy fn style
+		{name: "legacy fn meta",
+			resource: `
+apiVersion: v1beta1
+kind: Example
+metadata:
+  configFn:
+      container:
+        image: foo:v1.0.0
+`,
+			expectedFn: `
+container:
+    image: foo:v1.0.0
+`,
+		},
+
+		// no fn
+		{name: "no fn",
+			resource: `
+apiVersion: v1beta1
+kind: Example
+metadata:
+  annotations: {}
+`,
+			missingFn: true,
+		},
+
+		// test network, etc...
+	}
+
+	for i := range tests {
+		tt := tests[i]
+		t.Run(tt.name, func(t *testing.T) {
+			resource := yaml.MustParse(tt.resource)
+			fn := GetFunctionSpec(resource)
+			if tt.missingFn {
+				if !assert.Nil(t, fn) {
+					t.FailNow()
+				}
+			} else {
+				b, err := yaml.Marshal(fn)
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+				if !assert.Equal(t,
+					strings.TrimSpace(tt.expectedFn),
+					strings.TrimSpace(string(b))) {
+					t.FailNow()
+				}
+			}
+		})
+	}
+}
+
+func Test_GetContainerNetworkRequired(t *testing.T) {
+	tests := []struct {
+		input    string
+		required bool
+	}{
+		{
+			input: `apiVersion: v1
+kind: Foo
+metadata:
+  name: foo
+  configFn:
+    container:
+      image: gcr.io/kustomize-functions/example-tshirt:v0.1.0
+      network: true
+`,
+			required: true,
+		},
+		{
+			input: `apiVersion: v1
+kind: Foo
+metadata:
+  name: foo
+  configFn:
+    container:
+      image: gcr.io/kustomize-functions/example-tshirt:v0.1.0
+      network: false
+`,
+			required: false,
+		},
+		{
+
+			input: `apiVersion: v1
+kind: Foo
+metadata:
+  name: foo
+  configFn:
+    container:
+      image: gcr.io/kustomize-functions/example-tshirt:v0.1.0
+`,
+			required: false,
+		},
+		{
+			input: `apiVersion: v1
+kind: Foo
+metadata:
+  name: foo
+  annotations:
+    config.kubernetes.io/function: |
+      container:
+        image: gcr.io/kustomize-functions/example-tshirt:v0.1.0
+        network: true
+`,
+			required: true,
+		},
+	}
+
+	for _, tc := range tests {
+		cfg, err := yaml.Parse(tc.input)
+		if !assert.NoError(t, err) {
+			return
+		}
+		fn := GetFunctionSpec(cfg)
+		assert.Equal(t, tc.required, fn.Container.Network)
+	}
+}
+
+func Test_StringToStorageMount(t *testing.T) {
+	tests := []struct {
+		in          string
+		expectedOut string
+	}{
+		{
+			in:          "type=bind,src=/tmp/test/,dst=/tmp/source/",
+			expectedOut: "type=bind,source=/tmp/test/,target=/tmp/source/,readonly",
+		},
+		{
+			in:          "type=bind,src=/tmp/test/,dst=/tmp/source/,rw=true",
+			expectedOut: "type=bind,source=/tmp/test/,target=/tmp/source/",
+		},
+		{
+			in:          "type=bind,src=/tmp/test/,dst=/tmp/source/,rw=false",
+			expectedOut: "type=bind,source=/tmp/test/,target=/tmp/source/,readonly",
+		},
+		{
+			in:          "type=bind,src=/tmp/test/,dst=/tmp/source/,rw=",
+			expectedOut: "type=bind,source=/tmp/test/,target=/tmp/source/,readonly",
+		},
+		{
+			in:          "type=tmpfs,src=/tmp/test/,dst=/tmp/source/,rw=invalid",
+			expectedOut: "type=tmpfs,source=/tmp/test/,target=/tmp/source/,readonly",
+		},
+		{
+			in:          "type=tmpfs,src=/tmp/test/,dst=/tmp/source/,rwe=invalid",
+			expectedOut: "type=tmpfs,source=/tmp/test/,target=/tmp/source/,readonly",
+		},
+		{
+			in:          "type=tmpfs,src=/tmp/test/,dst",
+			expectedOut: "type=tmpfs,source=/tmp/test/,target=,readonly",
+		},
+		{
+			in:          "type=bind,source=/tmp/test/,target=/tmp/source/,rw=true",
+			expectedOut: "type=bind,source=/tmp/test/,target=/tmp/source/",
+		},
+		{
+			in:          "type=bind,source=/tmp/test/,target=/tmp/source/",
+			expectedOut: "type=bind,source=/tmp/test/,target=/tmp/source/,readonly",
+		},
+	}
+
+	for _, tc := range tests {
+		s := StringToStorageMount(tc.in)
+		assert.Equal(t, tc.expectedOut, (&s).String())
+	}
+}
+
+func TestContainerEnvGetDockerFlags(t *testing.T) {
+	tests := []struct {
+		input  *ContainerEnv
+		output []string
+	}{
+		{
+			input:  NewContainerEnvFromStringSlice([]string{"foo=bar"}),
+			output: []string{"-e", "LOG_TO_STDERR=true", "-e", "STRUCTURED_RESULTS=true", "-e", "foo=bar"},
+		},
+		{
+			input:  NewContainerEnvFromStringSlice([]string{"foo"}),
+			output: []string{"-e", "LOG_TO_STDERR=true", "-e", "STRUCTURED_RESULTS=true", "-e", "foo"},
+		},
+		{
+			input:  NewContainerEnvFromStringSlice([]string{"foo=bar", "baz"}),
+			output: []string{"-e", "LOG_TO_STDERR=true", "-e", "STRUCTURED_RESULTS=true", "-e", "foo=bar", "-e", "baz"},
+		},
+		{
+			input:  NewContainerEnv(),
+			output: []string{"-e", "LOG_TO_STDERR=true", "-e", "STRUCTURED_RESULTS=true"},
+		},
+	}
+
+	for _, tc := range tests {
+		flags := tc.input.GetDockerFlags()
+		assert.Equal(t, tc.output, flags)
+	}
+}
+
+func TestGetContainerEnv(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected ContainerEnv
+	}{
+		{
+			input: `
+apiVersion: v1
+kind: Foo
+metadata:
+  name: foo
+  configFn:
+    container:
+      image: gcr.io/kustomize-functions/example-tshirt:v0.1.0
+      envs:
+      - foo=bar
+`,
+			expected: *NewContainerEnvFromStringSlice([]string{"foo=bar"}),
+		},
+		{
+			input: `
+apiVersion: v1
+kind: Foo
+metadata:
+  name: foo
+  configFn:
+    container:
+      image: gcr.io/kustomize-functions/example-tshirt:v0.1.0
+      envs:
+      - foo=bar
+      - baz
+`,
+			expected: *NewContainerEnvFromStringSlice([]string{"foo=bar", "baz"}),
+		},
+		{
+			input: `
+apiVersion: v1
+kind: Foo
+metadata:
+  name: foo
+  configFn:
+    container:
+      image: gcr.io/kustomize-functions/example-tshirt:v0.1.0
+      envs:
+      - KUBECONFIG
+`,
+			expected: *NewContainerEnvFromStringSlice([]string{"KUBECONFIG"}),
+		},
+	}
+
+	for _, tc := range tests {
+		cfg, err := yaml.Parse(tc.input)
+		if !assert.NoError(t, err) {
+			return
+		}
+		fn := GetFunctionSpec(cfg)
+		assert.Equal(t, tc.expected, *NewContainerEnvFromStringSlice(fn.Container.Env))
+	}
+}

--- a/thirdparty/kyaml/fn/runtime/runtimeutil/types.go
+++ b/thirdparty/kyaml/fn/runtime/runtimeutil/types.go
@@ -1,0 +1,8 @@
+// Copyright 2019 The Kubernetes Authors.
+// SPDX-License-Identifier: Apache-2.0
+
+package runtimeutil
+
+type DeferFailureFunction interface {
+	GetExit() error
+}


### PR DESCRIPTION
This PR adds support for handling structured results from function execution.

An example run:

```
kubeval-failure $ ~/go/bin/kpt fn render --results-dir /tmp/results
Package ".":

[RUNNING] "gcr.io/kpt-fn/kubeval:v0.1"
[FAIL] "gcr.io/kpt-fn/kubeval:v0.1"
  Stderr:
    "[ERROR] selector is required in object 'apps/v1/Deployment//nginx-deployment' in file resources.yaml in field selector"
    "[ERROR] template is required in object 'apps/v1/Deployment//nginx-deployment' in file resources.yaml in field template"
    "[ERROR] Invalid type. Expected: [integer,null], given: string in object 'apps/v1/Deployment//nginx-deployment' in file resources.yaml in field spec.replicas"
    "[ERROR] Failed to parse raw kubeval output:"
    ...(5 line(s) truncated)
  Exit Code: 1

Results saved successfully at "/tmp/results/results.yaml".
```

Results output:

```sh
$ cat /tmp/results/results.yaml
items:
    - image: gcr.io/kpt-fn/kubeval:v0.1
      results:
        - message: selector is required
          severity: error
          resourceRef:
            apiVersion: apps/v1
            kind: Deployment
          field:
            path: selector
          file:
            path: resources.yaml
        - message: template is required
          severity: error
          resourceRef:
            apiVersion: apps/v1
            kind: Deployment
          field:
            path: template
          file:
            path: resources.yaml
        - message: 'Invalid type. Expected: [integer,null], given: string'
          severity: error
          resourceRef:
            apiVersion: apps/v1
            kind: Deployment
          field:
            path: spec.replicas
          file:
            path: resources.yaml
        - message: |
            Failed to parse raw kubeval output:
            Unexpected token E in JSON at position 0

            ERR  - stdin: Failed initializing schema file:///tmp/master-standalone-strict/custom-custom-v1.json: open /tmp/master-standalone-strict/custom-custom-v1.json: no such file or directory
          severity: error
          resourceRef:
            apiVersion: custom.io/v1
            kind: Custom
          file:
            path: resources.yaml
            index: 1
```