### PR TITLE
better handle multi-line stderr

### DIFF
--- a/e2e/testdata/fn-eval/invalid-fn-config-file/pkg/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/invalid-fn-config-file/pkg/.expected/config.yaml
@@ -16,4 +16,5 @@ testType: eval
 exitCode: 1
 image: gcr.io/kpt-fn/set-namespace:v0.1
 fnConfig: ../../config.yaml
-stdErr: "wrong Node Kind for  expected: MappingNode was ScalarNode: value: {I am not a valid config file}"
+stdErr:
+  - "wrong Node Kind for  expected: MappingNode was ScalarNode: value: {I am not a valid config file}"

--- a/e2e/testdata/fn-eval/missing-fn-config/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/missing-fn-config/.expected/config.yaml
@@ -15,4 +15,5 @@
 testType: eval
 exitCode: 1
 image: gcr.io/kpt-fn/set-namespace:v0.1
-stdErr: "failed to configure function: input namespace cannot be empty"
+stdErr:
+  - "failed to configure function: input namespace cannot be empty"

--- a/e2e/testdata/fn-eval/missing-fn-image/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/missing-fn-image/.expected/config.yaml
@@ -17,4 +17,5 @@ exitCode: 1
 image: gcr.io/kpt-fn/dne # non-existing image
 args:
   namespace: staging
-stdErr: 'failed to check function image existence: function image "gcr.io/kpt-fn/dne" doesn''t exist'
+stdErr:
+  - 'failed to check function image existence: function image "gcr.io/kpt-fn/dne" doesn''t exist'

--- a/e2e/testdata/fn-render/fn-failure-output-no-truncate/.expected/config.yaml
+++ b/e2e/testdata/fn-render/fn-failure-output-no-truncate/.expected/config.yaml
@@ -16,7 +16,8 @@
 # non-zero exit code and no changes in the resources.
 exitCode: 1
 disableOutputTruncate: true
-stdErr: "Invalid type. Expected: [integer,null], given: string in object 'apps/v1/Deployment//nginx-deployment' in file resources.yaml in field spec.replicas"
+stdErr:
+  - "Invalid type. Expected: [integer,null], given: string in object 'apps/v1/Deployment//nginx-deployment' in file resources.yaml in field spec.replicas"
 stdOut: |
   [RUNNING] "gcr.io/kpt-fn/kubeval:v0.1"
   [FAIL] "gcr.io/kpt-fn/kubeval:v0.1"

--- a/e2e/testdata/fn-render/fn-failure/.expected/config.yaml
+++ b/e2e/testdata/fn-render/fn-failure/.expected/config.yaml
@@ -15,7 +15,8 @@
 # One of the functions in the pipeline fails resulting in
 # non-zero exit code and no changes in the resources.
 exitCode: 1
-stdErr: "httpbin-gen:4:1: got newline, want primary expression"
+stdErr:
+  - "httpbin-gen:4:1: got newline, want primary expression"
 stdOut: |
   [RUNNING] "gcr.io/kpt-fn/starlark:unstable"
   [FAIL] "gcr.io/kpt-fn/starlark:unstable"

--- a/e2e/testdata/fn-render/invalid-configmap-fnconfig/.expected/config.yaml
+++ b/e2e/testdata/fn-render/invalid-configmap-fnconfig/.expected/config.yaml
@@ -13,4 +13,5 @@
 # limitations under the License.
 
 exitCode: 1
-stdErr: "line 14: cannot unmarshal !!seq into string"
+stdErr:
+  - "line 14: cannot unmarshal !!seq into string"

--- a/e2e/testdata/fn-render/invalid-inline-fnconfig/.expected/config.yaml
+++ b/e2e/testdata/fn-render/invalid-inline-fnconfig/.expected/config.yaml
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 exitCode: 1
-stdErr: "missing Resource metadata"
+stdErr:
+  - "missing Resource metadata"
 stdOut: |
   [RUNNING] "gcr.io/kpt-fn/set-namespace:unstable"
   [PASS] "gcr.io/kpt-fn/set-namespace:unstable"

--- a/e2e/testdata/fn-render/invalid-kptfile/.expected/config.yaml
+++ b/e2e/testdata/fn-render/invalid-kptfile/.expected/config.yaml
@@ -13,4 +13,5 @@
 # limitations under the License.
 
 exitCode: 1
-stdErr: "unable to parse \"Kptfile\": yaml: line 3: could not find expected ':'"
+stdErr:
+  - "unable to parse \"Kptfile\": yaml: line 3: could not find expected ':'"

--- a/e2e/testdata/fn-render/kubeval-failure/.expected/config.yaml
+++ b/e2e/testdata/fn-render/kubeval-failure/.expected/config.yaml
@@ -15,7 +15,8 @@
 # One of the functions in the pipeline fails resulting in
 # non-zero exit code and no changes in the resources.
 exitCode: 1
-stdErr: "[ERROR] Invalid type. Expected: [integer,null], given: string in object 'apps/v1/Deployment//nginx-deployment' in file resources.yaml in field spec.replicas"
+stdErr:
+  - "[ERROR] Invalid type. Expected: [integer,null], given: string in object 'apps/v1/Deployment//nginx-deployment' in file resources.yaml in field spec.replicas"
 stdOut: |
   [RUNNING] "gcr.io/kpt-fn/kubeval:v0.1"
   [FAIL] "gcr.io/kpt-fn/kubeval:v0.1"

--- a/e2e/testdata/fn-render/missing-fn-image/.expected/config.yaml
+++ b/e2e/testdata/fn-render/missing-fn-image/.expected/config.yaml
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 exitCode: 1
-stdErr: 'failed to check function image existence: function image "gcr.io/kpt-fn/set-label1" doesn''t exist:'
+stdErr:
+  - 'failed to check function image existence: function image "gcr.io/kpt-fn/set-label1" doesn''t exist:'
 stdOut: |
   [RUNNING] "gcr.io/kpt-fn/set-namespace:unstable"
   [PASS] "gcr.io/kpt-fn/set-namespace:unstable"

--- a/e2e/testdata/fn-render/missing-fnconfig/.expected/config.yaml
+++ b/e2e/testdata/fn-render/missing-fnconfig/.expected/config.yaml
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 exitCode: 1
-stdErr: 'Error: missing function config "labelconfig1.yaml"'
+stdErr:
+  - 'Error: missing function config "labelconfig1.yaml"'
 stdOut: |
   [RUNNING] "gcr.io/kpt-fn/set-label:unstable"
   [PASS] "gcr.io/kpt-fn/set-label:unstable"

--- a/e2e/testdata/fn-render/missing-kptfile/.expected/config.yaml
+++ b/e2e/testdata/fn-render/missing-kptfile/.expected/config.yaml
@@ -13,4 +13,5 @@
 # limitations under the License.
 
 exitCode: 1
-stdErr: "missing-kptfile/Kptfile: no such file or directory"
+stdErr:
+  - "missing-kptfile/Kptfile: no such file or directory"

--- a/e2e/testdata/fn-render/multiple-fnconfig/.expected/config.yaml
+++ b/e2e/testdata/fn-render/multiple-fnconfig/.expected/config.yaml
@@ -13,4 +13,5 @@
 # limitations under the License.
 
 exitCode: 1
-stdErr: "following fields are mutually exclusive: 'config', 'configMap', 'configPath'. Got \"configPath, configMap\""
+stdErr:
+  - "following fields are mutually exclusive: 'config', 'configMap', 'configPath'. Got \"configPath, configMap\""

--- a/e2e/testdata/fn-render/no-fnconfig/.expected/config.yaml
+++ b/e2e/testdata/fn-render/no-fnconfig/.expected/config.yaml
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 exitCode: 1
-stdErr: "failed to configure function: function config must be a ConfigMap or SetLabelConfig"
+stdErr:
+  - "failed to configure function: function config must be a ConfigMap or SetLabelConfig"
 stdOut: |
   [RUNNING] "gcr.io/kpt-fn/set-label:unstable"
   [FAIL] "gcr.io/kpt-fn/set-label:unstable"

--- a/e2e/testdata/fn-render/path-index-duplicate/.expected/config.yaml
+++ b/e2e/testdata/fn-render/path-index-duplicate/.expected/config.yaml
@@ -15,7 +15,8 @@
 # One of the functions in the pipeline fails resulting in
 # non-zero exit code and no changes in the resources.
 exitCode: 1
-stdErr: 'resource at path "resources.yaml" and index "0" already exists'
+stdErr:
+  - 'resource at path "resources.yaml" and index "0" already exists'
 stdOut: |
   [RUNNING] "gcr.io/kpt-fn/starlark:unstable"
   [PASS] "gcr.io/kpt-fn/starlark:unstable"

--- a/e2e/testdata/fn-render/subpkg-fn-failure/.expected/config.yaml
+++ b/e2e/testdata/fn-render/subpkg-fn-failure/.expected/config.yaml
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 exitCode: 1
-stdErr: "statefulset-filter:5:1: got newline, want primary expression"
+stdErr:
+  - "statefulset-filter:5:1: got newline, want primary expression"
 stdOut: |
   [RUNNING] "gcr.io/kpt-fn/starlark:unstable"
   [FAIL] "gcr.io/kpt-fn/starlark:unstable"

--- a/e2e/testdata/fn-render/subpkg-has-invalid-kptfile/.expected/config.yaml
+++ b/e2e/testdata/fn-render/subpkg-has-invalid-kptfile/.expected/config.yaml
@@ -13,4 +13,5 @@
 # limitations under the License.
 
 exitCode: 1
-stdErr: "unable to parse \"Kptfile\": yaml: line 10: mapping values are not allowed in this context"
+stdErr:
+  - "unable to parse \"Kptfile\": yaml: line 10: mapping values are not allowed in this context"

--- a/e2e/testdata/fn-render/validate-resource-failure/.expected/config.yaml
+++ b/e2e/testdata/fn-render/validate-resource-failure/.expected/config.yaml
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 exitCode: 1
-stdErr: "fail: could not find httpbin deployment"
+stdErr:
+  - "fail: could not find httpbin deployment"
 stdOut: |
   [RUNNING] "gcr.io/kpt-fn/starlark:unstable"
   [FAIL] "gcr.io/kpt-fn/starlark:unstable"

--- a/pkg/test/runner/config.go
+++ b/pkg/test/runner/config.go
@@ -56,8 +56,8 @@ type TestCaseConfig struct {
 	ExitCode int `json:"exitCode,omitempty" yaml:"exitCode,omitempty"`
 
 	// StdErr is the expected standard error output and should be checked
-	// when a nonzero exit code is expected. Default: ""
-	StdErr string `json:"stdErr,omitempty" yaml:"stdErr,omitempty"`
+	// when a nonzero exit code is expected. Default: empty list
+	StdErr []string `json:"stdErr,omitempty" yaml:"stdErr,omitempty"`
 
 	// StdOut is the expected standard output from running the command.
 	// Default: ""
@@ -182,7 +182,7 @@ func ScanTestCases(path string) (*TestCases, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to scan test cases in %s", path)
+		return nil, fmt.Errorf("failed to scan test cases in %s: %v", path, err)
 	}
 	return &cases, nil
 }

--- a/pkg/test/runner/runner.go
+++ b/pkg/test/runner/runner.go
@@ -312,12 +312,14 @@ func (r *Runner) compareResult(exitErr error, stdout string, stderr string, tmpP
 
 // check stdout and stderr against expected
 func (r *Runner) compareOutput(stdout string, stderr string) error {
-	expectedStderr := r.testCase.Config.StdErr
-	if expectedStderr == "" && stderr != "" {
+	expectedStderrStrings := r.testCase.Config.StdErr
+	if len(expectedStderrStrings) == 0 && stderr != "" {
 		return fmt.Errorf("unexpected stderr %s", stderr)
 	}
-	if !strings.Contains(stderr, expectedStderr) {
-		return fmt.Errorf("wanted stderr %s, got %s", expectedStderr, stderr)
+	for _, expectedStderrString := range expectedStderrStrings {
+		if !strings.Contains(stderr, expectedStderrString) {
+			return fmt.Errorf("wanted stderr to have %s, but got %s", expectedStderrString, stderr)
+		}
 	}
 	expectedStdout := r.testCase.Config.StdOut
 	if expectedStdout == "" && stdout != "" {


### PR DESCRIPTION
An example of multi-line stderr:
```
$ kpt fn render
Package ".": 

[RUNNING] "gcr.io/kpt-fn/kubeval:unstable"
[FAIL] "gcr.io/kpt-fn/kubeval:unstable"
  Stderr:
    "[ERROR] Additional property templates is not allowed in object 'v1/ReplicationController//bob' in file resources.yaml in field templates"
    "[ERROR] Invalid type. Expected: [integer,null], given: string in object 'v1/ReplicationController//bob' in file resources.yaml in field spec.replicas"
    ""
  Exit Code: 1
```

There are leading whitespaces in each line.
If we put this multi-line string in yaml like
```
exitCode: 1
stderr: |
      "[ERROR] Additional property templates is not allowed in object 'v1/ReplicationController//bob' in file resources.yaml in field templates"
      "[ERROR] Invalid type. Expected: [integer,null], given: string in object 'v1/ReplicationController//bob' in file resources.yaml in field spec.replicas"
```
the leading whitespace will be ignored and it makes it unable to test these scenarios.
