### PR TITLE
Introduce Additional Diff Tests

### DIFF
--- a/internal/util/diff/diff_test.go
+++ b/internal/util/diff/diff_test.go
@@ -12,6 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// These tests depend on `diff` which is not available on Windows
+// +build !windows
+
 // Package diff_test tests the diff package
 package diff_test
 
@@ -241,6 +244,13 @@ func TestCommand_Diff(t *testing.T) {
 		})
 	}
 }
+
+// Test case: no packages supplied to diff
+// Test case: one package supplied to diff
+// Test case: package supplied to diff directory does not exist
+// Test case: Package supplied to diff is not a kpt package/empty dir
+// Test case: Upstream package does not exist
+// Test case: 3-way diff not supported with diffutils
 
 // filterDiffMetadata removes information from the diff output that is test-run
 // specific for ex. removing directory name being used.


### PR DESCRIPTION
This introduces several tests over kpt's `pkg diff` command:

* Running a diff against a directory which does not contain a Kptfile (empty dir)
* Running a diff against a directory which does not exist
* Running a diff when an invalid git ref is provided
* Running a 3 way diff provides three parameters to the diff command

This also disables these tests when run on a Windows OS (the `diff` command used is not available).

Fixes #1776