### PR TITLE
nit: minor grammatical fix in FAQ

### DIFF
--- a/site/content/en/faq/_index.md
+++ b/site/content/en/faq/_index.md
@@ -79,7 +79,7 @@ directly, and merged when regenerated.
 
 #### **Q: I want to write high-level abstractions like CRDs, but on the client-side. Can I do this with `kpt`?**
 
-A: Yes. `kpt`'s architecture facilitates the developing programs which may
+A: Yes. `kpt`'s architecture facilitates developing programs which may
 generate or modify configuration. See the [Functions User Guide] for how to
 compose multiple programs together.
 


### PR DESCRIPTION
Reading the FAQ, "facilitates the developing programs" didn't seem right, maybe "facilitates developing programs" (or "facilitates the development of programs"?) is better.