### PR TITLE
Fn render reference

### DIFF
--- a/commands/fncmd.go
+++ b/commands/fncmd.go
@@ -45,22 +45,13 @@ func GetFnCommand(ctx context.Context, name string) *cobra.Command {
 		},
 	}
 
-	eval := cmdeval.EvalCommand(ctx, name)
-	eval.Short = fndocs.RunShort
-	eval.Long = fndocs.RunShort + "\n" + fndocs.RunLong
-	eval.Example = fndocs.RunExamples
-
-	render := cmdrender.NewCommand(ctx, name)
-
-	doc := cmdfndoc.NewCommand(name)
-	doc.Short = fndocs.DocShort
-	doc.Long = fndocs.DocShort + "\n" + fndocs.DocLong
-	doc.Example = fndocs.DocExamples
-
-	source := cmdsource.NewCommand(name)
-
-	sink := cmdsink.NewCommand(name)
-
-	functions.AddCommand(eval, render, doc, source, sink, cmdexport.ExportCommand())
+	functions.AddCommand(
+		cmdeval.EvalCommand(ctx, name),
+		cmdrender.NewCommand(ctx, name),
+		cmdfndoc.NewCommand(name),
+		cmdsource.NewCommand(name),
+		cmdsink.NewCommand(name),
+		cmdexport.ExportCommand(),
+	)
 	return functions
 }

--- a/internal/cmdexport/cmdexport.go
+++ b/internal/cmdexport/cmdexport.go
@@ -44,6 +44,7 @@ func GetExportRunner() *ExportRunner {
 		Args:    cobra.ExactArgs(1),
 		PreRunE: r.preRunE,
 		RunE:    r.runE,
+		Hidden:  true,
 	}
 
 	c.Flags().StringVarP(

--- a/internal/cmdrender/cmd.go
+++ b/internal/cmdrender/cmd.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 
+	docs "github.com/GoogleContainerTools/kpt/internal/docs/generated/fndocs"
 	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
 	"github.com/spf13/cobra"
@@ -29,10 +30,10 @@ import (
 func NewRunner(ctx context.Context, parent string) *Runner {
 	r := &Runner{ctx: ctx}
 	c := &cobra.Command{
-		Use:     "render [DIR]",
-		Short:   "render",
-		Long:    "render",
-		Example: "render",
+		Use:     "render [PKG_PATH] [flags]",
+		Short:   docs.RenderShort,
+		Long:    docs.RenderShort + "\n" + docs.RenderLong,
+		Example: docs.RenderExamples,
 		RunE:    r.runE,
 		PreRunE: r.preRunE,
 	}

--- a/internal/docs/generated/fndocs/docs.go
+++ b/internal/docs/generated/fndocs/docs.go
@@ -6,9 +6,6 @@ var FnLong = `
 The ` + "`" + `fn` + "`" + ` command group contains subcommands for transforming and validating ` + "`" + `kpt` + "`" + ` packages
 using containerized functions.
 `
-var FnExamples = `
-
-`
 
 var DocShort = `Display the documentation for a function`
 var DocLong = `

--- a/internal/docs/generated/fndocs/docs.go
+++ b/internal/docs/generated/fndocs/docs.go
@@ -6,6 +6,9 @@ var FnLong = `
 The ` + "`" + `fn` + "`" + ` command group contains subcommands for transforming and validating ` + "`" + `kpt` + "`" + ` packages
 using containerized functions.
 `
+var FnExamples = `
+
+`
 
 var DocShort = `Display the documentation for a function`
 var DocLong = `
@@ -53,6 +56,34 @@ var ExportExamples = `
   kpt fn export DIR/ --fn-path FUNCTIONS_DIR/ --workflow cloud-build
 `
 
+var RenderShort = `Render a package.`
+var RenderLong = `
+  kpt fn render [PKG_PATH] [flags]
+
+Args:
+
+  PKG_PATH:
+    Local package path to render. Directory must exist and contain a Kptfile
+    to be updated. Defaults to the current working directory.
+
+Flags:
+
+  --results-dir:
+    Path to a directory to write structured results. Directory must exist.
+    Structured results emitted by the functions are aggregated and saved
+    to ` + "`" + `results.yaml` + "`" + ` file in the specified directory.
+`
+var RenderExamples = `
+  # Render the package in current directory
+  $ kpt fn render
+
+  # Render the package in current directory and save results in my-results-dir
+  $ kpt fn --results-dir my-results-dir render
+
+  # Render my-package-dir
+  $ kpt fn render my-package-dir
+`
+
 var RunShort = `Locally execute one or more functions in containers`
 var RunLong = `
   kpt fn run DIR [flags]
@@ -73,6 +104,7 @@ var RunExamples = `
 
   # run the functions in FUNCTIONS_DIR against the Resources in DIR
   kpt fn run DIR/ --fn-path FUNCTIONS_DIR/
+
 
   # discover functions in DIR and run them against Resource in DIR.
   # functions may be scoped to a subset of Resources -- see ` + "`" + `kpt help fn run` + "`" + `

--- a/internal/docs/generated/fndocs/docs.go
+++ b/internal/docs/generated/fndocs/docs.go
@@ -69,6 +69,7 @@ Flags:
     Path to a directory to write structured results. Directory must exist.
     Structured results emitted by the functions are aggregated and saved
     to ` + "`" + `results.yaml` + "`" + ` file in the specified directory.
+    If not specified, no result files are written to the local filesystem.
 `
 var RenderExamples = `
   # Render the package in current directory

--- a/internal/docs/generated/pkgdocs/docs.go
+++ b/internal/docs/generated/pkgdocs/docs.go
@@ -207,6 +207,7 @@ Flags:
     Link to page with information about the package.
 `
 var InitExamples = `
+
   # Creates a new Kptfile with metadata in the cockroachdb directory.
   mkdir cockroachdb
   kpt pkg init cockroachdb --keywords "cockroachdb,nosql,db"  \

--- a/scripts/generate_site_sidebar/sidebar_template.md
+++ b/scripts/generate_site_sidebar/sidebar_template.md
@@ -9,6 +9,7 @@
         - [update](reference/pkg/update/)
     - [fn](reference/fn/)
         - [export](reference/fn/export/)
+        - [render](reference/fn/render/)
         - [run](reference/fn/run/)
         - [sink](reference/fn/sink/)
         - [source](reference/fn/source/)

--- a/scripts/generate_site_sidebar/sidebar_template.md
+++ b/scripts/generate_site_sidebar/sidebar_template.md
@@ -8,7 +8,6 @@
         - [init](reference/pkg/init/)
         - [update](reference/pkg/update/)
     - [fn](reference/fn/)
-        - [export](reference/fn/export/)
         - [render](reference/fn/render/)
         - [run](reference/fn/run/)
         - [sink](reference/fn/sink/)

--- a/site/reference/fn/README.md
+++ b/site/reference/fn/README.md
@@ -2,7 +2,7 @@
 title: "`fn`"
 linkTitle: "fn"
 type: docs
-weight: 1
+weight: 4
 description: >
    Transform and validate packages using containerized functions.
 ---
@@ -14,7 +14,4 @@ description: >
 <!--mdtogo:Long-->
 The `fn` command group contains subcommands for transforming and validating `kpt` packages
 using containerized functions.
-<!--mdtogo-->
-
-<!--mdtogo:Examples-->
 <!--mdtogo-->

--- a/site/reference/fn/README.md
+++ b/site/reference/fn/README.md
@@ -2,7 +2,7 @@
 title: "`fn`"
 linkTitle: "fn"
 type: docs
-weight: 4
+weight: 1
 description: >
    Transform and validate packages using containerized functions.
 ---
@@ -14,4 +14,7 @@ description: >
 <!--mdtogo:Long-->
 The `fn` command group contains subcommands for transforming and validating `kpt` packages
 using containerized functions.
+<!--mdtogo-->
+
+<!--mdtogo:Examples-->
 <!--mdtogo-->

--- a/site/reference/fn/render/README.md
+++ b/site/reference/fn/render/README.md
@@ -9,22 +9,40 @@ description: >
    Render a package.
 -->
 
-`render` executes the pipeline of functions, defined in the package Kptfile [kptfile reference] and writes the output back to the package directory.
+`render` validates the meta resources (i.e. `Kptfile` and `functionConfig`), executes
+the pipelines of functions on package resources and formats the output and writes to
+the local filesystem in-place.
 
-If a package contains sub packages, the sub packages are rendered before the parent package. For example, if a package A contains sub package B, then the pipeline in B is executed first and then the pipeline in A is executed on the KRM resources in A and resources produced by rendering of B.
+`render` executes the pipelines in the package hierarchy in a depth-first order. For example, if a package A contains subpackage B, then the pipeline in B is executed on resources in B and then the pipeline in A is executed on resources in A and the output of the pipeline from package B. The output of the pipeline from A is then formatted and
+written to the local filesystem in-place.
 
-Note that the Kptfile and the function config files referred in the pipeline are excluded from the inputs to the functions.
+Meta resources (i.e. `Kptfile` and `functionConfig`) are excluded from the inputs to the functions.
 
+If any of the functions in the pipeline fails, then the entire pipeline is aborted and the
+local filesystem is left intact.
+
+Refer to the [Declarative Functions Execution] for more details.
 ### Synopsis
 <!--mdtogo:Long-->
 ```
-kpt fn render [DIR]
+kpt fn render [PKG_PATH] [flags]
 ```
 
 #### Args
+
 ```
-DIR:
-  Path to a package directory. Defaults to current directory if unspecified.
+PKG_PATH:
+  Local package path to render. Directory must exist and contain a Kptfile
+  to be updated. Defaults to the current working directory.
+```
+
+#### Flags
+
+```
+--results-dir:
+  Path to a directory to write structured results. Directory must exist.
+  Structured results emitted by the functions are aggregated and saved
+  to `results.yaml` file in the specified directory.
 ```
 <!--mdtogo-->
 
@@ -34,14 +52,19 @@ DIR:
 
 ```shell
 # Render the package in current directory
-kpt fn render
+$ kpt fn render
 ```
 
 ```shell
-# Render the package in `my-package-dir` directory
-kpt fn render my-package-dir
+# Render the package in current directory and save results in my-results-dir
+$ kpt fn --results-dir my-results-dir render
 ```
 
-[kptfile reference]: https://kpt.dev/reference/kptfile#pipeline
+```shell
+# Render my-package-dir
+$ kpt fn render my-package-dir
+```
 
 <!--mdtogo-->
+
+[Declarative Functions Execution]: /book/04-using-functions/01-declarative-function-execution

--- a/site/reference/fn/render/README.md
+++ b/site/reference/fn/render/README.md
@@ -9,28 +9,35 @@ description: >
    Render a package.
 -->
 
-`render` validates the meta resources (i.e. `Kptfile` and `functionConfig`), executes
-the pipelines of functions on package resources and formats the output and writes to
-the local filesystem in-place.
+`render` executes the pipelines of functions on resources in the package and
+writes the output to the local filesystem in-place.
 
-`render` executes the pipelines in the package hierarchy in a depth-first order. For example, if a package A contains subpackage B, then the pipeline in B is executed on resources in B and then the pipeline in A is executed on resources in A and the output of the pipeline from package B. The output of the pipeline from A is then formatted and
-written to the local filesystem in-place.
+`render` executes the pipelines in the package hierarchy in a depth-first order.
+For example, if a package A contains subpackage B, then the pipeline in B is executed
+on resources in B and then the pipeline in A is executed on resources in A and
+the output of the pipeline from package B. The output of the pipeline from A is
+then written to the local filesystem in-place.
 
-Meta resources (i.e. `Kptfile` and `functionConfig`) are excluded from the inputs to the functions.
+`render` formats the resources before writing them to the local filesystem.
 
-If any of the functions in the pipeline fails, then the entire pipeline is aborted and the
-local filesystem is left intact.
+Meta resources (i.e. `Kptfile` and `functionConfig`) are excluded from the inputs
+to the functions.
+
+If any of the functions in the pipeline fails, then the entire pipeline is aborted and
+the local filesystem is left intact.
 
 Refer to the [Declarative Functions Execution] for more details.
+
 ### Synopsis
+
 <!--mdtogo:Long-->
-```
+```shell
 kpt fn render [PKG_PATH] [flags]
 ```
 
 #### Args
 
-```
+```shell
 PKG_PATH:
   Local package path to render. Directory must exist and contain a Kptfile
   to be updated. Defaults to the current working directory.
@@ -38,7 +45,7 @@ PKG_PATH:
 
 #### Flags
 
-```
+```shell
 --results-dir:
   Path to a directory to write structured results. Directory must exist.
   Structured results emitted by the functions are aggregated and saved

--- a/site/reference/fn/render/README.md
+++ b/site/reference/fn/render/README.md
@@ -1,0 +1,47 @@
+---
+title: "`render`"
+linkTitle: "render"
+type: docs
+description: >
+   Render a package
+---
+<!--mdtogo:Short
+   Render a package.
+-->
+
+`render` executes the pipeline of functions, defined in the package Kptfile [kptfile reference] and writes the output back to the package directory.
+
+If a package contains sub packages, the sub packages are rendered before the parent package. For example, if a package A contains sub package B, then the pipeline in B is executed first and then the pipeline in A is executed on the KRM resources in A and resources produced by rendering of B.
+
+Note that the Kptfile and the function config files referred in the pipeline are excluded from the inputs to the functions.
+
+### Synopsis
+<!--mdtogo:Long-->
+```
+kpt fn render [DIR]
+```
+
+#### Args
+```
+DIR:
+  Path to a package directory. Defaults to current directory if unspecified.
+```
+<!--mdtogo-->
+
+### Examples
+
+<!--mdtogo:Examples-->
+
+```shell
+# Render the package in current directory
+kpt fn render
+```
+
+```shell
+# Render the package in `my-package-dir` directory
+kpt fn render my-package-dir
+```
+
+[kptfile reference]: https://kpt.dev/reference/kptfile#pipeline
+
+<!--mdtogo-->

--- a/site/reference/fn/render/README.md
+++ b/site/reference/fn/render/README.md
@@ -50,6 +50,7 @@ PKG_PATH:
   Path to a directory to write structured results. Directory must exist.
   Structured results emitted by the functions are aggregated and saved
   to `results.yaml` file in the specified directory.
+  If not specified, no result files are written to the local filesystem.
 ```
 <!--mdtogo-->
 

--- a/site/sidebar.md
+++ b/site/sidebar.md
@@ -37,6 +37,7 @@
         - [update](reference/pkg/update/)
     - [fn](reference/fn/)
         - [export](reference/fn/export/)
+        - [render](reference/fn/render/)
         - [run](reference/fn/run/)
         - [sink](reference/fn/sink/)
         - [source](reference/fn/source/)

--- a/site/sidebar.md
+++ b/site/sidebar.md
@@ -36,7 +36,6 @@
         - [init](reference/pkg/init/)
         - [update](reference/pkg/update/)
     - [fn](reference/fn/)
-        - [export](reference/fn/export/)
         - [render](reference/fn/render/)
         - [run](reference/fn/run/)
         - [sink](reference/fn/sink/)

--- a/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
+++ b/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 
+	docs "github.com/GoogleContainerTools/kpt/internal/docs/generated/fndocs"
 	"github.com/GoogleContainerTools/kpt/thirdparty/cmdconfig/commands/runner"
 	"github.com/GoogleContainerTools/kpt/thirdparty/kyaml/runfn"
 	"github.com/spf13/cobra"
@@ -23,6 +24,9 @@ func GetEvalFnRunner(ctx context.Context, name string) *EvalFnRunner {
 	r := &EvalFnRunner{Ctx: ctx}
 	c := &cobra.Command{
 		Use:     "eval [DIR | -]",
+		Short:   docs.RunShort,
+		Long:    docs.RunLong,
+		Example: docs.RunExamples,
 		RunE:    r.runE,
 		PreRunE: r.preRunE,
 	}


### PR DESCRIPTION
This PR updates the reference docs for `kpt fn render`.

I am going to follow the structure in this PR (once reviewed) to update reference docs for all the subcommands under `fn` commandgroup.