### PR TITLE
Docs: Fix example state after invoking a setter

### DIFF
--- a/site/content/en/guides/producer/setters/_index.md
+++ b/site/content/en/guides/producer/setters/_index.md
@@ -203,7 +203,7 @@ kind: Deployment
 metadata:
   name: foo
 spec:
-  replicas: 3 # {"$kpt-set":"replicas"}
+  replicas: 5 # {"$kpt-set":"replicas"}
 ```
 
 {{% hide %}}


### PR DESCRIPTION
Fixing a copy-and-paste bug in the guide for using setters.