### PR TITLE
`kpt fn` CLI output enhancement for success structure results

### DIFF
--- a/e2e/testdata/fn-render/structured-results-from-muiltiple-fns/.expected/config.yaml
+++ b/e2e/testdata/fn-render/structured-results-from-muiltiple-fns/.expected/config.yaml
@@ -15,9 +15,7 @@
 # One of the functions in the pipeline fails resulting in
 # non-zero exit code and no changes in the resources.
 exitCode: 1
-stdErr: "[ERROR] Invalid type. Expected: [integer,null], given: string in object 'apps/v1/Deployment//nginx-deployment' in file resources.yaml in field spec.replicas"
+stdErr: "[ERROR] Invalid type. Expected: [integer,null], given: string in object"
 stdOut: |
-  [RUNNING] "gcr.io/kpt-fn/enforce-gatekeeper:unstable"
-  [PASS] "gcr.io/kpt-fn/enforce-gatekeeper:unstable"
-  [RUNNING] "gcr.io/kpt-fn/kubeval:unstable"
-  [FAIL] "gcr.io/kpt-fn/kubeval:unstable"
+   [RUNNING] "gcr.io/kpt-fn/enforce-gatekeeper:unstable"
+   [PASS] "gcr.io/kpt-fn/enforce-gatekeeper:unstable"

--- a/internal/cmdrender/executor.go
+++ b/internal/cmdrender/executor.go
@@ -104,7 +104,7 @@ func (e *Executor) saveFnResults(ctx context.Context, fnResults *fnresult.Result
 		return fmt.Errorf("failed to save function results: %w", err)
 	}
 
-	printerutil.PrintFnResultInfo(ctx, resultsFile)
+	printerutil.PrintFnResultInfo(ctx, resultsFile, false)
 	return nil
 }
 

--- a/internal/errors/resolver/misc.go
+++ b/internal/errors/resolver/misc.go
@@ -22,26 +22,7 @@ import (
 
 //nolint:gochecknoinits
 func init() {
-	AddErrorResolver(&fnExecErrorResolver{})
 	AddErrorResolver(&alreadyHandledErrorResolver{})
-}
-
-// gitExecErrorResolver is an implementation of the ErrorResolver interface
-// that can produce error messages for errors of the FnExecError type.
-type fnExecErrorResolver struct{}
-
-func (*fnExecErrorResolver) Resolve(err error) (ResolvedResult, bool) {
-	kioErr := errors.UnwrapKioError(err)
-
-	var fnErr *errors.FnExecError
-	if !goerrors.As(kioErr, &fnErr) {
-		return ResolvedResult{}, false
-	}
-
-	return ResolvedResult{
-		Message:  fnErr.String(),
-		ExitCode: 1,
-	}, true
 }
 
 type alreadyHandledErrorResolver struct{}

--- a/internal/fnruntime/container.go
+++ b/internal/fnruntime/container.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"github.com/GoogleContainerTools/kpt/internal/types"
 	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
@@ -90,7 +89,7 @@ func (f *ContainerFn) Run(reader io.Reader, writer io.Writer) error {
 	if err := cmd.Run(); err != nil {
 		var exitErr *exec.ExitError
 		if goerrors.As(err, &exitErr) {
-			return &errors.FnExecError{
+			return &ExecError{
 				OriginalErr:    exitErr,
 				ExitCode:       exitErr.ExitCode(),
 				Stderr:         errSink.String(),
@@ -117,10 +116,6 @@ func (f *ContainerFn) getDockerCmd() (*exec.Cmd, context.CancelFunc) {
 		"run", "--rm", "-i",
 		"-a", "STDIN", "-a", "STDOUT", "-a", "STDERR",
 		"--network", string(network),
-		// TODO: this env is only used in TS SDK to print the errors
-		// to stderr. We don't need this once we support structured
-		// results.
-		"-e", "LOG_TO_STDERR=true",
 		"--user", uidgid,
 		"--security-opt=no-new-privileges",
 	}
@@ -128,7 +123,7 @@ func (f *ContainerFn) getDockerCmd() (*exec.Cmd, context.CancelFunc) {
 		args = append(args, "--mount", storageMount.String())
 	}
 	args = append(args,
-		runtimeutil.NewContainerEnvFromStringSlice(f.Env).GetDockerFlags()...)
+		newContainerEnvFromStringSlice(f.Env).GetDockerFlags()...)
 	args = append(args, f.Image)
 	// setup container run timeout
 	timeout := defaultTimeout
@@ -137,6 +132,26 @@ func (f *ContainerFn) getDockerCmd() (*exec.Cmd, context.CancelFunc) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	return exec.CommandContext(ctx, dockerBin, args...), cancel
+}
+
+// newContainerEnvFromStringSlice returns a new ContainerEnv pointer with parsing
+// input envStr. envStr example: ["foo=bar", "baz"]
+// using this instead of runtimeutil.NewContainerEnvFromStringSlice() to avoid
+// default envs LOG_TO_STDERR
+func newContainerEnvFromStringSlice(envStr []string) *runtimeutil.ContainerEnv {
+	ce := &runtimeutil.ContainerEnv{
+		EnvVars: make(map[string]string),
+	}
+	// default envs
+	for _, e := range envStr {
+		parts := strings.SplitN(e, "=", 2)
+		if len(parts) == 1 {
+			ce.AddKey(e)
+		} else {
+			ce.AddKeyValue(parts[0], parts[1])
+		}
+	}
+	return ce
 }
 
 // prepareImage will check local images and pull it if it doesn't

--- a/internal/fnruntime/exec.go
+++ b/internal/fnruntime/exec.go
@@ -23,7 +23,6 @@ import (
 	"os/exec"
 	"time"
 
-	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/printer"
 )
 
@@ -59,7 +58,7 @@ func (f *ExecFn) Run(r io.Reader, w io.Writer) error {
 	if err := cmd.Run(); err != nil {
 		var exitErr *exec.ExitError
 		if goerrors.As(err, &exitErr) {
-			return &errors.FnExecError{
+			return &ExecError{
 				OriginalErr:    exitErr,
 				ExitCode:       exitErr.ExitCode(),
 				Stderr:         errSink.String(),

--- a/internal/fnruntime/fnerrors.go
+++ b/internal/fnruntime/fnerrors.go
@@ -49,30 +49,15 @@ type ExecError struct {
 // String returns string representation of the failure.
 func (fe *ExecError) String() string {
 	var b strings.Builder
-	universalIndent := strings.Repeat(" ", FnExecErrorIndentation)
-	b.WriteString(universalIndent + "Stderr:\n")
 
-	lineIndent := strings.Repeat(" ", FnExecErrorIndentation+2)
-	if !fe.TruncateOutput {
-		// stderr string should have indentations
-		for _, s := range strings.Split(fe.Stderr, "\n") {
-			b.WriteString(fmt.Sprintf(lineIndent+"%q\n", s))
-		}
-	} else {
-		printedLines := 0
-		lines := strings.Split(fe.Stderr, "\n")
-		for i, s := range lines {
-			if i >= FnExecErrorTruncateLines {
-				break
-			}
-			b.WriteString(fmt.Sprintf(lineIndent+"%q\n", s))
-			printedLines++
-		}
-		if printedLines < len(lines) {
-			b.WriteString(fmt.Sprintf(lineIndent+"...(%d line(s) truncated, use '--truncate-output=false' to disable)\n", len(lines)-printedLines))
-		}
+	errLines := &multiLineFormatter{
+		Title:          "Stderr",
+		Lines:          strings.Split(fe.Stderr, "\n"),
+		UseQuote:       true,
+		TruncateOutput: fe.TruncateOutput,
 	}
-	b.WriteString(fmt.Sprintf(universalIndent+"Exit Code: %d\n", fe.ExitCode))
+	b.WriteString(errLines.String())
+	b.WriteString(fmt.Sprintf("  Exit Code: %d\n", fe.ExitCode))
 	return b.String()
 }
 

--- a/internal/fnruntime/fnerrors.go
+++ b/internal/fnruntime/fnerrors.go
@@ -12,11 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package errors
+package fnruntime
 
 import (
 	"fmt"
 	"strings"
+
+	fnresult "github.com/GoogleContainerTools/kpt/pkg/api/fnresult/v1alpha2"
 )
 
 const (
@@ -26,9 +28,8 @@ const (
 	FnExecErrorIndentation = 2
 )
 
-// FnExecError contains the information about the function failure that will
-// be outputted.
-type FnExecError struct {
+// ExecError implements an error type that stores information about function failure.
+type ExecError struct {
 	// OriginalErr is the original error returned from function runtime
 	OriginalErr error
 
@@ -41,14 +42,12 @@ type FnExecError struct {
 	// ExitCode is the exit code returned from function
 	ExitCode int `yaml:"exitCode,omitempty"`
 
-	// TODO: This introduces import cycle between errors and fnresult package.
-	// Will require moving fnErrors outside errors package.
 	// FnResult is the structured result returned from the function
-	// FnResult *fnresult.Result
+	FnResult *fnresult.Result
 }
 
 // String returns string representation of the failure.
-func (fe *FnExecError) String() string {
+func (fe *ExecError) String() string {
 	var b strings.Builder
 	universalIndent := strings.Repeat(" ", FnExecErrorIndentation)
 	b.WriteString(universalIndent + "Stderr:\n")
@@ -77,6 +76,6 @@ func (fe *FnExecError) String() string {
 	return b.String()
 }
 
-func (fe *FnExecError) Error() string {
+func (fe *ExecError) Error() string {
 	return fe.String()
 }

--- a/internal/fnruntime/fnerrors_test.go
+++ b/internal/fnruntime/fnerrors_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package errors
+package fnruntime
 
 import (
 	"testing"
@@ -20,16 +20,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFnExecErrorString(t *testing.T) {
+func TestExecErrorString(t *testing.T) {
 	testcases := []struct {
 		name        string
-		fnExecError FnExecError
+		fnExecError ExecError
 		truncate    bool
 		expected    string
 	}{
 		{
 			name:        "no truncate - empty stderr",
-			fnExecError: FnExecError{},
+			fnExecError: ExecError{},
 			expected: `  Stderr:
     ""
   Exit Code: 0
@@ -37,7 +37,7 @@ func TestFnExecErrorString(t *testing.T) {
 		},
 		{
 			name: "no truncate - normal failure",
-			fnExecError: FnExecError{
+			fnExecError: ExecError{
 				Stderr: `error message1
 error message2`,
 				ExitCode: 1,
@@ -50,7 +50,7 @@ error message2`,
 		},
 		{
 			name: "no truncate - long stderr",
-			fnExecError: FnExecError{
+			fnExecError: ExecError{
 				Stderr: `error message
 error message
 error message
@@ -69,7 +69,7 @@ error message`,
 		},
 		{
 			name: "truncate - normal failure",
-			fnExecError: FnExecError{
+			fnExecError: ExecError{
 				Stderr: `error message
 error message
 error message
@@ -87,7 +87,7 @@ error message`,
 		},
 		{
 			name: "truncate - long stderr 1",
-			fnExecError: FnExecError{
+			fnExecError: ExecError{
 				Stderr: `error message
 error message
 error message
@@ -107,7 +107,7 @@ error message`,
 		},
 		{
 			name: "truncate - long stderr 2",
-			fnExecError: FnExecError{
+			fnExecError: ExecError{
 				Stderr: `error message
 error message
 error message

--- a/internal/fnruntime/runner.go
+++ b/internal/fnruntime/runner.go
@@ -229,7 +229,9 @@ type multiLineFormatter struct {
 
 // String returns multiline string.
 func (ri *multiLineFormatter) String() string {
-	ri.MaxLines = FnExecErrorTruncateLines
+	if ri.MaxLines == 0 {
+		ri.MaxLines = FnExecErrorTruncateLines
+	}
 	strInterpolator := "%s"
 	if ri.UseQuote {
 		strInterpolator = "%q"

--- a/internal/fnruntime/runner.go
+++ b/internal/fnruntime/runner.go
@@ -176,19 +176,18 @@ func parseStructuredResult(yml *yaml.RNode, fnResult *fnresult.Result) error {
 // format on kpt CLI.
 func printFnResult(ctx context.Context, fnResult *fnresult.Result) {
 	pr := printer.FromContextOrDie(ctx)
-	printOpt := printer.NewOpt()
 	if len(fnResult.Results) > 0 {
 		// function returned structured results
-		pr.OptPrintf(printOpt, "  Results:\n")
 		var lines []string
 		for _, item := range fnResult.Results {
 			lines = append(lines, resultToString(item))
 		}
 		ri := &multiLineFormatter{
+			Title:          "Results",
 			Lines:          lines,
 			TruncateOutput: printer.TruncateOutput,
 		}
-		pr.OptPrintf(printOpt, "%s", ri.String())
+		pr.Printf("%s", ri.String())
 	}
 }
 
@@ -198,8 +197,8 @@ func printFnExecErr(ctx context.Context, fnErr *ExecError) {
 	pr := printer.FromContextOrDie(ctx)
 	printOpt := printer.NewOpt()
 	if len(fnErr.Stderr) > 0 {
-		pr.OptPrintf(printOpt.Stderr(), "  Stderr:\n")
 		errLines := &multiLineFormatter{
+			Title:          "Stderr",
 			Lines:          strings.Split(fnErr.Stderr, "\n"),
 			UseQuote:       true,
 			TruncateOutput: printer.TruncateOutput,
@@ -212,6 +211,9 @@ func printFnExecErr(ctx context.Context, fnErr *ExecError) {
 // multiLineFormatter knows how to format multiple lines in pretty format
 // that can be displayed to an end user.
 type multiLineFormatter struct {
+	// Title under which lines need to be printed
+	Title string
+
 	// Lines to be printed on the CLI.
 	Lines []string
 
@@ -234,6 +236,8 @@ func (ri *multiLineFormatter) String() string {
 	}
 
 	var b strings.Builder
+
+	b.WriteString(fmt.Sprintf("  %s:\n", ri.Title))
 	lineIndent := strings.Repeat(" ", FnExecErrorIndentation+2)
 	if !ri.TruncateOutput {
 		// stderr string should have indentations

--- a/internal/fnruntime/runner.go
+++ b/internal/fnruntime/runner.go
@@ -21,12 +21,14 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"github.com/GoogleContainerTools/kpt/internal/types"
 	fnresult "github.com/GoogleContainerTools/kpt/pkg/api/fnresult/v1alpha2"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
+	"sigs.k8s.io/kustomize/kyaml/fn/framework"
 	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
@@ -48,7 +50,12 @@ func NewContainerRunner(ctx context.Context, f *kptfilev1alpha2.Function, pkgPat
 		Run:            cfn.Run,
 		FunctionConfig: config,
 	}
-	fnResult := &fnresult.Result{Image: f.Image}
+	fnResult := &fnresult.Result{
+		Image: f.Image,
+		// TODO(droot): This is required for making structured results subpackage aware.
+		// Enable this once test harness supports filepath based assertions.
+		// Pkg: string(pkgPath),
+	}
 	return NewFunctionRunner(ctx, fltr, false, fnResult, fnResults)
 }
 
@@ -84,29 +91,31 @@ type FunctionRunner struct {
 }
 
 func (fr *FunctionRunner) Filter(input []*yaml.RNode) (output []*yaml.RNode, err error) {
-
 	if fr.disableOutput {
-		output, err = fr.do(input)
-	} else {
-		pr := printer.FromContextOrDie(fr.ctx)
-		printOpt := printer.NewOpt()
-		pr.OptPrintf(printOpt, "[RUNNING] %q\n", fr.name)
-		output, err = fr.do(input)
-		if err != nil {
-			pr.OptPrintf(printOpt, "[FAIL] %q\n", fr.name)
-			var fnErr *errors.FnExecError
-			if goerrors.As(err, &fnErr) {
-				pr.OptPrintf(printOpt.Stderr(), "%s\n", fnErr.String())
-				return nil, errors.ErrAlreadyHandled
-			}
-			return nil, err
-		}
-		// capture the result from running the function
-		pr.OptPrintf(printOpt, "[PASS] %q\n", fr.name)
+		return fr.do(input)
 	}
+	pr := printer.FromContextOrDie(fr.ctx)
+	printOpt := printer.NewOpt()
+
+	pr.OptPrintf(printOpt, "[RUNNING] %q\n", fr.name)
+	output, err = fr.do(input)
+	if err != nil {
+		pr.OptPrintf(printOpt, "[FAIL] %q\n", fr.name)
+		printFnResult(fr.ctx, fr.fnResult)
+		var fnErr *ExecError
+		if goerrors.As(err, &fnErr) {
+			printFnExecErr(fr.ctx, fnErr)
+			return nil, errors.ErrAlreadyHandled
+		}
+		return nil, err
+	}
+	pr.OptPrintf(printOpt, "[PASS] %q\n", fr.name)
+	printFnResult(fr.ctx, fr.fnResult)
 	return output, err
 }
 
+// do executes the kpt function and returns the modified resources.
+// fnResult is updated with the function results returned by the kpt function.
 func (fr *FunctionRunner) do(input []*yaml.RNode) (output []*yaml.RNode, err error) {
 	fnResult := fr.fnResult
 
@@ -120,10 +129,11 @@ func (fr *FunctionRunner) do(input []*yaml.RNode) (output []*yaml.RNode, err err
 		return output, resultErr
 	}
 	if err != nil {
-		var fnErr *errors.FnExecError
+		var fnErr *ExecError
 		if goerrors.As(err, &fnErr) {
 			fnResult.ExitCode = fnErr.ExitCode
 			fnResult.Stderr = fnErr.Stderr
+			fnErr.FnResult = fnResult
 			fr.fnResults.ExitCode = 1
 		}
 		// accumulate the results
@@ -160,6 +170,140 @@ func parseStructuredResult(yml *yaml.RNode, fnResult *fnresult.Result) error {
 		return err
 	}
 	return nil
+}
+
+// printFnResult prints given function result in a user friendly
+// format on kpt CLI.
+func printFnResult(ctx context.Context, fnResult *fnresult.Result) {
+	pr := printer.FromContextOrDie(ctx)
+	printOpt := printer.NewOpt()
+	if len(fnResult.Results) > 0 {
+		// function returned structured results
+		pr.OptPrintf(printOpt, "  Results:\n")
+		var lines []string
+		for _, item := range fnResult.Results {
+			lines = append(lines, resultToString(item))
+		}
+		ri := &multiLineFormatter{
+			Lines:          lines,
+			TruncateOutput: printer.TruncateOutput,
+		}
+		pr.OptPrintf(printOpt, "%s", ri.String())
+	}
+}
+
+// printFnExecErr prints given ExecError in a user friendly format
+// on kpt CLI.
+func printFnExecErr(ctx context.Context, fnErr *ExecError) {
+	pr := printer.FromContextOrDie(ctx)
+	printOpt := printer.NewOpt()
+	if len(fnErr.Stderr) > 0 {
+		pr.OptPrintf(printOpt.Stderr(), "  Stderr:\n")
+		errLines := &multiLineFormatter{
+			Lines:          strings.Split(fnErr.Stderr, "\n"),
+			UseQuote:       true,
+			TruncateOutput: printer.TruncateOutput,
+		}
+		pr.OptPrintf(printOpt.Stderr(), "%s", errLines.String())
+	}
+	pr.OptPrintf(printOpt.Stderr(), "  Exit code: %d\n\n", fnErr.ExitCode)
+}
+
+// multiLineFormatter knows how to format multiple lines in pretty format
+// that can be displayed to an end user.
+type multiLineFormatter struct {
+	// Lines to be printed on the CLI.
+	Lines []string
+
+	// TruncateOuput determines if output needs to be truncated or not.
+	TruncateOutput bool
+
+	// MaxLines to be printed if truncation is enabled.
+	MaxLines int
+
+	// UseQuote determines if line needs to be quoted or not
+	UseQuote bool
+}
+
+// String returns multiline string.
+func (ri *multiLineFormatter) String() string {
+	ri.MaxLines = FnExecErrorTruncateLines
+	strInterpolator := "%s"
+	if ri.UseQuote {
+		strInterpolator = "%q"
+	}
+
+	var b strings.Builder
+	lineIndent := strings.Repeat(" ", FnExecErrorIndentation+2)
+	if !ri.TruncateOutput {
+		// stderr string should have indentations
+		for _, s := range ri.Lines {
+			// suppress newlines to avoid poor formatting
+			s = strings.ReplaceAll(s, "\n", " ")
+			b.WriteString(fmt.Sprintf(lineIndent+strInterpolator+"\n", s))
+		}
+		return b.String()
+	}
+	printedLines := 0
+	for i, s := range ri.Lines {
+		if i >= ri.MaxLines {
+			break
+		}
+		// suppress newlines to avoid poor formatting
+		s = strings.ReplaceAll(s, "\n", " ")
+		b.WriteString(fmt.Sprintf(lineIndent+strInterpolator+"\n", s))
+		printedLines++
+	}
+	truncatedLines := len(ri.Lines) - printedLines
+	if truncatedLines > 0 {
+		b.WriteString(fmt.Sprintf(lineIndent+"...(%d line(s) truncated, use '--truncate-output=false' to disable)\n", truncatedLines))
+	}
+	return b.String()
+}
+
+// resultToString converts given structured result item to string format.
+func resultToString(result framework.ResultItem) string {
+	// TODO: Go SDK should implement Stringer method
+	// for framework.ResultItem. This is a temporary
+	// wrapper that will eventually be moved to Go SDK.
+
+	defaultSeverity := "info"
+
+	s := strings.Builder{}
+
+	severity := defaultSeverity
+
+	if string(result.Severity) != "" {
+		severity = string(result.Severity)
+	}
+	s.WriteString(fmt.Sprintf("[%s] %s", strings.ToUpper(severity), result.Message))
+
+	if result.ResourceRef.Kind != "" {
+		// if an object is involved
+		s.WriteString(" in object ")
+		if result.ResourceRef.APIVersion != "" {
+			s.WriteString(fmt.Sprintf("%s/", result.ResourceRef.APIVersion))
+		}
+		if result.ResourceRef.Kind != "" {
+			s.WriteString(fmt.Sprintf("%s/", result.ResourceRef.Kind))
+		}
+		if result.ResourceRef.Namespace != "" {
+			s.WriteString(fmt.Sprintf("%s/", result.ResourceRef.Namespace))
+		}
+		if result.ResourceRef.Name != "" {
+			s.WriteString(result.ResourceRef.Name)
+		}
+	}
+
+	if result.File.Path != "" {
+		s.WriteString(fmt.Sprintf(" in file %q", result.File.Path))
+	}
+
+	if result.Field.Path != "" {
+		s.WriteString(fmt.Sprintf(" in field %q", result.Field.Path))
+	}
+
+	return s.String()
 }
 
 func newFnConfig(f *kptfilev1alpha2.Function, pkgPath types.UniquePath) (*yaml.RNode, error) {

--- a/internal/fnruntime/runner.go
+++ b/internal/fnruntime/runner.go
@@ -282,21 +282,10 @@ func resultToString(result framework.ResultItem) string {
 	}
 	s.WriteString(fmt.Sprintf("[%s] %s", strings.ToUpper(severity), result.Message))
 
-	if result.ResourceRef.Kind != "" {
+	resourceID := resourceRefToString(result.ResourceRef)
+	if resourceID != "" {
 		// if an object is involved
-		s.WriteString(" in object ")
-		if result.ResourceRef.APIVersion != "" {
-			s.WriteString(fmt.Sprintf("%s/", result.ResourceRef.APIVersion))
-		}
-		if result.ResourceRef.Kind != "" {
-			s.WriteString(fmt.Sprintf("%s/", result.ResourceRef.Kind))
-		}
-		if result.ResourceRef.Namespace != "" {
-			s.WriteString(fmt.Sprintf("%s/", result.ResourceRef.Namespace))
-		}
-		if result.ResourceRef.Name != "" {
-			s.WriteString(result.ResourceRef.Name)
-		}
+		s.WriteString(fmt.Sprintf(" in object %q", resourceID))
 	}
 
 	if result.File.Path != "" {
@@ -307,6 +296,23 @@ func resultToString(result framework.ResultItem) string {
 		s.WriteString(fmt.Sprintf(" in field %q", result.Field.Path))
 	}
 
+	return s.String()
+}
+
+func resourceRefToString(ref yaml.ResourceMeta) string {
+	s := strings.Builder{}
+	if ref.APIVersion != "" {
+		s.WriteString(fmt.Sprintf("%s/", ref.APIVersion))
+	}
+	if ref.Kind != "" {
+		s.WriteString(fmt.Sprintf("%s/", ref.Kind))
+	}
+	if ref.Namespace != "" {
+		s.WriteString(fmt.Sprintf("%s/", ref.Namespace))
+	}
+	if ref.Name != "" {
+		s.WriteString(ref.Name)
+	}
 	return s.String()
 }
 

--- a/internal/fnruntime/runner_test.go
+++ b/internal/fnruntime/runner_test.go
@@ -107,3 +107,59 @@ data: {foo: bar}
 		})
 	}
 }
+
+func TestMultilineFormatter(t *testing.T) {
+
+	type testcase struct {
+		ml       *multiLineFormatter
+		expected string
+	}
+
+	testcases := map[string]testcase{
+		"multiline should format lines and truncate": {
+			ml: &multiLineFormatter{
+				Title: "Results",
+				Lines: []string{
+					"line-1",
+					"line-2",
+					"line-3",
+					"line-4",
+					"line-5",
+				},
+				MaxLines:       3,
+				TruncateOutput: true,
+			},
+			expected: `  Results:
+    line-1
+    line-2
+    line-3
+    ...(2 line(s) truncated, use '--truncate-output=false' to disable)
+`,
+		},
+		"multiline should format without truncate": {
+			ml: &multiLineFormatter{
+				Title: "Results",
+				Lines: []string{
+					"line-1",
+					"line-2",
+					"line-3",
+					"line-4",
+					"line-5",
+				},
+			},
+			expected: `  Results:
+    line-1
+    line-2
+    line-3
+    line-4
+    line-5
+`,
+		},
+	}
+	for name, c := range testcases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, c.expected, c.ml.String())
+		})
+	}
+}

--- a/internal/util/printerutil/printerutil.go
+++ b/internal/util/printerutil/printerutil.go
@@ -21,9 +21,12 @@ import (
 )
 
 // PrintFnResultInfo displays information about the function results file.
-func PrintFnResultInfo(ctx context.Context, resultsFile string) {
+func PrintFnResultInfo(ctx context.Context, resultsFile string, withNewLine bool) {
 	pr := printer.FromContextOrDie(ctx)
 	if resultsFile != "" {
+		if withNewLine {
+			pr.Printf("\n")
+		}
 		pr.Printf("For complete results, see %s\n", resultsFile)
 	}
 }

--- a/pkg/api/fnresult/v1alpha2/types.go
+++ b/pkg/api/fnresult/v1alpha2/types.go
@@ -27,6 +27,10 @@ type Result struct {
 	Image string `yaml:"image,omitempty"`
 	// ExecPath is the the absolute os-specific path to the executable file
 	ExecPath string `yaml:"exec,omitempty"`
+	// TODO(droot): This is required for making structured results subpackage aware.
+	// Enable this once test harness supports filepath based assertions.
+	// Pkg is OS specific Absolute path to the package.
+	// Pkg string `yaml:"pkg,omitempty"`
 	// Stderr is the content in function stderr
 	Stderr string `yaml:"stderr,omitempty"`
 	// ExitCode is the exit code from running the function

--- a/thirdparty/kyaml/runfn/runfn.go
+++ b/thirdparty/kyaml/runfn/runfn.go
@@ -231,7 +231,7 @@ func (r RunFns) printFnResultsStatus(resultsFile string) {
 	if r.isOutputDisabled() {
 		return
 	}
-	printerutil.PrintFnResultInfo(r.Ctx, resultsFile)
+	printerutil.PrintFnResultInfo(r.Ctx, resultsFile, true)
 }
 
 // mergeContainerEnv will merge the envs specified by command line (imperative) and config
@@ -407,7 +407,11 @@ func (r *RunFns) defaultFnFilterProvider(spec runtimeutil.FunctionSpec, fnConfig
 		}
 	}
 	var fltr *runtimeutil.FunctionFilter
-	var fnResult *fnresult.Result
+	fnResult := &fnresult.Result{
+		// TODO(droot): This is required for making structured results subpackage aware.
+		// Enable this once test harness supports filepath based assertions.
+		// Pkg: string(r.uniquePath),
+	}
 	if spec.Container.Image != "" {
 		// TODO: Add a test for this behavior
 		uidgid, err := getUIDGID(r.AsCurrentUser, currentUser)
@@ -432,7 +436,7 @@ func (r *RunFns) defaultFnFilterProvider(spec runtimeutil.FunctionSpec, fnConfig
 			FunctionConfig: fnConfig,
 			DeferFailure:   spec.DeferFailure,
 		}
-		fnResult = &fnresult.Result{Image: spec.Container.Image}
+		fnResult.Image = spec.Container.Image
 	}
 
 	if spec.Exec.Path != "" {
@@ -444,7 +448,7 @@ func (r *RunFns) defaultFnFilterProvider(spec runtimeutil.FunctionSpec, fnConfig
 			FunctionConfig: fnConfig,
 			DeferFailure:   spec.DeferFailure,
 		}
-		fnResult = &fnresult.Result{ExecPath: spec.Exec.Path}
+		fnResult.ExecPath = spec.Exec.Path
 	}
 	return fnruntime.NewFunctionRunner(r.Ctx, fltr, r.isOutputDisabled(), fnResult, r.fnResults)
 }


### PR DESCRIPTION
This PR enhances the CLI output for `kpt fn` commands when function returns structured result on a successful run.

Example output:
```
$ ~/go/bin/kpt fn render --results-dir /tmp/results
Package ".":

[RUNNING] "gcr.io/kpt-fn/search-replace:v0.1"
[PASS] "gcr.io/kpt-fn/search-replace:v0.1"
  Results:
    [INFO] "Mutated field value to \"4\""

Successfully executed 1 function(s) in 1 package(s).
For complete results, see /tmp/results/results.yaml

```
Note the results produced by the function below. We could enhance the result item display by augmenting `file`, `field` info etc. but keeping it simple for now.

```
$ cat /tmp/results/results.yaml
apiVersion: kpt.dev/v1alpha2
kind: FunctionResultList
metadata:
    name: fnresults
exitCode: 0
items:
    - image: gcr.io/kpt-fn/search-replace:v0.1
      pkg: /tmp/fnresult-fn-success
      exitCode: 0
      results:
        - message: Mutated field value to "4"
          field:
            path: spec.replicas
          file:
            path: resources.yaml

```

Note: this is draft pull request to get early feedback on the output. This doesn't support truncation yet. On a second thought, I am re-thinking if we should really truncate the output (I feel optimization too soon) ?