### PR TITLE
remove eval flags

### DIFF
--- a/e2e/testdata/fn-render/fnresult-fn-success/search-replace-conf.yaml
+++ b/e2e/testdata/fn-render/fnresult-fn-success/search-replace-conf.yaml
@@ -1,3 +1,17 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
+++ b/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
@@ -27,8 +27,6 @@ func GetEvalFnRunner(ctx context.Context, name string) *EvalFnRunner {
 		PreRunE: r.preRunE,
 	}
 
-	c.Flags().BoolVar(&r.IncludeSubpackages, "include-subpackages", true,
-		"also print resources from subpackages.")
 	r.Command = c
 	r.Command.Flags().BoolVar(
 		&r.DryRun, "dry-run", false, "print results to stdout")
@@ -37,23 +35,17 @@ func GetEvalFnRunner(ctx context.Context, name string) *EvalFnRunner {
 		"run this image as a function")
 	r.Command.Flags().StringVar(
 		&r.ExecPath, "exec-path", "", "run an executable as a function. (Alpha)")
-
 	r.Command.Flags().StringVar(
 		&r.FnConfigPath, "fn-config", "", "path to the function config file")
-
 	r.Command.Flags().BoolVar(
 		&r.IncludeMetaResources, "include-meta-resources", false, "include package meta resources in function input")
-
 	r.Command.Flags().StringVar(
 		&r.ResultsDir, "results-dir", "", "write function results to this dir")
-
 	r.Command.Flags().BoolVar(
 		&r.Network, "network", false, "enable network access for functions that declare it")
 	r.Command.Flags().StringArrayVar(
 		&r.Mounts, "mount", []string{},
 		"a list of storage options read from the filesystem")
-	r.Command.Flags().BoolVar(
-		&r.LogSteps, "log-steps", false, "log steps to stderr")
 	r.Command.Flags().StringArrayVarP(
 		&r.Env, "env", "e", []string{},
 		"a list of environment variables to be used by functions")
@@ -68,7 +60,6 @@ func EvalCommand(ctx context.Context, name string) *cobra.Command {
 
 // EvalFnRunner contains the run function
 type EvalFnRunner struct {
-	IncludeSubpackages   bool
 	Command              *cobra.Command
 	DryRun               bool
 	Image                string
@@ -78,7 +69,6 @@ type EvalFnRunner struct {
 	ResultsDir           string
 	Network              bool
 	Mounts               []string
-	LogSteps             bool
 	Env                  []string
 	AsCurrentUser        bool
 	IncludeMetaResources bool
@@ -285,7 +275,6 @@ func (r *EvalFnRunner) preRunE(c *cobra.Command, args []string) error {
 		Network:              r.Network,
 		StorageMounts:        storageMounts,
 		ResultsDir:           r.ResultsDir,
-		LogSteps:             r.LogSteps,
 		Env:                  r.Env,
 		AsCurrentUser:        r.AsCurrentUser,
 		FnConfigPath:         r.FnConfigPath,

--- a/thirdparty/cmdconfig/commands/cmdeval/cmdeval_test.go
+++ b/thirdparty/cmdconfig/commands/cmdeval/cmdeval_test.go
@@ -213,28 +213,6 @@ apiVersion: v1
 			err:  "must have keys and values separated by",
 		},
 		{
-			name: "log steps",
-			args: []string{"eval", "dir", "--log-steps", "--image", "foo:bar"},
-			path: "dir",
-			expectedStruct: &runfn.RunFns{
-				Path:                  "dir",
-				LogSteps:              true,
-				Env:                   []string{},
-				ContinueOnEmptyResult: true,
-				Ctx:                   context.TODO(),
-			},
-			expected: `
-metadata:
-  name: function-input
-  annotations:
-    config.kubernetes.io/function: |
-      container: {image: 'foo:bar'}
-data: {}
-kind: ConfigMap
-apiVersion: v1
-`,
-		},
-		{
 			name: "envs",
 			args: []string{"eval", "dir", "--env", "FOO=BAR", "-e", "BAR", "--image", "foo:bar"},
 			path: "dir",

--- a/thirdparty/kyaml/runfn/runfn.go
+++ b/thirdparty/kyaml/runfn/runfn.go
@@ -64,12 +64,6 @@ type RunFns struct {
 
 	fnResults *fnresult.ResultList
 
-	// LogSteps enables logging the function that is running.
-	LogSteps bool
-
-	// LogWriter can be set to write the logs to LogWriter rather than stderr if LogSteps is enabled.
-	LogWriter io.Writer
-
 	// functionFilterProvider provides a filter to perform the function.
 	// this is a variable so it can be mocked in tests
 	functionFilterProvider func(
@@ -230,21 +224,6 @@ func (r RunFns) runFunctions(
 	if resultErr == nil {
 		r.printFnResultsStatus(resultsFile)
 	}
-
-	// check for deferred function errors
-	var errs []string
-	for i := range fltrs {
-		cf, ok := fltrs[i].(runtimeutil.DeferFailureFunction)
-		if !ok {
-			continue
-		}
-		if cf.GetExit() != nil {
-			errs = append(errs, cf.GetExit().Error())
-		}
-	}
-	if len(errs) > 0 {
-		return fmt.Errorf(strings.Join(errs, "\n---\n"))
-	}
 	return nil
 }
 
@@ -362,11 +341,6 @@ func (r *RunFns) init() error {
 	// functionFilterProvider set the filter provider
 	if r.functionFilterProvider == nil {
 		r.functionFilterProvider = r.defaultFnFilterProvider
-	}
-
-	// if LogSteps is enabled and LogWriter is not specified, use stderr
-	if r.LogSteps && r.LogWriter == nil {
-		r.LogWriter = os.Stderr
 	}
 
 	// fn config path should be absolute


### PR DESCRIPTION
Remove flags from `fn eval`:
 - `log-steps`: No need to have this since we have our own CLI output
 - `include-subpackages`: Not used in `fn eval` and `fn run`. The flag was added but the code which uses it in `fn run` is missing for some reason. If we want to support it we can reintroduce it as a new feature.