### PR TITLE
Improve error messages when failing to read/parse Kptfile

### DIFF
--- a/e2e/testdata/fn-render/invalid-kptfile/.expected/config.yaml
+++ b/e2e/testdata/fn-render/invalid-kptfile/.expected/config.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 exitCode: 1
-stdErr: "unable to parse \"Kptfile\": yaml: line 3: could not find expected ':'"
+stdErr: "can't be read.\n\nDetails:\nyaml: line 3: could not find expected ':'"

--- a/e2e/testdata/fn-render/missing-kptfile/.expected/config.yaml
+++ b/e2e/testdata/fn-render/missing-kptfile/.expected/config.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 exitCode: 1
-stdErr: "missing-kptfile/Kptfile: no such file or directory"
+stdErr: "No Kptfile found at"

--- a/e2e/testdata/fn-render/no-format-on-failure/.expected/config.yaml
+++ b/e2e/testdata/fn-render/no-format-on-failure/.expected/config.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 exitCode: 1
-stdErr: 'Error: unable to parse "Kptfile"'
+stdErr: "can't be read.\n\nDetails:\nyaml: unmarshal errors:\n  line 10: cannot unmarshal !!map into string"

--- a/e2e/testdata/fn-render/subpkg-has-invalid-kptfile/.expected/config.yaml
+++ b/e2e/testdata/fn-render/subpkg-has-invalid-kptfile/.expected/config.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 exitCode: 1
-stdErr: "unable to parse \"Kptfile\": yaml: line 10: mapping values are not allowed in this context"
+stdErr: "can't be read.\n\nDetails:\nyaml: line 10: mapping values are not allowed in this context"

--- a/internal/errors/resolver/pkg.go
+++ b/internal/errors/resolver/pkg.go
@@ -1,0 +1,66 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolver
+
+import (
+	"os"
+
+	"github.com/GoogleContainerTools/kpt/internal/errors"
+	"github.com/GoogleContainerTools/kpt/internal/pkg"
+)
+
+//nolint:gochecknoinits
+func init() {
+	AddErrorResolver(&pkgErrorResolver{})
+}
+
+const (
+	noKptfileMsg = `
+Error: No Kptfile found at {{ printf "%q" .path }}.
+`
+
+	kptfileReadErrMsg = `
+Error: Kptfile at {{ printf "%q" .path }} can't be read.
+
+{{- template "NestedErrDetails" . }}
+`
+)
+
+// pkgErrorResolver is an implementation of the ErrorResolver interface
+// that can produce error messages for errors of the pkg.KptfileError type.
+type pkgErrorResolver struct{}
+
+func (*pkgErrorResolver) Resolve(err error) (ResolvedResult, bool) {
+	var kptfileError *pkg.KptfileError
+	if errors.As(err, &kptfileError) {
+		path := kptfileError.Path
+		tmplArgs := map[string]interface{}{
+			"path": path,
+			"err":  kptfileError,
+		}
+
+		if errors.Is(kptfileError, os.ErrNotExist) {
+			return ResolvedResult{
+				Message: ExecuteTemplate(noKptfileMsg, tmplArgs),
+			}, true
+		}
+
+		return ResolvedResult{
+			Message: ExecuteTemplate(kptfileReadErrMsg, tmplArgs),
+		}, true
+	}
+
+	return ResolvedResult{}, false
+}

--- a/internal/errors/resolver/pkg.go
+++ b/internal/errors/resolver/pkg.go
@@ -54,11 +54,13 @@ func (*pkgErrorResolver) Resolve(err error) (ResolvedResult, bool) {
 		if errors.Is(kptfileError, os.ErrNotExist) {
 			return ResolvedResult{
 				Message: ExecuteTemplate(noKptfileMsg, tmplArgs),
+				ExitCode: 1,
 			}, true
 		}
 
 		return ResolvedResult{
 			Message: ExecuteTemplate(kptfileReadErrMsg, tmplArgs),
+			ExitCode: 1,
 		}, true
 	}
 

--- a/internal/errors/resolver/pkg_test.go
+++ b/internal/errors/resolver/pkg_test.go
@@ -1,0 +1,68 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolver
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/GoogleContainerTools/kpt/internal/pkg"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPkgErrorResolver(t *testing.T) {
+	testCases := map[string]struct {
+		err      error
+		expected string
+	}{
+		"kptfileError has nested ErrNotExist": {
+			err: &pkg.KptfileError{
+				Path: "/foo/bar",
+				Err:  os.ErrNotExist,
+			},
+			expected: "Error: No Kptfile found at \"/foo/bar\".",
+		},
+		"kptfileError doesn't have a known nested error": {
+			err: &pkg.KptfileError{
+				Path: "/some/path",
+				Err:  fmt.Errorf("this is a test"),
+			},
+			expected: `
+Error: Kptfile at "/some/path" can't be read.
+
+Details:
+this is a test
+`,
+		},
+		"kptfileError without nested error": {
+			err: &pkg.KptfileError{
+				Path: "/some/path",
+			},
+			expected: "Error: Kptfile at \"/some/path\" can't be read.",
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			res, ok := (&pkgErrorResolver{}).Resolve(tc.err)
+			if !ok {
+				t.Error("expected error to be resolved, but it wasn't")
+			}
+			assert.Equal(t, strings.TrimSpace(tc.expected), strings.TrimSpace(res.Message))
+		})
+	}
+}

--- a/internal/errors/resolver/template.go
+++ b/internal/errors/resolver/template.go
@@ -24,6 +24,7 @@ import (
 var baseTemplate = func() *template.Template {
 	tmpl := template.New("base")
 	tmpl = template.Must(tmpl.Parse(detailsHelperTemplate))
+	tmpl = template.Must(tmpl.Parse(nestedErrTemplate))
 	return tmpl
 }()
 
@@ -43,6 +44,21 @@ var (
 
 {{- if gt (len .stderr) 0 }}
 {{ printf "%s" .stderr }}
+{{- end }}
+{{ end }}
+`
+
+	// nestedErrTemplate is a helper subtemplate for printing details from
+	// a nested error.
+	nestedErrTemplate = `
+{{- define "NestedErrDetails" }}
+{{- if .err  }}
+{{- if .err.Err }}
+{{- if gt (len .err.Err.Error) 0 }}
+{{ printf "\nDetails:" }}
+{{ printf "%s" .err.Err.Error }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{ end }}
 `


### PR DESCRIPTION
Improve the error messages for situations where kpt fails to read or parse the Kptfile. 

Error message when Kptfile doesn't exist:
```
$ kpt fn render      
Error: No Kptfile found at "/tmp/kpttest".
```

Error message for other issues involving the Kptfile (in this example the Kptfile has an unrecognized property):
```
$ kpt fn render
Error: Kptfile at "/tmp/kpttest" can't be read.

Details:
yaml: unmarshal errors:
  line 7: field foo not found in type v1alpha2.KptFile 
```

Fixes: https://github.com/GoogleContainerTools/kpt/issues/1976
