### PR TITLE
Make testing stdout and stderr optional in the e2e test harness

### DIFF
--- a/pkg/test/runner/runner.go
+++ b/pkg/test/runner/runner.go
@@ -340,16 +340,10 @@ func (r *Runner) compareResult(exitErr error, stdout string, stderr string, tmpP
 // check stdout and stderr against expected
 func (r *Runner) compareOutput(stdout string, stderr string) error {
 	expectedStderr := r.testCase.Config.StdErr
-	if expectedStderr == "" && stderr != "" {
-		return fmt.Errorf("unexpected stderr %s", stderr)
-	}
 	if !strings.Contains(stderr, expectedStderr) {
 		return fmt.Errorf("wanted stderr %s, got %s", expectedStderr, stderr)
 	}
 	expectedStdout := r.testCase.Config.StdOut
-	if expectedStdout == "" && stdout != "" {
-		return fmt.Errorf("unexpected stdout %s", stdout)
-	}
 	if !strings.Contains(stdout, expectedStdout) {
 		return fmt.Errorf("wanted stdout %s, got %s", expectedStdout, stdout)
 	}


### PR DESCRIPTION
If there are no expected stdout or stderr in the config file, we don't test it.

Motivation: quote from Frank in other PR:

> With structured results design, there's a change in plan for testing. We should have a few e2e tests in the kpt repo to test the presentation layer. But otherwise, we should only test the structured output which should provide all the information we want to test the functions robustly including their stderr (depend on APIs not presentation layer). In particular, packages in the catalog repo shouldn't test the presentation layer. Otherwise, you'd get brittle change detector tests:
> 
> https://testing.googleblog.com/2015/01/testing-on-toilet-change-detector-tests.html
> 
> Changing the presentation layer in the future should involve updating just a few tests in the kpt repo and not here.

