### PR TITLE
Consistent formatting for eval

### DIFF
--- a/e2e/testdata/fn-eval/fn-config-file-in-pkg/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/fn-config-file-in-pkg/.expected/diff.patch
@@ -1,11 +1,18 @@
 diff --git a/config.yaml b/config.yaml
-index 3812e69..66e6d0a 100644
+index 3812e69..ea4fad1 100644
 --- a/config.yaml
 +++ b/config.yaml
-@@ -17,3 +17,4 @@ data:
+@@ -12,8 +12,9 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ apiVersion: v1
+-data:
+-  namespace: staging
  kind: ConfigMap
  metadata:
    name: config
++  namespace: staging
++data:
 +  namespace: staging
 diff --git a/resources.yaml b/resources.yaml
 index 7a494c9..254b9cd 100644

--- a/e2e/testdata/fn-eval/include-meta-resources/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/include-meta-resources/.expected/diff.patch
@@ -1,24 +1,34 @@
 diff --git a/Kptfile b/Kptfile
-index cdf6fa7..3903734 100644
+index cdf6fa7..7246298 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,6 +2,7 @@ apiVersion: kpt.dev/v1alpha2
+@@ -2,7 +2,8 @@ apiVersion: kpt.dev/v1alpha2
  kind: Kptfile
  metadata:
    name: app
 +  namespace: staging
  pipeline:
    mutators:
-     - configPath: labelconfig.yaml
+-    - configPath: labelconfig.yaml
+-      image: gcr.io/kpt-fn/set-label:v0.1
++    - image: gcr.io/kpt-fn/set-label:v0.1
++      configPath: labelconfig.yaml
 diff --git a/labelconfig.yaml b/labelconfig.yaml
-index bb5d15c..162c62f 100644
+index bb5d15c..f3a8b49 100644
 --- a/labelconfig.yaml
 +++ b/labelconfig.yaml
-@@ -17,3 +17,4 @@ data:
+@@ -12,8 +12,9 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ apiVersion: v1
+-data:
+-  tier: app
  kind: ConfigMap
  metadata:
    name: label-config
 +  namespace: staging
++data:
++  tier: app
 diff --git a/resources.yaml b/resources.yaml
 index 7a494c9..254b9cd 100644
 --- a/resources.yaml

--- a/e2e/testdata/fn-eval/simple-function-consistent-formatting/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/simple-function-consistent-formatting/.expected/config.yaml
@@ -1,0 +1,18 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+testType: eval
+image: gcr.io/kpt-fn/set-namespace:v0.1
+args:
+  namespace: staging

--- a/e2e/testdata/fn-eval/simple-function-consistent-formatting/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/simple-function-consistent-formatting/.expected/diff.patch
@@ -1,0 +1,30 @@
+diff --git a/resources.yaml b/resources.yaml
+index c0f48b0..9e31a48 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -14,9 +14,10 @@
+ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
++  name: my-nginx
++  namespace: staging
+   labels:
+     foo: bar
+-  name: my-nginx
+ spec:
+   replicas: 3
+   selector:
+@@ -28,8 +29,8 @@ spec:
+         app: nginx
+     spec:
+       containers:
+-      - image: 'nginx:1.14.2'
+-        name: nginx
+-        ports:
+-        - containerPort: 80
+-          protocol: TCP
++        - name: nginx
++          image: nginx:1.14.2
++          ports:
++            - protocol: TCP
++              containerPort: 80

--- a/e2e/testdata/fn-eval/simple-function-consistent-formatting/.krmignore
+++ b/e2e/testdata/fn-eval/simple-function-consistent-formatting/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-eval/simple-function-consistent-formatting/resources.yaml
+++ b/e2e/testdata/fn-eval/simple-function-consistent-formatting/resources.yaml
@@ -1,0 +1,35 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    foo: bar
+  name: my-nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+      - image: 'nginx:1.14.2'
+        name: nginx
+        ports:
+        - containerPort: 80
+          protocol: TCP

--- a/e2e/testdata/fn-eval/subpkg-include-meta-resources/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/subpkg-include-meta-resources/.expected/diff.patch
@@ -1,36 +1,49 @@
 diff --git a/Kptfile b/Kptfile
-index cdf6fa7..3903734 100644
+index cdf6fa7..7246298 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,6 +2,7 @@ apiVersion: kpt.dev/v1alpha2
+@@ -2,7 +2,8 @@ apiVersion: kpt.dev/v1alpha2
  kind: Kptfile
  metadata:
    name: app
 +  namespace: staging
  pipeline:
    mutators:
-     - configPath: labelconfig.yaml
+-    - configPath: labelconfig.yaml
+-      image: gcr.io/kpt-fn/set-label:v0.1
++    - image: gcr.io/kpt-fn/set-label:v0.1
++      configPath: labelconfig.yaml
 diff --git a/db/Kptfile b/db/Kptfile
-index 7d7cf73..0c5b45c 100644
+index 7d7cf73..64ade60 100644
 --- a/db/Kptfile
 +++ b/db/Kptfile
-@@ -2,6 +2,7 @@ apiVersion: kpt.dev/v1alpha2
+@@ -2,7 +2,8 @@ apiVersion: kpt.dev/v1alpha2
  kind: Kptfile
  metadata:
    name: db
 +  namespace: staging
  pipeline:
    mutators:
-     - configPath: labelconfig.yaml
+-    - configPath: labelconfig.yaml
+-      image: gcr.io/kpt-fn/set-label:unstable
++    - image: gcr.io/kpt-fn/set-label:unstable
++      configPath: labelconfig.yaml
 diff --git a/db/labelconfig.yaml b/db/labelconfig.yaml
-index ad6b09d..eff71c2 100644
+index ad6b09d..b7b0335 100644
 --- a/db/labelconfig.yaml
 +++ b/db/labelconfig.yaml
-@@ -17,3 +17,4 @@ data:
+@@ -12,8 +12,9 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ apiVersion: v1
+-data:
+-  namespace: db
  kind: ConfigMap
  metadata:
    name: db-label-config
 +  namespace: staging
++data:
++  namespace: db
 diff --git a/db/resources.yaml b/db/resources.yaml
 index ac1fd96..64ec0ee 100644
 --- a/db/resources.yaml
@@ -43,14 +56,21 @@ index ac1fd96..64ec0ee 100644
  spec:
    replicas: 3
 diff --git a/labelconfig.yaml b/labelconfig.yaml
-index bb5d15c..162c62f 100644
+index bb5d15c..f3a8b49 100644
 --- a/labelconfig.yaml
 +++ b/labelconfig.yaml
-@@ -17,3 +17,4 @@ data:
+@@ -12,8 +12,9 @@
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ apiVersion: v1
+-data:
+-  tier: app
  kind: ConfigMap
  metadata:
    name: label-config
 +  namespace: staging
++data:
++  tier: app
 diff --git a/resources.yaml b/resources.yaml
 index 7a494c9..254b9cd 100644
 --- a/resources.yaml

--- a/thirdparty/kyaml/runfn/runfn.go
+++ b/thirdparty/kyaml/runfn/runfn.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
 	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/kio/filters"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 
@@ -205,6 +206,10 @@ func (r RunFns) runFunctions(
 		// the output is nil (reading from Input)
 		outputs = append(outputs, kio.ByteWriter{Writer: r.Output})
 	}
+
+	// add format filter at the end to consistently format output resources
+	fmtfltr := filters.FormatFilter{UseSchema: true}
+	fltrs = append(fltrs, fmtfltr)
 
 	var err error
 	pipeline := kio.Pipeline{


### PR DESCRIPTION
This PR is to introduce consistent formatting for eval command. If any function is invoked by eval, the resources are consistently formatted at the end.

https://github.com/GoogleContainerTools/kpt/issues/1973