### PR TITLE
Remove Draft Flag from Next Releases

### DIFF
--- a/release/tag/goreleaser.yaml
+++ b/release/tag/goreleaser.yaml
@@ -61,5 +61,5 @@ release:
   github:
     owner: GoogleContainerTools
     name: kpt
-  draft: true
+  draft: false
   prerelease: true


### PR DESCRIPTION
Kpt vNext is no longer released as a draft.