### PR TITLE
Hide cat command, cleanup generated docs

### DIFF
--- a/commands/pkgcmd.go
+++ b/commands/pkgcmd.go
@@ -22,7 +22,6 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/cmdinit"
 	"github.com/GoogleContainerTools/kpt/internal/cmdupdate"
 	"github.com/GoogleContainerTools/kpt/internal/docs/generated/pkgdocs"
-	"github.com/GoogleContainerTools/kpt/thirdparty/cmdconfig/commands/cmdcat"
 	"github.com/GoogleContainerTools/kpt/thirdparty/cmdconfig/commands/cmdtree"
 	"github.com/spf13/cobra"
 )
@@ -48,7 +47,7 @@ func GetPkgCommand(ctx context.Context, name string) *cobra.Command {
 	pkg.AddCommand(
 		cmdget.NewCommand(ctx, name), cmdinit.NewCommand(name),
 		cmdupdate.NewCommand(ctx, name), cmddiff.NewCommand(ctx, name),
-		cmdcat.NewCommand(name), cmdtree.NewCommand(name),
+		cmdtree.NewCommand(name),
 	)
 	return pkg
 }

--- a/internal/docs/generated/livedocs/docs.go
+++ b/internal/docs/generated/livedocs/docs.go
@@ -9,10 +9,10 @@ The ` + "`" + `live` + "`" + ` command group contains subcommands for deploying 
 
 var ApplyShort = `Apply a package to the cluster (create, update, prune).`
 var ApplyLong = `
-  kpt live apply [PKG_PATH|-] [flags]
+  kpt live apply [PKG_PATH | -] [flags]
 
 Args:
-  PKG_PATH|-:
+  PKG_PATH | -:
     Path to the local package which should be applied to the cluster. It must 
     contain a Kptfile with inventory information. Defaults to the current working
     directory.
@@ -81,11 +81,11 @@ Flags:
 
 var DestroyShort = `Remove all previously applied resources in a package from the cluster`
 var DestroyLong = `
-  kpt live destroy [PKG_PATH|-]
+  kpt live destroy [PKG_PATH | -]
 
 Args:
 
-  PKG_PATH|-:
+  PKG_PATH | -:
     Path to the local package which should be deleted from the cluster. It must
     contain a Kptfile with inventory information. Defaults to the current working
     directory.
@@ -122,10 +122,10 @@ var DestroyExamples = `
 
 var DiffShort = `Display the diff between the local package and the live cluster resources.`
 var DiffLong = `
-  kpt live diff [PKG_PATH|-]
+  kpt live diff [PKG_PATH | -]
 
 Args:
-  PKG_PATH|-:
+  PKG_PATH | -:
     Path to the local package which should be diffed against the cluster. It must
     contain a Kptfile with inventory information. Defaults to the current working
     directory.
@@ -191,13 +191,45 @@ var InitExamples = `
   kpt live init --namespace=test my-dir
 `
 
+var MigrateShort = `Migrate a package and the inventory object to use the ResourceGroup CRD.`
+var MigrateLong = `
+  kpt live migrate [PKG_PATH] [flags]
+
+Args:
+  PKG_PATH:
+    Path to the local package. It must have a Kptfile and an existing inventory
+    template in the root of the package. It defaults to the current directory.
+
+Flags:
+  --dry-run:
+    Go through the steps of migration, but don't make any changes.
+  
+  --force:
+    Forces the inventory values in the Kptfile to be updated, even if they are
+    already set. Defaults to false.
+  
+  --name:
+    The name for the ResourceGroup resource that contains the inventory
+    for the package. Defaults to the same name as the existing ConfigMap
+    inventory object.
+  
+  --namespace:
+    The namespace for the ResourceGroup resource that contains the inventory
+    for the package. If not provided, it defaults to the same namespace as the
+    existing ConfigMap inventory object.
+`
+var MigrateExamples = `
+  # Migrate the package in the current directory.
+  kpt live migrate
+`
+
 var PreviewShort = `Preview the changes apply would make to the cluster`
 var PreviewLong = `
-  kpt live preview [PKG_PATH|-] [flags]
+  kpt live preview [PKG_PATH | -] [flags]
 
 Args:
 
-  PKG_PATH|-:
+  PKG_PATH | -:
     Path to the local package for which a preview of the operations of apply
     or destroy should be displayed. It must contain a Kptfile with inventory
     information. Defaults to the current working directory.
@@ -258,11 +290,11 @@ var PreviewExamples = `
 
 var StatusShort = `Display shows the status for the resources in the cluster`
 var StatusLong = `
-  kpt live status [PKG_PATH|-] [flags]
+  kpt live status [PKG_PATH | -] [flags]
 
 Args:
 
-  PKG_PATH|-:
+  PKG_PATH | -:
     Path to the local package for which the status of the package in the cluster
     should be displayed. It must contain a Kptfile with inventory information.
     Defaults to the current working directory.

--- a/internal/docs/generated/overview/docs.go
+++ b/internal/docs/generated/overview/docs.go
@@ -3,7 +3,7 @@ package overview
 
 var ReferenceShort = `Overview of kpt commands`
 var ReferenceLong = `
-Usage: kpt \<group> \<command> \<positional args> [PKG_PATH] [flags]
+  kpt <group> <command> <positional args> [PKG_PATH] [flags]
 
 kpt functionality is divided into the following command groups, each of
 which operates on a particular set of entities, with a consistent command

--- a/internal/docs/generated/pkgdocs/docs.go
+++ b/internal/docs/generated/pkgdocs/docs.go
@@ -10,34 +10,18 @@ from git repositories.
 var CatShort = `Print the resources in a file/directory`
 var CatLong = `
   kpt pkg cat [FILE | DIR]
-  
-  DIR:
-    Path to a directory with resources. Defaults to the current working directory.
-  
-  FILE:
-    Path to a resource file.
+
+Args:
+  FILE | DIR:
+    Path to a directory either a directory containing files with KRM resources, or
+    a file with KRM resource(s). Defaults to the current directory.
 `
 var CatExamples = `
-  # print resource from a file
+  # Print resource from a file.
   kpt pkg cat path/to/deployment.yaml
 
-  apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    name: nginx-deployment
-
-  # print resources from current directory
+  # Print resources from current directory.
   kpt pkg cat
-
-  apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    name: nginx-deployment
-  ---
-  apiVersion: apps/v1
-  kind: Service
-  metadata:
-    name: nginx-service
 `
 
 var DiffShort = `Show differences between a local package and upstream.`
@@ -202,21 +186,12 @@ var InitExamples = `
   kpt pkg init
 `
 
-var TreeShort = `Render resources using a tree structure`
+var TreeShort = `Display resources, files and packages in a tree structure.`
 var TreeLong = `
   kpt pkg tree [DIR | -]
-
-Args:
-
-  DIR:
-    Path to a package directory. Defaults to the current working directory.
-
-Flags:
-
-  
 `
 var TreeExamples = `
-  # print Resources using directory structure
+  # Show resources in the current directory.
   kpt pkg tree
 `
 

--- a/scripts/generate_site_sidebar/sidebar_template.md
+++ b/scripts/generate_site_sidebar/sidebar_template.md
@@ -3,7 +3,6 @@
 {{bookLayout}}
 - [Reference](reference/)
     - [pkg](reference/pkg/)
-        - [cat](reference/pkg/cat/)
         - [diff](reference/pkg/diff/)
         - [get](reference/pkg/get/)
         - [init](reference/pkg/init/)

--- a/site/reference/pkg/sidebar.md
+++ b/site/reference/pkg/sidebar.md
@@ -6,7 +6,6 @@
     - [Binaries](installation/binaries/)
 - [Reference](reference/)
     - [pkg](reference/pkg/)
-        - [cat](reference/pkg/cat/)
         - [diff](reference/pkg/diff/)
         - [get](reference/pkg/get/)
         - [init](reference/pkg/init/)

--- a/site/sidebar.md
+++ b/site/sidebar.md
@@ -31,7 +31,6 @@
 		- [6.2 Lifecycle of Applied Resources](book/06-apply/02-lifecycle-of-applied-resources.md)
 - [Reference](reference/)
     - [pkg](reference/pkg/)
-        - [cat](reference/pkg/cat/)
         - [diff](reference/pkg/diff/)
         - [get](reference/pkg/get/)
         - [init](reference/pkg/init/)


### PR DESCRIPTION
This PR is to hide cat command and cleanup stale generated docs. We should add `make generate` as a pre-commit hook similar to https://github.com/GoogleContainerTools/kpt-functions-catalog/pull/287. Will do in coming PR.