### PR TITLE
fix e2e tests failure caused by GoogleContainerTools/kpt-functions-catalog#304

### DIFF
--- a/e2e/testdata/fn-render/kubeval-failure/.expected/config.yaml
+++ b/e2e/testdata/fn-render/kubeval-failure/.expected/config.yaml
@@ -15,7 +15,3 @@
 # One of the functions in the pipeline fails resulting in
 # non-zero exit code and no changes in the resources.
 exitCode: 1
-stdErr: "[ERROR] Invalid type. Expected: [integer,null], given: string in object 'apps/v1/Deployment//nginx-deployment' in file resources.yaml in field spec.replicas"
-stdOut: |
-  [RUNNING] "gcr.io/kpt-fn/kubeval:unstable"
-  [FAIL] "gcr.io/kpt-fn/kubeval:unstable"

--- a/e2e/testdata/fn-render/kubeval-failure/.expected/results.yaml
+++ b/e2e/testdata/fn-render/kubeval-failure/.expected/results.yaml
@@ -5,13 +5,6 @@ metadata:
 exitCode: 1
 items:
     - image: gcr.io/kpt-fn/kubeval:unstable
-      stderr: |
-        [ERROR] selector is required in object 'apps/v1/Deployment//nginx-deployment' in file resources.yaml in field selector
-        [ERROR] template is required in object 'apps/v1/Deployment//nginx-deployment' in file resources.yaml in field template
-        [ERROR] Invalid type. Expected: [integer,null], given: string in object 'apps/v1/Deployment//nginx-deployment' in file resources.yaml in field spec.replicas
-        [ERROR] Validating arbitrary CRDs is not supported yet. You can skip them by setting ignore_missing_schemas or skip_kinds in the function config:
-        ERR  - stdin: Failed initializing schema file:///tmp/master-standalone-strict/custom-custom-v1.json: open /tmp/master-standalone-strict/custom-custom-v1.json: no such file or directory
-         in object 'custom.io/v1/Custom//custom' in file resources.yaml
       exitCode: 1
       results:
         - message: selector is required

--- a/e2e/testdata/fn-render/structured-results-from-muiltiple-fns/.expected/config.yaml
+++ b/e2e/testdata/fn-render/structured-results-from-muiltiple-fns/.expected/config.yaml
@@ -15,7 +15,3 @@
 # One of the functions in the pipeline fails resulting in
 # non-zero exit code and no changes in the resources.
 exitCode: 1
-stdErr: "[ERROR] Invalid type. Expected: [integer,null], given: string in object"
-stdOut: |
-   [RUNNING] "gcr.io/kpt-fn/enforce-gatekeeper:unstable"
-   [PASS] "gcr.io/kpt-fn/enforce-gatekeeper:unstable"

--- a/e2e/testdata/fn-render/structured-results-from-muiltiple-fns/.expected/results.yaml
+++ b/e2e/testdata/fn-render/structured-results-from-muiltiple-fns/.expected/results.yaml
@@ -34,10 +34,6 @@ items:
             path: resources.yaml
             index: 4
     - image: gcr.io/kpt-fn/kubeval:unstable
-      stderr: |
-        [ERROR] selector is required in object 'apps/v1/Deployment//nginx-deployment' in file resources.yaml in field selector
-        [ERROR] template is required in object 'apps/v1/Deployment//nginx-deployment' in file resources.yaml in field template
-        [ERROR] Invalid type. Expected: [integer,null], given: string in object 'apps/v1/Deployment//nginx-deployment' in file resources.yaml in field spec.replicas
       exitCode: 1
       results:
         - message: selector is required


### PR DESCRIPTION
We change kubeval to avoid dup output in kpt: https://github.com/GoogleContainerTools/kpt-functions-catalog/pull/304

Some tests in CI are failing. e.g. https://github.com/GoogleContainerTools/kpt/pull/2007/checks?check_run_id=2578813643
