### PR TITLE
fn sink and source reference docs

### DIFF
--- a/internal/docs/generated/fndocs/docs.go
+++ b/internal/docs/generated/fndocs/docs.go
@@ -193,13 +193,13 @@ var SinkLong = `
   kpt fn sink DIR [flags]
   
   DIR:
-    Path to a local directory to resources to. Directory must exist.
+    Path to a local directory to write resources to. Directory must exist.
 `
 var SinkExamples = `
   # read resources from DIR directory, execute my-fn on them and write the
   # output to DIR directory.
   $ kpt fn source DIR |
-    kpt fn run --image gcr.io/example.com/my-fn |
+    kpt fn eval --image gcr.io/example.com/my-fn |
     kpt fn sink DIR
 `
 
@@ -226,6 +226,6 @@ var SourceExamples = `
   # read resources from DIR directory, execute my-fn on them and write the
   # output to DIR directory.
   $ kpt fn source DIR |
-    kpt fn run --image gcr.io/example.com/my-fn |
+    kpt fn eval --image gcr.io/example.com/my-fn |
     kpt fn sink DIR
 `

--- a/internal/docs/generated/fndocs/docs.go
+++ b/internal/docs/generated/fndocs/docs.go
@@ -32,7 +32,16 @@ Args:
   DIR|-:
     Path to the local directory containing resources. Defaults to the current
     working directory. Using '-' as the directory path will cause ` + "`" + `eval` + "`" + ` to
-    read resources from ` + "`" + `stdin` + "`" + ` and write the output to ` + "`" + `stdout` + "`" + `.
+    read resources from ` + "`" + `stdin` + "`" + ` and write the output to ` + "`" + `stdout` + "`" + `. When resources are
+    read from ` + "`" + `stdin` + "`" + `, they must be in one of the following input formats:
+  
+    1. Multi object YAML where resources are separated by ` + "`" + `---` + "`" + `.
+  
+    2. [Function Specification] wire format where resources are wrapped in an object
+       of kind ResourceList. Refer to [Function Specification] format for more details.
+   
+    If the output is written to ` + "`" + `stdout` + "`" + `, resources are written in multi object YAML
+    format where resources are separated by ` + "`" + `---` + "`" + `.
 
   fn-args:
     function arguments to be provided as input to the function. These must be

--- a/internal/docs/generated/fndocs/docs.go
+++ b/internal/docs/generated/fndocs/docs.go
@@ -37,8 +37,8 @@ Args:
   
     1. Multi object YAML where resources are separated by ` + "`" + `---` + "`" + `.
   
-    2. [Function Specification] wire format where resources are wrapped in an object
-       of kind ResourceList. Refer to [Function Specification] format for more details.
+    2. ` + "`" + `Function Specification` + "`" + ` wire format where resources are wrapped in an object
+       of kind ResourceList.
    
     If the output is written to ` + "`" + `stdout` + "`" + `, resources are written in multi object YAML
     format where resources are separated by ` + "`" + `---` + "`" + `.

--- a/internal/docs/generated/fndocs/docs.go
+++ b/internal/docs/generated/fndocs/docs.go
@@ -199,7 +199,7 @@ var SinkExamples = `
   # read resources from DIR directory, execute my-fn on them and write the
   # output to DIR directory.
   $ kpt fn source DIR |
-    kpt fn eval --image gcr.io/example.com/my-fn |
+    kpt fn eval --image gcr.io/example.com/my-fn - |
     kpt fn sink DIR
 `
 
@@ -226,6 +226,6 @@ var SourceExamples = `
   # read resources from DIR directory, execute my-fn on them and write the
   # output to DIR directory.
   $ kpt fn source DIR |
-    kpt fn eval --image gcr.io/example.com/my-fn |
+    kpt fn eval --image gcr.io/example.com/my-fn - |
     kpt fn sink DIR
 `

--- a/internal/docs/generated/fndocs/docs.go
+++ b/internal/docs/generated/fndocs/docs.go
@@ -188,33 +188,44 @@ var RenderExamples = `
   $ kpt fn render my-package-dir
 `
 
-var SinkShort = `Specify a directory as an output sink package`
+var SinkShort = `Write resources to a local directory`
 var SinkLong = `
-  kpt fn sink [DIR]
+  kpt fn sink DIR [flags]
   
   DIR:
-    Path to a package directory.  Defaults to stdout if unspecified.
+    Path to a local directory to resources to. Directory must exist.
 `
 var SinkExamples = `
-  # run a function using explicit sources and sinks
-  kpt fn source DIR/ |
+  # read resources from DIR directory, execute my-fn on them and write the
+  # output to DIR directory.
+  $ kpt fn source DIR |
     kpt fn run --image gcr.io/example.com/my-fn |
-    kpt fn sink DIR/
+    kpt fn sink DIR
 `
 
-var SourceShort = `Specify a directory as an input source package`
+var SourceShort = `Source resources from a local directory`
 var SourceLong = `
-  kpt fn source [DIR...]
-  
+  kpt fn source [DIR] [flags]
+
+Args:
+
   DIR:
-    Path to a package directory.  Defaults to stdin if unspecified.
+    Path to the local directory containing resources. Defaults to the current
+    working directory.
+
+Flags:
+
+  --fn-config:
+    Path to the file containing ` + "`" + `functionConfig` + "`" + `.
+  
 `
 var SourceExamples = `
-  # print to stdout configuration from DIR/ formatted as an input source
-  kpt fn source DIR/
+  # read resources from DIR directory and write the output on stdout.
+  $ kpt fn source DIR
 
-  # run a function using explicit sources and sinks
-  kpt fn source DIR/ |
+  # read resources from DIR directory, execute my-fn on them and write the
+  # output to DIR directory.
+  $ kpt fn source DIR |
     kpt fn run --image gcr.io/example.com/my-fn |
-    kpt fn sink DIR/
+    kpt fn sink DIR
 `

--- a/site/reference/fn/eval/README.md
+++ b/site/reference/fn/eval/README.md
@@ -22,13 +22,13 @@ Refer to the [Imperative Function Execution] for detailed overview.
 
 <!--mdtogo:Long-->
 
-```shell
+```
 kpt fn eval [DIR|-] [flags] [-- fn-args]
 ```
 
 #### Args
 
-```shell
+```
 DIR|-:
   Path to the local directory containing resources. Defaults to the current
   working directory. Using '-' as the directory path will cause `eval` to
@@ -37,14 +37,14 @@ DIR|-:
 
   1. Multi object YAML where resources are separated by `---`.
 
-  2. [Function Specification] wire format where resources are wrapped in an object
-     of kind ResourceList. Refer to [Function Specification] format for more details.
+  2. `Function Specification` wire format where resources are wrapped in an object
+     of kind ResourceList.
  
   If the output is written to `stdout`, resources are written in multi object YAML
   format where resources are separated by `---`.
 ```
 
-```shell
+```
 fn-args:
   function arguments to be provided as input to the function. These must be
   provided in the `key=value` format and come after the separator `--`.
@@ -52,7 +52,7 @@ fn-args:
 
 #### Flags
 
-```shell
+```
 --as-current-user:
   Use the `uid` and `gid` of the kpt process for container function execution.
   By default, container function is executed as `nobody` user. You may want to use
@@ -107,55 +107,55 @@ fn-args:
 ## Examples
 <!--mdtogo:Examples-->
 
-```shell
+```
 # execute container my-fn on the resources in DIR directory and
 # write output back to DIR
 $ kpt fn eval DIR --image gcr.io/example.com/my-fn
 ```
 
-```shell
+```
 # execute container my-fn on the resources in DIR directory with
 # `functionConfig` my-fn-config
 $ kpt fn eval DIR --image gcr.io/example.com/my-fn --fn-config my-fn-config
 ```
 
-```shell
+```
 # execute container my-fn with an input ConfigMap containing `data: {foo: bar}`
 $ kpt fn eval DIR --image gcr.io/example.com/my-fn:v1.0.0 -- foo=bar
 ```
 
-```shell
+```
 # execute executable my-fn on the resources in DIR directory and
 # write output back to DIR
 $ kpt fn eval DIR --exec-path ./my-fn
 ```
 
-```shell
+```
 # execute container my-fn on the resources in DIR directory,
 # save structured results in /tmp/my-results dir and write output back to DIR
 $ kpt fn eval DIR --image gcr.io/example.com/my-fn --results-dir /tmp/my-results-dir
 ```
 
-```shell
+```
 # execute container my-fn on the resources in DIR directory with network access enabled,
 # and write output back to DIR
 $ kpt fn eval DIR --image gcr.io/example.com/my-fn --network 
 ```
 
-```shell
+```
 # execute container my-fn on the resource in DIR and export KUBECONFIG
 # and foo environment variable
 $ kpt fn eval DIR --image gcr.io/example.com/my-fn --env KUBECONFIG -e foo=bar
 ```
 
-```shell
+```
 # execute kubeval function by mounting schema from a local directory on wordpress package
 $ kpt fn eval --image gcr.io/kpt-fn/kubeval:v0.1 \
   --mount type=bind,src="/path/to/schema-dir",dst=/schema-dir \
   --as-current-user wordpress -- additional_schema_locations=/schema-dir
 ```
 
-```shell
+```
 # chaining functions using the unix pipe to set namespace and set labels on
 # wordpress package
 $ kpt fn source wordpress \

--- a/site/reference/fn/eval/README.md
+++ b/site/reference/fn/eval/README.md
@@ -32,7 +32,16 @@ kpt fn eval [DIR|-] [flags] [-- fn-args]
 DIR|-:
   Path to the local directory containing resources. Defaults to the current
   working directory. Using '-' as the directory path will cause `eval` to
-  read resources from `stdin` and write the output to `stdout`.
+  read resources from `stdin` and write the output to `stdout`. When resources are
+  read from `stdin`, they must be in one of the following input formats:
+
+  1. Multi object YAML where resources are separated by `---`.
+
+  2. [Function Specification] wire format where resources are wrapped in an object
+     of kind ResourceList. Refer to [Function Specification] format for more details.
+ 
+  If the output is written to `stdout`, resources are written in multi object YAML
+  format where resources are separated by `---`.
 ```
 
 ```shell
@@ -158,3 +167,4 @@ $ kpt fn source wordpress \
 
 [docker volumes]: https://docs.docker.com/storage/volumes/
 [Imperative Function Execution]: /book/04-using-functions/02-imperative-function-execution
+[Function Specification]: /book/05-developing-functions/02-function-specification

--- a/site/reference/fn/sink/README.md
+++ b/site/reference/fn/sink/README.md
@@ -15,8 +15,8 @@ Resources must be in one of the following input formats:
 
   1. Multi object YAML where resources are separated by `---`.
 
-  2. [Function Specification] wire format where resources are wrapped in an object
-     of kind ResourceList. Refer to [Function Specification] format for more details.
+  2. `Function Specification` wire format where resources are wrapped in an object
+     of kind ResourceList.
 
 `sink` is useful for chaining functions using Unix pipe. For more details,
 refer to [Chaining functions].
@@ -25,7 +25,7 @@ refer to [Chaining functions].
 
 <!--mdtogo:Long-->
 
-```shell
+```
 kpt fn sink DIR [flags]
 
 DIR:
@@ -38,7 +38,7 @@ DIR:
 
 <!--mdtogo:Examples-->
 
-```shell
+```
 # read resources from DIR directory, execute my-fn on them and write the
 # output to DIR directory.
 $ kpt fn source DIR |

--- a/site/reference/fn/sink/README.md
+++ b/site/reference/fn/sink/README.md
@@ -1,51 +1,45 @@
 ---
-title: "Sink"
+title: "`sink`"
 linkTitle: "sink"
 type: docs
 description: >
-   Specify a directory as an output sink package
+   Write resources to a local directory
 ---
 
 <!--mdtogo:Short
-    Specify a directory as an output sink package
+   Write resources to a local directory
 -->
 
-Implements a [sink function] by reading STDIN and writing configuration.
-
-Sink will not prune / delete files for delete resources because it only knows
-about files for which it sees input resources.
-
-### Examples
-
-<!--mdtogo:Examples-->
-
-```shell
-# run a function using explicit sources and sinks
-kpt fn source DIR/ |
-  kpt fn run --image gcr.io/example.com/my-fn |
-  kpt fn sink DIR/
-```
-
-<!--mdtogo-->
+`sink` reads resources from `stdin` and writes them to a local directory.
+It is useful for chaining functions using Unix pipe. For more details, refer to
+[Chaining functions].
 
 ### Synopsis
 
 <!--mdtogo:Long-->
 
 ```shell
-kpt fn sink [DIR]
+kpt fn sink DIR [flags]
 
 DIR:
-  Path to a package directory.  Defaults to stdout if unspecified.
+  Path to a local directory to resources to. Directory must exist.
 ```
 
 <!--mdtogo-->
 
-### Next Steps
+### Examples
 
-- Learn about [functions concepts] like sources, sinks, and pipelines.
-- See more examples of sink functions in the functions [catalog].
+<!--mdtogo:Examples-->
 
-[sink function]: https://kpt.dev#todo
-[functions concepts]: /book/02-concepts/02-functions
-[catalog]: https://kpt.dev#todo
+```shell
+# read resources from DIR directory, execute my-fn on them and write the
+# output to DIR directory.
+$ kpt fn source DIR |
+  kpt fn run --image gcr.io/example.com/my-fn |
+  kpt fn sink DIR
+```
+
+<!--mdtogo-->
+
+[Chaining functions]: /book/04-using-functions/02-imperative-function-execution?id=chaining-functions-using-the-unix-pipe
+[Function Specification]: /book/05-developing-functions/02-function-specification

--- a/site/reference/fn/sink/README.md
+++ b/site/reference/fn/sink/README.md
@@ -35,7 +35,7 @@ DIR:
 # read resources from DIR directory, execute my-fn on them and write the
 # output to DIR directory.
 $ kpt fn source DIR |
-  kpt fn eval --image gcr.io/example.com/my-fn |
+  kpt fn eval --image gcr.io/example.com/my-fn - |
   kpt fn sink DIR
 ```
 

--- a/site/reference/fn/sink/README.md
+++ b/site/reference/fn/sink/README.md
@@ -11,8 +11,15 @@ description: >
 -->
 
 `sink` reads resources from `stdin` and writes them to a local directory.
-It is useful for chaining functions using Unix pipe. For more details, refer to
-[Chaining functions].
+Resources must be in one of the following input formats:
+
+  1. Multi object YAML where resources are separated by `---`.
+
+  2. [Function Specification] wire format where resources are wrapped in an object
+     of kind ResourceList. Refer to [Function Specification] format for more details.
+
+`sink` is useful for chaining functions using Unix pipe. For more details,
+refer to [Chaining functions].
 
 ### Synopsis
 

--- a/site/reference/fn/sink/README.md
+++ b/site/reference/fn/sink/README.md
@@ -22,7 +22,7 @@ It is useful for chaining functions using Unix pipe. For more details, refer to
 kpt fn sink DIR [flags]
 
 DIR:
-  Path to a local directory to resources to. Directory must exist.
+  Path to a local directory to write resources to. Directory must exist.
 ```
 
 <!--mdtogo-->
@@ -35,7 +35,7 @@ DIR:
 # read resources from DIR directory, execute my-fn on them and write the
 # output to DIR directory.
 $ kpt fn source DIR |
-  kpt fn run --image gcr.io/example.com/my-fn |
+  kpt fn eval --image gcr.io/example.com/my-fn |
   kpt fn sink DIR
 ```
 

--- a/site/reference/fn/source/README.md
+++ b/site/reference/fn/source/README.md
@@ -20,13 +20,13 @@ is useful for chaining functions using Unix pipe. For more details, refer to
 
 <!--mdtogo:Long-->
 
-```shell
+```
 kpt fn source [DIR] [flags]
 ```
 
 #### Args
 
-```shell
+```
 DIR:
   Path to the local directory containing resources. Defaults to the current
   working directory.
@@ -34,7 +34,7 @@ DIR:
 
 #### Flags
 
-```shell
+```
 --fn-config:
   Path to the file containing `functionConfig`.
 
@@ -45,12 +45,12 @@ DIR:
 
 <!--mdtogo:Examples-->
 
-```shell
+```
 # read resources from DIR directory and write the output on stdout.
 $ kpt fn source DIR
 ```
 
-```shell
+```
 # read resources from DIR directory, execute my-fn on them and write the
 # output to DIR directory.
 $ kpt fn source DIR |

--- a/site/reference/fn/source/README.md
+++ b/site/reference/fn/source/README.md
@@ -54,7 +54,7 @@ $ kpt fn source DIR
 # read resources from DIR directory, execute my-fn on them and write the
 # output to DIR directory.
 $ kpt fn source DIR |
-  kpt fn run --image gcr.io/example.com/my-fn |
+  kpt fn eval --image gcr.io/example.com/my-fn |
   kpt fn sink DIR
 ```
 

--- a/site/reference/fn/source/README.md
+++ b/site/reference/fn/source/README.md
@@ -1,71 +1,64 @@
 ---
-title: "Source"
+title: "`source`"
 linkTitle: "source"
 type: docs
 description: >
-   Specify a directory as an input source package
+   Source resources from a local directory
 ---
 
 <!--mdtogo:Short
-    Specify a directory as an input source package
+    Source resources from a local directory
 -->
 
-Implements a [source function] by reading configuration and writing to STDOUT.
-
-### Examples
-
-{{% hide %}}
-
-<!-- @makeWorkplace @verifyExamples-->
-```
-# Set up workspace for the test.
-TEST_HOME=$(mktemp -d)
-cd $TEST_HOME
-```
-
-<!-- @fetchPackage @verifyExamples-->
-```shell
-export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
-kpt pkg get $SRC_REPO/package-examples/helloworld-set@next DIR/
-```
-
-{{% /hide %}}
-
-<!--mdtogo:Examples-->
-
-<!-- @fnSource @verifyExamples-->
-```shell
-# print to stdout configuration from DIR/ formatted as an input source
-kpt fn source DIR/
-```
-
-```shell
-# run a function using explicit sources and sinks
-kpt fn source DIR/ |
-  kpt fn run --image gcr.io/example.com/my-fn |
-  kpt fn sink DIR/
-```
-
-<!--mdtogo-->
+`source` reads resources from a local directory and writes them in `functionSpec`
+wire format to `stdout`. The output of the `source` can be pipe'd to commands
+such as `kpt fn eval` that accepts `functionSpec` format. It is useful for
+chaining functions using Unix pipe. For more details, refer to
+[Chaining functions] and [Function Specification].
 
 ### Synopsis
 
 <!--mdtogo:Long-->
 
 ```shell
-kpt fn source [DIR...]
+kpt fn source [DIR] [flags]
+```
 
+#### Args
+
+```shell
 DIR:
-  Path to a package directory.  Defaults to stdin if unspecified.
+  Path to the local directory containing resources. Defaults to the current
+  working directory.
+```
+
+#### Flags
+
+```shell
+--fn-config:
+  Path to the file containing `functionConfig`.
+
+```
+
+<!--mdtogo-->
+### Examples
+
+<!--mdtogo:Examples-->
+
+```shell
+# read resources from DIR directory and write the output on stdout.
+$ kpt fn source DIR
+```
+
+```shell
+# read resources from DIR directory, execute my-fn on them and write the
+# output to DIR directory.
+$ kpt fn source DIR |
+  kpt fn run --image gcr.io/example.com/my-fn |
+  kpt fn sink DIR
 ```
 
 <!--mdtogo-->
 
-### Next Steps
-
-- Learn about [functions concepts] like sources, sinks, and pipelines.
-- See more examples of source functions in the functions [catalog].
-
-[source function]: https://kpt.dev#todo
-[functions concepts]: /book/02-concepts/02-functions
-[catalog]: https://kpt.dev#todo
+[Chaining functions]: /book/04-using-functions/02-imperative-function-execution?id=chaining-functions-using-the-unix-pipe
+[Function Specification]: /book/05-developing-functions/02-function-specification

--- a/site/reference/fn/source/README.md
+++ b/site/reference/fn/source/README.md
@@ -54,7 +54,7 @@ $ kpt fn source DIR
 # read resources from DIR directory, execute my-fn on them and write the
 # output to DIR directory.
 $ kpt fn source DIR |
-  kpt fn eval --image gcr.io/example.com/my-fn |
+  kpt fn eval --image gcr.io/example.com/my-fn - |
   kpt fn sink DIR
 ```
 

--- a/site/reference/fn/source/README.md
+++ b/site/reference/fn/source/README.md
@@ -10,10 +10,10 @@ description: >
     Source resources from a local directory
 -->
 
-`source` reads resources from a local directory and writes them in `functionSpec`
+`source` reads resources from a local directory and writes them in [Function Specification]
 wire format to `stdout`. The output of the `source` can be pipe'd to commands
-such as `kpt fn eval` that accepts `functionSpec` format. It is useful for
-chaining functions using Unix pipe. For more details, refer to
+such as `kpt fn eval` that accepts [Function Specification] wire format. `source`
+is useful for chaining functions using Unix pipe. For more details, refer to
 [Chaining functions] and [Function Specification].
 
 ### Synopsis

--- a/thirdparty/cmdconfig/commands/cmdsink/cmdsink.go
+++ b/thirdparty/cmdconfig/commands/cmdsink/cmdsink.go
@@ -14,9 +14,9 @@ import (
 func GetSinkRunner(name string) *SinkRunner {
 	r := &SinkRunner{}
 	c := &cobra.Command{
-		Use:     "sink [DIR]",
+		Use:     "sink DIR [flags]",
 		Short:   fndocs.SinkShort,
-		Long:    fndocs.SinkLong,
+		Long:    fndocs.SinkShort + "\n" + fndocs.SinkLong,
 		Example: fndocs.SinkExamples,
 		RunE:    r.runE,
 		Args:    cobra.MinimumNArgs(1),

--- a/thirdparty/cmdconfig/commands/cmdsource/cmdsource.go
+++ b/thirdparty/cmdconfig/commands/cmdsource/cmdsource.go
@@ -15,23 +15,22 @@ import (
 
 // GetSourceRunner returns a command for Source.
 func GetSourceRunner(name string) *SourceRunner {
-	r := &SourceRunner{}
+	r := &SourceRunner{
+		WrapKind:       kio.ResourceListKind,
+		WrapAPIVersion: kio.ResourceListAPIVersion,
+	}
 	c := &cobra.Command{
-		Use:     "source [DIR]",
+		Use:     "source [DIR] [flags]",
 		Short:   fndocs.SourceShort,
-		Long:    fndocs.SourceLong,
+		Long:    fndocs.SourceShort + "\n" + fndocs.SourceLong,
 		Example: fndocs.SourceExamples,
 		Args:    cobra.MaximumNArgs(1),
 		RunE:    r.runE,
 	}
-	c.Flags().StringVar(&r.WrapKind, "wrap-kind", kio.ResourceListKind,
-		"output using this format.")
-	c.Flags().StringVar(&r.WrapAPIVersion, "wrap-version", kio.ResourceListAPIVersion,
-		"output using this format.")
-	c.Flags().StringVar(&r.FunctionConfig, "function-config", "",
-		"path to function config.")
+	c.Flags().StringVar(&r.FunctionConfig, "fn-config", "",
+		"path to function config file.")
 	r.Command = c
-	_ = c.MarkFlagFilename("function-config", "yaml", "json", "yml")
+	_ = c.MarkFlagFilename("fn-config", "yaml", "json", "yml")
 	return r
 }
 


### PR DESCRIPTION
This PR does the following:

- Add reference (help) docs for `kpt fn source` and `kpt fn sink`
- Drops `wrap-kind` `wrap-apiversion` flags from `kpt fn source`. I don't think they are useful. We can introduce them when we see the need. Locking the API surface area.
- Renamed `function-config` flag in `fn source` to `fn-config` to make it consistent with `fn eval`


