### PR TITLE
Docs: made changes in command reference

### DIFF
--- a/internal/docs/generated/fndocs/docs.go
+++ b/internal/docs/generated/fndocs/docs.go
@@ -91,30 +91,30 @@ Flags:
 var EvalExamples = `
   # execute container my-fn on the resources in DIR directory and
   # write output back to DIR
-  $ kpt fn --image gcr.io/example.com/my-fn eval DIR
+  $ kpt fn eval DIR --image gcr.io/example.com/my-fn
 
   # execute container my-fn on the resources in DIR directory with
   # ` + "`" + `functionConfig` + "`" + ` my-fn-config
-  $ kpt fn --image gcr.io/example.com/my-fn --fn-config my-fn-config eval DIR
+  $ kpt fn eval DIR --image gcr.io/example.com/my-fn --fn-config my-fn-config
 
   # execute container my-fn with an input ConfigMap containing ` + "`" + `data: {foo: bar}` + "`" + `
-  $ kpt fn --image gcr.io/example.com/my-fn:v1.0.0 eval DIR -- foo=bar
+  $ kpt fn eval DIR --image gcr.io/example.com/my-fn:v1.0.0 -- foo=bar
 
   # execute executable my-fn on the resources in DIR directory and
   # write output back to DIR
-  $ kpt fn --exec-path ./my-fn eval DIR
+  $ kpt fn eval DIR --exec-path ./my-fn
 
   # execute container my-fn on the resources in DIR directory,
   # save structured results in /tmp/my-results dir and write output back to DIR
-  $ kpt fn --image gcr.io/example.com/my-fn --results-dir /tmp/my-results-dir eval DIR
+  $ kpt fn eval DIR --image gcr.io/example.com/my-fn --results-dir /tmp/my-results-dir
 
   # execute container my-fn on the resources in DIR directory with network access enabled,
   # and write output back to DIR
-  $ kpt fn --image gcr.io/example.com/my-fn --network eval DIR
+  $ kpt fn eval DIR --image gcr.io/example.com/my-fn --network 
 
   # execute container my-fn on the resource in DIR and export KUBECONFIG
   # and foo environment variable
-  $ kpt fn --image gcr.io/example.com/my-fn --env KUBECONFIG -e foo=bar eval DIR
+  $ kpt fn eval DIR --image gcr.io/example.com/my-fn --env KUBECONFIG -e foo=bar
 
   # execute kubeval function by mounting schema from a local directory on wordpress package
   $ kpt fn eval --image gcr.io/kpt-fn/kubeval:v0.1 \
@@ -182,7 +182,7 @@ var RenderExamples = `
   $ kpt fn render
 
   # Render the package in current directory and save results in my-results-dir
-  $ kpt fn --results-dir my-results-dir render
+  $ kpt fn render --results-dir my-results-dir 
 
   # Render my-package-dir
   $ kpt fn render my-package-dir

--- a/internal/docs/generated/overview/docs.go
+++ b/internal/docs/generated/overview/docs.go
@@ -3,11 +3,11 @@ package overview
 
 var ReferenceShort = `Overview of kpt commands`
 var ReferenceLong = `
+All kpt commands follow this general synopsis:
+
   kpt <group> <command> <positional args> [PKG_PATH] [flags]
 
-kpt functionality is divided into the following command groups, each of
-which operates on a particular set of entities, with a consistent command
-syntax and pattern of inputs and outputs.
+kpt functionality is divided into three command groups:
 
 | Group   | Description                                                             |
 | --------| ------------------------------------------------------------------------|

--- a/site/reference/README.md
+++ b/site/reference/README.md
@@ -19,7 +19,7 @@ description: >
 All kpt commands follow this general synopsis:
 
 ```
-kpt <group> <command> [flags] <positional args> [PKG_PATH]
+kpt <group> <command> <positional args> [PKG_PATH] [flags]
 ```
 
 kpt functionality is divided into three command groups:

--- a/site/reference/fn/eval/README.md
+++ b/site/reference/fn/eval/README.md
@@ -101,30 +101,30 @@ fn-args:
 ```shell
 # execute container my-fn on the resources in DIR directory and
 # write output back to DIR
-$ kpt fn eval DIR --image gcr.io/example.com/my-fn  
+$ kpt fn eval DIR --image gcr.io/example.com/my-fn
 ```
 
 ```shell
 # execute container my-fn on the resources in DIR directory with
 # `functionConfig` my-fn-config
-$ kpt fn eval DIR --image gcr.io/example.com/my-fn --fn-config my-fn-config  
+$ kpt fn eval DIR --image gcr.io/example.com/my-fn --fn-config my-fn-config
 ```
 
 ```shell
 # execute container my-fn with an input ConfigMap containing `data: {foo: bar}`
-$ kpt fn eval DIR --image gcr.io/example.com/my-fn:v1.0.0   -- foo=bar
+$ kpt fn eval DIR --image gcr.io/example.com/my-fn:v1.0.0 -- foo=bar
 ```
 
 ```shell
 # execute executable my-fn on the resources in DIR directory and
 # write output back to DIR
-$ kpt fn eval DIR --exec-path ./my-fn  
+$ kpt fn eval DIR --exec-path ./my-fn
 ```
 
 ```shell
 # execute container my-fn on the resources in DIR directory,
 # save structured results in /tmp/my-results dir and write output back to DIR
-$ kpt fn eval DIR --image gcr.io/example.com/my-fn --results-dir /tmp/my-results-dir  
+$ kpt fn eval DIR --image gcr.io/example.com/my-fn --results-dir /tmp/my-results-dir
 ```
 
 ```shell
@@ -136,7 +136,7 @@ $ kpt fn eval DIR --image gcr.io/example.com/my-fn --network
 ```shell
 # execute container my-fn on the resource in DIR and export KUBECONFIG
 # and foo environment variable
-$ kpt fn eval DIR --image gcr.io/example.com/my-fn --env KUBECONFIG -e foo=bar  
+$ kpt fn eval DIR --image gcr.io/example.com/my-fn --env KUBECONFIG -e foo=bar
 ```
 
 ```shell

--- a/site/reference/fn/eval/README.md
+++ b/site/reference/fn/eval/README.md
@@ -101,42 +101,42 @@ fn-args:
 ```shell
 # execute container my-fn on the resources in DIR directory and
 # write output back to DIR
-$ kpt fn --image gcr.io/example.com/my-fn eval DIR
+$ kpt fn eval DIR --image gcr.io/example.com/my-fn  
 ```
 
 ```shell
 # execute container my-fn on the resources in DIR directory with
 # `functionConfig` my-fn-config
-$ kpt fn --image gcr.io/example.com/my-fn --fn-config my-fn-config eval DIR
+$ kpt fn eval DIR --image gcr.io/example.com/my-fn --fn-config my-fn-config  
 ```
 
 ```shell
 # execute container my-fn with an input ConfigMap containing `data: {foo: bar}`
-$ kpt fn --image gcr.io/example.com/my-fn:v1.0.0 eval DIR -- foo=bar
+$ kpt fn eval DIR --image gcr.io/example.com/my-fn:v1.0.0   -- foo=bar
 ```
 
 ```shell
 # execute executable my-fn on the resources in DIR directory and
 # write output back to DIR
-$ kpt fn --exec-path ./my-fn eval DIR
+$ kpt fn eval DIR --exec-path ./my-fn  
 ```
 
 ```shell
 # execute container my-fn on the resources in DIR directory,
 # save structured results in /tmp/my-results dir and write output back to DIR
-$ kpt fn --image gcr.io/example.com/my-fn --results-dir /tmp/my-results-dir eval DIR
+$ kpt fn eval DIR --image gcr.io/example.com/my-fn --results-dir /tmp/my-results-dir  
 ```
 
 ```shell
 # execute container my-fn on the resources in DIR directory with network access enabled,
 # and write output back to DIR
-$ kpt fn --image gcr.io/example.com/my-fn --network eval DIR
+$ kpt fn eval DIR --image gcr.io/example.com/my-fn --network 
 ```
 
 ```shell
 # execute container my-fn on the resource in DIR and export KUBECONFIG
 # and foo environment variable
-$ kpt fn --image gcr.io/example.com/my-fn --env KUBECONFIG -e foo=bar eval DIR
+$ kpt fn eval DIR --image gcr.io/example.com/my-fn --env KUBECONFIG -e foo=bar  
 ```
 
 ```shell

--- a/site/reference/fn/render/README.md
+++ b/site/reference/fn/render/README.md
@@ -65,7 +65,7 @@ $ kpt fn render
 
 ```shell
 # Render the package in current directory and save results in my-results-dir
-$ kpt fn --results-dir my-results-dir render
+$ kpt fn render --results-dir my-results-dir 
 ```
 
 ```shell


### PR DESCRIPTION
Moved the flags to the end of the command in the general synopsis. Made changes in the example commands of the documentation. Taken care that the example commands follow the syntax mentioned in the general synopsis. 