### PR TITLE
Return fast if include-meta-resources

### DIFF
--- a/e2e/testdata/fn-eval/include-meta-resources-v1alpha1/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/include-meta-resources-v1alpha1/.expected/config.yaml
@@ -1,0 +1,20 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+runCount: 2
+testType: eval
+image: gcr.io/kpt-fn/set-namespace:v0.1
+includeMetaResources: true
+args:
+  namespace: staging

--- a/e2e/testdata/fn-eval/include-meta-resources-v1alpha1/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/include-meta-resources-v1alpha1/.expected/diff.patch
@@ -1,0 +1,42 @@
+diff --git a/Kptfile b/Kptfile
+index 54ce0ac..c5b9758 100644
+--- a/Kptfile
++++ b/Kptfile
+@@ -2,6 +2,7 @@ apiVersion: kpt.dev/v1alpha1
+ kind: Kptfile
+ metadata:
+   name: nginx
++  namespace: staging
+ dependencies:
+   - name: hello-world
+     updateStrategy: fast-forward
+diff --git a/labelconfig.yaml b/labelconfig.yaml
+index 7ef9890..f3a8b49 100644
+--- a/labelconfig.yaml
++++ b/labelconfig.yaml
+@@ -15,5 +15,6 @@ apiVersion: v1
+ kind: ConfigMap
+ metadata:
+   name: label-config
++  namespace: staging
+ data:
+   tier: app
+diff --git a/resources.yaml b/resources.yaml
+index 7a494c9..254b9cd 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -15,6 +15,7 @@ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+   name: nginx-deployment
++  namespace: staging
+ spec:
+   replicas: 3
+ ---
+@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
+ kind: Custom
+ metadata:
+   name: custom
++  namespace: staging
+ spec:
+   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/include-meta-resources-v1alpha1/.krmignore
+++ b/e2e/testdata/fn-eval/include-meta-resources-v1alpha1/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-eval/include-meta-resources-v1alpha1/Kptfile
+++ b/e2e/testdata/fn-eval/include-meta-resources-v1alpha1/Kptfile
@@ -1,0 +1,101 @@
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
+metadata:
+  name: nginx
+dependencies:
+  - name: hello-world
+    updateStrategy: fast-forward
+    stdin:
+      filenamePattern: foo*
+      original: bar
+    autoSet: false
+    ensureNotExists: false
+    functions:
+      - image: gcr.io/kpt-fn/my-func:v0.1
+        config:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: function-config
+          data:
+            param1: value1
+    git:
+      directory: /package-examples/helloworld-set
+      ref: master
+      repo: https://github.com/GoogleContainerTools/kpt
+functions:
+  autoRunStarlark: true
+  starlarkFunctions:
+    - name: foo-star
+      path: path/to/foo-star.yaml
+inventory:
+  name: inventory-00933591
+  namespace: some-space
+  labels:
+    foo: bar
+  annotations:
+    abc: def
+  inventoryID: 92c234b7e9267815b0c3e17c9e4d7139a16c104f-1620493522822890000
+openAPI:
+  definitions:
+    io.k8s.cli.setters.image:
+      x-k8s-cli:
+        setter:
+          name: image
+          value: nginx
+    io.k8s.cli.setters.list:
+      type: array
+      x-k8s-cli:
+        setter:
+          name: list
+          value: ""
+          listValues:
+            - dev
+            - stage
+    io.k8s.cli.setters.namespace:
+      type: string
+      maxLength: 10
+      x-k8s-cli:
+        setter:
+          name: namespace
+          value: some-space
+    io.k8s.cli.setters.tag:
+      x-k8s-cli:
+        setter:
+          name: tag
+          value: 1.14.1
+    io.k8s.cli.substitutions.fullimage:
+      x-k8s-cli:
+        substitution:
+          name: fullimage
+          pattern: ${image}:${tag}
+          values:
+            - marker: ${image}
+              ref: '#/definitions/io.k8s.cli.setters.image'
+            - marker: ${tag}
+              ref: '#/definitions/io.k8s.cli.setters.tag'
+    io.k8s.cli.substitutions.imageidentifier:
+      x-k8s-cli:
+        substitution:
+          name: imageidentifier
+          pattern: deployment-${fullimage}
+          values:
+            - marker: ${fullimage}
+              ref: '#/definitions/io.k8s.cli.substitutions.fullimage'
+packageMetadata:
+  email: foo@gmail.com
+  license: license text
+  man: nginx man text
+  shortDescription: describe this package
+  tags:
+    - tag1
+    - tag2
+  url: https://github.com/GoogleContainerTools/kpt
+  version: v0.1
+upstream:
+  type: git
+  git:
+    commit: 4d2aa98b45ddee4b5fa45fbca16f2ff887de9efb
+    directory: package-examples/nginx
+    ref: v0.2
+    repo: https://github.com/GoogleContainerTools/kpt

--- a/e2e/testdata/fn-eval/include-meta-resources-v1alpha1/labelconfig.yaml
+++ b/e2e/testdata/fn-eval/include-meta-resources-v1alpha1/labelconfig.yaml
@@ -1,0 +1,19 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: label-config
+data:
+  tier: app

--- a/e2e/testdata/fn-eval/include-meta-resources-v1alpha1/resources.yaml
+++ b/e2e/testdata/fn-eval/include-meta-resources-v1alpha1/resources.yaml
@@ -1,0 +1,26 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+spec:
+  image: nginx:1.2.3

--- a/thirdparty/kyaml/runfn/runfn.go
+++ b/thirdparty/kyaml/runfn/runfn.go
@@ -109,13 +109,19 @@ func (r RunFns) Execute() error {
 // true if the file should be skipped during reading. Skipped files will not be included
 // in all steps following.
 func (r RunFns) functionConfigFilterFunc() (kio.LocalPackageSkipFileFunc, error) {
+	if r.IncludeMetaResources {
+		return func(relPath string) bool {
+			return false
+		}, nil
+	}
+
 	fnConfigPaths, err := pkg.FunctionConfigFilePaths(r.uniquePath, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pipeline config file paths: %w", err)
 	}
 
 	return func(relPath string) bool {
-		if len(fnConfigPaths) == 0 || r.IncludeMetaResources {
+		if len(fnConfigPaths) == 0 {
 			return false
 		}
 		// relPath is cleaned so we can directly use it here


### PR DESCRIPTION
This PR is to avoid calling pkg.FunctionConfigFilePaths if include-meta-resources in true to return fast. Existing behavior of the function will not change. This is to make sure that `eval` command is compatible with v1alpha1 packages if include-meta-resources flag is specified.