### PR TITLE
added github pre-commit hook for make generate

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "Updating docs..."
+make generate;
+diff=`git diff`
+
+if [[ $diff != "" ]];
+then 
+        echo "Found unstaged changes. Make sure to run `make generate` for updating the docs before you commit the changes."
+        exit 1
+else 
+        exit 0
+fi


### PR DESCRIPTION
Added `make generate` to the pre-commit hook similar to the [GoogleContainerTools/kpt-functions-catalog#287](https://github.com/GoogleContainerTools/kpt-functions-catalog/pull/287). This is to be enabled manually from the client-side by using following commands 
- `git config core.hooksPath .github/hooks`
- `chmod +x .github/hooks`
