### PR TITLE
use strict in kubeval example package

### DIFF
--- a/package-examples/nginx/Kptfile
+++ b/package-examples/nginx/Kptfile
@@ -9,3 +9,5 @@ info:
 pipeline:
   validators:
     - image: gcr.io/kpt-fn/kubeval:v0.1
+      configMap:
+        strict: 'true'


### PR DESCRIPTION
Closes: https://github.com/GoogleContainerTools/kpt/issues/1862

We should merge this PR after https://github.com/GoogleContainerTools/kpt/pull/1888.
