### PR TITLE
Temporarily disable gatekeeper function

### DIFF
--- a/e2e/testdata/fn-render/structured-results-from-muiltiple-fns/.expected/config.yaml
+++ b/e2e/testdata/fn-render/structured-results-from-muiltiple-fns/.expected/config.yaml
@@ -15,3 +15,5 @@
 # One of the functions in the pipeline fails resulting in
 # non-zero exit code and no changes in the resources.
 exitCode: 1
+# Skip for now because gatekeeper function output is not stable
+skip: true


### PR DESCRIPTION
We discovered that `ensure-gatekeeper` function's structured output is not stable (result ordering is random) that cause the test to be flaky. This PR `skips` this flaky tests until we the fix lands in `ensure-gatekeeper`.
