### PR TITLE
Fix breaking diff test

### DIFF
--- a/internal/util/diff/diff_test.go
+++ b/internal/util/diff/diff_test.go
@@ -346,7 +346,7 @@ locally changed: foo
 
 			filteredOutput := filterDiffMetadata(diffOutput)
 			if tc.hasLocalSubpackageChanges {
-				filteredOutput = regexp.MustCompile("Only in /tmp.+:").ReplaceAllString(filteredOutput, "locally changed:")
+				filteredOutput = regexp.MustCompile("Only in /(tmp|var).+:").ReplaceAllString(filteredOutput, "locally changed:")
 			}
 			assert.Equal(t, strings.TrimSpace(tc.expDiff)+"\n", filteredOutput)
 		})


### PR DESCRIPTION
This fixes a failing test for `diff`. We should look into a better solution here, the current approach seems fragile.
