### PR TITLE
Support fetching subpackages using tag partials.

### DIFF
--- a/internal/util/fetch/fetch.go
+++ b/internal/util/fetch/fetch.go
@@ -140,9 +140,15 @@ func ClonerUsingGitExec(ctx context.Context, repoSpec *git.RepoSpec) error {
 
 	// Check if we have a ref in the upstream that matches the package-specific
 	// reference. If we do, we use that reference.
-	packageRef := path.Join(strings.TrimLeft(repoSpec.Path, "/"), repoSpec.Ref)
-	if _, found := upstreamRepo.ResolveTag(packageRef); found {
-		repoSpec.Ref = packageRef
+	ps := strings.Split(repoSpec.Path, "/")
+	for len(ps) != 0 {
+		p := path.Join(ps...)
+		packageRef := path.Join(strings.TrimLeft(p, "/"), repoSpec.Ref)
+		if _, found := upstreamRepo.ResolveTag(packageRef); found {
+			repoSpec.Ref = packageRef
+			break
+		}
+		ps = ps[:len(ps)-1]
 	}
 
 	// Pull the required ref into the repo git cache.

--- a/internal/util/fetch/fetch_test.go
+++ b/internal/util/fetch/fetch_test.go
@@ -531,7 +531,7 @@ func TestCommand_Run_subdir_at_tag(t *testing.T) {
 func TestCommand_Run_no_subdir_at_valid_tag(t *testing.T) {
 	dir := "/java/expected"
 	tag := "java/v2"
-	expectedName := "expected"
+	expectedName := "expected_dir_is_not_here"
 	repos, rw, clean := testutil.SetupReposAndWorkspace(t, map[string][]testutil.Content{
 		testutil.Upstream: {
 			{
@@ -576,14 +576,14 @@ func TestCommand_Run_no_subdir_at_valid_tag(t *testing.T) {
 func TestCommand_Run_no_subdir_at_invalid_tag(t *testing.T) {
 	dir := "/java/expected"
 	nonexistentTag := "notjava/v2"
-	expectedName := "expected"
+	expectedName := "expected_dir_is_here"
 	repos, rw, clean := testutil.SetupReposAndWorkspace(t, map[string][]testutil.Content{
 		testutil.Upstream: {
 			{
 				Pkg: pkgbuilder.NewRootPkg().
 					WithSubPackages(pkgbuilder.NewSubPkg("java").
 						WithResource("deployment").
-						WithSubPackages(pkgbuilder.NewSubPkg("expected").
+						WithSubPackages(pkgbuilder.NewSubPkg(expectedName).
 							WithFile("expected.txt", "My kptfile and I should be the only objects"))),
 				Branch: "main",
 				Tag:    "java/v2",

--- a/internal/util/fetch/fetch_test.go
+++ b/internal/util/fetch/fetch_test.go
@@ -15,6 +15,7 @@
 package fetch_test
 
 import (
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -461,7 +462,7 @@ func TestCommand_Run_subdir_at_tag(t *testing.T) {
 		t.FailNow()
 	}
 
-	files, err := os.ReadDir(actualPkg.UniquePath.String())
+	files, err := ioutil.ReadDir(actualPkg.UniquePath.String())
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/internal/util/fetch/fetch_test.go
+++ b/internal/util/fetch/fetch_test.go
@@ -19,7 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/GoogleContainerTools/kpt/internal/pkg"
+	pkgtesting "github.com/GoogleContainerTools/kpt/internal/pkg/testing"
 	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
 	"github.com/GoogleContainerTools/kpt/internal/testutil/pkgbuilder"
@@ -58,14 +58,6 @@ func createKptfile(workspace *testutil.TestWorkspace, git *kptfilev1alpha2.Git, 
 	return kptfileutil.WriteFile(workspace.FullPackagePath(), kf)
 }
 
-func createPackage(t *testing.T, pkgPath string) *pkg.Pkg {
-	p, err := pkg.New(pkgPath)
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	return p
-}
-
 // TestCommand_Run_failEmptyRepo verifies that Command fail if no Kptfile
 func TestCommand_Run_failNoKptfile(t *testing.T) {
 	g, w, clean := testutil.SetupRepoAndWorkspace(t, testutil.Content{
@@ -81,7 +73,7 @@ func TestCommand_Run_failNoKptfile(t *testing.T) {
 	}
 
 	err = Command{
-		Pkg: createPackage(t, pkgPath),
+		Pkg: pkgtesting.CreatePkgOrFail(t, pkgPath),
 	}.Run(fake.CtxWithNilPrinter())
 	if !assert.Error(t, err) {
 		t.FailNow()
@@ -100,7 +92,7 @@ func TestCommand_Run_failNoGit(t *testing.T) {
 	}
 
 	err = Command{
-		Pkg: createPackage(t, w.FullPackagePath()),
+		Pkg: pkgtesting.CreatePkgOrFail(t, w.FullPackagePath()),
 	}.Run(fake.CtxWithNilPrinter())
 	if !assert.Error(t, err) {
 		t.FailNow()
@@ -123,7 +115,7 @@ func TestCommand_Run_failEmptyRepo(t *testing.T) {
 	}
 
 	err = Command{
-		Pkg: createPackage(t, w.FullPackagePath()),
+		Pkg: pkgtesting.CreatePkgOrFail(t, w.FullPackagePath()),
 	}.Run(fake.CtxWithNilPrinter())
 	if !assert.Error(t, err) {
 		t.FailNow()
@@ -146,7 +138,7 @@ func TestCommand_Run_failNoRevision(t *testing.T) {
 	}
 
 	err = Command{
-		Pkg: createPackage(t, w.FullPackagePath()),
+		Pkg: pkgtesting.CreatePkgOrFail(t, w.FullPackagePath()),
 	}.Run(fake.CtxWithNilPrinter())
 	if !assert.Error(t, err) {
 		t.FailNow()
@@ -173,7 +165,7 @@ func TestCommand_Run(t *testing.T) {
 
 	absPath := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	err = Command{
-		Pkg: createPackage(t, w.FullPackagePath()),
+		Pkg: pkgtesting.CreatePkgOrFail(t, w.FullPackagePath()),
 	}.Run(fake.CtxWithNilPrinter())
 	assert.NoError(t, err)
 
@@ -235,7 +227,7 @@ func TestCommand_Run_subdir(t *testing.T) {
 
 	absPath := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	err = Command{
-		Pkg: createPackage(t, w.FullPackagePath()),
+		Pkg: pkgtesting.CreatePkgOrFail(t, w.FullPackagePath()),
 	}.Run(fake.CtxWithNilPrinter())
 	assert.NoError(t, err)
 
@@ -313,7 +305,7 @@ func TestCommand_Run_branch(t *testing.T) {
 	}
 
 	err = Command{
-		Pkg: createPackage(t, w.FullPackagePath()),
+		Pkg: pkgtesting.CreatePkgOrFail(t, w.FullPackagePath()),
 	}.Run(fake.CtxWithNilPrinter())
 	assert.NoError(t, err)
 
@@ -394,7 +386,7 @@ func TestCommand_Run_tag(t *testing.T) {
 	}
 
 	err = Command{
-		Pkg: createPackage(t, w.FullPackagePath()),
+		Pkg: pkgtesting.CreatePkgOrFail(t, w.FullPackagePath()),
 	}.Run(fake.CtxWithNilPrinter())
 	assert.NoError(t, err)
 
@@ -461,7 +453,7 @@ func TestCommand_Run_subdir_at_tag(t *testing.T) {
 		return
 	}
 
-	actualPkg := createPackage(t, g.LocalWorkspace.FullPackagePath())
+	actualPkg := pkgtesting.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath())
 	err := Command{
 		Pkg: actualPkg,
 	}.Run(fake.CtxWithNilPrinter())
@@ -496,7 +488,7 @@ func TestCommand_Run_failInvalidRepo(t *testing.T) {
 	}
 
 	err = Command{
-		Pkg: createPackage(t, w.FullPackagePath()),
+		Pkg: pkgtesting.CreatePkgOrFail(t, w.FullPackagePath()),
 	}.Run(fake.CtxWithNilPrinter())
 	if !assert.Error(t, err) {
 		t.FailNow()
@@ -520,7 +512,7 @@ func TestCommand_Run_failInvalidBranch(t *testing.T) {
 	}
 
 	err = Command{
-		Pkg: createPackage(t, w.FullPackagePath()),
+		Pkg: pkgtesting.CreatePkgOrFail(t, w.FullPackagePath()),
 	}.Run(fake.CtxWithNilPrinter())
 	if !assert.Error(t, err) {
 		t.FailNow()
@@ -547,7 +539,7 @@ func TestCommand_Run_failInvalidTag(t *testing.T) {
 	}
 
 	err = Command{
-		Pkg: createPackage(t, w.FullPackagePath()),
+		Pkg: pkgtesting.CreatePkgOrFail(t, w.FullPackagePath()),
 	}.Run(fake.CtxWithNilPrinter())
 	if !assert.Error(t, err) {
 		t.FailNow()


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/kpt/issues/1829
Consolidates usage of the `CreatePkgOrFail` test helper function within `fetch_test.go`