### PR TITLE
add test for eval stdout

### DIFF
--- a/e2e/testdata/fn-eval/output-to-stdout/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/output-to-stdout/.expected/config.yaml
@@ -1,0 +1,47 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+stdOut: |
+  # Copyright 2021 Google LLC
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #      http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: nginx-deployment
+    namespace: staging
+    annotations:
+      config.kubernetes.io/path: resources.yaml
+  spec:
+    replicas: 3
+  ---
+  apiVersion: custom.io/v1
+  kind: Custom
+  metadata:
+    name: custom
+    namespace: staging
+    annotations:
+      config.kubernetes.io/path: resources.yaml
+  spec:
+    image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/output-to-stdout/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/output-to-stdout/.expected/exec.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+kpt fn source |\
+kpt fn eval - --image gcr.io/kpt-fn/set-namespace:v0.1 -- namespace=staging

--- a/e2e/testdata/fn-eval/output-to-stdout/.krmignore
+++ b/e2e/testdata/fn-eval/output-to-stdout/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-eval/output-to-stdout/resources.yaml
+++ b/e2e/testdata/fn-eval/output-to-stdout/resources.yaml
@@ -11,13 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# One of the functions in the pipeline fails resulting in
-# non-zero exit code and no changes in the resources.
-exitCode: 0
-# This test checks function results and result output is not idempotent
-# because the results produced by search replace function gets changed
-# in the subsequent runs. So skipping it for now.
-nonIdempotent: true
-stdOut: |
-  [RUNNING] "gcr.io/kpt-fn/search-replace:v0.1"
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+spec:
+  image: nginx:1.2.3

--- a/pkg/test/runner/runner.go
+++ b/pkg/test/runner/runner.go
@@ -382,11 +382,9 @@ func (r *Runner) compareResult(exitErr error, stdout string, stderr string, tmpP
 		return fmt.Errorf("actual exit code %d doesn't match expected %d", exitCode, r.testCase.Config.ExitCode)
 	}
 
-	if exitCode != 0 {
-		err := r.compareOutput(stdout, stderr)
-		if err != nil {
-			return err
-		}
+	err = r.compareOutput(stdout, stderr)
+	if err != nil {
+		return err
 	}
 
 	// compare results


### PR DESCRIPTION
Add a test case for `fn eval` stdout output. Also make test runner to always check stdout and stderr.
