### PR TITLE
Add version disclaimer on top of every page.

### DIFF
--- a/site/layouts/partials/version-banner.html
+++ b/site/layouts/partials/version-banner.html
@@ -1,0 +1,5 @@
+
+  {{ $color := "primary" }}
+  <div class="pageinfo pageinfo-{{ $color }}">
+    This is the documentation for version 0.39. For versions >= 1.0.0-alpha.1, see <a href="https://kpt.dev/">kpt.dev</a>.
+    </div>

--- a/site/layouts/partials/version-banner.html
+++ b/site/layouts/partials/version-banner.html
@@ -1,5 +1,5 @@
 
   {{ $color := "primary" }}
   <div class="pageinfo pageinfo-{{ $color }}">
-    This is the documentation for version 0.39. For versions >= 1.0.0-alpha.1, see <a href="https://kpt.dev/installation/">kpt.dev</a>.
+    This is the documentation for version 0.39. For versions >= 1.0.0-alpha.1, see <a href="https://kpt.dev/">kpt.dev</a>.
     </div>

--- a/site/layouts/partials/version-banner.html
+++ b/site/layouts/partials/version-banner.html
@@ -1,5 +1,5 @@
 
   {{ $color := "primary" }}
   <div class="pageinfo pageinfo-{{ $color }}">
-    This is the documentation for version 0.39. For versions >= 1.0.0-alpha.1, see <a href="https://kpt.dev/">kpt.dev</a>.
+    This is the documentation for version 0.39. For versions >= 1.0.0-alpha.1, see <a href="https://kpt.dev/installation/">kpt.dev</a>.
     </div>

--- a/site/themes/docsy/layouts/partials/page-meta-lastmod.html
+++ b/site/themes/docsy/layouts/partials/page-meta-lastmod.html
@@ -1,5 +1,1 @@
-<div>
-    This documentation is for the current public release of kpt.
-    View documentation for the next release of kpt at <a href="https://kpt.dev">kpt.dev</a>
-</div>
 {{ T "post_last_mod"}} {{ .Lastmod.Format .Site.Params.time_format_default }}{{ with .GitInfo }}: <a  href="{{ $.Site.Params.github_repo }}/commit/{{ .Hash }}">{{ .Subject }} ({{ .AbbreviatedHash }})</a>{{end }}

--- a/site/themes/docsy/layouts/partials/page-meta-lastmod.html
+++ b/site/themes/docsy/layouts/partials/page-meta-lastmod.html
@@ -1,1 +1,5 @@
+<div>
+    This documentation is for the current public release of kpt.
+    View documentation for the next release of kpt at <a href="https://kpt.dev">kpt.dev</a>
+</div>
 {{ T "post_last_mod"}} {{ .Lastmod.Format .Site.Params.time_format_default }}{{ with .GitInfo }}: <a  href="{{ $.Site.Params.github_repo }}/commit/{{ .Hash }}">{{ .Subject }} ({{ .AbbreviatedHash }})</a>{{end }}


### PR DESCRIPTION
Addresses https://github.com/GoogleContainerTools/kpt/issues/1662 for old site.
![image](https://user-images.githubusercontent.com/31711490/119067449-fe714080-b996-11eb-880b-8b06113af856.png)
