### PR TITLE
add test for out-of-place sink

### DIFF
--- a/e2e/testdata/fn-eval/out-of-place/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/out-of-place/.expected/diff.patch
@@ -1,0 +1,19 @@
+diff --git a/resources.yaml b/resources.yaml
+index 7a494c9..254b9cd 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -15,6 +15,7 @@ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+   name: nginx-deployment
++  namespace: staging
+ spec:
+   replicas: 3
+ ---
+@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
+ kind: Custom
+ metadata:
+   name: custom
++  namespace: staging
+ spec:
+   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/out-of-place/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/out-of-place/.expected/exec.sh
@@ -23,6 +23,7 @@ kpt fn source \
 | kpt fn sink $TEMP_DIR
 
 # copy back the resources
+rm -r ./*
 cp $TEMP_DIR/* .
 
 # remove temporary directory

--- a/e2e/testdata/fn-eval/out-of-place/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/out-of-place/.expected/exec.sh
@@ -1,0 +1,29 @@
+#! /bin/bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+# create a temporary directory
+TEMP_DIR=$(mktemp -d)
+
+kpt fn source \
+| kpt fn eval - --image gcr.io/kpt-fn/set-namespace:v0.1 -- namespace=staging \
+| kpt fn sink $TEMP_DIR
+
+# copy back the resources
+cp $TEMP_DIR/* .
+
+# remove temporary directory
+rm -r $TEMP_DIR

--- a/e2e/testdata/fn-eval/out-of-place/.krmignore
+++ b/e2e/testdata/fn-eval/out-of-place/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-eval/out-of-place/resources.yaml
+++ b/e2e/testdata/fn-eval/out-of-place/resources.yaml
@@ -1,0 +1,26 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+spec:
+  image: nginx:1.2.3


### PR DESCRIPTION
This test case works in this way:

1. Create a temporary directory
2. Run eval and sink to the temp dir
3. Copy back the results
