### PR TITLE
Test behavior of kpt live init when there is not Kptfile

### DIFF
--- a/internal/cmdliveinit/cmdliveinit_test.go
+++ b/internal/cmdliveinit/cmdliveinit_test.go
@@ -105,6 +105,28 @@ func TestCmd_generateID(t *testing.T) {
 	}
 }
 
+func TestCmd_Run_NoKptfile(t *testing.T) {
+	// Set up fake test factory
+	tf := cmdtesting.NewTestFactory().WithNamespace("test-ns")
+	defer tf.Cleanup()
+	ioStreams, _, _, _ := genericclioptions.NewTestIOStreams() //nolint:dogsled
+
+	w, clean := testutil.SetupWorkspace(t)
+	defer clean()
+
+	revert := testutil.Chdir(t, w.WorkspaceDirectory)
+	defer revert()
+
+	runner := NewRunner(fake.CtxWithNilPrinter(), tf, ioStreams)
+	runner.Command.SetArgs([]string{})
+	err := runner.Command.Execute()
+
+	if !assert.Error(t, err) {
+		t.FailNow()
+	}
+	assert.Contains(t, err.Error(), "error reading Kptfile at")
+}
+
 func TestCmd_Run(t *testing.T) {
 	testCases := map[string]struct {
 		kptfile           string

--- a/internal/cmdmigrate/migratecmd.go
+++ b/internal/cmdmigrate/migratecmd.go
@@ -13,6 +13,7 @@ import (
 	"os"
 
 	"github.com/GoogleContainerTools/kpt/internal/cmdliveinit"
+	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	"github.com/GoogleContainerTools/kpt/pkg/live"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -180,8 +181,12 @@ func (mr *MigrateRunner) applyCRD() error {
 func (mr *MigrateRunner) updateKptfile(ctx context.Context, args []string, prevID string) error {
 	fmt.Fprint(mr.ioStreams.Out, "  updating Kptfile inventory values...")
 	if !mr.dryRun {
-		err := (&cmdliveinit.ConfigureInventoryInfo{
-			Path:        args[0],
+		p, err := pkg.New(args[0])
+		if err != nil {
+			return err
+		}
+		err = (&cmdliveinit.ConfigureInventoryInfo{
+			Pkg:         p,
 			Factory:     mr.rgProvider.Factory(),
 			Quiet:       true,
 			InventoryID: prevID,


### PR DESCRIPTION
This adds an additional unit test to verify the behavior when a Kptfile can't be found when running the `kpt live init` command. It also updates the error handling so we get the same error message as with the `pkg` and `fn` commands.
