### PR TITLE
support both ts and go sdk formats for fn results

### DIFF
--- a/e2e/testdata/fn-render/fnresult-fn-failure/.expected/results.yaml
+++ b/e2e/testdata/fn-render/fnresult-fn-failure/.expected/results.yaml
@@ -21,8 +21,7 @@ items:
           resourceRef:
             apiVersion: apps/v1
             kind: Deployment
-            metadata:
-                name: nginx-deployment
+            name: nginx-deployment
           field:
             path: selector
           file:
@@ -32,8 +31,7 @@ items:
           resourceRef:
             apiVersion: apps/v1
             kind: Deployment
-            metadata:
-                name: nginx-deployment
+            name: nginx-deployment
           field:
             path: template
           file:
@@ -43,8 +41,7 @@ items:
           resourceRef:
             apiVersion: apps/v1
             kind: Deployment
-            metadata:
-                name: nginx-deployment
+            name: nginx-deployment
           field:
             path: spec.replicas
           file:
@@ -58,8 +55,7 @@ items:
           resourceRef:
             apiVersion: custom.io/v1
             kind: Custom
-            metadata:
-                name: custom
+            name: custom
           file:
             path: resources.yaml
             index: 1

--- a/e2e/testdata/fn-render/fnresult-fn-failure/.expected/results.yaml
+++ b/e2e/testdata/fn-render/fnresult-fn-failure/.expected/results.yaml
@@ -22,7 +22,7 @@ items:
             apiVersion: apps/v1
             kind: Deployment
             metadata:
-              name: nginx-deployment
+                name: nginx-deployment
           field:
             path: selector
           file:
@@ -33,7 +33,7 @@ items:
             apiVersion: apps/v1
             kind: Deployment
             metadata:
-              name: nginx-deployment
+                name: nginx-deployment
           field:
             path: template
           file:
@@ -44,7 +44,7 @@ items:
             apiVersion: apps/v1
             kind: Deployment
             metadata:
-              name: nginx-deployment
+                name: nginx-deployment
           field:
             path: spec.replicas
           file:
@@ -59,7 +59,7 @@ items:
             apiVersion: custom.io/v1
             kind: Custom
             metadata:
-              name: custom
+                name: custom
           file:
             path: resources.yaml
             index: 1

--- a/e2e/testdata/fn-render/fnresult-fn-failure/.expected/results.yaml
+++ b/e2e/testdata/fn-render/fnresult-fn-failure/.expected/results.yaml
@@ -21,6 +21,8 @@ items:
           resourceRef:
             apiVersion: apps/v1
             kind: Deployment
+            metadata:
+              name: nginx-deployment
           field:
             path: selector
           file:
@@ -30,6 +32,8 @@ items:
           resourceRef:
             apiVersion: apps/v1
             kind: Deployment
+            metadata:
+              name: nginx-deployment
           field:
             path: template
           file:
@@ -39,6 +43,8 @@ items:
           resourceRef:
             apiVersion: apps/v1
             kind: Deployment
+            metadata:
+              name: nginx-deployment
           field:
             path: spec.replicas
           file:
@@ -52,6 +58,8 @@ items:
           resourceRef:
             apiVersion: custom.io/v1
             kind: Custom
+            metadata:
+              name: custom
           file:
             path: resources.yaml
             index: 1

--- a/e2e/testdata/fn-render/kubeval-failure/.expected/config.yaml
+++ b/e2e/testdata/fn-render/kubeval-failure/.expected/config.yaml
@@ -15,3 +15,4 @@
 # One of the functions in the pipeline fails resulting in
 # non-zero exit code and no changes in the resources.
 exitCode: 1
+stdOut: "[ERROR] selector is required in object \"apps/v1/Deployment/nginx-deployment\" in file \"resources.yaml\" in field \"selector\""

--- a/e2e/testdata/fn-render/kubeval-failure/.expected/results.yaml
+++ b/e2e/testdata/fn-render/kubeval-failure/.expected/results.yaml
@@ -12,6 +12,8 @@ items:
           resourceRef:
             apiVersion: apps/v1
             kind: Deployment
+            metadata:
+                name: nginx-deployment
           field:
             path: selector
           file:
@@ -21,6 +23,8 @@ items:
           resourceRef:
             apiVersion: apps/v1
             kind: Deployment
+            metadata:
+                name: nginx-deployment
           field:
             path: template
           file:
@@ -30,6 +34,8 @@ items:
           resourceRef:
             apiVersion: apps/v1
             kind: Deployment
+            metadata:
+                name: nginx-deployment
           field:
             path: spec.replicas
           file:
@@ -41,6 +47,8 @@ items:
           resourceRef:
             apiVersion: custom.io/v1
             kind: Custom
+            metadata:
+                name: custom
           file:
             path: resources.yaml
             index: 1

--- a/e2e/testdata/fn-render/kubeval-failure/.expected/results.yaml
+++ b/e2e/testdata/fn-render/kubeval-failure/.expected/results.yaml
@@ -12,8 +12,7 @@ items:
           resourceRef:
             apiVersion: apps/v1
             kind: Deployment
-            metadata:
-                name: nginx-deployment
+            name: nginx-deployment
           field:
             path: selector
           file:
@@ -23,8 +22,7 @@ items:
           resourceRef:
             apiVersion: apps/v1
             kind: Deployment
-            metadata:
-                name: nginx-deployment
+            name: nginx-deployment
           field:
             path: template
           file:
@@ -34,8 +32,7 @@ items:
           resourceRef:
             apiVersion: apps/v1
             kind: Deployment
-            metadata:
-                name: nginx-deployment
+            name: nginx-deployment
           field:
             path: spec.replicas
           file:
@@ -47,8 +44,7 @@ items:
           resourceRef:
             apiVersion: custom.io/v1
             kind: Custom
-            metadata:
-                name: custom
+            name: custom
           file:
             path: resources.yaml
             index: 1

--- a/internal/fnruntime/runner.go
+++ b/internal/fnruntime/runner.go
@@ -27,7 +27,6 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"github.com/GoogleContainerTools/kpt/internal/types"
-	"github.com/GoogleContainerTools/kpt/pkg/api/fnresult/v1alpha2"
 	fnresult "github.com/GoogleContainerTools/kpt/pkg/api/fnresult/v1alpha2"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
@@ -344,7 +343,7 @@ func (ri *multiLineFormatter) String() string {
 }
 
 // resultToString converts given structured result item to string format.
-func resultToString(result v1alpha2.ResultItem) string {
+func resultToString(result fnresult.ResultItem) string {
 	// TODO: Go SDK should implement Stringer method
 	// for framework.ResultItem. This is a temporary
 	// wrapper that will eventually be moved to Go SDK.

--- a/internal/fnruntime/runner_test.go
+++ b/internal/fnruntime/runner_test.go
@@ -583,14 +583,12 @@ file:
 		yml, err := yaml.Parse(tc.input)
 		assert.NoError(t, err)
 
-		result := fnresult.ResultItem{}
-		err = yaml.Unmarshal([]byte(tc.input), &result)
+		result := &fnresult.ResultItem{}
+		err = yaml.Unmarshal([]byte(tc.input), result)
 		assert.NoError(t, err)
+		assert.NoError(t, populateResourceRef(yml, result))
 
-		fnResult := &fnresult.Result{Results: []fnresult.ResultItem{result}}
-		assert.NoError(t, getResourceRefMetadata(yml, fnResult, 0))
-
-		out, err := yaml.Marshal(fnResult.Results[0])
+		out, err := yaml.Marshal(result)
 		assert.NoError(t, err)
 		assert.Equal(t, tc.expected, string(out))
 	}

--- a/pkg/api/fnresult/v1alpha2/types.go
+++ b/pkg/api/fnresult/v1alpha2/types.go
@@ -36,7 +36,7 @@ type Result struct {
 	// ExitCode is the exit code from running the function
 	ExitCode int `yaml:"exitCode"`
 	// Results is the list of results for the function
-	Results []framework.ResultItem `yaml:"results,omitempty"`
+	Results []ResultItem `yaml:"results,omitempty"`
 }
 
 const (
@@ -72,4 +72,21 @@ func NewResultList() *ResultList {
 		},
 		Items: []Result{},
 	}
+}
+
+type ResultItem struct {
+	// Message is a human readable message
+	Message string `yaml:"message,omitempty"`
+
+	// Severity is the severity of this result
+	Severity framework.Severity `yaml:"severity,omitempty"`
+
+	// ResourceRef is a reference to a resource
+	ResourceRef yaml.ResourceIdentifier `yaml:"resourceRef,omitempty"`
+
+	// Field is a reference to the field in a resource this result refers to
+	Field framework.Field `yaml:"field,omitempty"`
+
+	// File references a file containing the resource this result refers to
+	File framework.File `yaml:"file,omitempty"`
 }

--- a/pkg/api/fnresult/v1alpha2/types.go
+++ b/pkg/api/fnresult/v1alpha2/types.go
@@ -76,7 +76,7 @@ func NewResultList() *ResultList {
 
 // ResultItem is a duplicate of framework.ResultItem, except that
 // ResourceRef uses yaml.ResourceIdentifier here, whereas framework.ResultItem
-// uses yaml.ResourceMeta Eventually, we will need to fix it upstream.
+// uses yaml.ResourceMeta. Eventually, we will need to fix it upstream.
 // TODO: https://github.com/GoogleContainerTools/kpt/issues/2091
 type ResultItem struct {
 	// Message is a human readable message

--- a/pkg/api/fnresult/v1alpha2/types.go
+++ b/pkg/api/fnresult/v1alpha2/types.go
@@ -74,6 +74,10 @@ func NewResultList() *ResultList {
 	}
 }
 
+// ResultItem is a duplicate of framework.ResultItem, except that
+// ResourceRef uses yaml.ResourceIdentifier here, whereas framework.ResultItem
+// uses yaml.ResourceMeta Eventually, we will need to fix it upstream.
+// TODO: https://github.com/GoogleContainerTools/kpt/issues/2091
 type ResultItem struct {
 	// Message is a human readable message
 	Message string `yaml:"message,omitempty"`


### PR DESCRIPTION
workaround for https://github.com/GoogleContainerTools/kpt/issues/2056

There is a discrepancy between the results definition in functions SDK and the results definition in kpt. 

This PR adds some extra work in kpt to get the name/namespace from the functions result. 

It would be better to have a consistent schema between kpt and the functions sdk. 