### PR TITLE
Default to exit code 0 for resolved errors

### DIFF
--- a/internal/errors/resolver/container.go
+++ b/internal/errors/resolver/container.go
@@ -35,7 +35,6 @@ func (*containerImageErrorResolver) Resolve(err error) (ResolvedResult, bool) {
 		return ResolvedResult{}, false
 	}
 	return ResolvedResult{
-		Message:  containerImageError.Error(),
-		ExitCode: 1,
+		Message: containerImageError.Error(),
 	}, true
 }

--- a/internal/errors/resolver/git.go
+++ b/internal/errors/resolver/git.go
@@ -105,7 +105,6 @@ func (*gitExecErrorResolver) Resolve(err error) (ResolvedResult, bool) {
 		msg = ExecuteTemplate(genericGitExecError, tmplArgs)
 	}
 	return ResolvedResult{
-		Message:  msg,
-		ExitCode: 1,
+		Message: msg,
 	}, true
 }

--- a/internal/errors/resolver/live.go
+++ b/internal/errors/resolver/live.go
@@ -121,8 +121,7 @@ func (*liveErrorResolver) Resolve(err error) (ResolvedResult, bool) {
 	var invExistsError *cmdliveinit.InvExistsError
 	if errors.As(err, &invExistsError) {
 		return ResolvedResult{
-			Message:  ExecuteTemplate(invInfoAlreadyExistsMsg, tmplArgs),
-			ExitCode: 1,
+			Message: ExecuteTemplate(invInfoAlreadyExistsMsg, tmplArgs),
 		}, true
 	}
 

--- a/internal/errors/resolver/pkg.go
+++ b/internal/errors/resolver/pkg.go
@@ -55,20 +55,17 @@ func (*pkgErrorResolver) Resolve(err error) (ResolvedResult, bool) {
 
 		if errors.Is(kptfileError, os.ErrNotExist) {
 			return ResolvedResult{
-				Message:  ExecuteTemplate(noKptfileMsg, tmplArgs),
-				ExitCode: 1,
+				Message: ExecuteTemplate(noKptfileMsg, tmplArgs),
 			}, true
 		}
 
 		return ResolvedResult{
-			Message:  ExecuteTemplate(kptfileReadErrMsg, tmplArgs),
-			ExitCode: 1,
+			Message: ExecuteTemplate(kptfileReadErrMsg, tmplArgs),
 		}, true
 	}
 	if errors.As(err, &validateError) {
 		return ResolvedResult{
-			Message:  validateError.Error(),
-			ExitCode: 1,
+			Message: validateError.Error(),
 		}, true
 	}
 

--- a/internal/errors/resolver/resolver.go
+++ b/internal/errors/resolver/resolver.go
@@ -28,9 +28,14 @@ func AddErrorResolver(er ErrorResolver) {
 // the error could not be resolved.
 func ResolveError(err error) (ResolvedResult, bool) {
 	for _, resolver := range errorResolvers {
-		msg, found := resolver.Resolve(err)
+		rr, found := resolver.Resolve(err)
+		// If the exit code hasn't been set, we default it to 1. We should
+		// never return exit code 0 for errors.
+		if rr.ExitCode == 0 {
+			rr.ExitCode = 1
+		}
 		if found {
-			return msg, true
+			return rr, true
 		}
 	}
 	return ResolvedResult{}, false

--- a/internal/errors/resolver/update.go
+++ b/internal/errors/resolver/update.go
@@ -58,8 +58,7 @@ func (*updateErrorResolver) Resolve(err error) (ResolvedResult, bool) {
 
 	if msg != "" {
 		return ResolvedResult{
-			Message:  msg,
-			ExitCode: 1,
+			Message: msg,
 		}, true
 	}
 	return ResolvedResult{}, false


### PR DESCRIPTION
Instead of requiring every resolver to specify an exit code, we default to exit code 1 if no exit code is provided.

Fixes: https://github.com/GoogleContainerTools/kpt/issues/2085
