### PR TITLE
Improve output when function fails in pipe

### DIFF
--- a/e2e/testdata/fn-eval/error-in-pipe/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/error-in-pipe/.expected/config.yaml
@@ -13,8 +13,14 @@
 # limitations under the License.
 
 exitCode: 1
-stdErr: |
-  error:   Stderr:
+stdErr: |2
+  [FAIL] "gcr.io/kpt-fn/set-namespace:v0.1"
+    Results:
+      [ERROR] failed to configure function: input namespace cannot be empty
+    Stderr:
       "failed to configure function: input namespace cannot be empty"
-    Exit Code: 1
+    Exit code: 1
+
+   
+  [FAIL] "gcr.io/kpt-fn/dne"
   error: Function image "gcr.io/kpt-fn/dne" doesn't exist.

--- a/e2e/testdata/fn-eval/error-in-pipe/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/error-in-pipe/.expected/config.yaml
@@ -1,0 +1,20 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exitCode: 1
+stdErr: |
+  error:   Stderr:
+      "failed to configure function: input namespace cannot be empty"
+    Exit Code: 1
+  error: Function image "gcr.io/kpt-fn/dne" doesn't exist.

--- a/e2e/testdata/fn-eval/error-in-pipe/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/error-in-pipe/.expected/exec.sh
@@ -1,0 +1,21 @@
+#! /bin/bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+kpt fn source \
+| kpt fn eval - --image gcr.io/kpt-fn/set-namespace:v0.1 \
+| kpt fn eval - --image gcr.io/kpt-fn/dne -- foo=bar \
+| kpt fn sink .

--- a/e2e/testdata/fn-eval/error-in-pipe/.krmignore
+++ b/e2e/testdata/fn-eval/error-in-pipe/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-eval/missing-fn-config/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/missing-fn-config/.expected/config.yaml
@@ -18,4 +18,3 @@ image: gcr.io/kpt-fn/set-namespace:v0.1
 stdErr: "failed to configure function: input namespace cannot be empty"
 stdOut: |
   [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1"
-  [FAIL] "gcr.io/kpt-fn/set-namespace:v0.1"

--- a/e2e/testdata/fn-eval/missing-fn-image/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/missing-fn-image/.expected/config.yaml
@@ -20,4 +20,3 @@ args:
 stdErr: 'Function image "gcr.io/kpt-fn/dne" doesn''t exist'
 stdOut: |
   [RUNNING] "gcr.io/kpt-fn/dne"
-  [FAIL] "gcr.io/kpt-fn/dne"

--- a/e2e/testdata/fn-render/fn-failure-output-no-truncate/.expected/config.yaml
+++ b/e2e/testdata/fn-render/fn-failure-output-no-truncate/.expected/config.yaml
@@ -19,4 +19,3 @@ disableOutputTruncate: true
 stdErr: "Invalid type. Expected: [integer,null], given: string in object 'apps/v1/Deployment//nginx-deployment' in file resources.yaml in field spec.replicas"
 stdOut: |
   [RUNNING] "gcr.io/kpt-fn/kubeval:v0.1"
-  [FAIL] "gcr.io/kpt-fn/kubeval:v0.1"

--- a/e2e/testdata/fn-render/fn-failure/.expected/config.yaml
+++ b/e2e/testdata/fn-render/fn-failure/.expected/config.yaml
@@ -18,4 +18,3 @@ exitCode: 1
 stdErr: "httpbin-gen:4:1: got newline, want primary expression"
 stdOut: |
   [RUNNING] "gcr.io/kpt-fn/starlark:unstable"
-  [FAIL] "gcr.io/kpt-fn/starlark:unstable"

--- a/e2e/testdata/fn-render/fnresult-fn-failure/.expected/config.yaml
+++ b/e2e/testdata/fn-render/fnresult-fn-failure/.expected/config.yaml
@@ -18,4 +18,3 @@ exitCode: 1
 stdErr: "[ERROR] Invalid type. Expected: [integer,null], given: string in object 'apps/v1/Deployment//nginx-deployment' in file resources.yaml in field spec.replicas"
 stdOut: |
   [RUNNING] "gcr.io/kpt-fn/kubeval:v0.1"
-  [FAIL] "gcr.io/kpt-fn/kubeval:v0.1"

--- a/e2e/testdata/fn-render/kubeval-failure/.expected/config.yaml
+++ b/e2e/testdata/fn-render/kubeval-failure/.expected/config.yaml
@@ -15,4 +15,4 @@
 # One of the functions in the pipeline fails resulting in
 # non-zero exit code and no changes in the resources.
 exitCode: 1
-stdOut: "[ERROR] selector is required in object \"apps/v1/Deployment/nginx-deployment\" in file \"resources.yaml\" in field \"selector\""
+stdErr: '[ERROR] selector is required in object "apps/v1/Deployment/nginx-deployment" in file "resources.yaml" in field "selector"'

--- a/e2e/testdata/fn-render/no-fnconfig/.expected/config.yaml
+++ b/e2e/testdata/fn-render/no-fnconfig/.expected/config.yaml
@@ -16,4 +16,3 @@ exitCode: 1
 stdErr: "failed to configure function: function config must be a ConfigMap or SetLabelConfig"
 stdOut: |
   [RUNNING] "gcr.io/kpt-fn/set-labels:unstable"
-  [FAIL] "gcr.io/kpt-fn/set-labels:unstable"

--- a/e2e/testdata/fn-render/path-index-duplicate/.expected/config.yaml
+++ b/e2e/testdata/fn-render/path-index-duplicate/.expected/config.yaml
@@ -18,4 +18,3 @@ exitCode: 1
 stdErr: 'resource at path "resources.yaml" and index "0" already exists'
 stdOut: |
   [RUNNING] "gcr.io/kpt-fn/starlark:unstable"
-  [FAIL] "gcr.io/kpt-fn/starlark:unstable"

--- a/e2e/testdata/fn-render/subpkg-fn-failure/.expected/config.yaml
+++ b/e2e/testdata/fn-render/subpkg-fn-failure/.expected/config.yaml
@@ -16,4 +16,3 @@ exitCode: 1
 stdErr: "statefulset-filter:5:1: got newline, want primary expression"
 stdOut: |
   [RUNNING] "gcr.io/kpt-fn/starlark:unstable"
-  [FAIL] "gcr.io/kpt-fn/starlark:unstable"

--- a/e2e/testdata/fn-render/validate-resource-failure/.expected/config.yaml
+++ b/e2e/testdata/fn-render/validate-resource-failure/.expected/config.yaml
@@ -16,4 +16,3 @@ exitCode: 1
 stdErr: "fail: could not find httpbin deployment"
 stdOut: |
   [RUNNING] "gcr.io/kpt-fn/starlark:unstable"
-  [FAIL] "gcr.io/kpt-fn/starlark:unstable"

--- a/internal/cmdrender/executor.go
+++ b/internal/cmdrender/executor.go
@@ -67,7 +67,7 @@ func (e *Executor) Execute(ctx context.Context) error {
 	if err != nil {
 		// Note(droot): ignore the error in function result saving
 		// to avoid masking the hydration error.
-		_ = e.saveFnResults(ctx, hctx.fnResults)
+		_ = e.saveFnResults(ctx, hctx.fnResults, true)
 		return errors.E(op, root.pkg.UniquePath, err)
 	}
 
@@ -94,17 +94,16 @@ func (e *Executor) Execute(ctx context.Context) error {
 
 	pr.Printf("Successfully executed %d function(s) in %d package(s).\n", hctx.executedFunctionCnt, len(hctx.pkgs))
 
-	return e.saveFnResults(ctx, hctx.fnResults)
+	return e.saveFnResults(ctx, hctx.fnResults, false)
 }
 
-func (e *Executor) saveFnResults(ctx context.Context, fnResults *fnresult.ResultList) error {
-
+func (e *Executor) saveFnResults(ctx context.Context, fnResults *fnresult.ResultList, toStdErr bool) error {
 	resultsFile, err := fnruntime.SaveResults(e.ResultsDirPath, fnResults)
 	if err != nil {
 		return fmt.Errorf("failed to save function results: %w", err)
 	}
 
-	printerutil.PrintFnResultInfo(ctx, resultsFile, false)
+	printerutil.PrintFnResultInfo(ctx, resultsFile, false, toStdErr)
 	return nil
 }
 

--- a/internal/fnruntime/runner.go
+++ b/internal/fnruntime/runner.go
@@ -93,17 +93,16 @@ type FunctionRunner struct {
 }
 
 func (fr *FunctionRunner) Filter(input []*yaml.RNode) (output []*yaml.RNode, err error) {
-	if fr.disableOutput {
-		return fr.do(input)
-	}
 	pr := printer.FromContextOrDie(fr.ctx)
-	printOpt := printer.NewOpt()
 
-	pr.OptPrintf(printOpt, "[RUNNING] %q\n", fr.name)
+	if !fr.disableOutput {
+		pr.Printf("[RUNNING] %q\n", fr.name)
+	}
 	output, err = fr.do(input)
 	if err != nil {
+		printOpt := printer.NewOpt().Stderr()
 		pr.OptPrintf(printOpt, "[FAIL] %q\n", fr.name)
-		printFnResult(fr.ctx, fr.fnResult)
+		printFnResult(fr.ctx, fr.fnResult, printOpt)
 		var fnErr *ExecError
 		if goerrors.As(err, &fnErr) {
 			printFnExecErr(fr.ctx, fnErr)
@@ -111,8 +110,10 @@ func (fr *FunctionRunner) Filter(input []*yaml.RNode) (output []*yaml.RNode, err
 		}
 		return nil, err
 	}
-	pr.OptPrintf(printOpt, "[PASS] %q\n", fr.name)
-	printFnResult(fr.ctx, fr.fnResult)
+	if !fr.disableOutput {
+		pr.Printf("[PASS] %q\n", fr.name)
+		printFnResult(fr.ctx, fr.fnResult, printer.NewOpt())
+	}
 	return output, err
 }
 
@@ -179,7 +180,7 @@ func parseStructuredResult(yml *yaml.RNode, fnResult *fnresult.Result) error {
 
 // printFnResult prints given function result in a user friendly
 // format on kpt CLI.
-func printFnResult(ctx context.Context, fnResult *fnresult.Result) {
+func printFnResult(ctx context.Context, fnResult *fnresult.Result, opt *printer.Options) {
 	pr := printer.FromContextOrDie(ctx)
 	if len(fnResult.Results) > 0 {
 		// function returned structured results
@@ -192,7 +193,7 @@ func printFnResult(ctx context.Context, fnResult *fnresult.Result) {
 			Lines:          lines,
 			TruncateOutput: printer.TruncateOutput,
 		}
-		pr.Printf("%s", ri.String())
+		pr.OptPrintf(opt, "%s", ri.String())
 	}
 }
 

--- a/internal/util/printerutil/printerutil.go
+++ b/internal/util/printerutil/printerutil.go
@@ -21,12 +21,16 @@ import (
 )
 
 // PrintFnResultInfo displays information about the function results file.
-func PrintFnResultInfo(ctx context.Context, resultsFile string, withNewLine bool) {
+func PrintFnResultInfo(ctx context.Context, resultsFile string, withNewLine, toStdErr bool) {
 	pr := printer.FromContextOrDie(ctx)
+	var opt *printer.Options
+	if toStdErr {
+		opt = printer.NewOpt().Stderr()
+	}
 	if resultsFile != "" {
 		if withNewLine {
-			pr.Printf("\n")
+			pr.OptPrintf(opt, "\n")
 		}
-		pr.Printf("For complete results, see %s\n", resultsFile)
+		pr.OptPrintf(opt, "For complete results, see %s\n", resultsFile)
 	}
 }

--- a/pkg/test/runner/runner.go
+++ b/pkg/test/runner/runner.go
@@ -421,11 +421,11 @@ func (r *Runner) compareResult(exitErr error, stdout string, stderr string, tmpP
 func (r *Runner) compareOutput(stdout string, stderr string) error {
 	expectedStderr := r.testCase.Config.StdErr
 	if !strings.Contains(stderr, expectedStderr) {
-		return fmt.Errorf("wanted stderr %s, got %s", expectedStderr, stderr)
+		return fmt.Errorf("wanted stderr %q, got %q", expectedStderr, stderr)
 	}
 	expectedStdout := r.testCase.Config.StdOut
 	if !strings.Contains(stdout, expectedStdout) {
-		return fmt.Errorf("wanted stdout %s, got %s", expectedStdout, stdout)
+		return fmt.Errorf("wanted stdout %q, got %q", expectedStdout, stdout)
 	}
 	return nil
 }

--- a/thirdparty/kyaml/runfn/runfn.go
+++ b/thirdparty/kyaml/runfn/runfn.go
@@ -227,22 +227,23 @@ func (r RunFns) runFunctions(
 	err = pipeline.Execute()
 	resultsFile, resultErr := fnruntime.SaveResults(r.ResultsDir, r.fnResults)
 	if err != nil {
+		// function fails
 		if resultErr == nil {
-			r.printFnResultsStatus(resultsFile)
+			r.printFnResultsStatus(resultsFile, true)
 		}
 		return err
 	}
 	if resultErr == nil {
-		r.printFnResultsStatus(resultsFile)
+		r.printFnResultsStatus(resultsFile, false)
 	}
 	return nil
 }
 
-func (r RunFns) printFnResultsStatus(resultsFile string) {
+func (r RunFns) printFnResultsStatus(resultsFile string, toStdErr bool) {
 	if r.isOutputDisabled() {
 		return
 	}
-	printerutil.PrintFnResultInfo(r.Ctx, resultsFile, true)
+	printerutil.PrintFnResultInfo(r.Ctx, resultsFile, true, toStdErr)
 }
 
 // mergeContainerEnv will merge the envs specified by command line (imperative) and config


### PR DESCRIPTION
When there is any error in function:

1. The function failure message `[FAIL] "gcr.io/kpt-fn/xxx"` will be output to stderr.
2. Structured results will be output to stderr.
3. Content in stderr and exit code will be output to stderr.

The output of piped eval command
```
kpt fn source \
| kpt fn eval - --image gcr.io/kpt-fn/set-namespace:v0.1 \
| kpt fn eval - --image gcr.io/kpt-fn/dne -- foo=bar \
| kpt fn sink .
```
changed from 
```
error: Stderr:
    "failed to configure function: input namespace cannot be empty"
  Exit Code: 1
error: Function image "gcr.io/kpt-fn/dne" doesn't exist.
```
to
```
[FAIL] "gcr.io/kpt-fn/set-namespace:v0.1"
  Results:
    [ERROR] failed to configure function: input namespace cannot be empty
  Stderr:
    "failed to configure function: input namespace cannot be empty"
  Exit code: 1


[FAIL] "gcr.io/kpt-fn/dne"
error: Function image "gcr.io/kpt-fn/dne" doesn't exist.
```

#2010 