### PR TITLE
Check docs synchronization

### DIFF
--- a/.github/workflows/checkDocSync.yml
+++ b/.github/workflows/checkDocSync.yml
@@ -14,10 +14,6 @@
 
 name: Check Documentation Synchronized
 on:
-  push:
-    branches:
-      - master
-      - next
   pull_request:
     branches:
       - master

--- a/.github/workflows/checkDocSync.yml
+++ b/.github/workflows/checkDocSync.yml
@@ -28,4 +28,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: |
-          ./.github/pre-commit
+          ./.github/hooks/pre-commit

--- a/.github/workflows/checkDocSync.yml
+++ b/.github/workflows/checkDocSync.yml
@@ -1,0 +1,31 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Check Documentation Synchronized
+on:
+  push:
+    branches:
+      - master
+      - next
+  pull_request:
+    branches:
+      - master
+      - next
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          ./.github/pre-commit

--- a/site/reference/fn/doc/README.md
+++ b/site/reference/fn/doc/README.md
@@ -7,7 +7,7 @@ description: >
 ---
 
 <!--mdtogo:Short
-    Display the documentation for a function
+    Display the documentation for a function image
 -->
 
 ### Synopsis

--- a/site/reference/fn/doc/README.md
+++ b/site/reference/fn/doc/README.md
@@ -7,7 +7,7 @@ description: >
 ---
 
 <!--mdtogo:Short
-    Display the documentation for a function image
+    Display the documentation for a function
 -->
 
 ### Synopsis


### PR DESCRIPTION
This wraps the pre-commit hook introduced in #2025 with a GitHub Action. This can help catch documentation desync if the pre-commit hook is not installed on the contributors machine and helps provide visibility to the state of documentation for reviewers.

There is potential future improvement to automatically resolve these issues with documentation desync by automatically committing make generate results but that is a larger task.