### PR TITLE
Fix e2e test errors

### DIFF
--- a/e2e/testdata/fn-eval/error-in-pipe/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/error-in-pipe/.expected/config.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 exitCode: 1
-stdErr: |2
+stdErr: |2-
   [FAIL] "gcr.io/kpt-fn/set-namespace:v0.1"
     Results:
       [ERROR] failed to configure function: input namespace cannot be empty
@@ -23,4 +23,4 @@ stdErr: |2
 
    
   [FAIL] "gcr.io/kpt-fn/dne"
-  error: Function image "gcr.io/kpt-fn/dne" doesn't exist.
+  error: Function image "gcr.io/kpt-fn/dne" doesn't exist

--- a/e2e/testdata/fn-eval/function-env/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/function-env/.expected/config.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 exitCode: 1
-stdErr: "FOO=BAR EXPORT_ENV=export_env_value"
+stdErr: "EXPORT_ENV=export_env_value"


### PR DESCRIPTION
- Error messages are updated when the image doesn't exist.
- env order is not consistent, so we only check one env key-value pair. 
