### PR TITLE
Improve error messages when inventory information is missing or invalid

### DIFF
--- a/internal/cmdapply/cmdapply.go
+++ b/internal/cmdapply/cmdapply.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/GoogleContainerTools/kpt/internal/cmdutil"
+	"github.com/GoogleContainerTools/kpt/internal/util/strings"
 	"github.com/GoogleContainerTools/kpt/pkg/live"
 	"github.com/GoogleContainerTools/kpt/thirdparty/cli-utils/flagutils"
 	"github.com/GoogleContainerTools/kpt/thirdparty/cli-utils/printers"
@@ -56,7 +57,7 @@ func NewRunner(ctx context.Context, provider provider.Provider,
 	c.Flags().StringVar(&r.serverSideOptions.FieldManager, "field-manager", common.DefaultFieldManager,
 		"The client owner of the fields being applied on the server-side.")
 	c.Flags().StringVar(&r.output, "output", printers.DefaultPrinter(),
-		fmt.Sprintf("Output format, must be one of %s", cmdutil.JoinStringsWithQuotes(printers.SupportedPrinters())))
+		fmt.Sprintf("Output format, must be one of %s", strings.JoinStringsWithQuotes(printers.SupportedPrinters())))
 	c.Flags().DurationVar(&r.period, "poll-period", 2*time.Second,
 		"Polling period for resource statuses.")
 	c.Flags().DurationVar(&r.reconcileTimeout, "reconcile-timeout", time.Duration(0),

--- a/internal/cmddestroy/cmddestroy.go
+++ b/internal/cmddestroy/cmddestroy.go
@@ -19,8 +19,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/GoogleContainerTools/kpt/internal/cmdutil"
 	"github.com/GoogleContainerTools/kpt/internal/docs/generated/livedocs"
+	"github.com/GoogleContainerTools/kpt/internal/util/strings"
 	"github.com/GoogleContainerTools/kpt/pkg/live"
 	"github.com/GoogleContainerTools/kpt/thirdparty/cli-utils/flagutils"
 	"github.com/GoogleContainerTools/kpt/thirdparty/cli-utils/printers"
@@ -53,7 +53,7 @@ func NewRunner(ctx context.Context, provider provider.Provider,
 	r.Command = c
 
 	c.Flags().StringVar(&r.output, "output", printers.DefaultPrinter(),
-		fmt.Sprintf("Output format, must be one of %s", cmdutil.JoinStringsWithQuotes(printers.SupportedPrinters())))
+		fmt.Sprintf("Output format, must be one of %s", strings.JoinStringsWithQuotes(printers.SupportedPrinters())))
 	c.Flags().StringVar(&r.inventoryPolicyString, flagutils.InventoryPolicyFlag, flagutils.InventoryPolicyStrict,
 		"It determines the behavior when the resources don't belong to current inventory. Available options "+
 			fmt.Sprintf("%q and %q.", flagutils.InventoryPolicyStrict, flagutils.InventoryPolicyAdopt))

--- a/internal/cmdliveinit/cmdliveinit.go
+++ b/internal/cmdliveinit/cmdliveinit.go
@@ -189,10 +189,6 @@ func updateKptfile(p *pkg.Pkg, inv *kptfilev1alpha2.Inventory, force bool) error
 	if !isEmpty && !force {
 		return errors.E(op, p.UniquePath, &InvExistsError{})
 	}
-	// Check the new inventory values are valid.
-	if err := inv.Validate(); err != nil {
-		return errors.E(op, p.UniquePath, err)
-	}
 	// Finally, set the inventory parameters in the Kptfile and write it.
 	kf.Inventory = inv
 	if err := kptfileutil.WriteFile(p.UniquePath.String(), *kf); err != nil {

--- a/internal/cmdutil/util.go
+++ b/internal/cmdutil/util.go
@@ -16,8 +16,6 @@ package cmdutil
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"github.com/GoogleContainerTools/kpt/pkg/live"
@@ -74,17 +72,4 @@ type NoResourceGroupCRDError struct{}
 
 func (*NoResourceGroupCRDError) Error() string {
 	return "type ResourceGroup not found"
-}
-
-// JoinStringsWithQuotes combines the elements in the string slice into
-// a string, with each element inside quotes.
-func JoinStringsWithQuotes(strs []string) string {
-	b := new(strings.Builder)
-	for i, s := range strs {
-		b.WriteString(fmt.Sprintf("%q", s))
-		if i < (len(s) - 2) {
-			b.WriteString(", ")
-		}
-	}
-	return b.String()
 }

--- a/internal/errors/resolver/live.go
+++ b/internal/errors/resolver/live.go
@@ -18,6 +18,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/cmdliveinit"
 	"github.com/GoogleContainerTools/kpt/internal/cmdutil"
 	"github.com/GoogleContainerTools/kpt/internal/errors"
+	"github.com/GoogleContainerTools/kpt/pkg/live"
 	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 )
@@ -66,6 +67,20 @@ Error: The ResourceGroup CRD was not found in the cluster. Please install it eit
 	//nolint:lll
 	invInfoAlreadyExistsMsg = `
 Error: Inventory information has already been added to the package Kptfile. Changing it after a package has been applied to the cluster can lead to undesired results. Use the --force flag to suppress this error.
+`
+
+	multipleInvInfoMsg = `
+Error: Multiple Kptfile resources with inventory information found. Please make sure at most one Kptfile resource contains inventory information.
+`
+
+	//nolint:lll
+	inventoryInfoValidationMsg = `
+Error: The inventory information is not valid. Please update the information in the Kptfile or provide information with the command line flags. To generate the inventory information the first time, use the 'kpt live init' command.
+
+Details:
+{{- range .err.Violations}}
+{{printf "%s" .Reason }}
+{{- end}}
 `
 
 	TimeoutErrorExitCode = 3
@@ -125,5 +140,18 @@ func (*liveErrorResolver) Resolve(err error) (ResolvedResult, bool) {
 		}, true
 	}
 
+	var multipleInvInfoError *live.MultipleInventoryInfoError
+	if errors.As(err, &multipleInvInfoError) {
+		return ResolvedResult{
+			Message: ExecuteTemplate(multipleInvInfoMsg, tmplArgs),
+		}, true
+	}
+
+	var inventoryInfoValidationError *live.InventoryInfoValidationError
+	if errors.As(err, &inventoryInfoValidationError) {
+		return ResolvedResult{
+			Message: ExecuteTemplate(inventoryInfoValidationMsg, tmplArgs),
+		}, true
+	}
 	return ResolvedResult{}, false
 }

--- a/internal/errors/validate.go
+++ b/internal/errors/validate.go
@@ -1,0 +1,55 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	"fmt"
+
+	"github.com/GoogleContainerTools/kpt/internal/util/strings"
+)
+
+// ValidationError is an error type used when validation fails.
+type ValidationError struct {
+	Violations Violations
+}
+
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("validation failed for fields %s",
+		strings.JoinStringsWithQuotes(e.Violations.Fields()))
+}
+
+type ViolationType string
+
+const (
+	Missing ViolationType = "missing"
+	Invalid ViolationType = "invalid"
+)
+
+type Violations []Violation
+
+func (v Violations) Fields() []string {
+	var fields []string
+	for _, v := range v {
+		fields = append(fields, v.Field)
+	}
+	return fields
+}
+
+type Violation struct {
+	Field  string
+	Value  string
+	Type   ViolationType
+	Reason string
+}

--- a/internal/util/strings/strings.go
+++ b/internal/util/strings/strings.go
@@ -1,0 +1,19 @@
+package strings
+
+import (
+	"fmt"
+	"strings"
+)
+
+// JoinStringsWithQuotes combines the elements in the string slice into
+// a string, with each element inside quotes.
+func JoinStringsWithQuotes(strs []string) string {
+	b := new(strings.Builder)
+	for i, s := range strs {
+		b.WriteString(fmt.Sprintf("%q", s))
+		if i < (len(strs) - 1) {
+			b.WriteString(", ")
+		}
+	}
+	return b.String()
+}

--- a/internal/util/strings/strings_test.go
+++ b/internal/util/strings/strings_test.go
@@ -1,0 +1,42 @@
+package strings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJoinStringsWithQuotes(t *testing.T) {
+	testCases := map[string]struct {
+		slice    []string
+		expected string
+	}{
+		"empty slice": {
+			slice:    []string{},
+			expected: ``,
+		},
+		"single element": {
+			slice:    []string{"a"},
+			expected: `"a"`,
+		},
+		"two elements": {
+			slice:    []string{"a", "b"},
+			expected: `"a", "b"`,
+		},
+		"three elements": {
+			slice:    []string{"a", "b", "c"},
+			expected: `"a", "b", "c"`,
+		},
+		"multiple elements": {
+			slice:    []string{"a", "b", "c", "d", "e"},
+			expected: `"a", "b", "c", "d", "e"`,
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			res := JoinStringsWithQuotes(tc.slice)
+			assert.Equal(t, tc.expected, res)
+		})
+	}
+}

--- a/pkg/api/kptfile/v1alpha2/validation.go
+++ b/pkg/api/kptfile/v1alpha2/validation.go
@@ -166,17 +166,3 @@ func (e *ValidateError) Error() string {
 	sb.WriteString(fmt.Sprintf("Reason: %s\n", e.Reason))
 	return sb.String()
 }
-
-// Validate validates the fields in the inventory.
-func (i *Inventory) Validate() error {
-	if len(i.Name) == 0 {
-		return fmt.Errorf("name is required")
-	}
-	if len(i.Namespace) == 0 {
-		return fmt.Errorf("namespace is required")
-	}
-	if len(i.InventoryID) == 0 {
-		return fmt.Errorf("inventoryID is required")
-	}
-	return nil
-}

--- a/pkg/kptfile/kptfileutil/util.go
+++ b/pkg/kptfile/kptfileutil/util.go
@@ -17,11 +17,9 @@ package kptfileutil
 import (
 	"bytes"
 	goerrors "errors"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/types"
@@ -78,32 +76,6 @@ func WriteFile(dir string, k kptfilev1alpha2.KptFile) error {
 		return errors.E(op, errors.IO, types.UniquePath(dir), err)
 	}
 	return nil
-}
-
-// ValidateInventory returns true and a nil error if the passed inventory
-// is valid; otherwise, false and the reason the inventory is not valid
-// is returned. A valid inventory must have a non-empty namespace, name,
-// and id.
-func ValidateInventory(inv *kptfilev1alpha2.Inventory) (bool, error) {
-	const op errors.Op = "kptfileutil.ValidateInventory"
-	if inv == nil {
-		return false, errors.E(op, errors.MissingParam,
-			fmt.Errorf("kptfile missing inventory section"))
-	}
-	// Validate the name, namespace, and inventory id
-	if strings.TrimSpace(inv.Name) == "" {
-		return false, errors.E(op, errors.MissingParam,
-			fmt.Errorf("kptfile inventory empty name"))
-	}
-	if strings.TrimSpace(inv.Namespace) == "" {
-		return false, errors.E(op, errors.MissingParam,
-			fmt.Errorf("kptfile inventory empty namespace"))
-	}
-	if strings.TrimSpace(inv.InventoryID) == "" {
-		return false, errors.E(op, errors.MissingParam,
-			fmt.Errorf("kptfile inventory missing inventoryID"))
-	}
-	return true, nil
 }
 
 func Equal(kf1, kf2 kptfilev1alpha2.KptFile) (bool, error) {

--- a/pkg/kptfile/kptfileutil/util_test.go
+++ b/pkg/kptfile/kptfileutil/util_test.go
@@ -27,41 +27,6 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
-// TestValidateInventory tests the ValidateInventory function.
-func TestValidateInventory(t *testing.T) {
-	// nil inventory should not validate
-	isValid, err := ValidateInventory(nil)
-	if isValid || err == nil {
-		t.Errorf("nil inventory should not validate")
-	}
-	// Empty inventory should not validate
-	inv := &kptfilev1alpha2.Inventory{}
-	isValid, err = ValidateInventory(inv)
-	if isValid || err == nil {
-		t.Errorf("empty inventory should not validate")
-	}
-	// Empty inventory parameters strings should not validate
-	inv = &kptfilev1alpha2.Inventory{
-		Namespace:   "",
-		Name:        "",
-		InventoryID: "",
-	}
-	isValid, err = ValidateInventory(inv)
-	if isValid || err == nil {
-		t.Errorf("empty inventory parameters strings should not validate")
-	}
-	// Inventory with non-empty namespace, name, and id should validate.
-	inv = &kptfilev1alpha2.Inventory{
-		Namespace:   "test-namespace",
-		Name:        "test-name",
-		InventoryID: "test-id",
-	}
-	isValid, err = ValidateInventory(inv)
-	if !isValid || err != nil {
-		t.Errorf("inventory with non-empty namespace, name, and id should validate")
-	}
-}
-
 // TestReadFile tests the ReadFile function.
 func TestReadFile(t *testing.T) {
 	dir, err := ioutil.TempDir("", fmt.Sprintf("%s-pkgfile-read", "test-kpt"))

--- a/thirdparty/cli-utils/status/cmdstatus.go
+++ b/thirdparty/cli-utils/status/cmdstatus.go
@@ -9,8 +9,8 @@ import (
 	"os"
 	"time"
 
-	"github.com/GoogleContainerTools/kpt/internal/cmdutil"
 	"github.com/GoogleContainerTools/kpt/internal/docs/generated/livedocs"
+	"github.com/GoogleContainerTools/kpt/internal/util/strings"
 	"github.com/GoogleContainerTools/kpt/pkg/live"
 	"github.com/GoogleContainerTools/kpt/thirdparty/cli-utils/status/printers"
 	"github.com/go-errors/errors"
@@ -60,7 +60,7 @@ func NewRunner(ctx context.Context, provider provider.Provider,
 	c.Flags().DurationVar(&r.period, "poll-period", 2*time.Second,
 		"Polling period for resource statuses.")
 	c.Flags().StringVar(&r.pollUntil, "poll-until", "known",
-		fmt.Sprintf("When to stop polling. Must be one of %s", cmdutil.JoinStringsWithQuotes(PollUntilOptions)))
+		fmt.Sprintf("When to stop polling. Must be one of %s", strings.JoinStringsWithQuotes(PollUntilOptions)))
 	c.Flags().StringVar(&r.output, "output", "events", "Output format.")
 	c.Flags().DurationVar(&r.timeout, "timeout", 0,
 		"How long to wait before exiting")
@@ -91,7 +91,7 @@ type Runner struct {
 func (r *Runner) preRunE(*cobra.Command, []string) error {
 	if !slice.ContainsString(PollUntilOptions, r.pollUntil, nil) {
 		return fmt.Errorf("pollUntil must be one of %s",
-			cmdutil.JoinStringsWithQuotes(PollUntilOptions))
+			strings.JoinStringsWithQuotes(PollUntilOptions))
 	}
 	return nil
 }

--- a/thirdparty/cli-utils/status/cmdstatus_test.go
+++ b/thirdparty/cli-utils/status/cmdstatus_test.go
@@ -60,7 +60,7 @@ func TestStatusCommand(t *testing.T) {
 	}{
 		"no inventory template": {
 			kptfileInv:     nil,
-			expectedErrMsg: "missing parameter value: kptfile inventory empty name",
+			expectedErrMsg: "inventory failed validation",
 		},
 		"invalid value for pollUntil": {
 			pollUntil:      "doesNotExist",


### PR DESCRIPTION
This PR improves the error messages displayed to users concerning the inventory information:
 * If there are multiple `Kptfile` resources with inventory information, we report that as an error to the user. This only applies to when we are reading resources from stdin where we have no way to decide which Kptfile resource we should use. When reading from disk, we only look for this information in the Kptfile in the root package.
 * If any of `name`, `namespace`, or `inventory-id` are not set when we are trying to apply/destroy, we report an error.

Examples:

Multiple Kptfiles with inventory:
```
Error: Multiple Kptfile resources with inventory information found. Please make sure at most one Kptfile resource contains inventory information.
```

Inventory name is missing:
```
Error: The inventory information is not valid. Please update the information in the Kptfile or provide information with the command line flags. To generate the inventory information the first time, use the 'kpt live init' command.

Details:
"inventory.name" must not be empty
```

Must be merged after https://github.com/GoogleContainerTools/kpt/pull/2116