### PR TITLE
Rename references branch `next` to `main`.

### DIFF
--- a/.github/workflows/checkLicenses.yml
+++ b/.github/workflows/checkLicenses.yml
@@ -17,11 +17,11 @@ on:
   push:
     branches:
       - master
-      - next
+      - main
   pull_request:
     branches:
       - master
-      - next
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2eEnvironment.yml
+++ b/.github/workflows/e2eEnvironment.yml
@@ -16,17 +16,17 @@ name: "Kpt Live - KinD Tests"
 on:
   pull_request:
     branches:
-      - next
+      - main
     paths-ignore:
-      - 'docs/**'
-      - 'site/**'
+      - "docs/**"
+      - "site/**"
 
 jobs:
   kind:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [ 1.18, 1.19 ]
+        version: [1.18, 1.19]
     steps:
       - name: Set up Go
         uses: actions/setup-go@v2

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -2,10 +2,10 @@
 # https://github.com/firebase/firebase-tools
 
 name: Deploy to Firebase Hosting on merge
-'on':
+"on":
   push:
     branches:
-      - next
+      - main
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
@@ -15,8 +15,8 @@ jobs:
         run: make site-generate
       - uses: FirebaseExtended/action-hosting-deploy@276388dd6c2cde23455b30293105cc866c22282d # v0
         with:
-          repoToken: '${{ secrets.GITHUB_TOKEN }}'
-          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_KPT_DEV }}'
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_KPT_DEV }}"
           channelId: live
           projectId: kpt-dev
         env:

--- a/internal/docs/generated/fndocs/docs.go
+++ b/internal/docs/generated/fndocs/docs.go
@@ -187,9 +187,11 @@ var ExportLong = `
     output is stdout
 `
 var ExportExamples = `
+
   # read functions from DIR, run them against it as one step.
   # write the generated GitHub Actions pipeline to main.yaml.
   kpt fn export DIR/ --output main.yaml --workflow github-actions
+
 
   # discover functions in FUNCTIONS_DIR and run them against resource in DIR.
   # write the generated Cloud Build pipeline to stdout.

--- a/package-examples/helloworld-set/README.md
+++ b/package-examples/helloworld-set/README.md
@@ -16,7 +16,7 @@ setters in it.
 Get the example package on to local using `kpt pkg get`
 
 ```shell
-$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/helloworld-set@next
+$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/helloworld-set
 
 fetching package /package-examples/helloworld-set from https://github.com/GoogleContainerTools/kpt to helloworld-set
 ```
@@ -36,10 +36,10 @@ Package "helloworld-set"
 
 ### Configure functions
 
-The package contains a function pipeline in the `Kptfile` which has
-one `apply-setters` function.  The `apply-setters` function allows you to
-set a simple value throughout the package configuration.  In this case
-you can set the replicas, image, tag and http-port of a simple application.
+The package contains a function pipeline in the `Kptfile` which has one
+`apply-setters` function. The `apply-setters` function allows you to set a
+simple value throughout the package configuration. In this case you can set the
+replicas, image, tag and http-port of a simple application.
 
 ```yaml
 pipeline:

--- a/package-examples/helloworld-tshirt/README.md
+++ b/package-examples/helloworld-tshirt/README.md
@@ -1,9 +1,9 @@
 # helloworld-tshirt
 
-This is a package that has both a setter and a simple hydration function.  The
+This is a package that has both a setter and a simple hydration function. The
 hydration function examines the configuration and looks for the t-shirt size
-value.  Depending on the size (small, medium, large) it then sets the 
-resource sizes.
+value. Depending on the size (small, medium, large) it then sets the resource
+sizes.
 
 ## Steps
 
@@ -18,7 +18,7 @@ resource sizes.
 Get the example package on to local using `kpt pkg get`
 
 ```shell
-$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/helloworld-tshirt@next
+$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/helloworld-tshirt
 
 fetching package /package-examples/helloworld-tshirt from https://github.com/GoogleContainerTools/kpt to helloworld-tshirt
 ```
@@ -38,11 +38,10 @@ Package "helloworld-tshirt"
 
 ### Configure functions
 
-The package contains a function pipeline in the `Kptfile` which has
-one `apply-setters` and 'example-tshirt' functions.  The `apply-setters` 
-function allows you to set a simple value throughout the package 
-configuration.  In this case the value sets the t-shirt size.  You can 
-set it to medium.
+The package contains a function pipeline in the `Kptfile` which has one
+`apply-setters` and 'example-tshirt' functions. The `apply-setters` function
+allows you to set a simple value throughout the package configuration. In this
+case the value sets the t-shirt size. You can set it to medium.
 
 ```yaml
 pipeline:

--- a/package-examples/helloworld/README.md
+++ b/package-examples/helloworld/README.md
@@ -1,7 +1,7 @@
 # helloworld
 
-Sample helloworld package. Showcases what a bare bones package is which
-doesn't do anything beyond declaring the current directory as a `kpt` package.
+Sample helloworld package. Showcases what a bare bones package is which doesn't
+do anything beyond declaring the current directory as a `kpt` package.
 
 ## Steps
 
@@ -14,7 +14,7 @@ doesn't do anything beyond declaring the current directory as a `kpt` package.
 Get the example package on to local using `kpt pkg get`
 
 ```shell
-$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/helloworld@next
+$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/helloworld
 
 fetching package /package-examples/helloworld from https://github.com/GoogleContainerTools/kpt to helloworld
 ```

--- a/package-examples/kustomize-pkg/README.md
+++ b/package-examples/kustomize-pkg/README.md
@@ -1,6 +1,8 @@
 # kustomize-pkg
 
-This is a simple package that shows how kpt packages can be used instead of remote bases in kustomize.  That allows you to take advantage of kpt's rebase and local, in-place edits.
+This is a simple package that shows how kpt packages can be used instead of
+remote bases in kustomize. That allows you to take advantage of kpt's rebase and
+local, in-place edits.
 
 ## Steps
 
@@ -13,14 +15,15 @@ This is a simple package that shows how kpt packages can be used instead of remo
 
 ### Fetch the package
 
-Get the example package on to local using `kpt pkg get`. Note that this package is for this example, wihin that package we are also using the nginx sub-package which is an alternative to having a remote base. 
+Get the example package on to local using `kpt pkg get`. Note that this package
+is for this example, wihin that package we are also using the nginx sub-package
+which is an alternative to having a remote base.
 
 ```shell
-$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/kustomize-pkg@next
+$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/kustomize-pkg
 
 fetching package /package-examples/kustomize-pkg from https://github.com/GoogleContainerTools/kpt to kustomize-pkg
 ```
-
 
 ### View the package contents
 
@@ -51,30 +54,38 @@ kustomize-pkg
 
 ### kustomize the config
 
-Kustomize is a great tool for out of place hydration, but we don't recommend that you mix kpt packages and remote bases.  It's best to have a clear delienation what you are using each tools for: kpt for packages and remote resources, kustomize for hydration like adding labels, setting namespaces and overlays.
+Kustomize is a great tool for out of place hydration, but we don't recommend
+that you mix kpt packages and remote bases. It's best to have a clear
+delienation what you are using each tools for: kpt for packages and remote
+resources, kustomize for hydration like adding labels, setting namespaces and
+overlays.
 
-In the example below what was a remote base is now fetched locally as a kpt package and kustomize is used for hydration.
+In the example below what was a remote base is now fetched locally as a kpt
+package and kustomize is used for hydration.
 
 ```yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../bases/nginx
-- Kptfile
+  - ../../bases/nginx
+  - Kptfile
 patches:
-- path: pass-patch.yaml
-  target:
-    kind: Deployment
+  - path: pass-patch.yaml
+    target:
+      kind: Deployment
 commonLabels:
-    environ: dev
+  environ: dev
 namePrefix: dev-
 ```
 
 ### Render the kustomization
 
-You can see the final configuration that the patch is going to render. The major difference between this and in place edit is that you can't just go to the file and look at it in isolation, you need to run `kustomize build` and examine the final results.
+You can see the final configuration that the patch is going to render. The major
+difference between this and in place edit is that you can't just go to the file
+and look at it in isolation, you need to run `kustomize build` and examine the
+final results.
 
-```shell
+````shell
 $ kustomize build kustomize-pkg/overlays/dev
 
 apiVersion: v1
@@ -134,14 +145,16 @@ It is possible to use kustomize build and kpt live apply, but it does require pa
 $ kpt live init kustomize-pkg/overlays/dev
 
 initializing Kptfile inventory info (namespace: default)...success
-```
+````
 
-You might have noticed that the overlays have Kptfiles and they are added to the kustomization.yaml so the contents are passed all the way through the kustomize build.
+You might have noticed that the overlays have Kptfiles and they are added to the
+kustomization.yaml so the contents are passed all the way through the kustomize
+build.
 
 Kustomize build will need to be piped to kpt live apply:
 
 ```shell
-$ kustomize build kustomize-pkg/overlays/dev | kpt live apply - 
+$ kustomize build kustomize-pkg/overlays/dev | kpt live apply -
 
 service/dev-my-nginx-svc created
 deployment.apps/dev-my-nginx created
@@ -151,10 +164,12 @@ deployment.apps/dev-my-nginx created
 
 ### Clean up resources
 
-You can use kpt to prune and clean up resources from your build by using `kpt live destroy`.  As long as the inventory information is passed in kpt will know how to clean everything up:
+You can use kpt to prune and clean up resources from your build by using
+`kpt live destroy`. As long as the inventory information is passed in kpt will
+know how to clean everything up:
 
 ```shell
-$ kustomize build kustomize-pkg/overlays/dev | kpt live destroy - 
+$ kustomize build kustomize-pkg/overlays/dev | kpt live destroy -
 
 deployment.apps/dev-my-nginx deleted
 service/dev-my-nginx-svc deleted

--- a/package-examples/pipeline-validate/README.md
+++ b/package-examples/pipeline-validate/README.md
@@ -1,10 +1,11 @@
 # pipeline-validate
 
-This example package demonstrates how you can modify the config and ensure 
-that modifications are compliant with the policies. This package uses:
+This example package demonstrates how you can modify the config and ensure that
+modifications are compliant with the policies. This package uses:
 
 1. a `mutator` function called `set-labels` to customize (or modify) the config
-2. a `validator` function `gatekeeper` to ensure changes are inline with the policy 
+2. a `validator` function `gatekeeper` to ensure changes are inline with the
+   policy
 
 Putting a validation function into your package allows you to give package
 consumers instant feedback on whether their customization violates config
@@ -12,8 +13,8 @@ policy.
 
 ## Steps
 
-This is a simple workflow where you can download, configure, render,
-validate and apply the package:
+This is a simple workflow where you can download, configure, render, validate
+and apply the package:
 
 1. [Fetch the package](#fetch-the-package)
 2. [View the package contents](#view-the-package-contents)
@@ -26,7 +27,7 @@ validate and apply the package:
 Get the example package on to local using `kpt pkg get`
 
 ```shell
-$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/pipeline-validate@next
+$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/pipeline-validate
 
 fetching package /package-examples/pipeline-validate from https://github.com/GoogleContainerTools/kpt to pipeline-validate
 ```
@@ -50,11 +51,11 @@ Package "pipeline-validate"
 
 ### Configure functions
 
-The package contains a function pipeline in the `Kptfile` which has
-one `set-labels` and `enforce-gatekeeper` functions.
-The `set-labels` function allows you to set one or more labels to every
-resource that supports labeles.  The `enforce-gatekeeper` function allows
-you to use gatekeeper for checks on the configuration.
+The package contains a function pipeline in the `Kptfile` which has one
+`set-labels` and `enforce-gatekeeper` functions. The `set-labels` function
+allows you to set one or more labels to every resource that supports labeles.
+The `enforce-gatekeeper` function allows you to use gatekeeper for checks on the
+configuration.
 
 ```yaml
 pipeline:
@@ -78,8 +79,8 @@ package "pipeline-validate": running function "gcr.io/kpt-fn/enforce-gatekeeper:
 package "pipeline-validate": rendered successfully
 ```
 
-If you remove the owner label from `resources.yaml` and re-run the rendering
-you should see an error:
+If you remove the owner label from `resources.yaml` and re-run the rendering you
+should see an error:
 
 ```shell
 $ kpt fn render pipeline-validate/

--- a/package-examples/wordpress/README.md
+++ b/package-examples/wordpress/README.md
@@ -1,8 +1,9 @@
 # wordpress
 
-Here is an example to get, view, customize and apply contents of an example kpt package with a subpackage
-in its directory tree. As part of customization, we will be setting common namespace for both the packages
-and apply setters for individual packages.
+Here is an example to get, view, customize and apply contents of an example kpt
+package with a subpackage in its directory tree. As part of customization, we
+will be setting common namespace for both the packages and apply setters for
+individual packages.
 
 ## Steps
 
@@ -18,7 +19,7 @@ and apply setters for individual packages.
 Get the example package on to local using `kpt pkg get`
 
 ```sh
-$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/wordpress@next
+$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/wordpress@main
 
 fetching package /package-examples/wordpress from https://github.com/GoogleContainerTools/kpt to wordpress
 ```
@@ -45,8 +46,9 @@ Package "wordpress"
 
 ### Configure namespace
 
-By default, these packages will be deployed into `default` namespace. Provide a namespace by
-adding [set-namespace] function to the pipeline definition in `wordpress/Kptfile`.
+By default, these packages will be deployed into `default` namespace. Provide a
+namespace by adding [set-namespace] function to the pipeline definition in
+`wordpress/Kptfile`.
 
 ```yaml
 - image: gcr.io/kpt-fn/set-namespace:v0.1
@@ -56,9 +58,10 @@ adding [set-namespace] function to the pipeline definition in `wordpress/Kptfile
 
 ### Configure setter values
 
-Setters are listed under `apply-setters` function in the pipeline definition of each package.
-You may declare new desired values for the setters by editing the `Kptfile` directly. Declare
-new value `wp-tag: 4.9-aapache` in `wordpress/Kptfile` and `ms-tag: 5.7` in `wordpress/mysql/Kptfile`
+Setters are listed under `apply-setters` function in the pipeline definition of
+each package. You may declare new desired values for the setters by editing the
+`Kptfile` directly. Declare new value `wp-tag: 4.9-aapache` in
+`wordpress/Kptfile` and `ms-tag: 5.7` in `wordpress/mysql/Kptfile`
 
 ### Render the declared values
 
@@ -94,4 +97,5 @@ persistentvolumeclaim/wp-pv-claim created
 deployment.apps/wordpress created
 ```
 
-[set-namespace]: https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/functions/go/set-namespace
+[set-namespace]:
+  https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/master/functions/go/set-namespace

--- a/package-examples/wordpress/README.md
+++ b/package-examples/wordpress/README.md
@@ -19,7 +19,7 @@ individual packages.
 Get the example package on to local using `kpt pkg get`
 
 ```sh
-$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/wordpress@main
+$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/wordpress
 
 fetching package /package-examples/wordpress from https://github.com/GoogleContainerTools/kpt to wordpress
 ```

--- a/release/README.md
+++ b/release/README.md
@@ -6,11 +6,15 @@ To cut a new kpt release perform the following:
 
 - Ensure kpt is importing the latest dependent releases
   - [cli-utils](https://github.com/kubernetes-sigs/cli-utils/tree/master/release)
-  - Within kustomize: [kyaml](https://github.com/kubernetes-sigs/kustomize/blob/master/releasing)
-  - Within kustomize: [cmd/config](https://github.com/kubernetes-sigs/kustomize/blob/master/releasing)
-  - Update `go.mod` file with correct versions of `cli-utils`, `kyaml`, and `cmd/config`
+  - Within kustomize:
+    [kyaml](https://github.com/kubernetes-sigs/kustomize/blob/master/releasing)
+  - Within kustomize:
+    [cmd/config](https://github.com/kubernetes-sigs/kustomize/blob/master/releasing)
+  - Update `go.mod` file with correct versions of `cli-utils`, `kyaml`, and
+    `cmd/config`
   - Run `make all` (which should update `go.sum` and run `go mod tidy`)
-  - Create a `kpt` PR with previous `go.mod` and `go.sum` changes, and submit. [Example PR](https://github.com/GoogleContainerTools/kpt/pull/594)
+  - Create a `kpt` PR with previous `go.mod` and `go.sum` changes, and submit.
+    [Example PR](https://github.com/GoogleContainerTools/kpt/pull/594)
 - Fetch the latest master changes to a clean branch
   - `git checkout -b release`
   - `git fetch upstream`
@@ -18,9 +22,11 @@ To cut a new kpt release perform the following:
 - Tag the commit
   - `git tag 1.0.0-(alpha|beta|rc).*`
   - `git push upstream 1.0.0-(alpha|beta|rc).*`
-- This will trigger a Github Action that will use goreleaser to make the release. The
-  result will be a github release in the draft state and upload docker images to GCR.
-  - Verify that the release looks good. If it does, publish the release through the github UI.
+- This will trigger a Github Action that will use goreleaser to make the
+  release. The result will be a github release in the draft state and upload
+  docker images to GCR.
+  - Verify that the release looks good. If it does, publish the release through
+    the github UI.
 - Update the Homebrew release
   - `go run ./release/formula/main.go v0.MINOR.0`
   - `git add . && git commit -m "update homebrew to v0.MINOR.0"`
@@ -29,7 +35,8 @@ To cut a new kpt release perform the following:
 
 ## Artifacts
 
-Release artifacts such as binaries and images will be built automatically by the Github Action.
-The binaries linked from the README.md docs will be automatically updated
-because they point to the `latest` binaries which are updated for tagged releases. Images
-created from the `next` branch will not be tagged with `latest`.
+Release artifacts such as binaries and images will be built automatically by the
+Github Action. The binaries linked from the README.md docs will be automatically
+updated because they point to the `latest` binaries which are updated for tagged
+releases. Images created from the `main` branch will not be tagged with
+`latest`.

--- a/site/README.md
+++ b/site/README.md
@@ -14,4 +14,5 @@ If your question is not a [FAQ](/faq/), please [reach out](/contact/)!
 
 kpt is an OSS project and anyone can [contribute]!
 
-[contribute]: https://github.com/GoogleContainerTools/kpt/blob/next/CONTRIBUTING.md
+[contribute]:
+  https://github.com/GoogleContainerTools/kpt/blob/main/CONTRIBUTING.md

--- a/site/faq/README.md
+++ b/site/faq/README.md
@@ -83,5 +83,5 @@ don't have to alias it. It is pronounced "kept".
 [contact]: /contact/
 [functions catalog]: https://catalog.kpt.dev/
 [roadmap document]:
-  https://github.com/GoogleContainerTools/kpt/blob/next/docs/ROADMAP.md
+  https://github.com/GoogleContainerTools/kpt/blob/main/docs/ROADMAP.md
 [kpt milestones]: https://github.com/GoogleContainerTools/kpt/milestones

--- a/site/installation/README.md
+++ b/site/installation/README.md
@@ -2,16 +2,15 @@
 
 Users can get kpt in a variety of ways:
 
-?> If you are migrating from kpt `v0.39`, please follow the [migration guide] to kpt `v1.0+` binary.
+?> If you are migrating from kpt `v0.39`, please follow the [migration guide] to
+kpt `v1.0+` binary.
 
 ## Binaries
 
 Download pre-compiled binaries.
 
-| Platform
-| ------------------------
-| [Linux (x64)][linux]
-| [macOS (x64)][darwin]
+| Platform | ------------------------ | [Linux (x64)][linux] | [macOS
+(x64)][darwin]
 
 ```shell
 # For linux/mac
@@ -19,13 +18,13 @@ $ chmod +x kpt
 ```
 
 **Note:** to run on **MacOS** the first time, it may be necessary to open the
-program from the finder with *ctrl-click open*.
+program from the finder with _ctrl-click open_.
 
 ```shell
 $ kpt version
 ```
 
-<!-- gcloud and homebrew are not yet available for builds from the next branch. 
+<!-- gcloud and homebrew are not yet available for builds from the main branch.
 ## gcloud
 
 Install with gcloud.
@@ -53,16 +52,17 @@ $ brew install kpt
 $ kpt version
 ```
 -->
+
 ## Docker
 
 Use one of the kpt docker images.
 
 | Feature   | `kpt` | `kpt-gcloud` |
-| --------- |:-----:|:------------:|
-| kpt       | X     | X            |
-| git       | X     | X            |
-| diffutils | X     | X            |
-| gcloud    |       | X            |
+| --------- | :---: | :----------: |
+| kpt       |   X   |      X       |
+| git       |   X   |      X       |
+| diffutils |   X   |      X       |
+| gcloud    |       |      X       |
 
 ### `kpt`
 
@@ -83,19 +83,23 @@ $ docker run gcr.io/kpt-dev/kpt-gcloud:next version
 Install by compiling the source.
 
 ```shell
-$ GO111MODULE=on go get -v github.com/GoogleContainerTools/kpt@next
+$ GO111MODULE=on go get -v github.com/GoogleContainerTools/kpt@main
 ```
 
-**Note:** `kpt version` will return *unknown* for binaries installed
-with `go get`.
+**Note:** `kpt version` will return _unknown_ for binaries installed with
+`go get`.
 
 ```shell
 kpt help
 ```
 
-[gcr.io/kpt-dev/kpt]: https://console.cloud.google.com/gcr/images/kpt-dev/GLOBAL/kpt?gcrImageListsize=30
-[gcr.io/kpt-dev/kpt-gcloud]: https://console.cloud.google.com/gcr/images/kpt-dev/GLOBAL/kpt-gcloud?gcrImageListsize=30
+[gcr.io/kpt-dev/kpt]:
+  https://console.cloud.google.com/gcr/images/kpt-dev/GLOBAL/kpt?gcrImageListsize=30
+[gcr.io/kpt-dev/kpt-gcloud]:
+  https://console.cloud.google.com/gcr/images/kpt-dev/GLOBAL/kpt-gcloud?gcrImageListsize=30
 [cloud-sdk]: https://github.com/GoogleCloudPlatform/cloud-sdk-docker
-[linux]: https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-alpha.7/kpt_linux_amd64
-[darwin]: https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-alpha.7/kpt_darwin_amd64
+[linux]:
+  https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-alpha.7/kpt_linux_amd64
+[darwin]:
+  https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-alpha.7/kpt_darwin_amd64
 [migration guide]: /installation/migration

--- a/site/installation/README.md
+++ b/site/installation/README.md
@@ -83,7 +83,7 @@ $ docker run gcr.io/kpt-dev/kpt-gcloud:next version
 Install by compiling the source.
 
 ```shell
-$ GO111MODULE=on go get -v github.com/GoogleContainerTools/kpt@main
+$ GO111MODULE=on go get -v github.com/GoogleContainerTools/kpt
 ```
 
 **Note:** `kpt version` will return _unknown_ for binaries installed with

--- a/site/installation/migration.md
+++ b/site/installation/migration.md
@@ -275,7 +275,7 @@ doesn't guarantee functional parity.
 [v0.39 commands]: https://googlecontainertools.github.io/kpt/reference/
 [v1.0 commands]: https://kpt.dev/reference/cli/
 [v1alpha2 kptfile]:
-  https://github.com/GoogleContainerTools/kpt/blob/next/pkg/api/kptfile/v1alpha2/types.go
+  https://github.com/GoogleContainerTools/kpt/blob/main/pkg/api/kptfile/v1alpha2/types.go
 [starlark functions]: https://catalog.kpt.dev/starlark/v0.1/
 [starlark function]: https://catalog.kpt.dev/starlark/v0.1/
 [apply-setters]: https://catalog.kpt.dev/apply-setters/v0.1/

--- a/site/reference/cli/fn/export/README.md
+++ b/site/reference/cli/fn/export/README.md
@@ -29,7 +29,7 @@ cd $TEST_HOME
 
 ```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
-kpt pkg get $SRC_REPO/package-examples/helloworld-set@main DIR/
+kpt pkg get $SRC_REPO/package-examples/helloworld-set DIR/
 ```
 
 {{% /hide %}}

--- a/site/reference/cli/fn/export/README.md
+++ b/site/reference/cli/fn/export/README.md
@@ -3,7 +3,7 @@ title: "Export"
 linkTitle: "export"
 type: docs
 description: >
-   Auto-generating function pipelines for different workflow orchestrators
+  Auto-generating function pipelines for different workflow orchestrators
 ---
 
 <!--mdtogo:Short
@@ -18,6 +18,7 @@ configurations.
 {{% hide %}}
 
 <!-- @makeWorkplace @verifyExamples-->
+
 ```
 # Set up workspace for the test.
 TEST_HOME=$(mktemp -d)
@@ -25,9 +26,10 @@ cd $TEST_HOME
 ```
 
 <!-- @fetchPackage @verifyExamples-->
+
 ```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
-kpt pkg get $SRC_REPO/package-examples/helloworld-set@next DIR/
+kpt pkg get $SRC_REPO/package-examples/helloworld-set@main DIR/
 ```
 
 {{% /hide %}}
@@ -35,6 +37,7 @@ kpt pkg get $SRC_REPO/package-examples/helloworld-set@next DIR/
 <!--mdtogo:Examples-->
 
 <!-- @fnExport @verifyExamples-->
+
 ```shell
 # read functions from DIR, run them against it as one step.
 # write the generated GitHub Actions pipeline to main.yaml.
@@ -42,6 +45,7 @@ kpt fn export DIR/ --output main.yaml --workflow github-actions
 ```
 
 <!-- @fnExport @verifyExamples-->
+
 ```shell
 # discover functions in FUNCTIONS_DIR and run them against resource in DIR.
 # write the generated Cloud Build pipeline to stdout.
@@ -78,7 +82,7 @@ OUTPUT_FILENAME:
 
 ## Next Steps
 
-- Get detailed tutorials on how to use `kpt fn export` from the
-  [Export a Workflow] guide.
+- Get detailed tutorials on how to use `kpt fn export` from the [Export a
+  Workflow] guide.
 
-[Export a Workflow]: https://kpt.dev#todo
+[export a workflow]: https://kpt.dev#todo

--- a/site/reference/cli/pkg/diff/README.md
+++ b/site/reference/cli/pkg/diff/README.md
@@ -115,7 +115,7 @@ cd $TEST_HOME
 
 ```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
-kpt pkg get $SRC_REPO/package-examples/helloworld-set@next hello-world
+kpt pkg get $SRC_REPO/package-examples/helloworld-set@main hello-world
 cd hello-world
 ```
 

--- a/site/reference/cli/pkg/diff/README.md
+++ b/site/reference/cli/pkg/diff/README.md
@@ -115,7 +115,7 @@ cd $TEST_HOME
 
 ```shell
 export SRC_REPO=https://github.com/GoogleContainerTools/kpt.git
-kpt pkg get $SRC_REPO/package-examples/helloworld-set@main hello-world
+kpt pkg get $SRC_REPO/package-examples/helloworld-set hello-world
 cd hello-world
 ```
 

--- a/site/static/js/plugins.js
+++ b/site/static/js/plugins.js
@@ -25,7 +25,7 @@ function addGitHubWidget(hook) {
     let path = document.location.pathname;
     const pageName = path.match(bookPath) ? "00.md" : "README.md";
     path += path.endsWith("/") ? pageName : ".md";
-    editPage.href = `https://github.com/GoogleContainerTools/kpt/edit/next/site${path}`;
+    editPage.href = `https://github.com/GoogleContainerTools/kpt/edit/main/site${path}`;
 
     const container = document.createElement("div");
     container.classList.add("github-widget");


### PR DESCRIPTION
This does not affect binary release artifacts (e.g. docker tags).

Part of https://github.com/GoogleContainerTools/kpt/issues/2051