### PR TITLE
Add Ignore property to Kptfile

### DIFF
--- a/pkg/api/kptfile/v1alpha2/types.go
+++ b/pkg/api/kptfile/v1alpha2/types.go
@@ -55,10 +55,11 @@ type KptFile struct {
 	// Inventory contains parameters for the inventory object used in apply.
 	Inventory *Inventory `yaml:"inventory,omitempty"`
 
-	// Ignore contains .gitignore-style patterns for files and directories that should
-	// be ignored by kpt. Files/directories that match will be fetched and
-	// updated as part of the package, but will be ignored by the other
-	// kpt functionality.
+	// Ignore contains a list of .gitignore patterns for files and directories
+	// that should be ignored by kpt. Files/directories that match will be
+	// fetched and updated as part of the package, but will be ignored by the other
+	// kpt functionality. The patterns will only impact resources within the
+	// same package, and it is not possible to ignore subpackages.
 	//
 	// The following patterns are supported:
 	// * Absolute path (/path/to/ignore): If the pattern has a leading slash, it will

--- a/pkg/api/kptfile/v1alpha2/types.go
+++ b/pkg/api/kptfile/v1alpha2/types.go
@@ -54,6 +54,12 @@ type KptFile struct {
 
 	// Inventory contains parameters for the inventory object used in apply.
 	Inventory *Inventory `yaml:"inventory,omitempty"`
+
+	// Ignore contains .gitignore-style patterns for files and directories that should
+	// be ignored by kpt. Files/directories that match will be fetched and
+	// updated as part of the package, but will be ignored by the other
+	// kpt functionality.
+	Ignore []string `yaml:"ignore,omitempty"`
 }
 
 // OriginType defines the type of origin for a package.

--- a/pkg/api/kptfile/v1alpha2/types.go
+++ b/pkg/api/kptfile/v1alpha2/types.go
@@ -59,6 +59,23 @@ type KptFile struct {
 	// be ignored by kpt. Files/directories that match will be fetched and
 	// updated as part of the package, but will be ignored by the other
 	// kpt functionality.
+	//
+	// The following patterns are supported:
+	// * Absolute path (/path/to/ignore): If the pattern has a leading slash, it will
+	//   only match the specific path underneath the package root.
+	//   Example: "/ignore.me" will only match the file if it is in the root of
+	//   the package.
+	// * Relative path (path/to/ignore): If the pattern does not have a leading slash,
+	//   it will match at any depth in the package.
+	//   Example: "ignore.me" will match all files called "ignore.me" within the
+	//   package.
+	// * Accept pattern (!path/to/accept): Negate a previous pattern so the path
+	//   will be included.
+	// * Directory pattern (path/to/directory/): If the pattern has a slash at the
+	//   end, it will only match directories.
+	// * Glob pattern (path/to/*.txt): * matches all characters except slash.
+	//
+	// Recursive patterns (path/**/ignore) are not supported.
 	Ignore []string `yaml:"ignore,omitempty"`
 }
 


### PR DESCRIPTION
This adds the `Ignore` property to the Kptfile. The code that leverages this will be added in follow-up PRs.
