### PR TITLE
Fix spelling

### DIFF
--- a/site/book/05-developing-functions/00.md
+++ b/site/book/05-developing-functions/00.md
@@ -34,7 +34,7 @@ an anti-pattern if it grows in complexity. We recommend limiting their use to:
 - Small amount of logic (< 20 lines)
 - You do not forsee this logic growing in complexity in the future
 
-Otherwise, you are better of developing functions in a general-purpose language
+Otherwise, you are better off developing functions in a general-purpose language
 where you can take advantage of proper abstractions and language features,
 better testing, rich IDE experience, and existing libraries.
 

--- a/site/book/05-developing-functions/00.md
+++ b/site/book/05-developing-functions/00.md
@@ -25,7 +25,7 @@ and Typescript. We will cover these later in this chapter.
 
 Instead of developing a custom image, you can use an existing function image
 containing a language interpreter, and provide your business logic in a KRM
-resource. This is referred to _executable configuration_. We will see two
+resource. This is referred to as _executable configuration_. We will see two
 examples of executable configuration pattern in this chapter.
 
 Although using executable configuration saves some time initially, it can become


### PR DESCRIPTION
Fixes a spelling error in the function creation docs. `of` -> `off`