### PR TITLE
check for docker before running `fn eval`

### DIFF
--- a/internal/util/cmdutil/cmdutil.go
+++ b/internal/util/cmdutil/cmdutil.go
@@ -22,7 +22,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/fnruntime"
 	"github.com/spf13/cobra"
 )
@@ -80,10 +79,8 @@ func ResolveAbsAndRelPaths(path string) (string, string, error) {
 // DockerCmdAvailable runs `docker ps` to check that the docker command is
 // available, and returns an error with installation instructions if it is not
 func DockerCmdAvailable() error {
-	const op errors.Op = "docker.check"
-
-	suggestedText := `Docker is required to run this command.
-To install docker, follow the instructions at https://docs.docker.com/get-docker/
+	suggestedText := `docker must be running to use this command
+To install docker, follow the instructions at https://docs.docker.com/get-docker/.
 `
 	buffer := &bytes.Buffer{}
 
@@ -91,7 +88,7 @@ To install docker, follow the instructions at https://docs.docker.com/get-docker
 	cmd.Stderr = buffer
 	err := cmd.Run()
 	if err != nil {
-		return errors.E(op, fmt.Errorf("%s", suggestedText))
+		return fmt.Errorf("%s", suggestedText)
 	}
 	return nil
 }

--- a/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
+++ b/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
@@ -227,6 +227,12 @@ func (r *EvalFnRunner) preRunE(c *cobra.Command, args []string) error {
 	if r.Image == "" && r.ExecPath == "" {
 		return errors.Errorf("must specify --image or --exec-path")
 	}
+	if r.Image != "" {
+		err := cmdutil.DockerCmdAvailable()
+		if err != nil {
+			return err
+		}
+	}
 	if err := cmdutil.ValidateImagePullPolicyValue(r.ImagePullPolicy); err != nil {
 		return err
 	}


### PR DESCRIPTION
fixes https://github.com/GoogleContainerTools/kpt/issues/2084

Adds a check for docker before running `fn eval`.

For example:
```
$ kpt fn eval simple-function --image gcr.io/kpt-fn/set-namespace:v0.1.3 -- namespace=staging

error: docker must be running to use this command
To install docker, follow the instructions at https://docs.docker.com/get-docker/.
```

```
$ kpt fn render basic-pipeline

Package "basic-pipeline":
error: docker must be running to use this command
To install docker, follow the instructions at https://docs.docker.com/get-docker/.
```