### PR TITLE
renamed e2e testcase to fix mysterious git submodule bug

### DIFF
--- a/e2e/testdata/fn-render/fnconfig-cannot-refer-subpkgs/.expected/config.yaml
+++ b/e2e/testdata/fn-render/fnconfig-cannot-refer-subpkgs/.expected/config.yaml
@@ -1,0 +1,20 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exitCode: 1
+stdErr: |
+  Kptfile is invalid:
+  Field: `pipeline.mutators[0].configPath`
+  Value: "db/labelconfig.yaml"
+  Reason: functionConfig must exist in the current package

--- a/e2e/testdata/fn-render/fnconfig-cannot-refer-subpkgs/.krmignore
+++ b/e2e/testdata/fn-render/fnconfig-cannot-refer-subpkgs/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-render/fnconfig-cannot-refer-subpkgs/Kptfile
+++ b/e2e/testdata/fn-render/fnconfig-cannot-refer-subpkgs/Kptfile
@@ -1,0 +1,8 @@
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: app-with-db
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-label:unstable
+      configPath: db/labelconfig.yaml

--- a/e2e/testdata/fn-render/fnconfig-cannot-refer-subpkgs/db/Kptfile
+++ b/e2e/testdata/fn-render/fnconfig-cannot-refer-subpkgs/db/Kptfile
@@ -1,0 +1,4 @@
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: db

--- a/e2e/testdata/fn-render/fnconfig-cannot-refer-subpkgs/db/labelconfig.yaml
+++ b/e2e/testdata/fn-render/fnconfig-cannot-refer-subpkgs/db/labelconfig.yaml
@@ -1,0 +1,19 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: label-config
+data:
+  tier: db

--- a/e2e/testdata/fn-render/fnconfig-cannot-refer-subpkgs/db/resources.yaml
+++ b/e2e/testdata/fn-render/fnconfig-cannot-refer-subpkgs/db/resources.yaml
@@ -1,0 +1,29 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: db
+  namespace: staging
+  labels:
+    tier: db
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      tier: db
+  template:
+    metadata:
+      labels:
+        tier: db

--- a/e2e/testdata/fn-render/fnconfig-cannot-refer-subpkgs/resources.yaml
+++ b/e2e/testdata/fn-render/fnconfig-cannot-refer-subpkgs/resources.yaml
@@ -1,0 +1,39 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: staging
+  labels:
+    tier: db
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      tier: db
+  template:
+    metadata:
+      labels:
+        tier: db
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+  namespace: staging
+  labels:
+    tier: db
+spec:
+  image: nginx:1.2.3


### PR DESCRIPTION
It's been observed the old version of kpt fails to fetch examples pkg from next branch reporting an unhelpful message (due to some mystery incomplete git submodule error). This [PR](https://github.com/GoogleContainerTools/kpt/pull/2059/files#diff-403ab80c48fff31f0b1d7b3068b9d73e10422191413142b99c9750523f91abad) is a suspect. This PR just renames the suspected folder, let see if it works.