### PR TITLE
Display helpful error when encountering old Kptfile format

### DIFF
--- a/.github/workflows/e2eEnvironment.yml
+++ b/.github/workflows/e2eEnvironment.yml
@@ -28,6 +28,10 @@ jobs:
       matrix:
         version: [ 1.18, 1.19 ]
     steps:
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
       - uses: actions/checkout@master
       # Pinned to Commit to ensure action is consistent: https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
       # If you upgrade this version confirm the changes match your expectations

--- a/e2e/live/end-to-end-test.sh
+++ b/e2e/live/end-to-end-test.sh
@@ -144,6 +144,8 @@ function downloadPreviousKpt {
 function buildKpt {
     set -e
     if [ -z $BUILD_DEPS_AT_HEAD ]; then
+	echo "checking go version"
+	go version
 	echo "Building kpt locally..."
 	go build -o $BIN_DIR -v . > $OUTPUT_DIR/kptbuild 2>&1
 	echo "Building kpt locally...SUCCESS"

--- a/internal/cmdliveinit/cmdliveinit.go
+++ b/internal/cmdliveinit/cmdliveinit.go
@@ -192,7 +192,7 @@ func updateKptfile(p *pkg.Pkg, inv *kptfilev1alpha2.Inventory, force bool) error
 	}
 	// Finally, set the inventory parameters in the Kptfile and write it.
 	kf.Inventory = inv
-	if err := kptfileutil.WriteFile(p.UniquePath.String(), *kf); err != nil {
+	if err := kptfileutil.WriteFile(p.UniquePath.String(), kf); err != nil {
 		return errors.E(op, p.UniquePath, err)
 	}
 	return nil

--- a/internal/cmdliveinit/cmdliveinit_test.go
+++ b/internal/cmdliveinit/cmdliveinit_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
-	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
@@ -26,7 +26,7 @@ var (
 )
 
 var kptFile = `
-apiVersion: kpt.dev/v1alph2
+apiVersion: kpt.dev/v1alpha2
 kind: Kptfile
 metadata:
   name: test1
@@ -225,7 +225,7 @@ func TestCmd_Run(t *testing.T) {
 
 			// Otherwise, validate the kptfile values
 			assert.NoError(t, err)
-			kf, err := kptfileutil.ReadFile(w.WorkspaceDirectory)
+			kf, err := pkg.ReadKptfile(w.WorkspaceDirectory)
 			assert.NoError(t, err)
 			if !assert.NotNil(t, kf.Inventory) {
 				t.FailNow()

--- a/internal/cmdmigrate/migratecmd_test.go
+++ b/internal/cmdmigrate/migratecmd_test.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
-	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
 	"github.com/GoogleContainerTools/kpt/pkg/live"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -156,8 +156,10 @@ func TestKptMigrate_updateKptfile(t *testing.T) {
 				return
 			}
 			assert.NoError(t, err)
-			kf, err := kptfileutil.ReadFile(dir)
-			assert.NoError(t, err)
+			kf, err := pkg.ReadKptfile(dir)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
 			// Check the kptfile inventory section now has values.
 			if !tc.dryRun {
 				assert.Equal(t, inventoryNamespace, kf.Inventory.Namespace)
@@ -361,7 +363,7 @@ inventory:
 const testInventoryID = "SSSSSSSSSS-RRRRR"
 
 var kptFile = `
-apiVersion: kpt.dev/v1alph2
+apiVersion: kpt.dev/v1alpha2
 kind: Kptfile
 metadata:
   name: test1

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/kpt/internal/gitutil"
+	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
 	"github.com/GoogleContainerTools/kpt/internal/util/addmergecomment"
 	"github.com/GoogleContainerTools/kpt/internal/util/git"
@@ -127,11 +128,11 @@ func KptfileAwarePkgEqual(t *testing.T, pkg1, pkg2 string, addMergeCommentsToSou
 
 		// Read the Kptfiles and set the Commit field to an empty
 		// string before we compare.
-		pkg1kf, err := kptfileutil.ReadFile(filepath.Dir(pkg1Path))
+		pkg1kf, err := pkg.ReadKptfile(filepath.Dir(pkg1Path))
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}
-		pkg2kf, err := kptfileutil.ReadFile(filepath.Dir(pkg2Path))
+		pkg2kf, err := pkg.ReadKptfile(filepath.Dir(pkg2Path))
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}
@@ -449,7 +450,7 @@ func SetupWorkspace(t *testing.T) (*TestWorkspace, func()) {
 
 // AddKptfileToWorkspace writes the provided Kptfile to the workspace
 // and makes a commit.
-func AddKptfileToWorkspace(t *testing.T, w *TestWorkspace, kf kptfilev1alpha2.KptFile) {
+func AddKptfileToWorkspace(t *testing.T, w *TestWorkspace, kf *kptfilev1alpha2.KptFile) {
 	err := os.MkdirAll(w.FullPackagePath(), 0700)
 	if !assert.NoError(t, err) {
 		t.FailNow()
@@ -639,12 +640,12 @@ func replaceData(repo, data string) error {
 		// For Kptfiles we want to keep the Upstream section if the Kptfile
 		// in the data directory doesn't already include one.
 		if filepath.Base(path) == "Kptfile" {
-			dataKptfile, err := kptfileutil.ReadFile(filepath.Dir(path))
+			dataKptfile, err := pkg.ReadKptfile(filepath.Dir(path))
 			if err != nil {
 				return err
 			}
 			repoKptfileDir := filepath.Dir(filepath.Join(repo, rel))
-			repoKptfile, err := kptfileutil.ReadFile(repoKptfileDir)
+			repoKptfile, err := pkg.ReadKptfile(repoKptfileDir)
 			if err != nil {
 				return err
 			}

--- a/internal/util/diff/diff.go
+++ b/internal/util/diff/diff.go
@@ -118,7 +118,7 @@ type Command struct {
 func (c *Command) Run(ctx context.Context) error {
 	c.DefaultValues()
 
-	kptFile, err := kptfileutil.ReadFile(c.Path)
+	kptFile, err := pkg.ReadKptfile(c.Path)
 	if err != nil {
 		return errors.Errorf("package missing Kptfile at '%s': %v", c.Path, err)
 	}

--- a/internal/util/diff/pkgdiff.go
+++ b/internal/util/diff/pkgdiff.go
@@ -20,9 +20,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	"github.com/GoogleContainerTools/kpt/internal/util/pkgutil"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
-	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
 	"sigs.k8s.io/kustomize/kyaml/sets"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
@@ -77,11 +77,11 @@ func PkgDiff(pkg1, pkg2 string) (sets.String, error) {
 }
 
 func kptfilesEqual(pkg1, pkg2, filePath string) (bool, error) {
-	pkg1Kf, err := kptfileutil.ReadFile(filepath.Join(pkg1, filepath.Dir(filePath)))
+	pkg1Kf, err := pkg.ReadKptfile(filepath.Join(pkg1, filepath.Dir(filePath)))
 	if err != nil {
 		return false, err
 	}
-	pkg2Kf, err := kptfileutil.ReadFile(filepath.Join(pkg2, filepath.Dir(filePath)))
+	pkg2Kf, err := pkg.ReadKptfile(filepath.Join(pkg2, filepath.Dir(filePath)))
 	if err != nil {
 		return false, err
 	}

--- a/internal/util/fetch/fetch_test.go
+++ b/internal/util/fetch/fetch_test.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	pkgtesting "github.com/GoogleContainerTools/kpt/internal/pkg/testing"
 	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
@@ -59,7 +60,7 @@ func createKptfile(workspace *testutil.TestWorkspace, git *kptfilev1alpha2.Git, 
 }
 
 func setKptfileName(workspace *testutil.TestWorkspace, name string) error {
-	kf, err := kptfileutil.ReadFile(workspace.FullPackagePath())
+	kf, err := pkg.ReadKptfile(workspace.FullPackagePath())
 	if err != nil {
 		return err
 	}

--- a/internal/util/git/git.go
+++ b/internal/util/git/git.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -93,4 +94,12 @@ func LookupCommit(repoPath string) (string, error) {
 	}
 	commit := strings.TrimSpace(string(b))
 	return commit, nil
+}
+
+func (rs *RepoSpec) RepoRef() string {
+	repoPath := path.Join(rs.CloneSpec(), rs.Path)
+	if rs.Ref != "" {
+		return repoPath + fmt.Sprintf("@%s", rs.Ref)
+	}
+	return repoPath
 }

--- a/internal/util/man/man.go
+++ b/internal/util/man/man.go
@@ -25,8 +25,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	"github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
-	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
 	"github.com/cpuguy83/go-md2man/v2/md2man"
 	"sigs.k8s.io/kustomize/kyaml/errors"
 )
@@ -58,7 +58,7 @@ func (m Command) Run() error {
 	}
 
 	// lookup the path to the man page
-	k, err := kptfileutil.ReadFile(m.Path)
+	k, err := pkg.ReadKptfile(m.Path)
 	if err != nil {
 		return err
 	}

--- a/internal/util/pkgutil/pkgutil.go
+++ b/internal/util/pkgutil/pkgutil.go
@@ -319,7 +319,7 @@ func RoundTripKptfilesInPkg(pkgPath string) error {
 	pkgsPaths = append(pkgsPaths, pkgPath)
 
 	for _, pkgPath := range pkgsPaths {
-		kf, err := kptfileutil.ReadFile(pkgPath)
+		kf, err := pkg.ReadKptfile(pkgPath)
 		if err != nil {
 			// do not throw error if formatting fails
 			return err

--- a/internal/util/update/common.go
+++ b/internal/util/update/common.go
@@ -18,20 +18,20 @@ import (
 	"reflect"
 
 	"github.com/GoogleContainerTools/kpt/internal/errors"
+	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	"github.com/GoogleContainerTools/kpt/internal/types"
-	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
 )
 
 // PkgHasUpdatedUpstream checks if the the local package has different
 // upstream information than origin.
 func PkgHasUpdatedUpstream(local, origin string) (bool, error) {
 	const op errors.Op = "update.PkgHasUpdatedUpstream"
-	originKf, err := kptfileutil.ReadFile(origin)
+	originKf, err := pkg.ReadKptfile(origin)
 	if err != nil {
 		return false, errors.E(op, types.UniquePath(local), err)
 	}
 
-	localKf, err := kptfileutil.ReadFile(local)
+	localKf, err := pkg.ReadKptfile(local)
 	if err != nil {
 		return false, errors.E(op, types.UniquePath(local), err)
 	}

--- a/internal/util/update/fastforward.go
+++ b/internal/util/update/fastforward.go
@@ -116,7 +116,7 @@ func (u FastForwardUpdater) checkForLocalChanges(localPath, originalPath string)
 
 func hasKfDiff(localPath, orgPath string) (bool, error) {
 	const op errors.Op = "update.hasKfDiff"
-	localKf, err := kptfileutil.ReadFile(localPath)
+	localKf, err := pkg.ReadKptfile(localPath)
 	if err != nil {
 		return false, errors.E(op, types.UniquePath(localPath), err)
 	}
@@ -137,7 +137,7 @@ func hasKfDiff(localPath, orgPath string) (bool, error) {
 		}
 		return false, errors.E(op, types.UniquePath(localPath), err)
 	}
-	orgKf, err := kptfileutil.ReadFile(orgPath)
+	orgKf, err := pkg.ReadKptfile(orgPath)
 	if err != nil {
 		return false, errors.E(op, types.UniquePath(localPath), err)
 	}
@@ -151,7 +151,7 @@ func hasKfDiff(localPath, orgPath string) (bool, error) {
 	return !equal, nil
 }
 
-func isDefaultKptfile(localKf kptfilev1alpha2.KptFile, name string) (bool, error) {
+func isDefaultKptfile(localKf *kptfilev1alpha2.KptFile, name string) (bool, error) {
 	defaultKf := kptfileutil.DefaultKptfile(name)
 	return kptfileutil.Equal(localKf, defaultKf)
 }

--- a/internal/util/update/update.go
+++ b/internal/util/update/update.go
@@ -132,7 +132,7 @@ func (u Command) Run(ctx context.Context) error {
 	if u.Strategy != "" {
 		rootKf.Upstream.UpdateStrategy = u.Strategy
 	}
-	err = kptfileutil.WriteFile(u.Pkg.UniquePath.String(), *rootKf)
+	err = kptfileutil.WriteFile(u.Pkg.UniquePath.String(), rootKf)
 	if err != nil {
 		return errors.E(op, u.Pkg.UniquePath, err)
 	}
@@ -442,7 +442,7 @@ func (u Command) mergePackage(ctx context.Context, localPath, updatedPath, origi
 		// Both exists, so just go ahead as normal.
 	}
 
-	pkgKf, err := kptfileutil.ReadFile(localPath)
+	pkgKf, err := pkg.ReadKptfile(localPath)
 	if err != nil {
 		return errors.E(op, types.UniquePath(localPath), err)
 	}

--- a/internal/util/update/update_test.go
+++ b/internal/util/update/update_test.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	pkgtest "github.com/GoogleContainerTools/kpt/internal/pkg/testing"
 	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
@@ -383,7 +384,7 @@ func TestCommand_Run_localPackageChanges(t *testing.T) {
 			expectedErr: "local package files have been modified",
 			expectedCommit: func(writer *testutil.TestSetupManager) (string, error) {
 				upstreamRepo := writer.Repos[testutil.Upstream]
-				f, err := kptfileutil.ReadFile(filepath.Join(writer.LocalWorkspace.WorkspaceDirectory, upstreamRepo.RepoName))
+				f, err := pkg.ReadKptfile(filepath.Join(writer.LocalWorkspace.WorkspaceDirectory, upstreamRepo.RepoName))
 				if err != nil {
 					return "", err
 				}
@@ -1809,7 +1810,7 @@ func TestCommand_Run_local_subpackages(t *testing.T) {
 
 				expectedPath := result.expectedLocal.ExpandPkgWithName(t,
 					g.LocalWorkspace.PackageDir, testutil.ToReposInfo(g.Repos))
-				kf, err := kptfileutil.ReadFile(expectedPath)
+				kf, err := pkg.ReadKptfile(expectedPath)
 				if !assert.NoError(t, err) {
 					t.FailNow()
 				}


### PR DESCRIPTION
Adds verification that the Kptfile is using the `v1alpha2` format. If a file with the legacy `v1alpha1` version is found, an error message is shown to the user.

If the legacy version if found in a file that is already in the local fork, we display an error that includes the path to the package on the local filesystem. If a Kptfile with the legacy version is found when fetching/updating a package from an upstream repo, we display an error message that includes the git reference (instead of the path to some temporary directory).

To make sure we only have to do this check in one place, this PR removes the `ReadFile` function from the `kptfileutil` package and updates all code to read Kptfiles using the function in the `pkg` package. It also makes sure we pass around the Kptfile struct as a pointer rather than a value. Both are valid, but this makes sure we are consistent.

Error message when running `kpt fn render` on an old package: 
```
$ kpt fn render helloworld-set 
Error: Kptfile at "/Users/mortent/Development/mortent/temp/kpttest/helloworld-set" has an old version ("v1alpha1") of the Kptfile schema. Please update the package to the latest format. See https://kpt.dev/installation/migration for more details
```

Error message when using `kpt pkg get` to fetch an old package:
```
$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/helloworld-set

Package "helloworld-set":
Fetching https://github.com/GoogleContainerTools/kpt@master.
From https://github.com/GoogleContainerTools/kpt
 * branch              master     -> FETCH_HEAD
Error: Kptfile at "https:/github.com/GoogleContainerTools/kpt/package-examples/helloworld-set@master" has an old version ("v1alpha1") of the Kptfile schema. Please update the package to the latest format. See https://kpt.dev/installation/migration for more details. 
```

Error message when running `kpt fn render` on a package where the Kptfile has an unknown GVK:
```
Error: Kptfile at "/Users/mortent/Development/mortent/temp/kpttest/helloworld-set" has an unknown resource type ("kpt.com/v1beta1, Kind=Kptfile").
```