### PR TITLE
out of place support in test harness

### DIFF
--- a/e2e/testdata/fn-render/basicpipeline-out-of-place/.expected/config.yaml
+++ b/e2e/testdata/fn-render/basicpipeline-out-of-place/.expected/config.yaml
@@ -1,0 +1,15 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+debug: true

--- a/e2e/testdata/fn-render/basicpipeline-out-of-place/.expected/diff.patch
+++ b/e2e/testdata/fn-render/basicpipeline-out-of-place/.expected/diff.patch
@@ -1,0 +1,45 @@
+diff --git a/out/resources.yaml b/out/resources.yaml
+new file mode 100644
+index 0000000..a9dd224
+--- /dev/null
++++ b/out/resources.yaml
+@@ -0,0 +1,39 @@
++# Copyright 2021 Google LLC
++#
++# Licensed under the Apache License, Version 2.0 (the "License");
++# you may not use this file except in compliance with the License.
++# You may obtain a copy of the License at
++#
++#      http://www.apache.org/licenses/LICENSE-2.0
++#
++# Unless required by applicable law or agreed to in writing, software
++# distributed under the License is distributed on an "AS IS" BASIS,
++# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++# See the License for the specific language governing permissions and
++# limitations under the License.
++apiVersion: apps/v1
++kind: Deployment
++metadata:
++  name: nginx-deployment
++  namespace: staging
++  labels:
++    tier: backend
++spec:
++  replicas: 3
++  selector:
++    matchLabels:
++      tier: backend
++  template:
++    metadata:
++      labels:
++        tier: backend
++---
++apiVersion: custom.io/v1
++kind: Custom
++metadata:
++  name: custom
++  namespace: staging
++  labels:
++    tier: backend
++spec:
++  image: nginx:1.2.3

--- a/e2e/testdata/fn-render/basicpipeline-out-of-place/.krmignore
+++ b/e2e/testdata/fn-render/basicpipeline-out-of-place/.krmignore
@@ -1,0 +1,2 @@
+.expected
+out

--- a/e2e/testdata/fn-render/basicpipeline-out-of-place/Kptfile
+++ b/e2e/testdata/fn-render/basicpipeline-out-of-place/Kptfile
@@ -1,0 +1,12 @@
+apiVersion: kpt.dev/v1alpha2
+kind: Kptfile
+metadata:
+  name: app
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-namespace:v0.1.3
+      configMap:
+        namespace: staging
+    - image: gcr.io/kpt-fn/set-labels:v0.1.4
+      configMap:
+        tier: backend

--- a/e2e/testdata/fn-render/basicpipeline-out-of-place/resources.yaml
+++ b/e2e/testdata/fn-render/basicpipeline-out-of-place/resources.yaml
@@ -1,0 +1,26 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+spec:
+  image: nginx:1.2.3

--- a/pkg/test/runner/runner.go
+++ b/pkg/test/runner/runner.go
@@ -52,6 +52,7 @@ const (
 	expectedResultsFile string = "results.yaml"
 	expectedDiffFile    string = "diff.patch"
 	expectedConfigFile  string = "config.yaml"
+	outDir              string = "out"
 	setupScript         string = "setup.sh"
 	teardownScript      string = "teardown.sh"
 	execScript          string = "exec.sh"
@@ -243,6 +244,12 @@ func (r *Runner) IsFnResultExpected() bool {
 	return err == nil
 }
 
+// IsOutOfPlace determines if command output is saved in a different directory (out-of-place).
+func (r *Runner) IsOutOfPlace() bool {
+	_, err := ioutil.ReadDir(filepath.Join(r.testCase.Path, outDir))
+	return err == nil
+}
+
 func (r *Runner) runFnRender() error {
 	r.t.Logf("Running test against package %s\n", r.pkgName)
 	tmpDir, err := ioutil.TempDir("", "kpt-pipeline-e2e-*")
@@ -264,7 +271,7 @@ func (r *Runner) runFnRender() error {
 		return fmt.Errorf("failed to create original dir %s: %w", origPkgPath, err)
 	}
 
-	var resultsDir string
+	var resultsDir, destDir string
 
 	if r.IsFnResultExpected() {
 		// create result dir
@@ -273,6 +280,10 @@ func (r *Runner) runFnRender() error {
 		if err != nil {
 			return fmt.Errorf("failed to create results dir %s: %w", resultsDir, err)
 		}
+	}
+
+	if r.IsOutOfPlace() {
+		destDir = filepath.Join(pkgPath, outDir)
 	}
 
 	// copy package to temp directory
@@ -312,6 +323,10 @@ func (r *Runner) runFnRender() error {
 
 			if resultsDir != "" {
 				kptArgs = append(kptArgs, "--results-dir", resultsDir)
+			}
+
+			if destDir != "" {
+				kptArgs = append(kptArgs, "-o", destDir)
 			}
 
 			if r.testCase.Config.ImagePullPolicy != "" {


### PR DESCRIPTION
This PR demonstrates how test harness can be modified to test out-of-place workflow.

@phanimarupaka the change is very minimal and can be added in your out of place support PR because that is required to test this support, hence, keeping this PR in draft mode.

/cc @phanimarupaka @Shell32-Natsu 