### PR TITLE
Update installation links to alpha v6

### DIFF
--- a/site/installation/README.md
+++ b/site/installation/README.md
@@ -96,6 +96,6 @@ kpt help
 [gcr.io/kpt-dev/kpt]: https://console.cloud.google.com/gcr/images/kpt-dev/GLOBAL/kpt?gcrImageListsize=30
 [gcr.io/kpt-dev/kpt-gcloud]: https://console.cloud.google.com/gcr/images/kpt-dev/GLOBAL/kpt-gcloud?gcrImageListsize=30
 [cloud-sdk]: https://github.com/GoogleCloudPlatform/cloud-sdk-docker
-[linux]: https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-alpha.5/kpt_linux_amd64
-[darwin]: https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-alpha.5/kpt_darwin_amd64
+[linux]: https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-alpha.6/kpt_linux_amd64
+[darwin]: https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-alpha.6/kpt_darwin_amd64
 [migration guide]: /installation/migration


### PR DESCRIPTION
Update to kpt.dev to increment installation binary to kpt alpha 6.