### PR TITLE
Print error message to users when encountering a Kptfile with an unknown version of the Kptfile resource

### DIFF
--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -243,14 +243,14 @@ metadata:
   name: nginx-deployment
 spec:
   replicas: 3
- `,
+`,
 			inputOpenAPI: `
-apiVersion: v1alpha1
-kind: Example
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
 `,
 			expectedOpenAPI: `
-apiVersion: v1alpha1
-kind: Example
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
 openAPI:
   definitions:
     io.k8s.cli.setters.replicas:
@@ -260,7 +260,7 @@ openAPI:
           name: replicas
           value: "3"
           setBy: me
- `,
+`,
 			expectedResources: `
 apiVersion: apps/v1
 kind: Deployment
@@ -268,7 +268,7 @@ metadata:
   name: nginx-deployment
 spec:
   replicas: 3 # {"$kpt-set":"replicas"}
- `,
+`,
 		},
 		{
 			name:    "substitution replicas",
@@ -289,10 +289,10 @@ spec:
         image: nginx:1.7.9
       - name: sidecar
         image: sidecar:1.7.9
- `,
+`,
 			inputOpenAPI: `
-apiVersion: v1alpha1
-kind: Example
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
 openAPI:
   definitions:
     io.k8s.cli.setters.my-image-setter:
@@ -305,10 +305,10 @@ openAPI:
         setter:
           name: my-tag-setter
           value: "1.7.9"
- `,
+`,
 			expectedOpenAPI: `
-apiVersion: v1alpha1
-kind: Example
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
 openAPI:
   definitions:
     io.k8s.cli.setters.my-image-setter:
@@ -331,7 +331,7 @@ openAPI:
             ref: '#/definitions/io.k8s.cli.setters.my-image-setter'
           - marker: ${my-tag-setter}
             ref: '#/definitions/io.k8s.cli.setters.my-tag-setter'
- `,
+`,
 			expectedResources: `
 apiVersion: apps/v1
 kind: Deployment
@@ -346,7 +346,7 @@ spec:
         image: nginx:1.7.9 # {"$kpt-set":"my-image-subst"}
       - name: sidecar
         image: sidecar:1.7.9
- `,
+`,
 		},
 		{
 			name:    "set replicas",
@@ -354,8 +354,8 @@ spec:
 			args:    []string{"replicas", "4", "--description", "hi there", "--set-by", "pw"},
 			out:     "set 1 fields\n",
 			inputOpenAPI: `
-apiVersion: v1alpha1
-kind: Example
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
 openAPI:
   definitions:
     io.k8s.cli.setters.replicas:
@@ -365,7 +365,7 @@ openAPI:
           name: replicas
           value: "3"
           setBy: me
- `,
+`,
 			input: `
 apiVersion: apps/v1
 kind: Deployment
@@ -373,10 +373,10 @@ metadata:
   name: nginx-deployment
 spec:
   replicas: 3 # {"$kpt-set":"replicas"}
- `,
+`,
 			expectedOpenAPI: `
-apiVersion: v1alpha1
-kind: Example
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
 openAPI:
   definitions:
     io.k8s.cli.setters.replicas:
@@ -387,7 +387,7 @@ openAPI:
           value: "4"
           setBy: pw
           isSet: true
- `,
+`,
 			expectedResources: `
 apiVersion: apps/v1
 kind: Deployment
@@ -395,7 +395,7 @@ metadata:
   name: nginx-deployment
 spec:
   replicas: 4 # {"$kpt-set":"replicas"}
- `,
+`,
 		},
 		{
 			name:    "empty string setter",
@@ -403,8 +403,8 @@ spec:
 			args:    []string{"foo", "testnew"},
 			out:     "set 1 fields\n",
 			inputOpenAPI: `
-apiVersion: v1alpha1
-kind: Example
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
 openAPI:
   definitions:
     io.k8s.cli.setters.foo:
@@ -437,8 +437,8 @@ foo: "test" # {"$kpt-set":"foo"}
 baz: "test-baz" # {"$kpt-set":"baz"}
  `,
 			expectedOpenAPI: `
-apiVersion: v1alpha1
-kind: Example
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
 openAPI:
   definitions:
     io.k8s.cli.setters.foo:
@@ -561,8 +561,8 @@ func TestLiveCommands(t *testing.T) {
 			name:    "test preview command setters pre-check",
 			command: "preview",
 			inputOpenAPI: `
-apiVersion: v1alpha1
-kind: OpenAPIfile
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
 openAPI:
   definitions:
     io.k8s.cli.setters.replicas:
@@ -581,8 +581,8 @@ openAPI:
 			name:    "test apply command setters pre-check",
 			command: "apply",
 			inputOpenAPI: `
-apiVersion: v1alpha1
-kind: OpenAPIfile
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
 openAPI:
   definitions:
     io.k8s.cli.setters.replicas:
@@ -601,8 +601,8 @@ openAPI:
 			name:    "preview command setters pre-check pass",
 			command: "preview",
 			inputOpenAPI: `
-apiVersion: v1alpha1
-kind: OpenAPIfile
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
 openAPI:
   definitions:
     io.k8s.cli.setters.replicas:
@@ -620,8 +620,8 @@ openAPI:
 			name:    "apply command setters pre-check pass",
 			command: "apply",
 			inputOpenAPI: `
-apiVersion: v1alpha1
-kind: OpenAPIfile
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
 openAPI:
   definitions:
     io.k8s.cli.setters.replicas:

--- a/internal/testutil/testdata/dataset-with-autosetters-set/mysql/Kptfile
+++ b/internal/testutil/testdata/dataset-with-autosetters-set/mysql/Kptfile
@@ -1,4 +1,4 @@
-apiVersion: krm.dev/v1alpha1
+apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: mysql

--- a/internal/testutil/testdata/dataset-with-autosetters-set/mysql/nosetters/Kptfile
+++ b/internal/testutil/testdata/dataset-with-autosetters-set/mysql/nosetters/Kptfile
@@ -1,4 +1,4 @@
-apiVersion: krm.dev/v1alpha1
+apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: nosetters

--- a/internal/testutil/testdata/dataset-with-autosetters-set/mysql/storage/Kptfile
+++ b/internal/testutil/testdata/dataset-with-autosetters-set/mysql/storage/Kptfile
@@ -1,5 +1,5 @@
-apiVersion: krm.dev/v1alpha1
-kind: Krmfile
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
 metadata:
   name: storage
 packageMetadata:

--- a/internal/testutil/testdata/dataset-with-autosetters/mysql/Kptfile
+++ b/internal/testutil/testdata/dataset-with-autosetters/mysql/Kptfile
@@ -1,4 +1,4 @@
-apiVersion: krm.dev/v1alpha1
+apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: mysql

--- a/internal/testutil/testdata/dataset-with-autosetters/mysql/nosetters/Kptfile
+++ b/internal/testutil/testdata/dataset-with-autosetters/mysql/nosetters/Kptfile
@@ -1,4 +1,4 @@
-apiVersion: krm.dev/v1alpha1
+apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: nosetters

--- a/internal/testutil/testdata/dataset-with-autosetters/mysql/storage/Kptfile
+++ b/internal/testutil/testdata/dataset-with-autosetters/mysql/storage/Kptfile
@@ -1,5 +1,5 @@
-apiVersion: krm.dev/v1alpha1
-kind: Krmfile
+apiVersion: kpt.dev/v1alpha1
+kind: Kptfile
 metadata:
   name: storage
 packageMetadata:

--- a/internal/util/git/git.go
+++ b/internal/util/git/git.go
@@ -16,6 +16,8 @@
 package git
 
 import (
+	"fmt"
+	"path"
 	"path/filepath"
 	"strings"
 )
@@ -69,4 +71,12 @@ func isAzureHost(host string) bool {
 // https://docs.aws.amazon.com/codecommit/latest/userguide/regions.html
 func isAWSHost(host string) bool {
 	return strings.Contains(host, "amazonaws.com")
+}
+
+func (rs *RepoSpec) RepoRef() string {
+	repoPath := path.Join(rs.CloneSpec(), rs.Path)
+	if rs.Ref != "" {
+		return repoPath + fmt.Sprintf("@%s", rs.Ref)
+	}
+	return repoPath
 }

--- a/internal/util/setters/setters_test.go
+++ b/internal/util/setters/setters_test.go
@@ -248,7 +248,7 @@ func TestSetInheritedSetters(t *testing.T) {
 			name:       "autoset-inherited-setters",
 			parentPath: "${baseDir}/parentPath",
 			childPath:  "${baseDir}/parentPath/somedir/childPath",
-			parentKptfile: `apiVersion: krm.dev/v1alpha1
+			parentKptfile: `apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: parent
@@ -270,7 +270,7 @@ kind: Deployment
 metadata:
   namespace: child_namespace # {"$kpt-set":"namespace"}
   name: child_name # {"$kpt-set":"name"}`,
-			nestedKptfile: `apiVersion: krm.dev/v1alpha1
+			nestedKptfile: `apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: child
@@ -292,7 +292,7 @@ kind: Deployment
 metadata:
   namespace: child_namespace # {"$kpt-set":"namespace"}
   name: child_name # {"$kpt-set":"name"}`,
-			childKptfile: `apiVersion: krm.dev/v1alpha1
+			childKptfile: `apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: child
@@ -309,7 +309,7 @@ openAPI:
           name: name
           value: child_name
 `,
-			expectedChildKptfile: `apiVersion: krm.dev/v1alpha1
+			expectedChildKptfile: `apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: child
@@ -343,7 +343,7 @@ automatically set 1 field(s) for setter "name" to value "parent_name" in package
 			name:       "child-has-no-parent",
 			parentPath: "${baseDir}/parentPath",
 			childPath:  "${baseDir}/childPath",
-			parentKptfile: `apiVersion: krm.dev/v1alpha1
+			parentKptfile: `apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: parent
@@ -359,7 +359,7 @@ kind: Deployment
 metadata:
   namespace: child_namespace # {"$kpt-set":"namespace"}
 `,
-			childKptfile: `apiVersion: krm.dev/v1alpha1
+			childKptfile: `apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: child
@@ -371,7 +371,7 @@ openAPI:
           name: namespace
           value: child_namespace
 `,
-			expectedChildKptfile: `apiVersion: krm.dev/v1alpha1
+			expectedChildKptfile: `apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: child
@@ -393,7 +393,7 @@ metadata:
 			name:       "autoset-inherited-setters-error",
 			parentPath: "${baseDir}/parentPath",
 			childPath:  "${baseDir}/parentPath/somedir/childPath",
-			parentKptfile: `apiVersion: krm.dev/v1alpha1
+			parentKptfile: `apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: parent
@@ -409,7 +409,7 @@ kind: Deployment
 metadata:
   namespace: child_namespace # {"$kpt-set":"namespace"}
 `,
-			childKptfile: `apiVersion: krm.dev/v1alpha1
+			childKptfile: `apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: child
@@ -422,7 +422,7 @@ openAPI:
           name: namespace
           value: child_namespace
 `,
-			expectedChildKptfile: `apiVersion: krm.dev/v1alpha1
+			expectedChildKptfile: `apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: child
@@ -450,7 +450,7 @@ namespace in body should be at most 15 chars long
 			name:       "skip-autoset-inherited-setters-already-set",
 			parentPath: "${baseDir}/parentPath",
 			childPath:  "${baseDir}/parentPath/somedir/childPath",
-			parentKptfile: `apiVersion: krm.dev/v1alpha1
+			parentKptfile: `apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: parent
@@ -465,7 +465,7 @@ openAPI:
 kind: Deployment
 metadata:
   namespace: child_namespace # {"$kpt-set":"namespace"}`,
-			childKptfile: `apiVersion: krm.dev/v1alpha1
+			childKptfile: `apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: child
@@ -478,7 +478,7 @@ openAPI:
           value: child_namespace
           isSet: true
 `,
-			expectedChildKptfile: `apiVersion: krm.dev/v1alpha1
+			expectedChildKptfile: `apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: child
@@ -501,7 +501,7 @@ metadata:
 			name:       "no setter definitions in parent",
 			parentPath: "${baseDir}/parentPath",
 			childPath:  "${baseDir}/parentPath/somedir/childPath",
-			parentKptfile: `apiVersion: krm.dev/v1alpha1
+			parentKptfile: `apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: parent`,
@@ -509,7 +509,7 @@ metadata:
 kind: Deployment
 metadata:
   namespace: child_namespace # {"$kpt-set":"namespace"}`,
-			childKptfile: `apiVersion: krm.dev/v1alpha1
+			childKptfile: `apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: child
@@ -522,7 +522,7 @@ openAPI:
           value: child_namespace
           isSet: true
 `,
-			expectedChildKptfile: `apiVersion: krm.dev/v1alpha1
+			expectedChildKptfile: `apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: child
@@ -545,7 +545,7 @@ metadata:
 			name:       "inherit-defalut-values-from-parent",
 			parentPath: "${baseDir}/parentPath",
 			childPath:  "${baseDir}/parentPath/somedir/childPath",
-			parentKptfile: `apiVersion: krm.dev/v1alpha1
+			parentKptfile: `apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: parent
@@ -560,7 +560,7 @@ openAPI:
 kind: Deployment
 metadata:
   namespace: child_namespace # {"$kpt-set":"namespace"}`,
-			childKptfile: `apiVersion: krm.dev/v1alpha1
+			childKptfile: `apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: child
@@ -572,7 +572,7 @@ openAPI:
           name: namespace
           value: child_namespace
 `,
-			expectedChildKptfile: `apiVersion: krm.dev/v1alpha1
+			expectedChildKptfile: `apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: child

--- a/internal/util/update/resource-merge_test.go
+++ b/internal/util/update/resource-merge_test.go
@@ -71,7 +71,7 @@ func TestMergeSubPackages(t *testing.T) {
 	defer os.RemoveAll(originalRoot)
 
 	// modify updated/upstream by adding a new setter definition to one of the subpackages Kptfile
-	nosettersUpdated := `apiVersion: krm.dev/v1alpha1
+	nosettersUpdated := `apiVersion: kpt.dev/v1alpha1
 kind: Kptfile
 metadata:
   name: nosetters

--- a/pkg/kptfile/kptfileutil/util.go
+++ b/pkg/kptfile/kptfileutil/util.go
@@ -44,7 +44,7 @@ func (e *UnknownKptfileVersionError) Error() string {
 	} else {
 		source = e.PkgPath
 	}
-	return fmt.Sprintf("package at %q is using an unknown version of the Kptfile schema. It might be for a newer version of kpt. Please try updating kpt.", source)
+	return fmt.Sprintf("package at %q is using a newer version (%q) of the Kptfile schema. Please try updating kpt.", source, e.Version)
 }
 
 // ReadFile reads the KptFile in the given directory


### PR DESCRIPTION
This verifies that the Kptfile resource within a Kptfile actually uses the `v1alpha1` version. If a different version is found, it will return an error asking users to upgrade kpt. 

Examples:

Fetching a package with a v1alpha2 version of the Kptfile:
```
$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/wordpress@next .
fetching package "/package-examples/wordpress" from "https://github.com/GoogleContainerTools/kpt" to "wordpress"
error: failed to clone git repo: package at "https:/github.com/GoogleContainerTools/kpt/package-examples/wordpress@next" is using a newer version ("v1alpha2") of the Kptfile schema. Please try updating kpt.
```

Running `kpt fn run` on a package with v1alpha2 version of the Kptfile:
```
$ kpt fn run wordpress
error: package at "<path>/wordpress" is using a newer version ("v1alpha2") of the Kptfile schema. Please try updating kpt.
```
