### PR TITLE
shorten timeout for some docker commands

### DIFF
--- a/internal/fnruntime/exec.go
+++ b/internal/fnruntime/exec.go
@@ -41,7 +41,7 @@ type ExecFn struct {
 // writes the output to w.
 func (f *ExecFn) Run(r io.Reader, w io.Writer) error {
 	// setup exec run timeout
-	timeout := defaultTimeout
+	timeout := defaultLongTimeout
 	if f.Timeout != 0 {
 		timeout = f.Timeout
 	}

--- a/internal/util/cmdutil/cmdutil.go
+++ b/internal/util/cmdutil/cmdutil.go
@@ -16,12 +16,14 @@ package cmdutil
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/GoogleContainerTools/kpt/internal/fnruntime"
 	"github.com/spf13/cobra"
@@ -30,10 +32,11 @@ import (
 )
 
 const (
-	StackTraceOnErrors = "COBRA_STACK_TRACE_ON_ERRORS"
-	trueString         = "true"
-	Stdout             = "stdout"
-	Unwrap             = "unwrap"
+	StackTraceOnErrors                 = "COBRA_STACK_TRACE_ON_ERRORS"
+	trueString                         = "true"
+	Stdout                             = "stdout"
+	Unwrap                             = "unwrap"
+	dockerVersionTimeout time.Duration = 5 * time.Second
 )
 
 // FixDocs replaces instances of old with new in the docs for c
@@ -89,7 +92,9 @@ To install docker, follow the instructions at https://docs.docker.com/get-docker
 `
 	buffer := &bytes.Buffer{}
 
-	cmd := exec.Command("docker", "version")
+	ctx, cancel := context.WithTimeout(context.Background(), dockerVersionTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "docker", "version")
 	cmd.Stderr = buffer
 	err := cmd.Run()
 	if err != nil {


### PR DESCRIPTION
1. docker image inspect: 5s
2. docker image pull: 5min
3. docker run: 5min
4. docker version: 5s

close #2005