### PR TITLE
Remove trailing periods after printing git ref

### DIFF
--- a/internal/util/get/get.go
+++ b/internal/util/get/get.go
@@ -127,7 +127,7 @@ func (c Command) fetchPackages(ctx context.Context, rootPkg *pkg.Pkg) error {
 		if kf.Upstream != nil && kf.UpstreamLock == nil {
 			packageCount += 1
 			pr.PrintPackage(p, !(p == rootPkg))
-			pr.Printf("Fetching %s@%s.\n", kf.Upstream.Git.Repo, kf.Upstream.Git.Ref)
+			pr.Printf("Fetching %s@%s\n", kf.Upstream.Git.Repo, kf.Upstream.Git.Ref)
 			err := (&fetch.Command{
 				Pkg: p,
 			}).Run(ctx)

--- a/internal/util/update/update.go
+++ b/internal/util/update/update.go
@@ -249,7 +249,7 @@ func (u Command) updateRootPackage(ctx context.Context, p *pkg.Pkg) error {
 
 	g := kf.Upstream.Git
 	updated := &git.RepoSpec{OrgRepo: g.Repo, Path: g.Directory, Ref: g.Ref}
-	pr.Printf("Fetching upstream from %s@%s.\n", kf.Upstream.Git.Repo, kf.Upstream.Git.Ref)
+	pr.Printf("Fetching upstream from %s@%s\n", kf.Upstream.Git.Repo, kf.Upstream.Git.Ref)
 	if err := fetch.ClonerUsingGitExec(ctx, updated); err != nil {
 		return errors.E(op, p.UniquePath, err)
 	}
@@ -259,7 +259,7 @@ func (u Command) updateRootPackage(ctx context.Context, p *pkg.Pkg) error {
 	if kf.UpstreamLock != nil {
 		gLock := kf.UpstreamLock.Git
 		originRepoSpec := &git.RepoSpec{OrgRepo: gLock.Repo, Path: gLock.Directory, Ref: gLock.Commit}
-		pr.Printf("Fetching origin from %s@%s.\n", kf.Upstream.Git.Repo, kf.Upstream.Git.Ref)
+		pr.Printf("Fetching origin from %s@%s\n", kf.Upstream.Git.Repo, kf.Upstream.Git.Ref)
 		if err := fetch.ClonerUsingGitExec(ctx, originRepoSpec); err != nil {
 			return errors.E(op, p.UniquePath, err)
 		}


### PR DESCRIPTION
Remove trailing period after printing git refs. Refs might be versions that contain periods, so the additional trailing one can be misleading.
