### PR TITLE
use kyaml resultItem

### DIFF
--- a/internal/fnruntime/runner.go
+++ b/internal/fnruntime/runner.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/types"
 	fnresult "github.com/GoogleContainerTools/kpt/pkg/api/fnresult/v1alpha2"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
+	"sigs.k8s.io/kustomize/kyaml/fn/framework"
 	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
@@ -199,7 +200,7 @@ func parseNameAndNamespace(yml *yaml.RNode, fnResult *fnresult.Result) error {
 	return nil
 }
 
-func populateResourceRef(item *yaml.RNode, resultItem *fnresult.ResultItem) error {
+func populateResourceRef(item *yaml.RNode, resultItem *framework.ResultItem) error {
 	r, err := item.Pipe(yaml.Lookup("resourceRef", "metadata"))
 	if err != nil {
 		return err
@@ -349,7 +350,7 @@ func (ri *multiLineFormatter) String() string {
 }
 
 // resultToString converts given structured result item to string format.
-func resultToString(result fnresult.ResultItem) string {
+func resultToString(result framework.ResultItem) string {
 	// TODO: Go SDK should implement Stringer method
 	// for framework.ResultItem. This is a temporary
 	// wrapper that will eventually be moved to Go SDK.

--- a/internal/fnruntime/runner_test.go
+++ b/internal/fnruntime/runner_test.go
@@ -24,11 +24,10 @@ import (
 	"strings"
 	"testing"
 
-	fnresult "github.com/GoogleContainerTools/kpt/pkg/api/fnresult/v1alpha2"
-
 	"github.com/GoogleContainerTools/kpt/internal/types"
 	kptfilev1alpha2 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/kustomize/kyaml/fn/framework"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
@@ -567,7 +566,7 @@ file:
 		yml, err := yaml.Parse(tc.input)
 		assert.NoError(t, err)
 
-		result := &fnresult.ResultItem{}
+		result := &framework.ResultItem{}
 		err = yaml.Unmarshal([]byte(tc.input), result)
 		assert.NoError(t, err)
 		assert.NoError(t, populateResourceRef(yml, result))

--- a/pkg/api/fnresult/v1alpha2/types.go
+++ b/pkg/api/fnresult/v1alpha2/types.go
@@ -36,7 +36,7 @@ type Result struct {
 	// ExitCode is the exit code from running the function
 	ExitCode int `yaml:"exitCode"`
 	// Results is the list of results for the function
-	Results []ResultItem `yaml:"results,omitempty"`
+	Results []framework.ResultItem `yaml:"results,omitempty"`
 }
 
 const (
@@ -72,25 +72,4 @@ func NewResultList() *ResultList {
 		},
 		Items: []Result{},
 	}
-}
-
-// ResultItem is a duplicate of framework.ResultItem, except that
-// ResourceRef uses yaml.ResourceIdentifier here, whereas framework.ResultItem
-// uses yaml.ResourceMeta. Eventually, we will need to fix it upstream.
-// TODO: https://github.com/GoogleContainerTools/kpt/issues/2091
-type ResultItem struct {
-	// Message is a human readable message
-	Message string `yaml:"message,omitempty"`
-
-	// Severity is the severity of this result
-	Severity framework.Severity `yaml:"severity,omitempty"`
-
-	// ResourceRef is a reference to a resource
-	ResourceRef yaml.ResourceIdentifier `yaml:"resourceRef,omitempty"`
-
-	// Field is a reference to the field in a resource this result refers to
-	Field framework.Field `yaml:"field,omitempty"`
-
-	// File references a file containing the resource this result refers to
-	File framework.File `yaml:"file,omitempty"`
 }


### PR DESCRIPTION
Cleanup for #2091 

Now that `ResultItem` has been fixed in kyaml, we can remove the duplicate introduced in https://github.com/GoogleContainerTools/kpt/pull/2086.

At the time of writing, `parseNameAndNamespace` https://github.com/GoogleContainerTools/kpt/blob/c198ed4c27fc570429f822903cd520c22fa7bd57/internal/fnruntime/runner.go#L187 is still used to support the old resourceRef schema with a metadata field.
