### PR TITLE
proper error message for fn source/sink when there are non-KRM resources

### DIFF
--- a/internal/docs/generated/livedocs/docs.go
+++ b/internal/docs/generated/livedocs/docs.go
@@ -181,7 +181,7 @@ var InitExamples = `
   # initialize a package in the current directory.
   $ kpt live init
 
-  # initialize a package with a specific name for the group of resources.
+  # initialize a package with explicit namespace for the ResourceGroup.
   $ kpt live init --namespace=test my-dir
 `
 

--- a/internal/util/cmdutil/cmdutil.go
+++ b/internal/util/cmdutil/cmdutil.go
@@ -22,10 +22,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 	"strings"
 	"time"
 
 	"github.com/GoogleContainerTools/kpt/internal/fnruntime"
+	kptfile "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1alpha2"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
@@ -165,4 +167,11 @@ func WriteToOutput(r io.Reader, w io.Writer, outDir string) error {
 	return kio.Pipeline{
 		Inputs:  []kio.Reader{&kio.ByteReader{Reader: r}},
 		Outputs: outputs}.Execute()
+}
+
+func AreKrmFilter(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
+	if err := kptfile.AreKRM(nodes); err != nil {
+		return nodes, err
+	}
+	return nodes, nil
 }

--- a/internal/util/cmdutil/cmdutil.go
+++ b/internal/util/cmdutil/cmdutil.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sigs.k8s.io/kustomize/kyaml/yaml"
 	"strings"
 	"time"
 
@@ -31,6 +30,7 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 const (

--- a/pkg/api/kptfile/v1alpha2/validation.go
+++ b/pkg/api/kptfile/v1alpha2/validation.go
@@ -186,11 +186,7 @@ func IsKRM(n *yaml.RNode) error {
 
 func AreKRM(nodes []*yaml.RNode) error {
 	for i := range nodes {
-		// don't do this check for .json files
 		path, _, _ := kioutil.GetFileAnnotations(nodes[i])
-		if strings.HasSuffix(path, ".json") {
-			continue
-		}
 		if err := IsKRM(nodes[i]); err != nil {
 			return fmt.Errorf("%s: %s", path, err.Error())
 		}

--- a/pkg/api/kptfile/v1alpha2/validation.go
+++ b/pkg/api/kptfile/v1alpha2/validation.go
@@ -186,8 +186,12 @@ func IsKRM(n *yaml.RNode) error {
 
 func AreKRM(nodes []*yaml.RNode) error {
 	for i := range nodes {
+		// don't do this check for .json files
+		path, _, _ := kioutil.GetFileAnnotations(nodes[i])
+		if strings.HasSuffix(path, ".json") {
+			continue
+		}
 		if err := IsKRM(nodes[i]); err != nil {
-			path, _, _ := kioutil.GetFileAnnotations(nodes[i])
 			return fmt.Errorf("%s: %s", path, err.Error())
 		}
 	}

--- a/thirdparty/cmdconfig/commands/cmdsink/cmdsink_test.go
+++ b/thirdparty/cmdconfig/commands/cmdsink/cmdsink_test.go
@@ -37,7 +37,7 @@ items:
       config.kubernetes.io/path: 'f1.yaml'
   spec:
     replicas: 1
-- apiVersion: apps/v1
+- apiVersion: v1
   kind: Service
   metadata:
     name: foo
@@ -94,7 +94,7 @@ metadata:
 spec:
   replicas: 1
 ---
-apiVersion: apps/v1
+apiVersion: v1
 kind: Service
 metadata:
   name: foo

--- a/thirdparty/cmdconfig/commands/cmdsink/cmdsink_test.go
+++ b/thirdparty/cmdconfig/commands/cmdsink/cmdsink_test.go
@@ -151,7 +151,7 @@ func TestSinkCommandJSON(t *testing.T) {
 	r.Command.SetIn(bytes.NewBufferString(`apiVersion: config.kubernetes.io/v1alpha1
 kind: ResourceList
 items:
-- {"kind": "Deployment", "metadata": {"labels": {"app": "nginx2"}, "name": "foo",
+- {"apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"labels": {"app": "nginx2"}, "name": "foo",
     "annotations": {"app": "nginx2", config.kubernetes.io/index: '0',
       config.kubernetes.io/path: 'f1.json'}}, "spec": {"replicas": 1}}
 `))
@@ -165,6 +165,7 @@ items:
 		t.FailNow()
 	}
 	expected := `{
+  "apiVersion": "apps/v1",
   "kind": "Deployment",
   "metadata": {
     "annotations": {

--- a/thirdparty/cmdconfig/commands/cmdsink/cmdsink_test.go
+++ b/thirdparty/cmdconfig/commands/cmdsink/cmdsink_test.go
@@ -25,7 +25,8 @@ func TestSinkCommand(t *testing.T) {
 	r.Command.SetIn(bytes.NewBufferString(`apiVersion: config.kubernetes.io/v1alpha1
 kind: ResourceList
 items:
-- kind: Deployment
+- apiVersion: apps/v1
+  kind: Deployment
   metadata:
     labels:
       app: nginx2
@@ -36,7 +37,8 @@ items:
       config.kubernetes.io/path: 'f1.yaml'
   spec:
     replicas: 1
-- kind: Service
+- apiVersion: apps/v1
+  kind: Service
   metadata:
     name: foo
     annotations:
@@ -81,7 +83,8 @@ items:
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
-	expected := `kind: Deployment
+	expected := `apiVersion: apps/v1
+kind: Deployment
 metadata:
   labels:
     app: nginx2
@@ -91,6 +94,7 @@ metadata:
 spec:
   replicas: 1
 ---
+apiVersion: apps/v1
 kind: Service
 metadata:
   name: foo

--- a/thirdparty/cmdconfig/commands/cmdsource/cmdsource.go
+++ b/thirdparty/cmdconfig/commands/cmdsource/cmdsource.go
@@ -121,17 +121,11 @@ func (r *SourceRunner) runE(c *cobra.Command, args []string) error {
 		})
 	}
 
-	f := kio.FilterFunc(func(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
-		if err := kptfile.AreKRM(nodes); err != nil {
-			return nodes, err
-		}
-		return nodes, nil
-	})
-
 	err := kio.Pipeline{
 		Inputs: inputs,
 		Outputs: outputs,
-		Filters: []kio.Filter{f}}.Execute()
+		Filters: []kio.Filter{kio.FilterFunc(cmdutil.AreKrmFilter)},
+	}.Execute()
 
 	return runner.HandleError(r.Ctx, err)
 }

--- a/thirdparty/cmdconfig/commands/cmdsource/cmdsource.go
+++ b/thirdparty/cmdconfig/commands/cmdsource/cmdsource.go
@@ -122,7 +122,7 @@ func (r *SourceRunner) runE(c *cobra.Command, args []string) error {
 	}
 
 	err := kio.Pipeline{
-		Inputs: inputs,
+		Inputs:  inputs,
 		Outputs: outputs,
 		Filters: []kio.Filter{kio.FilterFunc(cmdutil.AreKrmFilter)},
 	}.Execute()

--- a/thirdparty/cmdconfig/commands/cmdsource/cmdsource.go
+++ b/thirdparty/cmdconfig/commands/cmdsource/cmdsource.go
@@ -121,6 +121,17 @@ func (r *SourceRunner) runE(c *cobra.Command, args []string) error {
 		})
 	}
 
-	err := kio.Pipeline{Inputs: inputs, Outputs: outputs}.Execute()
+	f := kio.FilterFunc(func(nodes []*yaml.RNode) ([]*yaml.RNode, error) {
+		if err := kptfile.AreKRM(nodes); err != nil {
+			return nodes, err
+		}
+		return nodes, nil
+	})
+
+	err := kio.Pipeline{
+		Inputs: inputs,
+		Outputs: outputs,
+		Filters: []kio.Filter{f}}.Execute()
+
 	return runner.HandleError(r.Ctx, err)
 }

--- a/thirdparty/cmdconfig/commands/cmdsource/cmdsource_test.go
+++ b/thirdparty/cmdconfig/commands/cmdsource/cmdsource_test.go
@@ -33,7 +33,7 @@ metadata:
 spec:
   replicas: 1
 ---
-apiVersion: apps/v1
+apiVersion: v1
 kind: Service
 metadata:
   name: foo
@@ -97,7 +97,7 @@ items:
         config.kubernetes.io/path: 'f1.yaml'
     spec:
       replicas: 1
-  - apiVersion: apps/v1
+  - apiVersion: v1
     kind: Service
     metadata:
       name: foo
@@ -294,7 +294,7 @@ metadata:
 spec:
   replicas: 1
 ---
-apiVersion: apps/v1
+apiVersion: v1
 kind: Service
 metadata:
   name: foo
@@ -363,7 +363,7 @@ items:
         config.kubernetes.io/path: 'f1.yaml'
     spec:
       replicas: 1
-  - apiVersion: apps/v1
+  - apiVersion: v1
     kind: Service
     metadata:
       name: foo

--- a/thirdparty/cmdconfig/commands/cmdsource/cmdsource_test.go
+++ b/thirdparty/cmdconfig/commands/cmdsource/cmdsource_test.go
@@ -22,6 +22,7 @@ func TestSourceCommand(t *testing.T) {
 	defer os.RemoveAll(d)
 
 	err = ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -32,6 +33,7 @@ metadata:
 spec:
   replicas: 1
 ---
+apiVersion: apps/v1
 kind: Service
 metadata:
   name: foo
@@ -83,7 +85,8 @@ spec:
 	if !assert.Equal(t, `apiVersion: config.kubernetes.io/v1alpha1
 kind: ResourceList
 items:
-  - kind: Deployment
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       labels:
         app: nginx2
@@ -94,7 +97,8 @@ items:
         config.kubernetes.io/path: 'f1.yaml'
     spec:
       replicas: 1
-  - kind: Service
+  - apiVersion: apps/v1
+    kind: Service
     metadata:
       name: foo
       annotations:
@@ -279,6 +283,7 @@ func TestSourceCommand_DefaultDir(t *testing.T) {
 	defer os.RemoveAll(d)
 
 	err = ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -289,6 +294,7 @@ metadata:
 spec:
   replicas: 1
 ---
+apiVersion: apps/v1
 kind: Service
 metadata:
   name: foo
@@ -345,7 +351,8 @@ spec:
 	if !assert.Equal(t, `apiVersion: config.kubernetes.io/v1alpha1
 kind: ResourceList
 items:
-  - kind: Deployment
+  - apiVersion: apps/v1
+    kind: Deployment
     metadata:
       labels:
         app: nginx2
@@ -356,7 +363,8 @@ items:
         config.kubernetes.io/path: 'f1.yaml'
     spec:
       replicas: 1
-  - kind: Service
+  - apiVersion: apps/v1
+    kind: Service
     metadata:
       name: foo
       annotations:

--- a/thirdparty/cmdconfig/commands/cmdsource/cmdsource_test.go
+++ b/thirdparty/cmdconfig/commands/cmdsource/cmdsource_test.go
@@ -417,6 +417,7 @@ func TestSourceCommandJSON(t *testing.T) {
 
 	err = ioutil.WriteFile(filepath.Join(d, "f1.json"), []byte(`
 {
+  "apiVersion": "apps/v1",
   "kind": "Deployment",
   "metadata": {
     "labels": {
@@ -468,7 +469,7 @@ func TestSourceCommandJSON(t *testing.T) {
 	expected := `apiVersion: config.kubernetes.io/v1alpha1
 kind: ResourceList
 items:
-  - {"kind": "Deployment", "metadata": {"labels": {"app": "nginx2"}, "name": "foo", "annotations": {"app": "nginx2", config.kubernetes.io/index: '0', config.kubernetes.io/path: 'f1.json'}}, "spec": {"replicas": 1}}
+  - {"apiVersion": "apps/v1", "kind": "Deployment", "metadata": {"labels": {"app": "nginx2"}, "name": "foo", "annotations": {"app": "nginx2", config.kubernetes.io/index: '0', config.kubernetes.io/path: 'f1.json'}}, "spec": {"replicas": 1}}
   - {"apiVersion": "v1", "kind": "Abstraction", "metadata": {"name": "foo", "annotations": {"config.kubernetes.io/function": "container:\n  image: gcr.io/example/reconciler:v1\n", "config.kubernetes.io/local-config": "true", config.kubernetes.io/index: '0', config.kubernetes.io/path: 'f2.json'}}, "spec": {"replicas": 3}}
 `
 

--- a/thirdparty/cmdconfig/commands/cmdsource/cmdsource_test.go
+++ b/thirdparty/cmdconfig/commands/cmdsource/cmdsource_test.go
@@ -146,6 +146,7 @@ func TestSourceCommand_Unwrap(t *testing.T) {
 	defer os.RemoveAll(d)
 
 	err = ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(`
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -156,6 +157,7 @@ metadata:
 spec:
   replicas: 1
 ---
+apiVersion: v1
 kind: Service
 metadata:
   name: foo
@@ -199,7 +201,8 @@ spec:
 		return
 	}
 
-	if !assert.Equal(t, `kind: Deployment
+	if !assert.Equal(t, `apiVersion: apps/v1
+kind: Deployment
 metadata:
   labels:
     app: nginx2
@@ -209,6 +212,7 @@ metadata:
 spec:
   replicas: 1
 ---
+apiVersion: v1
 kind: Service
 metadata:
   name: foo


### PR DESCRIPTION
fixes https://github.com/GoogleContainerTools/kpt/issues/2039

sample output: 

```
$ kpt fn source
error: f1.yaml: resource must have `metadata.name`
```