### PR TITLE
Avoid deleting local resources removed from upstream if there are local changes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,5 +22,5 @@ require (
 	k8s.io/kubectl v0.21.1
 	sigs.k8s.io/cli-utils v0.25.1-0.20210603052138-670dee18a123
 	sigs.k8s.io/kustomize/api v0.8.10 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.10.21
+	sigs.k8s.io/kustomize/kyaml v0.10.22-0.20210614195535-7e8ba62e9fd9
 )

--- a/go.sum
+++ b/go.sum
@@ -992,8 +992,8 @@ sigs.k8s.io/kustomize/cmd/config v0.9.10/go.mod h1:Mrby0WnRH7hA6OwOYnYpfpiY0WJIM
 sigs.k8s.io/kustomize/kustomize/v4 v4.1.2/go.mod h1:PxBvo4WGYlCLeRPL+ziT64wBXqbgfcalOS/SXa/tcyo=
 sigs.k8s.io/kustomize/kyaml v0.10.17/go.mod h1:mlQFagmkm1P+W4lZJbJ/yaxMd8PqMRSC4cPcfUVt5Hg=
 sigs.k8s.io/kustomize/kyaml v0.10.20/go.mod h1:TYWhGwW9vjoRh3rWqBwB/ZOXyEGRVWe7Ggc3+KZIO+c=
-sigs.k8s.io/kustomize/kyaml v0.10.21 h1:KdoEgz3HzmcaLUTFqs6aaqFpsaA9MVRIwOZbi8vMaD0=
-sigs.k8s.io/kustomize/kyaml v0.10.21/go.mod h1:TYWhGwW9vjoRh3rWqBwB/ZOXyEGRVWe7Ggc3+KZIO+c=
+sigs.k8s.io/kustomize/kyaml v0.10.22-0.20210614195535-7e8ba62e9fd9 h1:voAjfxarCKo1j3Kh34T3dSqbTi6EpfcVn/xGDvcWotE=
+sigs.k8s.io/kustomize/kyaml v0.10.22-0.20210614195535-7e8ba62e9fd9/go.mod h1:TYWhGwW9vjoRh3rWqBwB/ZOXyEGRVWe7Ggc3+KZIO+c=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.0 h1:C4r9BgJ98vrKnnVCjwCSXcWjWe0NKcUQkmzDXZXGwH8=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.0/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=

--- a/internal/util/merge/merge3.go
+++ b/internal/util/merge/merge3.go
@@ -97,7 +97,11 @@ func (m Merge3) Merge() error {
 	})
 
 	rmMatcher := ResourceMergeMatcher{MergeOnPath: m.MergeOnPath}
-	kyamlMerge := filters.Merge3{Matcher: &rmMatcher}
+	resourceHandler := resourceHandler{}
+	kyamlMerge := filters.Merge3{
+		Matcher: &rmMatcher,
+		Handler: &resourceHandler,
+	}
 
 	return kio.Pipeline{
 		Inputs:  inputs,
@@ -267,4 +271,75 @@ func metadataComment(node *yaml.RNode) string {
 		return ""
 	}
 	return mf.Key.YNode().LineComment
+}
+
+// resourceHandler is an implementation of the ResourceHandler interface from
+// kyaml. It is used to decide how a resource should be handled during the
+// 3-way merge. This differs from the default implementation in that if a
+// resource is deleted from upstream, it will only be deleted from local if
+// there is no diff between origin and local.
+type resourceHandler struct {
+	keptResources []*yaml.RNode
+}
+
+func (r *resourceHandler) Handle(origin, upstream, local *yaml.RNode) (filters.ResourceMergeStrategy, error) {
+	var strategy filters.ResourceMergeStrategy
+	switch {
+	case origin == nil && upstream == nil && local != nil:
+		strategy = filters.KeepDest
+	case upstream != nil && local == nil:
+		strategy = filters.KeepUpdated
+	case upstream == nil && local == nil:
+		strategy = filters.Skip
+	case origin != nil && upstream == nil:
+		equal, err := r.equals(origin, local)
+		if err != nil {
+			return strategy, err
+		}
+		if equal {
+			strategy = filters.Skip
+		} else {
+			r.keptResources = append(r.keptResources, local)
+			strategy = filters.KeepDest
+		}
+	case origin != nil && local == nil:
+		strategy = filters.Skip
+	default:
+		strategy = filters.Merge
+	}
+	return strategy, nil
+}
+
+func (*resourceHandler) equals(r1, r2 *yaml.RNode) (bool, error) {
+	// We need to create new copies of the resources since we need to
+	// mutate them before comparing them.
+	r1Clone, err := yaml.Parse(r1.MustString())
+	if err != nil {
+		return false, err
+	}
+	r2Clone, err := yaml.Parse(r2.MustString())
+	if err != nil {
+		return false, err
+	}
+
+	// The resources include annotations with information used during the merge
+	// process. We need to remove those before comparing the resources.
+	if err := stripKyamlAnnos(r1Clone); err != nil {
+		return false, err
+	}
+	if err := stripKyamlAnnos(r2Clone); err != nil {
+		return false, err
+	}
+
+	return r1Clone.MustString() == r2Clone.MustString(), nil
+}
+
+func stripKyamlAnnos(n *yaml.RNode) error {
+	for _, a := range []string{mergeSourceAnnotation, kioutil.PathAnnotation, kioutil.IndexAnnotation} {
+		err := n.PipeE(yaml.ClearAnnotation(a))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/internal/util/merge/merge3_test.go
+++ b/internal/util/merge/merge3_test.go
@@ -262,13 +262,6 @@ metadata:
   namespace: my-space
 spec:
   replicas: 3
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: nginx-deployment
-spec:
-  replicas: 4
 `},
 
 		`Conflict: User fetches package, copies a resource in same file, adds different name suffix`: {

--- a/internal/util/merge/merge3_test.go
+++ b/internal/util/merge/merge3_test.go
@@ -18,6 +18,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
@@ -187,22 +188,31 @@ func createPkgMultipleMutators(packageMutators, subPackageMutators []yaml.Filter
 		)
 }
 
-var merge3Cases = []testCase{
-	{
-		description: `Most common: add namespace and name-prefix on local, merge upstream changes`,
-		origin: `apiVersion: apps/v1
+func TestMerge3_Merge_path(t *testing.T) {
+	testCases := map[string]struct {
+		origin   string
+		update   string
+		local    string
+		expected string
+		errMsg   string
+	}{
+		`Most common: add namespace and name-prefix on local, merge upstream changes`: {
+			origin: `
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
 spec:
   replicas: 3`,
-		update: `apiVersion: apps/v1
+			update: `
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
 spec:
   replicas: 4`,
-		local: `apiVersion: apps/v1
+			local: `
+apiVersion: apps/v1
 kind: Deployment
 metadata: # kpt-merge: /nginx-deployment
   name: dev-nginx-deployment
@@ -210,7 +220,8 @@ metadata: # kpt-merge: /nginx-deployment
 spec:
   replicas: 3
 `,
-		expected: `apiVersion: apps/v1
+			expected: `
+apiVersion: apps/v1
 kind: Deployment
 metadata: # kpt-merge: /nginx-deployment
   name: dev-nginx-deployment
@@ -219,21 +230,23 @@ spec:
   replicas: 4
 `},
 
-	{
-		description: `Add namespace and name-prefix on local manually without adding annotations, adds new resource`,
-		origin: `apiVersion: apps/v1
+		`Add namespace and name-prefix on local manually without adding annotations, adds new resource`: {
+			origin: `
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
 spec:
   replicas: 3`,
-		update: `apiVersion: apps/v1
+			update: `
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
 spec:
   replicas: 4`,
-		local: `apiVersion: apps/v1
+			local: `
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dev-nginx-deployment
@@ -241,7 +254,8 @@ metadata:
 spec:
   replicas: 3
 `,
-		expected: `apiVersion: apps/v1
+			expected: `
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: dev-nginx-deployment
@@ -257,21 +271,23 @@ spec:
   replicas: 4
 `},
 
-	{
-		description: `Conflict: User fetches package, copies a resource in same file, adds different name suffix`,
-		origin: `apiVersion: apps/v1
+		`Conflict: User fetches package, copies a resource in same file, adds different name suffix`: {
+			origin: `
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
 spec:
   replicas: 3`,
-		update: `apiVersion: apps/v1
+			update: `
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
 spec:
   replicas: 4`,
-		local: `apiVersion: apps/v1
+			local: `
+apiVersion: apps/v1
 kind: Deployment
 metadata: # kpt-merge: default/nginx-deployment
   name: nginx-deployment-1
@@ -287,30 +303,33 @@ metadata: # kpt-merge: default/nginx-deployment
 spec:
   replicas: 3
 `,
-		errMsg: `found duplicate "local" resources in file "f1.yaml"`},
+			errMsg: `found duplicate "local" resources in file "f1.yaml"`},
 
-	{
-		description: `Publisher changes name in upstream but want to maintain original identity, no local customizations, fetch upstream changes`,
-		origin: `apiVersion: apps/v1
+		`Publisher changes name in upstream but want to maintain original identity, no local customizations, fetch upstream changes`: {
+			origin: `
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
 spec:
   replicas: 3`,
-		update: `apiVersion: apps/v1
+			update: `
+apiVersion: apps/v1
 kind: Deployment
 metadata: # kpt-merge: /nginx-deployment
   name: nginx-deployment-new
 spec:
   replicas: 4`,
-		local: `apiVersion: apps/v1
+			local: `
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
 spec:
   replicas: 3
 `,
-		expected: `apiVersion: apps/v1
+			expected: `
+apiVersion: apps/v1
 kind: Deployment
 metadata: # kpt-merge: /nginx-deployment
   name: nginx-deployment-new
@@ -318,22 +337,23 @@ spec:
   replicas: 4
 `},
 
-	{
-		description: `Publisher changes name in upstream but want to maintain original identity, consumer adds name-prefix 
-on local, fetch upstream changes`,
-		origin: `apiVersion: apps/v1
+		`Publisher changes name in upstream but want to maintain original identity, consumer adds name-prefix on local, fetch upstream changes`: {
+			origin: `
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
 spec:
   replicas: 3`,
-		update: `apiVersion: apps/v1
+			update: `
+apiVersion: apps/v1
 kind: Deployment
 metadata: # kpt-merge: default/nginx-deployment
   name: nginx-deployment-new
 spec:
   replicas: 4`,
-		local: `apiVersion: apps/v1
+			local: `
+apiVersion: apps/v1
 kind: Deployment
 metadata: # kpt-merge: default/nginx-deployment
   name: dev-nginx-deployment
@@ -341,7 +361,8 @@ metadata: # kpt-merge: default/nginx-deployment
 spec:
   replicas: 3
 `,
-		expected: `apiVersion: apps/v1
+			expected: `
+apiVersion: apps/v1
 kind: Deployment
 metadata: # kpt-merge: default/nginx-deployment
   name: nginx-deployment-new
@@ -350,22 +371,24 @@ spec:
   replicas: 4
 `},
 
-	{
-		description: `Publisher changes name in upstream but don't want to maintain original identity which is equivalent 
-to delete existing resource and add new one, consumer adds name-prefix on local`,
-		origin: `apiVersion: apps/v1
+		`Publisher changes name in upstream but don't want to maintain original identity which is equivalent 
+to delete existing resource and add new one, consumer adds name-prefix on local`: {
+			origin: `
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
 spec:
   replicas: 3`,
-		update: `apiVersion: apps/v1
+			update: `
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment-new
 spec:
   replicas: 4`,
-		local: `apiVersion: apps/v1
+			local: `
+apiVersion: apps/v1
 kind: Deployment
 metadata: # kpt-merge: /nginx-deployment
   name: dev-nginx-deployment
@@ -373,38 +396,16 @@ metadata: # kpt-merge: /nginx-deployment
 spec:
   replicas: 3
 `,
-		expected: `apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: nginx-deployment-new
-spec:
-  replicas: 4
-`},
-
-	{
-		description: `Publisher changes name in upstream but don't want to maintain original identity which is equivalent 
-to delete existing resource and add new one, consumer adds name-prefix on local`,
-		origin: `apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: nginx-deployment
-spec:
-  replicas: 3`,
-		update: `apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: nginx-deployment-new
-spec:
-  replicas: 4`,
-		local: `apiVersion: apps/v1
+			expected: `
+apiVersion: apps/v1
 kind: Deployment
 metadata: # kpt-merge: /nginx-deployment
   name: dev-nginx-deployment
   namespace: my-space
 spec:
   replicas: 3
-`,
-		expected: `apiVersion: apps/v1
+---
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment-new
@@ -412,29 +413,32 @@ spec:
   replicas: 4
 `},
 
-	{
-		description: `Publisher changes name multiple times in upstream but maintains original identity, no local customizations,
-fetch upstream changes`,
-		origin: `apiVersion: apps/v1
+		`Publisher changes name multiple times in upstream but maintains original identity, no local customizations,
+fetch upstream changes`: {
+			origin: `
+apiVersion: apps/v1
 kind: Deployment
 metadata: # kpt-merge: default/nginx-deployment
   name: nginx-deployment-new
 spec:
   replicas: 4`,
-		update: `apiVersion: apps/v1
+			update: `
+apiVersion: apps/v1
 kind: Deployment
 metadata: # kpt-merge: default/nginx-deployment
   name: nginx-deployment-new-again
 spec:
   replicas: 5`,
-		local: `apiVersion: apps/v1
+			local: `
+apiVersion: apps/v1
 kind: Deployment
 metadata: # kpt-merge: default/nginx-deployment
   name: nginx-deployment-new
 spec:
   replicas: 5
 `,
-		expected: `apiVersion: apps/v1
+			expected: `
+apiVersion: apps/v1
 kind: Deployment
 metadata: # kpt-merge: default/nginx-deployment
   name: nginx-deployment-new-again
@@ -442,22 +446,24 @@ spec:
   replicas: 5
 `},
 
-	{
-		description: `Publisher changes name multiple times in upstream but maintains original identity, consumer adds name-prefix 
-on local, fetch upstream changes`,
-		origin: `apiVersion: apps/v1
+		`Publisher changes name multiple times in upstream but maintains original identity, consumer adds name-prefix 
+on local, fetch upstream changes`: {
+			origin: `
+apiVersion: apps/v1
 kind: Deployment
 metadata: # kpt-merge: default/nginx-deployment
   name: nginx-deployment-new
 spec:
   replicas: 4`,
-		update: `apiVersion: apps/v1
+			update: `
+apiVersion: apps/v1
 kind: Deployment
 metadata: # kpt-merge: default/nginx-deployment
   name: nginx-deployment-new-again
 spec:
   replicas: 5`,
-		local: `apiVersion: apps/v1
+			local: `
+apiVersion: apps/v1
 kind: Deployment
 metadata: # kpt-merge: default/nginx-deployment
   name: dev-nginx-deployment
@@ -465,7 +471,8 @@ metadata: # kpt-merge: default/nginx-deployment
 spec:
   replicas: 5
 `,
-		expected: `apiVersion: apps/v1
+			expected: `
+apiVersion: apps/v1
 kind: Deployment
 metadata: # kpt-merge: default/nginx-deployment
   name: nginx-deployment-new-again
@@ -474,118 +481,106 @@ spec:
   replicas: 5
 `},
 
-	{
-		description: `Version changes are just like any other changes`,
-		origin: `apiVersion: apps/v1
+		`Version changes are just like any other changes`: {
+			origin: `
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
 spec:
   replicas: 3`,
-		update: `apiVersion: apps/v2
+			update: `
+apiVersion: apps/v2
 kind: Deployment
 metadata:
   name: nginx-deployment
 spec:
   replicas: 4`,
-		local: `apiVersion: apps/v1
+			local: `
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deployment
 spec:
   replicas: 3
 `,
-		expected: `apiVersion: apps/v2
+			expected: `
+apiVersion: apps/v2
 kind: Deployment
 metadata:
   name: nginx-deployment
 spec:
   replicas: 4
 `},
-}
-
-var testCases = [][]testCase{merge3Cases}
-
-func TestMerge3_Merge_path(t *testing.T) {
-	for i := range testCases {
-		for j := range testCases[i] {
-			tc := testCases[i][j]
-			t.Run(tc.description, func(t *testing.T) {
-
-				// setup the local directory
-				dir, err := ioutil.TempDir("", "merge3-test")
-				if !assert.NoError(t, err) {
-					t.FailNow()
-				}
-				defer os.RemoveAll(dir)
-
-				err = os.MkdirAll(filepath.Join(dir, "localDir"), 0700)
-				if !assert.NoError(t, err) {
-					t.FailNow()
-				}
-
-				err = os.MkdirAll(filepath.Join(dir, "updatedDir"), 0700)
-				if !assert.NoError(t, err) {
-					t.FailNow()
-				}
-
-				err = os.MkdirAll(filepath.Join(dir, "originalDir"), 0700)
-				if !assert.NoError(t, err) {
-					t.FailNow()
-				}
-
-				err = ioutil.WriteFile(filepath.Join(dir, "originalDir", "f1.yaml"), []byte(tc.origin), 0700)
-				if !assert.NoError(t, err) {
-					t.FailNow()
-				}
-
-				err = ioutil.WriteFile(filepath.Join(dir, "updatedDir", "f1.yaml"), []byte(tc.update), 0700)
-				if !assert.NoError(t, err) {
-					t.FailNow()
-				}
-
-				err = ioutil.WriteFile(filepath.Join(dir, "localDir", "f1.yaml"), []byte(tc.local), 0700)
-				if !assert.NoError(t, err) {
-					t.FailNow()
-				}
-
-				err = merge.Merge3{
-					OriginalPath: filepath.Join(dir, "originalDir"),
-					UpdatedPath:  filepath.Join(dir, "updatedDir"),
-					DestPath:     filepath.Join(dir, "localDir"),
-					MergeOnPath:  true,
-				}.Merge()
-				if tc.errMsg == "" {
-					if !assert.NoError(t, err) {
-						t.FailNow()
-					}
-				} else {
-					if !assert.Error(t, err) {
-						t.FailNow()
-					}
-					if !assert.Contains(t, err.Error(), tc.errMsg) {
-						t.FailNow()
-					}
-					return
-				}
-
-				b, err := ioutil.ReadFile(filepath.Join(dir, "localDir", "f1.yaml"))
-				if !assert.NoError(t, err) {
-					t.FailNow()
-				}
-				if !assert.Equal(t, tc.expected, string(b)) {
-					t.FailNow()
-				}
-			})
-		}
 	}
-}
 
-type testCase struct {
-	description string
-	origin      string
-	update      string
-	local       string
-	expected    string
-	errMsg      string
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+
+			// setup the local directory
+			dir, err := ioutil.TempDir("", "merge3-test")
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			defer os.RemoveAll(dir)
+
+			err = os.MkdirAll(filepath.Join(dir, "localDir"), 0700)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			err = os.MkdirAll(filepath.Join(dir, "updatedDir"), 0700)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			err = os.MkdirAll(filepath.Join(dir, "originalDir"), 0700)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			err = ioutil.WriteFile(filepath.Join(dir, "originalDir", "f1.yaml"), []byte(strings.TrimSpace(tc.origin)), 0700)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			err = ioutil.WriteFile(filepath.Join(dir, "updatedDir", "f1.yaml"), []byte(strings.TrimSpace(tc.update)), 0700)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			err = ioutil.WriteFile(filepath.Join(dir, "localDir", "f1.yaml"), []byte(strings.TrimSpace(tc.local)), 0700)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			err = merge.Merge3{
+				OriginalPath: filepath.Join(dir, "originalDir"),
+				UpdatedPath:  filepath.Join(dir, "updatedDir"),
+				DestPath:     filepath.Join(dir, "localDir"),
+				MergeOnPath:  true,
+			}.Merge()
+			if tc.errMsg == "" {
+				if !assert.NoError(t, err) {
+					t.FailNow()
+				}
+			} else {
+				if !assert.Error(t, err) {
+					t.FailNow()
+				}
+				if !assert.Contains(t, err.Error(), tc.errMsg) {
+					t.FailNow()
+				}
+				return
+			}
+
+			b, err := ioutil.ReadFile(filepath.Join(dir, "localDir", "f1.yaml"))
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			if !assert.Equal(t, strings.TrimSpace(tc.expected), strings.TrimSpace(string(b))) {
+				t.FailNow()
+			}
+		})
+	}
 }

--- a/internal/util/update/resource-merge_test.go
+++ b/internal/util/update/resource-merge_test.go
@@ -249,6 +249,30 @@ func TestUpdate_ResourceMerge(t *testing.T) {
 				WithResource(pkgbuilder.SecretResource).
 				WithResource(pkgbuilder.DeploymentResource, pkgbuilder.SetFieldPath("5", "spec", "replicas")),
 		},
+		"does not re-add files from upstream if deleted from local": {
+			origin: pkgbuilder.NewRootPkg().
+				WithResource(pkgbuilder.SecretResource).
+				WithResource(pkgbuilder.DeploymentResource),
+			local: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithUpstream("github.com/GoogleContainerTools/kpt", "/", "feature-branch", "resource-merge").
+						WithUpstreamLock("github.com/GoogleContainerTools/kpt", "/", "feature-branch", "def456"),
+				).
+				WithResource(pkgbuilder.SecretResource),
+			updated: pkgbuilder.NewRootPkg().
+				WithResource(pkgbuilder.SecretResource).
+				WithResource(pkgbuilder.DeploymentResource),
+			relPackagePath: "/",
+			isRoot:         true,
+			expected: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithUpstream("github.com/GoogleContainerTools/kpt", "/", "feature-branch", "resource-merge").
+						WithUpstreamLock("github.com/GoogleContainerTools/kpt", "/", "feature-branch", "def456"),
+				).
+				WithResource(pkgbuilder.SecretResource),
+		},
 	}
 
 	for tn, tc := range testCases {

--- a/internal/util/update/resource-merge_test.go
+++ b/internal/util/update/resource-merge_test.go
@@ -224,6 +224,31 @@ func TestUpdate_ResourceMerge(t *testing.T) {
 				).
 				WithResource(pkgbuilder.SecretResource),
 		},
+		"does not remove a file from local if it has local changes": {
+			origin: pkgbuilder.NewRootPkg().
+				WithResource(pkgbuilder.SecretResource).
+				WithResource(pkgbuilder.DeploymentResource),
+			local: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithUpstream("github.com/GoogleContainerTools/kpt", "/", "feature-branch", "resource-merge").
+						WithUpstreamLock("github.com/GoogleContainerTools/kpt", "/", "feature-branch", "def456"),
+				).
+				WithResource(pkgbuilder.SecretResource).
+				WithResource(pkgbuilder.DeploymentResource, pkgbuilder.SetFieldPath("5", "spec", "replicas")),
+			updated: pkgbuilder.NewRootPkg().
+				WithResource(pkgbuilder.SecretResource),
+			relPackagePath: "/",
+			isRoot:         true,
+			expected: pkgbuilder.NewRootPkg().
+				WithKptfile(
+					pkgbuilder.NewKptfile().
+						WithUpstream("github.com/GoogleContainerTools/kpt", "/", "feature-branch", "resource-merge").
+						WithUpstreamLock("github.com/GoogleContainerTools/kpt", "/", "feature-branch", "def456"),
+				).
+				WithResource(pkgbuilder.SecretResource).
+				WithResource(pkgbuilder.DeploymentResource, pkgbuilder.SetFieldPath("5", "spec", "replicas")),
+		},
 	}
 
 	for tn, tc := range testCases {


### PR DESCRIPTION
This PR changes the default behavior of the 3-way merge algorithm from kyaml in how it handles resources deleted in upstream. Instead of always removing any resources from local if they have been deleted from upstream, this will only delete the resources if they don't have local changes. This means we don't end up deleting customizations by the user.

There scenarios where we probably want to delete resources with changes, in particular if the changes result from running the pipeline. There is a separate issue for this: https://github.com/GoogleContainerTools/kpt/issues/1438

This PR does not include printing information to the user whenever a resource remains in the local fork due to local changes. Since this decision happens pretty deep in the update functionality, it requires some larger changes. I have a separate issue for this: https://github.com/GoogleContainerTools/kpt/issues/2241

Fixes: https://github.com/GoogleContainerTools/kpt/issues/2232