### PR TITLE
Remoove packageInfo.doc

### DIFF
--- a/pkg/api/kptfile/v1alpha2/types.go
+++ b/pkg/api/kptfile/v1alpha2/types.go
@@ -205,9 +205,6 @@ type PackageInfo struct {
 	// Relative slash-delimited path to the license file (e.g. LICENSE.txt)
 	LicenseFile string `yaml:"licenseFile,omitempty"`
 
-	// Doc is the path to documentation about the package.
-	Doc string `yaml:"doc,omitempty"`
-
 	// Description contains a short description of the package.
 	Description string `yaml:"description,omitempty"`
 


### PR DESCRIPTION
It overlaps with `packageInfo.man` which is already used in code.

