### PR TITLE
update kustomize example

### DIFF
--- a/package-examples/kustomize/bases/nginx/kustomization.yaml
+++ b/package-examples/kustomize/bases/nginx/kustomization.yaml
@@ -11,7 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: kustomization
 resources:
 - deployment.yaml
 - svc.yaml

--- a/package-examples/kustomize/overlays/dev/kustomization.yaml
+++ b/package-examples/kustomize/overlays/dev/kustomization.yaml
@@ -14,6 +14,8 @@
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  name: kustomization
 resources:
 - ../../bases/nginx
 - Kptfile

--- a/package-examples/kustomize/overlays/prod/kustomization.yaml
+++ b/package-examples/kustomize/overlays/prod/kustomization.yaml
@@ -14,6 +14,8 @@
 
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+metadata:
+  name: kustomization
 resources:
 - ../../bases/nginx
 - Kptfile


### PR DESCRIPTION
This example fails with `kpt fn render` and `kpt fn eval` currently: https://kubernetes.slack.com/archives/C0155NSPJSZ/p1623923678034500

This is because they require all files in the directory to be valid KRM resources. For now, this PR fixes the examples.
