### PR TITLE
support exec args

### DIFF
--- a/e2e/testdata/fn-eval/exec-function-with-args/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/exec-function-with-args/.expected/diff.patch
@@ -1,0 +1,21 @@
+diff --git a/resources.yaml b/resources.yaml
+index e8ae6bb..297b99f 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -15,7 +15,7 @@ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+   name: nginx-deployment
+-  namespace: foo
++  namespace: bar
+ spec:
+   replicas: 3
+ ---
+@@ -23,6 +23,6 @@ apiVersion: custom.io/v1
+ kind: Custom
+ metadata:
+   name: custom
+-  namespace: foo
++  namespace: bar
+ spec:
+   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/exec-function-with-args/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/exec-function-with-args/.expected/exec.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+kpt fn eval --exec "sed -e 's/foo/bar/'"

--- a/e2e/testdata/fn-eval/exec-function-with-args/.krmignore
+++ b/e2e/testdata/fn-eval/exec-function-with-args/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-eval/exec-function-with-args/resources.yaml
+++ b/e2e/testdata/fn-eval/exec-function-with-args/resources.yaml
@@ -1,0 +1,28 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: foo
+spec:
+  replicas: 3
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+  namespace: foo
+spec:
+  image: nginx:1.2.3

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.0
 	github.com/go-errors/errors v1.4.0
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/igorsobreira/titlecase v0.0.0-20140109233139-4156b5b858ac
 	github.com/philopon/go-toposort v0.0.0-20170620085441-9be86dbd762f
 	github.com/posener/complete/v2 v2.0.1-alpha.12

--- a/internal/docs/generated/fndocs/docs.go
+++ b/internal/docs/generated/fndocs/docs.go
@@ -60,10 +60,11 @@ Flags:
     the key of an already exported environment variable.
   
   --exec:
-    Path to the local executable binary to execute as a function. ` + "`" + `eval` + "`" + ` executes
-    only one function, so do not use ` + "`" + `--image` + "`" + ` flag with this flag. This is useful
-    for testing function locally during development. It enables faster dev iterations
-    by avoiding the function to be published as container image.
+    Path to the local executable binary to execute as a function. Quotes are needed
+    if the executable requires arguments. ` + "`" + `eval` + "`" + ` executes only one function, so do
+    not use ` + "`" + `--image` + "`" + ` flag with this flag. This is useful for testing function locally
+    during development. It enables faster dev iterations by avoiding the function to
+    be published as container image.
   
   --fn-config:
     Path to the file containing ` + "`" + `functionConfig` + "`" + ` for the function.
@@ -126,6 +127,10 @@ var EvalExamples = `
   # execute executable my-fn on the resources in DIR directory and
   # write output back to DIR
   $ kpt fn eval DIR --exec ./my-fn
+
+  # execute executable my-fn with arguments on the resources in DIR directory and
+  # write output back to DIR
+  $ kpt fn eval DIR --exec "./my-fn arg1 arg2"
 
   # execute container my-fn on the resources in DIR directory,
   # save structured results in /tmp/my-results dir and write output back to DIR

--- a/pkg/api/fnresult/v1alpha2/types.go
+++ b/pkg/api/fnresult/v1alpha2/types.go
@@ -26,6 +26,8 @@ type Result struct {
 	// Image and Exec are mutually exclusive
 	Image string `yaml:"image,omitempty"`
 	// ExecPath is the the absolute os-specific path to the executable file
+	// If user provides an executable file with commands, ExecPath should
+	// contain the entire input string.
 	ExecPath string `yaml:"exec,omitempty"`
 	// TODO(droot): This is required for making structured results subpackage aware.
 	// Enable this once test harness supports filepath based assertions.

--- a/site/book/05-developing-functions/03-developing-in-Typescript.md
+++ b/site/book/05-developing-functions/03-developing-in-Typescript.md
@@ -94,9 +94,7 @@ Currently supported platforms: amd64 Linux/Mac
    ```
 
    ```shell
-   $ kpt fn source $CONFIGS \
-     | kpt fn eval - --exec "node dist/label_namespace_run.js -d label_name=color -d label_value=orange" \
-     | kpt fn sink $CONFIGS
+   $ kpt fn eval $CONFIGS --exec "node dist/label_namespace_run.js" -- label_name=color label_value=orange
    ```
 
    As the name suggests, this function added the given label to all `Namespace`
@@ -142,9 +140,7 @@ Currently supported platforms: amd64 Linux/Mac
 1. Run `validate-rolebinding` on `example-configs`.
 
    ```shell
-   $ kpt fn source $CONFIGS \
-     | kpt fn eval - --exec "node dist/validate_rolebinding_run.js -d subject_name=alice@foo-corp.com" \
-     | kpt fn sink $CONFIGS
+   $ kpt fn eval $CONFIGS --exec "node dist/validate_rolebinding_run.js" -- subject_name=alice@foo-corp.com
    ```
 
    Look at the changes made by the function:
@@ -219,9 +215,7 @@ Currently supported platforms: amd64 Linux/Mac
 1. Run `expand-team-cr` on `example-configs`.
 
    ```shell
-   $ kpt fn source $CONFIGS \
-    | kpt fn eval - --exec "node dist/expand_team_cr_run.js" \
-    | kpt fn sink $CONFIGS
+   $ kpt fn eval $CONFIGS --exec "node dist/expand_team_cr_run.js"
    ```
 
    Look at the changes made by the function:

--- a/site/book/05-developing-functions/03-developing-in-Typescript.md
+++ b/site/book/05-developing-functions/03-developing-in-Typescript.md
@@ -95,7 +95,7 @@ Currently supported platforms: amd64 Linux/Mac
 
    ```shell
    $ kpt fn source $CONFIGS \
-     | node dist/label_namespace_run.js -d label_name=color -d label_value=orange \
+     | kpt fn eval - --exec "node dist/label_namespace_run.js -d label_name=color -d label_value=orange" \
      | kpt fn sink $CONFIGS
    ```
 
@@ -143,7 +143,7 @@ Currently supported platforms: amd64 Linux/Mac
 
    ```shell
    $ kpt fn source $CONFIGS \
-     | node dist/validate_rolebinding_run.js -d subject_name=alice@foo-corp.com \
+     | kpt fn eval - --exec "node dist/validate_rolebinding_run.js -d subject_name=alice@foo-corp.com" \
      | kpt fn sink $CONFIGS
    ```
 
@@ -220,7 +220,7 @@ Currently supported platforms: amd64 Linux/Mac
 
    ```shell
    $ kpt fn source $CONFIGS \
-    | node dist/expand_team_cr_run.js \
+    | kpt fn eval - --exec "node dist/expand_team_cr_run.js" \
     | kpt fn sink $CONFIGS
    ```
 

--- a/site/reference/cli/fn/eval/README.md
+++ b/site/reference/cli/fn/eval/README.md
@@ -65,10 +65,11 @@ fn-args:
   the key of an already exported environment variable.
 
 --exec:
-  Path to the local executable binary to execute as a function. `eval` executes
-  only one function, so do not use `--image` flag with this flag. This is useful
-  for testing function locally during development. It enables faster dev iterations
-  by avoiding the function to be published as container image.
+  Path to the local executable binary to execute as a function. Quotes are needed
+  if the executable requires arguments. `eval` executes only one function, so do
+  not use `--image` flag with this flag. This is useful for testing function locally
+  during development. It enables faster dev iterations by avoiding the function to
+  be published as container image.
 
 --fn-config:
   Path to the file containing `functionConfig` for the function.
@@ -144,6 +145,12 @@ $ kpt fn eval DIR -i gcr.io/example.com/my-fn:v1.0.0 -- foo=bar
 # execute executable my-fn on the resources in DIR directory and
 # write output back to DIR
 $ kpt fn eval DIR --exec ./my-fn
+```
+
+```shell
+# execute executable my-fn with arguments on the resources in DIR directory and
+# write output back to DIR
+$ kpt fn eval DIR --exec "./my-fn arg1 arg2"
 ```
 
 ```shell

--- a/site/sdk/ts-guide.md
+++ b/site/sdk/ts-guide.md
@@ -162,7 +162,7 @@ runtime.
    using the exec runtime.
 
    ```shell
-   $ kpt fn eval DIR --exec ./my_func_run-macos
+   $ kpt fn eval DIR --exec "node dist/my_func_run.js"
    ```
 
 ## Build and push container images

--- a/site/sdk/ts-guide.md
+++ b/site/sdk/ts-guide.md
@@ -150,14 +150,6 @@ runtime.
 
 ### Steps
 
-1. Use the pkg CLI to create an executable from your function's distributable
-   file. For a `my_fn` function built using the typescript SDK, this is
-   `dist/my_fn_run.js`.
-
-   ```shell
-   $ npx pkg dist/my_func_run.js
-   ```
-
 1. Pass the path to the appropriate executable for your OS when running kpt
    using the exec runtime.
 

--- a/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
+++ b/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
@@ -42,7 +42,7 @@ func GetEvalFnRunner(ctx context.Context, parent string) *EvalFnRunner {
 	r.Command.Flags().StringVarP(
 		&r.Image, "image", "i", "", "run this image as a function")
 	r.Command.Flags().StringVar(
-		&r.ExecPath, "exec", "", "run an executable as a function.")
+		&r.Exec, "exec", "", "run an executable as a function")
 	r.Command.Flags().StringVar(
 		&r.FnConfigPath, "fn-config", "", "path to the function config file")
 	r.Command.Flags().BoolVar(
@@ -76,7 +76,7 @@ type EvalFnRunner struct {
 	OutContent           bytes.Buffer
 	FromStdin            bool
 	Image                string
-	ExecPath             string
+	Exec                 string
 	FnConfigPath         string
 	RunFns               runfn.RunFns
 	ResultsDir           string
@@ -97,61 +97,16 @@ func (r *EvalFnRunner) runE(c *cobra.Command, _ []string) error {
 	return cmdutil.WriteFnOutput(r.Dest, r.OutContent.String(), r.FromStdin, printer.FromContextOrDie(r.Ctx).OutStream())
 }
 
-// getContainerFunctions parses the commandline flags and arguments into explicit
-// Functions to run.
-// TODO: refactor this function to avoid using annotations in function config.
-func (r *EvalFnRunner) getContainerFunctions(dataItems []string) (
-	[]*yaml.RNode, error) {
+// getCLIFunctionConfig parses the commandline flags and arguments into explicit
+// function config
+func (r *EvalFnRunner) getCLIFunctionConfig(dataItems []string) (
+	*yaml.RNode, error) {
 
-	if r.Image == "" && r.ExecPath == "" {
+	if r.Image == "" && r.Exec == "" {
 		return nil, nil
 	}
 
-	var fn *yaml.RNode
 	var err error
-
-	if r.Image != "" {
-		// create the function spec to set as an annotation
-		fn, err = yaml.Parse(`container: {}`)
-		if err != nil {
-			return nil, err
-		}
-		// TODO: add support network, volumes, etc based on flag values
-		err = fn.PipeE(
-			yaml.Lookup("container"),
-			yaml.SetField("image", yaml.NewScalarRNode(r.Image)))
-		if err != nil {
-			return nil, err
-		}
-		if r.Network {
-			err = fn.PipeE(
-				yaml.Lookup("container"),
-				yaml.SetField("network", yaml.NewScalarRNode("true")))
-			if err != nil {
-				return nil, err
-			}
-		}
-	} else if r.ExecPath != "" {
-		// check the flags that doesn't make sense with exec function
-		// --mount, --as-current-user, --network and --env are
-		// only used with container functions
-		if r.AsCurrentUser || r.Network ||
-			len(r.Mounts) != 0 || len(r.Env) != 0 {
-			return nil, fmt.Errorf("--mount, --as-current-user, --network and --env can only be used with container functions")
-		}
-		// create the function spec to set as an annotation
-		fn, err = yaml.Parse(`exec: {}`)
-		if err != nil {
-			return nil, err
-		}
-
-		err = fn.PipeE(
-			yaml.Lookup("exec"),
-			yaml.SetField("path", yaml.NewScalarRNode(r.ExecPath)))
-		if err != nil {
-			return nil, err
-		}
-	}
 
 	// create the function config
 	rc, err := yaml.Parse(`
@@ -159,19 +114,6 @@ metadata:
   name: function-input
 data: {}
 `)
-	if err != nil {
-		return nil, err
-	}
-
-	// set the function annotation on the function config so it
-	// is parsed by RunFns
-	value, err := fn.String()
-	if err != nil {
-		return nil, err
-	}
-	err = rc.PipeE(
-		yaml.LookupCreate(yaml.MappingNode, "metadata", "annotations"),
-		yaml.SetField(runtimeutil.FunctionAnnotationKey, yaml.NewScalarRNode(value)))
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +153,33 @@ data: {}
 	if err != nil {
 		return nil, err
 	}
-	return []*yaml.RNode{rc}, nil
+	return rc, nil
+}
+
+func (r *EvalFnRunner) getFunctionSpec() (*runtimeutil.FunctionSpec, []string, error) {
+	fn := &runtimeutil.FunctionSpec{}
+	var execArgs []string
+	if r.Image != "" {
+		fn.Container.Image = r.Image
+	} else if r.Exec != "" {
+		// check the flags that doesn't make sense with exec function
+		// --mount, --as-current-user, --network and --env are
+		// only used with container functions
+		if r.AsCurrentUser || r.Network ||
+			len(r.Mounts) != 0 || len(r.Env) != 0 {
+			return nil, nil, fmt.Errorf("--mount, --as-current-user, --network and --env can only be used with container functions")
+		}
+		if !strings.Contains(r.Exec, " ") {
+			fn.Exec.Path = r.Exec
+		} else {
+			// we use sh to run the commands so we don't need to
+			// parse the input command string to valid format that accepted
+			// by os.exec
+			fn.Exec.Path = "sh"
+			execArgs = append(execArgs, "-c", r.Exec)
+		}
+	}
+	return fn, execArgs, nil
 }
 
 func toStorageMounts(mounts []string) []runtimeutil.StorageMount {
@@ -237,7 +205,7 @@ func (r *EvalFnRunner) preRunE(c *cobra.Command, args []string) error {
 		}
 	}
 
-	if r.Image == "" && r.ExecPath == "" {
+	if r.Image == "" && r.Exec == "" {
 		return errors.Errorf("must specify --image or --exec")
 	}
 	if r.Image != "" {
@@ -271,7 +239,11 @@ func (r *EvalFnRunner) preRunE(c *cobra.Command, args []string) error {
 		return fmt.Errorf("function arguments can only be specified without function config file")
 	}
 
-	fns, err := r.getContainerFunctions(dataItems)
+	fnConfig, err := r.getCLIFunctionConfig(dataItems)
+	if err != nil {
+		return err
+	}
+	fnSpec, execArgs, err := r.getFunctionSpec()
 	if err != nil {
 		return err
 	}
@@ -310,7 +282,8 @@ func (r *EvalFnRunner) preRunE(c *cobra.Command, args []string) error {
 
 	r.RunFns = runfn.RunFns{
 		Ctx:                  r.Ctx,
-		Functions:            fns,
+		Function:             fnSpec,
+		ExecArgs:             execArgs,
 		Output:               output,
 		Input:                input,
 		Path:                 path,
@@ -319,6 +292,7 @@ func (r *EvalFnRunner) preRunE(c *cobra.Command, args []string) error {
 		ResultsDir:           r.ResultsDir,
 		Env:                  r.Env,
 		AsCurrentUser:        r.AsCurrentUser,
+		FnConfig:             fnConfig,
 		FnConfigPath:         r.FnConfigPath,
 		IncludeMetaResources: r.IncludeMetaResources,
 		ImagePullPolicy:      cmdutil.StringToImagePullPolicy(r.ImagePullPolicy),

--- a/thirdparty/cmdconfig/commands/cmdeval/cmdeval_test.go
+++ b/thirdparty/cmdconfig/commands/cmdeval/cmdeval_test.go
@@ -299,14 +299,14 @@ apiVersion: v1
 		},
 		{
 			name: "exec args",
-			args: []string{"eval", "dir", "--exec", "execPath arg1 arg2", "--", "a=b", "c=d", "e=f"},
+			args: []string{"eval", "dir", "--exec", "execPath arg1 'arg2 arg3'", "--", "a=b", "c=d", "e=f"},
 			path: "dir",
 			expectedFn: &runtimeutil.FunctionSpec{
 				Exec: runtimeutil.ExecSpec{
-					Path: "sh",
+					Path: "execPath",
 				},
 			},
-			expectedExecArgs: []string{"-c", "execPath arg1 arg2"},
+			expectedExecArgs: []string{"arg1", "arg2 arg3"},
 			expectedFnConfig: `
 metadata:
   name: function-input

--- a/thirdparty/cmdconfig/commands/cmdeval/cmdeval_test.go
+++ b/thirdparty/cmdconfig/commands/cmdeval/cmdeval_test.go
@@ -15,34 +15,39 @@ import (
 	"github.com/GoogleContainerTools/kpt/thirdparty/kyaml/runfn"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
 )
 
 // TestRunFnCommand_preRunE verifies that preRunE correctly parses the commandline
 // flags and arguments into the RunFns structure to be executed.
 func TestRunFnCommand_preRunE(t *testing.T) {
 	tests := []struct {
-		name           string
-		args           []string
-		expected       string
-		expectedStruct *runfn.RunFns
-		err            string
-		path           string
-		input          io.Reader
-		output         io.Writer
-		fnConfigPath   string
-		network        bool
-		mount          []string
+		name             string
+		args             []string
+		expectedFnConfig string
+		expectedFn       *runtimeutil.FunctionSpec
+		expectedStruct   *runfn.RunFns
+		expectedExecArgs []string
+		err              string
+		path             string
+		input            io.Reader
+		output           io.Writer
+		fnConfigPath     string
+		network          bool
+		mount            []string
 	}{
 		{
 			name: "config map",
 			args: []string{"eval", "dir", "--image", "foo:bar", "--", "a=b", "c=d", "e=f"},
 			path: "dir",
-			expected: `
+			expectedFn: &runtimeutil.FunctionSpec{
+				Container: runtimeutil.ContainerSpec{
+					Image: "foo:bar",
+				},
+			},
+			expectedFnConfig: `
 metadata:
   name: function-input
-  annotations:
-    config.kubernetes.io/function: |
-      container: {image: 'foo:bar'}
 data: {a: b, c: d, e: f}
 kind: ConfigMap
 apiVersion: v1
@@ -53,12 +58,14 @@ apiVersion: v1
 			args:   []string{"eval", "-", "--image", "foo:bar", "--", "a=b", "c=d", "e=f"},
 			input:  os.Stdin,
 			output: &bytes.Buffer{},
-			expected: `
+			expectedFn: &runtimeutil.FunctionSpec{
+				Container: runtimeutil.ContainerSpec{
+					Image: "foo:bar",
+				},
+			},
+			expectedFnConfig: `
 metadata:
   name: function-input
-  annotations:
-    config.kubernetes.io/function: |
-      container: {image: 'foo:bar'}
 data: {a: b, c: d, e: f}
 kind: ConfigMap
 apiVersion: v1
@@ -69,12 +76,14 @@ apiVersion: v1
 			args:   []string{"eval", "dir", "--image", "foo:bar", "-o", "stdout", "--", "a=b", "c=d", "e=f"},
 			output: &bytes.Buffer{},
 			path:   "dir",
-			expected: `
+			expectedFn: &runtimeutil.FunctionSpec{
+				Container: runtimeutil.ContainerSpec{
+					Image: "foo:bar",
+				},
+			},
+			expectedFnConfig: `
 metadata:
   name: function-input
-  annotations:
-    config.kubernetes.io/function: |
-      container: {image: 'foo:bar'}
 data: {a: b, c: d, e: f}
 kind: ConfigMap
 apiVersion: v1
@@ -84,12 +93,14 @@ apiVersion: v1
 			name: "config map no args",
 			args: []string{"eval", "dir", "--image", "foo:bar"},
 			path: "dir",
-			expected: `
+			expectedFn: &runtimeutil.FunctionSpec{
+				Container: runtimeutil.ContainerSpec{
+					Image: "foo:bar",
+				},
+			},
+			expectedFnConfig: `
 metadata:
   name: function-input
-  annotations:
-    config.kubernetes.io/function: |
-      container: {image: 'foo:bar'}
 data: {}
 kind: ConfigMap
 apiVersion: v1
@@ -100,12 +111,14 @@ apiVersion: v1
 			args:    []string{"eval", "dir", "--image", "foo:bar", "--network"},
 			path:    "dir",
 			network: true,
-			expected: `
+			expectedFn: &runtimeutil.FunctionSpec{
+				Container: runtimeutil.ContainerSpec{
+					Image: "foo:bar",
+				},
+			},
+			expectedFnConfig: `
 metadata:
   name: function-input
-  annotations:
-    config.kubernetes.io/function: |
-      container: {image: 'foo:bar', network: true}
 data: {}
 kind: ConfigMap
 apiVersion: v1
@@ -116,12 +129,14 @@ apiVersion: v1
 			args:    []string{"eval", "dir", "--image", "foo:bar", "--network"},
 			path:    "dir",
 			network: true,
-			expected: `
+			expectedFn: &runtimeutil.FunctionSpec{
+				Container: runtimeutil.ContainerSpec{
+					Image: "foo:bar",
+				},
+			},
+			expectedFnConfig: `
 metadata:
   name: function-input
-  annotations:
-    config.kubernetes.io/function: |
-      container: {image: 'foo:bar', network: true}
 data: {}
 kind: ConfigMap
 apiVersion: v1
@@ -131,12 +146,14 @@ apiVersion: v1
 			name: "custom kind",
 			args: []string{"eval", "dir", "--image", "foo:bar", "--", "Foo", "g=h"},
 			path: "dir",
-			expected: `
+			expectedFn: &runtimeutil.FunctionSpec{
+				Container: runtimeutil.ContainerSpec{
+					Image: "foo:bar",
+				},
+			},
+			expectedFnConfig: `
 metadata:
   name: function-input
-  annotations:
-    config.kubernetes.io/function: |
-      container: {image: 'foo:bar'}
 data: {g: h}
 kind: Foo
 apiVersion: v1
@@ -146,12 +163,14 @@ apiVersion: v1
 			name: "custom kind '=' in data",
 			args: []string{"eval", "dir", "--image", "foo:bar", "--", "Foo", "g=h", "i=j=k"},
 			path: "dir",
-			expected: `
+			expectedFn: &runtimeutil.FunctionSpec{
+				Container: runtimeutil.ContainerSpec{
+					Image: "foo:bar",
+				},
+			},
+			expectedFnConfig: `
 metadata:
   name: function-input
-  annotations:
-    config.kubernetes.io/function: |
-      container: {image: 'foo:bar'}
 data: {g: h, i: j=k}
 kind: Foo
 apiVersion: v1
@@ -166,12 +185,14 @@ apiVersion: v1
 				"--image", "foo:bar", "--", "Foo", "g=h", "i=j=k"},
 			path:  "dir",
 			mount: []string{"type=bind,src=/mount/path,dst=/local/", "type=volume,src=myvol,dst=/local/", "type=tmpfs,dst=/local/"},
-			expected: `
+			expectedFn: &runtimeutil.FunctionSpec{
+				Container: runtimeutil.ContainerSpec{
+					Image: "foo:bar",
+				},
+			},
+			expectedFnConfig: `
 metadata:
   name: function-input
-  annotations:
-    config.kubernetes.io/function: |
-      container: {image: 'foo:bar'}
 data: {g: h, i: j=k}
 kind: Foo
 apiVersion: v1
@@ -189,12 +210,14 @@ apiVersion: v1
 				ContinueOnEmptyResult: true,
 				Ctx:                   context.TODO(),
 			},
-			expected: `
+			expectedFn: &runtimeutil.FunctionSpec{
+				Container: runtimeutil.ContainerSpec{
+					Image: "foo:bar",
+				},
+			},
+			expectedFnConfig: `
 metadata:
   name: function-input
-  annotations:
-    config.kubernetes.io/function: |
-      container: {image: 'foo:bar'}
 data: {a: b, c: d, e: f}
 kind: ConfigMap
 apiVersion: v1
@@ -226,12 +249,14 @@ apiVersion: v1
 				ContinueOnEmptyResult: true,
 				Ctx:                   context.TODO(),
 			},
-			expected: `
+			expectedFn: &runtimeutil.FunctionSpec{
+				Container: runtimeutil.ContainerSpec{
+					Image: "foo:bar",
+				},
+			},
+			expectedFnConfig: `
 metadata:
   name: function-input
-  annotations:
-    config.kubernetes.io/function: |
-      container: {image: 'foo:bar'}
 data: {}
 kind: ConfigMap
 apiVersion: v1
@@ -249,12 +274,14 @@ apiVersion: v1
 				ContinueOnEmptyResult: true,
 				Ctx:                   context.TODO(),
 			},
-			expected: `
+			expectedFn: &runtimeutil.FunctionSpec{
+				Container: runtimeutil.ContainerSpec{
+					Image: "foo:bar",
+				},
+			},
+			expectedFnConfig: `
 metadata:
   name: function-input
-  annotations:
-    config.kubernetes.io/function: |
-      container: {image: 'foo:bar'}
 data: {}
 kind: ConfigMap
 apiVersion: v1
@@ -269,6 +296,24 @@ apiVersion: v1
 			name: "--fn-config with function arguments",
 			args: []string{"eval", "dir", "--fn-config", "a/b/c", "--image", "foo:bar", "--", "a=b", "c=d", "e=f"},
 			err:  "function arguments can only be specified without function config file",
+		},
+		{
+			name: "exec args",
+			args: []string{"eval", "dir", "--exec", "execPath arg1 arg2", "--", "a=b", "c=d", "e=f"},
+			path: "dir",
+			expectedFn: &runtimeutil.FunctionSpec{
+				Exec: runtimeutil.ExecSpec{
+					Path: "sh",
+				},
+			},
+			expectedExecArgs: []string{"-c", "execPath arg1 arg2"},
+			expectedFnConfig: `
+metadata:
+  name: function-input
+data: {a: b, c: d, e: f}
+kind: ConfigMap
+apiVersion: v1
+`,
 		},
 	}
 
@@ -343,19 +388,34 @@ apiVersion: v1
 				t.FailNow()
 			}
 
-			// check if Functions were set
-			if tt.expected != "" {
-				if !assert.Len(t, r.RunFns.Functions, 1) {
+			// check if function config was set
+			if tt.expectedFnConfig != "" {
+				actual := strings.TrimSpace(r.RunFns.FnConfig.MustString())
+				if !assert.Equal(t, strings.TrimSpace(tt.expectedFnConfig), actual) {
 					t.FailNow()
 				}
-				actual := strings.TrimSpace(r.RunFns.Functions[0].MustString())
-				if !assert.Equal(t, strings.TrimSpace(tt.expected), actual) {
+			}
+
+			// check if function was set
+			if tt.expectedFn != nil {
+				if !assert.NotNil(t, r.RunFns.Function) {
+					t.FailNow()
+				}
+				if !assert.EqualValues(t, tt.expectedFn, r.RunFns.Function) {
+					t.FailNow()
+				}
+			}
+
+			// check if exec arguments were set
+			if len(tt.expectedExecArgs) != 0 {
+				if !assert.EqualValues(t, tt.expectedExecArgs, r.RunFns.ExecArgs) {
 					t.FailNow()
 				}
 			}
 
 			if tt.expectedStruct != nil {
-				r.RunFns.Functions = nil
+				r.RunFns.Function = nil
+				r.RunFns.FnConfig = nil
 				tt.expectedStruct.FnConfigPath = tt.fnConfigPath
 				if !assert.Equal(t, *tt.expectedStruct, r.RunFns) {
 					t.FailNow()

--- a/thirdparty/kyaml/runfn/runfn.go
+++ b/thirdparty/kyaml/runfn/runfn.go
@@ -91,6 +91,9 @@ type RunFns struct {
 	// ExecArgs are the arguments for exec commands
 	ExecArgs []string
 
+	// OriginalExec is the original exec commands
+	OriginalExec string
+
 	ImagePullPolicy fnruntime.ImagePullPolicy
 }
 
@@ -353,12 +356,7 @@ func (r *RunFns) defaultFnFilterProvider(spec runtimeutil.FunctionSpec, fnConfig
 			FunctionConfig: fnConfig,
 			DeferFailure:   spec.DeferFailure,
 		}
-		if len(r.ExecArgs) == 0 {
-			fnResult.ExecPath = spec.Exec.Path
-		} else {
-			// the commands are run in shell we only show the real command
-			fnResult.ExecPath = r.ExecArgs[1]
-		}
+		fnResult.ExecPath = r.OriginalExec
 
 	}
 	return fnruntime.NewFunctionRunner(r.Ctx, fltr, fnResult, r.fnResults)

--- a/thirdparty/kyaml/runfn/runfn.go
+++ b/thirdparty/kyaml/runfn/runfn.go
@@ -9,18 +9,13 @@ import (
 	"io"
 	"os"
 	"os/user"
-	"path"
 	"path/filepath"
-	"sort"
-	"strconv"
-	"strings"
 
 	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/filters"
-	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 
 	"github.com/GoogleContainerTools/kpt/internal/fnruntime"
@@ -49,8 +44,11 @@ type RunFns struct {
 	// The exact format depends on the OS.
 	FnConfigPath string
 
-	// Functions is an explicit list of functions to run against the input.
-	Functions []*yaml.RNode
+	// Function is an function to run against the input.
+	Function *runtimeutil.FunctionSpec
+
+	// FnConfig is the configurations passed from command line
+	FnConfig *yaml.RNode
 
 	// Input can be set to read the Resources from Input rather than from a directory
 	Input io.Reader
@@ -89,6 +87,9 @@ type RunFns struct {
 	// IncludeMetaResources indicates will kpt add pkg meta resources such as
 	// Kptfile to the input resources to the function.
 	IncludeMetaResources bool
+
+	// ExecArgs are the arguments for exec commands
+	ExecArgs []string
 
 	ImagePullPolicy fnruntime.ImagePullPolicy
 }
@@ -148,33 +149,22 @@ func (r RunFns) getNodesAndFilters() (
 }
 
 func (r RunFns) getFilters() ([]kio.Filter, error) {
-	fns := r.Functions
-	var fltrs []kio.Filter
-	for i := range fns {
-		api := fns[i]
-		spec := runtimeutil.GetFunctionSpec(api)
-		if spec == nil {
-			// resource doesn't have function spec
-			continue
-		}
-		if spec.Container.Network && !r.Network {
-			// TODO(eddiezane): Provide error info about which function needs the network
-			return fltrs, errors.Errorf("network required but not enabled with --network")
-		}
-		// merge envs from imperative and declarative
-		spec.Container.Env = r.mergeContainerEnv(spec.Container.Env)
-
-		c, err := r.functionFilterProvider(*spec, api, user.Current)
-		if err != nil {
-			return nil, err
-		}
-
-		if c == nil {
-			continue
-		}
-		fltrs = append(fltrs, c)
+	spec := r.Function
+	if spec == nil {
+		return nil, nil
 	}
-	return fltrs, nil
+	// merge envs from imperative and declarative
+	spec.Container.Env = r.mergeContainerEnv(spec.Container.Env)
+
+	c, err := r.functionFilterProvider(*spec, r.FnConfig, user.Current)
+	if err != nil {
+		return nil, err
+	}
+
+	if c == nil {
+		return nil, nil
+	}
+	return []kio.Filter{c}, nil
 }
 
 // runFunctions runs the fltrs against the input and writes to either r.Output or output
@@ -240,72 +230,6 @@ func (r RunFns) mergeContainerEnv(envs []string) []string {
 	}
 
 	return declarative.Raw()
-}
-
-// sortFns sorts functions so that functions with the longest paths come first
-func sortFns(buff *kio.PackageBuffer) error {
-	var outerErr error
-	// sort the nodes so that we traverse them depth first
-	// functions deeper in the file system tree should be run first
-	sort.Slice(buff.Nodes, func(i, j int) bool {
-		mi, _ := buff.Nodes[i].GetMeta()
-		pi := filepath.ToSlash(mi.Annotations[kioutil.PathAnnotation])
-
-		mj, _ := buff.Nodes[j].GetMeta()
-		pj := filepath.ToSlash(mj.Annotations[kioutil.PathAnnotation])
-
-		// If the path is the same, we decide the ordering based on the
-		// index annotation.
-		if pi == pj {
-			iIndex, err := strconv.Atoi(mi.Annotations[kioutil.IndexAnnotation])
-			if err != nil {
-				outerErr = err
-				return false
-			}
-			jIndex, err := strconv.Atoi(mj.Annotations[kioutil.IndexAnnotation])
-			if err != nil {
-				outerErr = err
-				return false
-			}
-			return iIndex < jIndex
-		}
-
-		if filepath.Base(path.Dir(pi)) == "functions" {
-			// don't count the functions dir, the functions are scoped 1 level above
-			pi = filepath.Dir(path.Dir(pi))
-		} else {
-			pi = filepath.Dir(pi)
-		}
-
-		if filepath.Base(path.Dir(pj)) == "functions" {
-			// don't count the functions dir, the functions are scoped 1 level above
-			pj = filepath.Dir(path.Dir(pj))
-		} else {
-			pj = filepath.Dir(pj)
-		}
-
-		// i is "less" than j (comes earlier) if its depth is greater -- e.g. run
-		// i before j if it is deeper in the directory structure
-		li := len(strings.Split(pi, "/"))
-		if pi == "." {
-			// local dir should have 0 path elements instead of 1
-			li = 0
-		}
-		lj := len(strings.Split(pj, "/"))
-		if pj == "." {
-			// local dir should have 0 path elements instead of 1
-			lj = 0
-		}
-		if li != lj {
-			// use greater-than because we want to sort with the longest
-			// paths FIRST rather than last
-			return li > lj
-		}
-
-		// sort by path names if depths are equal
-		return pi < pj
-	})
-	return outerErr
 }
 
 // init initializes the RunFns with a containerFilterProvider.
@@ -404,7 +328,7 @@ func (r *RunFns) defaultFnFilterProvider(spec runtimeutil.FunctionSpec, fnConfig
 			Env:             spec.Container.Env,
 			FnResult:        fnResult,
 			Perm: fnruntime.ContainerFnPermission{
-				AllowNetwork: spec.Container.Network,
+				AllowNetwork: r.Network,
 				// mounts are always from CLI flags so we allow
 				// them by default for eval
 				AllowMount: true,
@@ -421,6 +345,7 @@ func (r *RunFns) defaultFnFilterProvider(spec runtimeutil.FunctionSpec, fnConfig
 	if spec.Exec.Path != "" {
 		e := &fnruntime.ExecFn{
 			Path:     spec.Exec.Path,
+			Args:     r.ExecArgs,
 			FnResult: fnResult,
 		}
 		fltr = &runtimeutil.FunctionFilter{
@@ -428,7 +353,13 @@ func (r *RunFns) defaultFnFilterProvider(spec runtimeutil.FunctionSpec, fnConfig
 			FunctionConfig: fnConfig,
 			DeferFailure:   spec.DeferFailure,
 		}
-		fnResult.ExecPath = spec.Exec.Path
+		if len(r.ExecArgs) == 0 {
+			fnResult.ExecPath = spec.Exec.Path
+		} else {
+			// the commands are run in shell we only show the real command
+			fnResult.ExecPath = r.ExecArgs[1]
+		}
+
 	}
 	return fnruntime.NewFunctionRunner(r.Ctx, fltr, fnResult, r.fnResults)
 }

--- a/thirdparty/kyaml/runfn/runfn_test.go
+++ b/thirdparty/kyaml/runfn/runfn_test.go
@@ -26,12 +26,6 @@ import (
 const (
 	ValueReplacerYAMLData = `apiVersion: v1
 kind: ValueReplacer
-metadata:
-  annotations:
-    config.kubernetes.io/function: |
-      container:
-        image: gcr.io/example.com/image:version
-    config.kubernetes.io/local-config: "true"
 stringMatch: Deployment
 replace: StatefulSet
 `
@@ -79,13 +73,13 @@ func TestRunFns_Execute__initDefault(t *testing.T) {
 		},
 		{
 			name:     "explicit functions -- no functions from input",
-			instance: RunFns{Functions: []*yaml.RNode{{}}},
-			expected: RunFns{Output: os.Stdout, Input: os.Stdin, Functions: []*yaml.RNode{{}}},
+			instance: RunFns{Function: nil},
+			expected: RunFns{Output: os.Stdout, Input: os.Stdin, Function: nil},
 		},
 		{
 			name:     "explicit functions -- yes functions from input",
-			instance: RunFns{Functions: []*yaml.RNode{{}}},
-			expected: RunFns{Output: os.Stdout, Input: os.Stdin, Functions: []*yaml.RNode{{}}},
+			instance: RunFns{Function: nil},
+			expected: RunFns{Output: os.Stdout, Input: os.Stdin, Function: nil},
 		},
 		{
 			name:     "explicit functions in paths -- no functions from input",
@@ -127,108 +121,26 @@ func TestRunFns_Execute__initDefault(t *testing.T) {
 	}
 }
 
-func TestRunFns_sortFns(t *testing.T) {
-	testCases := []struct {
-		name           string
-		nodes          []*yaml.RNode
-		expectedImages []string
-		expectedErrMsg string
-	}{
-		{
-			name: "multiple functions in the same file are ordered by index",
-			nodes: []*yaml.RNode{
-				yaml.MustParse(`
-metadata:
-  annotations:
-    config.kubernetes.io/path: functions.yaml
-    config.kubernetes.io/index: 1
-    config.kubernetes.io/function: |
-      container:
-        image: a
-`),
-				yaml.MustParse(`
-metadata:
-  annotations:
-    config.kubernetes.io/path: functions.yaml
-    config.kubernetes.io/index: 0
-    config.kubernetes.io/function: |
-      container:
-        image: b
-`),
-			},
-			expectedImages: []string{"b", "a"},
-		},
-		{
-			name: "non-integer value in index annotation is an error",
-			nodes: []*yaml.RNode{
-				yaml.MustParse(`
-metadata:
-  annotations:
-    config.kubernetes.io/path: functions.yaml
-    config.kubernetes.io/index: 0
-    config.kubernetes.io/function: |
-      container:
-        image: a
-`),
-				yaml.MustParse(`
-metadata:
-  annotations:
-    config.kubernetes.io/path: functions.yaml
-    config.kubernetes.io/index: abc
-    config.kubernetes.io/function: |
-      container:
-        image: b
-`),
-			},
-			expectedErrMsg: "strconv.Atoi: parsing \"abc\": invalid syntax",
-		},
-	}
-
-	for i := range testCases {
-		test := testCases[i]
-		t.Run(test.name, func(t *testing.T) {
-			packageBuff := &kio.PackageBuffer{
-				Nodes: test.nodes,
-			}
-
-			err := sortFns(packageBuff)
-			if test.expectedErrMsg != "" {
-				if !assert.Error(t, err) {
-					t.FailNow()
-				}
-				assert.Equal(t, test.expectedErrMsg, err.Error())
-				return
-			}
-
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
-
-			var images []string
-			for _, n := range packageBuff.Nodes {
-				spec := runtimeutil.GetFunctionSpec(n)
-				images = append(images, spec.Container.Image)
-			}
-
-			assert.Equal(t, test.expectedImages, images)
-		})
-	}
-}
-
 func TestCmd_Execute(t *testing.T) {
 	dir := setupTest(t)
 	defer os.RemoveAll(dir)
 
-	fn, err := yaml.Parse(ValueReplacerYAMLData)
+	fnConfig, err := yaml.Parse(ValueReplacerYAMLData)
 	if err != nil {
 		t.Fatal(err)
+	}
+	fn := &runtimeutil.FunctionSpec{
+		Container: runtimeutil.ContainerSpec{
+			Image: "gcr.io/example.com/image:version",
+		},
 	}
 
 	instance := RunFns{
 		Ctx:                    fake.CtxWithDefaultPrinter(),
 		Path:                   dir,
 		functionFilterProvider: getFilterProvider(t),
-		Functions:              []*yaml.RNode{fn},
+		Function:               fn,
+		FnConfig:               fnConfig,
 		fnResults:              fnresult.NewResultList(),
 	}
 	if !assert.NoError(t, instance.Execute()) {
@@ -246,9 +158,14 @@ func TestCmd_Execute_includeMetaResources(t *testing.T) {
 	dir := setupTest(t)
 	defer os.RemoveAll(dir)
 
-	fn, err := yaml.Parse(ValueReplacerYAMLData)
+	fnConfig, err := yaml.Parse(ValueReplacerYAMLData)
 	if err != nil {
 		t.Fatal(err)
+	}
+	fn := &runtimeutil.FunctionSpec{
+		Container: runtimeutil.ContainerSpec{
+			Image: "gcr.io/example.com/image:version",
+		},
 	}
 
 	// write a Kptfile to the directory of configuration
@@ -262,7 +179,8 @@ func TestCmd_Execute_includeMetaResources(t *testing.T) {
 		Path:                   dir,
 		functionFilterProvider: getMetaResourceFilterProvider(),
 		IncludeMetaResources:   true,
-		Functions:              []*yaml.RNode{fn},
+		Function:               fn,
+		FnConfig:               fnConfig,
 		fnResults:              fnresult.NewResultList(),
 	}
 	if !assert.NoError(t, instance.Execute()) {
@@ -365,9 +283,14 @@ func TestCmd_Execute_setFnConfigPath(t *testing.T) {
 		return
 	}
 
-	fn, err := yaml.Parse(ValueReplacerYAMLData)
+	fnConfig, err := yaml.Parse(ValueReplacerYAMLData)
 	if err != nil {
 		t.Fatal(err)
+	}
+	fn := &runtimeutil.FunctionSpec{
+		Container: runtimeutil.ContainerSpec{
+			Image: "gcr.io/example.com/image:version",
+		},
 	}
 
 	// run the functions, providing the path to the directory of filters
@@ -375,7 +298,8 @@ func TestCmd_Execute_setFnConfigPath(t *testing.T) {
 		Ctx:          fake.CtxWithDefaultPrinter(),
 		FnConfigPath: tmpF.Name(),
 		Path:         dir,
-		Functions:    []*yaml.RNode{fn},
+		Function:     fn,
+		FnConfig:     fnConfig,
 		fnResults:    fnresult.NewResultList(),
 	}
 	instance.functionFilterProvider = getFnConfigPathFilterProvider(t, &instance)
@@ -399,9 +323,14 @@ func TestCmd_Execute_setOutput(t *testing.T) {
 	dir := setupTest(t)
 	defer os.RemoveAll(dir)
 
-	fn, err := yaml.Parse(ValueReplacerYAMLData)
+	fnConfig, err := yaml.Parse(ValueReplacerYAMLData)
 	if err != nil {
 		t.Fatal(err)
+	}
+	fn := &runtimeutil.FunctionSpec{
+		Container: runtimeutil.ContainerSpec{
+			Image: "gcr.io/example.com/image:version",
+		},
 	}
 
 	out := &bytes.Buffer{}
@@ -410,7 +339,8 @@ func TestCmd_Execute_setOutput(t *testing.T) {
 		Output:                 out, // write to out
 		Path:                   dir,
 		functionFilterProvider: getFilterProvider(t),
-		Functions:              []*yaml.RNode{fn},
+		Function:               fn,
+		FnConfig:               fnConfig,
 		fnResults:              fnresult.NewResultList(),
 	}
 	// initialize the defaults
@@ -432,9 +362,14 @@ func TestCmd_Execute_setOutput(t *testing.T) {
 func TestCmd_Execute_setInput(t *testing.T) {
 	dir := setupTest(t)
 	defer os.RemoveAll(dir)
-	fn, err := yaml.Parse(ValueReplacerYAMLData)
+	fnConfig, err := yaml.Parse(ValueReplacerYAMLData)
 	if err != nil {
 		t.Fatal(err)
+	}
+	fn := &runtimeutil.FunctionSpec{
+		Container: runtimeutil.ContainerSpec{
+			Image: "gcr.io/example.com/image:version",
+		},
 	}
 
 	read, err := kio.LocalPackageReader{PackagePath: dir}.Read()
@@ -461,7 +396,8 @@ func TestCmd_Execute_setInput(t *testing.T) {
 		Input:                  input, // read from input
 		Path:                   outDir,
 		functionFilterProvider: getFilterProvider(t),
-		Functions:              []*yaml.RNode{fn},
+		Function:               fn,
+		FnConfig:               fnConfig,
 		fnResults:              fnresult.NewResultList(),
 	}
 	// initialize the defaults
@@ -476,78 +412,6 @@ func TestCmd_Execute_setInput(t *testing.T) {
 		t.FailNow()
 	}
 	assert.Contains(t, string(b), "kind: StatefulSet")
-}
-
-func getGeneratorFilterProvider(t *testing.T) func(runtimeutil.FunctionSpec, *yaml.RNode, currentUserFunc) (kio.Filter, error) {
-	return func(f runtimeutil.FunctionSpec, node *yaml.RNode, currentUser currentUserFunc) (kio.Filter, error) {
-		return kio.FilterFunc(func(items []*yaml.RNode) ([]*yaml.RNode, error) {
-			if f.Container.Image == "generate" {
-				node, err := yaml.Parse("kind: generated")
-				if !assert.NoError(t, err) {
-					t.FailNow()
-				}
-				return append(items, node), nil
-			}
-			return items, nil
-		}), nil
-	}
-}
-func TestRunFns_ContinueOnEmptyResult(t *testing.T) {
-	fn1, err := yaml.Parse(`
-kind: fakefn
-metadata:
-  annotations:
-    config.kubernetes.io/function: |
-      container:
-        image: pass
-`)
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	fn2, err := yaml.Parse(`
-kind: fakefn
-metadata:
-  annotations:
-    config.kubernetes.io/function: |
-      container:
-        image: generate
-`)
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-
-	var test = []struct {
-		ContinueOnEmptyResult bool
-		ExpectedOutput        string
-	}{
-		{
-			ContinueOnEmptyResult: false,
-			ExpectedOutput:        "",
-		},
-		{
-			ContinueOnEmptyResult: true,
-			ExpectedOutput: `apiVersion: config.kubernetes.io/v1alpha1
-kind: ResourceList
-items:
-  - kind: generated
-`,
-		},
-	}
-	for i := range test {
-		ouputBuffer := bytes.Buffer{}
-		r := RunFns{
-			Ctx:                    fake.CtxWithDefaultPrinter(),
-			Input:                  bytes.NewReader([]byte{}),
-			Output:                 &ouputBuffer,
-			Functions:              []*yaml.RNode{fn1, fn2},
-			functionFilterProvider: getGeneratorFilterProvider(t),
-			ContinueOnEmptyResult:  test[i].ContinueOnEmptyResult,
-		}
-		if !assert.NoError(t, r.Execute()) {
-			t.FailNow()
-		}
-		assert.Equal(t, test[i].ExpectedOutput, ouputBuffer.String())
-	}
 }
 
 // setupTest initializes a temp test directory containing test data


### PR DESCRIPTION
#2046

1. Support arguments for `--exec`. Example: `kpt fn eval --exec "sed -e 's/foo/bar/'"`. If there are arguments they must be quoted.
2. Refactor eval runner and entirely remove the annotation `config.kubernetes.io/function`.