### PR TITLE
Fix support for local-config annotation

### DIFF
--- a/pkg/live/helpers_test.go
+++ b/pkg/live/helpers_test.go
@@ -101,4 +101,22 @@ kind: Custom
 metadata:
   name: cr
 `
+	localConfig = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data: {}
+`
+	notLocalConfig = `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+  annotations:
+    config.kubernetes.io/local-config: "false"
+data: {}
+`
 )

--- a/pkg/live/rgpath_test.go
+++ b/pkg/live/rgpath_test.go
@@ -97,6 +97,32 @@ func TestPathManifestReader_Read(t *testing.T) {
 				},
 			},
 		},
+		"Function config resources which are marked as not being local config remains": {
+			manifests: map[string]string{
+				"Kptfile":           kptFileWithPipeline,
+				"deployment-a.yaml": deploymentA,
+				"cm.yaml":           notLocalConfig,
+			},
+			namespace: "test-namespace",
+			expectedObjs: []object.ObjMetadata{
+				{
+					GroupKind: schema.GroupKind{
+						Group: "",
+						Kind:  "ConfigMap",
+					},
+					Name:      "cm",
+					Namespace: "test-namespace",
+				},
+				{
+					GroupKind: schema.GroupKind{
+						Group: "apps",
+						Kind:  "Deployment",
+					},
+					Name:      "test-deployment",
+					Namespace: "test-namespace",
+				},
+			},
+		},
 		"CR and CRD in the same set is ok": {
 			manifests: map[string]string{
 				"crd.yaml": crd,
@@ -126,6 +152,23 @@ func TestPathManifestReader_Read(t *testing.T) {
 			},
 			namespace:      "test-namespace",
 			expectedErrMsg: "unknown resource types: Custom.custom.io",
+		},
+		"local-config is filtered out": {
+			manifests: map[string]string{
+				"deployment-a.yaml": deploymentA,
+				"lc.yaml":           localConfig,
+			},
+			namespace: "test-namespace",
+			expectedObjs: []object.ObjMetadata{
+				{
+					GroupKind: schema.GroupKind{
+						Group: "apps",
+						Kind:  "Deployment",
+					},
+					Name:      "test-deployment",
+					Namespace: "test-namespace",
+				},
+			},
 		},
 	}
 


### PR DESCRIPTION
This adds back the support for the local config annotation that was removed in error in an earlier PR. This also adds support for using `config.kubernetes.io/local-config: "false"` to explicitly set a resource as not being local config. This means that even if the file with the resource is referenced from the hydration pipeline, it will be applied by kpt. 

Any other values than `"true"` or `"false"` are also allowed and they will cause the resource to be considered local config. This is a little strange, but I don't think we should let kpt error out on other values.
