### PR TITLE
Only install the ResourceGroup CRD once

### DIFF
--- a/internal/cmdapply/cmdapply.go
+++ b/internal/cmdapply/cmdapply.go
@@ -187,9 +187,13 @@ func (r *Runner) runE(c *cobra.Command, args []string) error {
 func runApply(r *Runner, invInfo inventory.InventoryInfo, objs []*unstructured.Unstructured,
 	dryRunStrategy common.DryRunStrategy) error {
 	if r.installCRD {
-		err := cmdutil.InstallResourceGroupCRD(r.ctx, r.provider.Factory())
-		if err != nil {
-			return err
+		f := r.provider.Factory()
+		// Only install the ResourceGroup CRD if it is not already installed.
+		if err := cmdutil.VerifyResourceGroupCRD(f); err != nil {
+			err = cmdutil.InstallResourceGroupCRD(r.ctx, f)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
* Only installs `ResourceGroup` CRD once before apply.
* Adds end-to-end tests to verify.
* Fixes https://github.com/GoogleContainerTools/kpt/issues/2253
