### PR TITLE
fn eval and render should understand image refs via SHA

### DIFF
--- a/pkg/api/kptfile/v1/validation.go
+++ b/pkg/api/kptfile/v1/validation.go
@@ -60,7 +60,7 @@ func (p *Pipeline) validate(pkgPath types.UniquePath) error {
 }
 
 func (f *Function) validate(fnType string, idx int, pkgPath types.UniquePath) error {
-	err := validateFunctionName(f.Image)
+	err := ValidateFunctionName(f.Image)
 	if err != nil {
 		return &ValidateError{
 			Field:  fmt.Sprintf("pipeline.%s[%d].image", fnType, idx),
@@ -95,7 +95,7 @@ func (f *Function) validate(fnType string, idx int, pkgPath types.UniquePath) er
 	return nil
 }
 
-// validateFunctionName validates the function name.
+// ValidateFunctionName validates the function name.
 // According to Docker implementation
 // https://github.com/docker/distribution/blob/master/reference/reference.go. A valid
 // name definition is:
@@ -106,14 +106,16 @@ func (f *Function) validate(fnType string, idx int, pkgPath types.UniquePath) er
 //	path-component                  := alpha-numeric [separator alpha-numeric]*
 // 	alpha-numeric                   := /[a-z0-9]+/
 //	separator                       := /[_.]|__|[-]*/
-func validateFunctionName(name string) error {
+func ValidateFunctionName(name string) error {
 	pathComponentRegexp := `(?:[a-z0-9](?:(?:[_.]|__|[-]*)[a-z0-9]+)*)`
 	domainComponentRegexp := `(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])`
 	domainRegexp := fmt.Sprintf(`%s(?:\.%s)*(?:\:[0-9]+)?`, domainComponentRegexp, domainComponentRegexp)
 	nameRegexp := fmt.Sprintf(`(?:%s\/)?%s(?:\/%s)*`, domainRegexp,
 		pathComponentRegexp, pathComponentRegexp)
 	tagRegexp := `(?:[\w][\w.-]{0,127})`
-	r := fmt.Sprintf(`^(?:%s(?:\:%s)?)$`, nameRegexp, tagRegexp)
+	shaRegexp := `(sha256:[a-zA-Z0-9]{64})`
+	versionRegexp := fmt.Sprintf(`(%s|%s)`, tagRegexp, shaRegexp)
+	r := fmt.Sprintf(`^(?:%s(?:(\:|@)%s)?)$`, nameRegexp, versionRegexp)
 
 	matched, err := regexp.MatchString(r, name)
 	if err != nil {

--- a/pkg/api/kptfile/v1/validation.go
+++ b/pkg/api/kptfile/v1/validation.go
@@ -60,7 +60,7 @@ func (p *Pipeline) validate(pkgPath types.UniquePath) error {
 }
 
 func (f *Function) validate(fnType string, idx int, pkgPath types.UniquePath) error {
-	err := ValidateFunctionName(f.Image)
+	err := ValidateFunctionImageURL(f.Image)
 	if err != nil {
 		return &ValidateError{
 			Field:  fmt.Sprintf("pipeline.%s[%d].image", fnType, idx),
@@ -95,7 +95,7 @@ func (f *Function) validate(fnType string, idx int, pkgPath types.UniquePath) er
 	return nil
 }
 
-// ValidateFunctionName validates the function name.
+// ValidateFunctionImageURL validates the function name.
 // According to Docker implementation
 // https://github.com/docker/distribution/blob/master/reference/reference.go. A valid
 // name definition is:
@@ -106,7 +106,7 @@ func (f *Function) validate(fnType string, idx int, pkgPath types.UniquePath) er
 //	path-component                  := alpha-numeric [separator alpha-numeric]*
 // 	alpha-numeric                   := /[a-z0-9]+/
 //	separator                       := /[_.]|__|[-]*/
-func ValidateFunctionName(name string) error {
+func ValidateFunctionImageURL(name string) error {
 	pathComponentRegexp := `(?:[a-z0-9](?:(?:[_.]|__|[-]*)[a-z0-9]+)*)`
 	domainComponentRegexp := `(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])`
 	domainRegexp := fmt.Sprintf(`%s(?:\.%s)*(?:\:[0-9]+)?`, domainComponentRegexp, domainComponentRegexp)

--- a/pkg/api/kptfile/v1/validation_test.go
+++ b/pkg/api/kptfile/v1/validation_test.go
@@ -235,7 +235,7 @@ func TestValidateFunctionName(t *testing.T) {
 	for _, n := range inputs {
 		n := n
 		t.Run(n.Name, func(t *testing.T) {
-			err := ValidateFunctionName(n.Name)
+			err := ValidateFunctionImageURL(n.Name)
 			if n.Valid && err != nil {
 				t.Fatalf("function name %s should be valid", n.Name)
 			}

--- a/pkg/api/kptfile/v1/validation_test.go
+++ b/pkg/api/kptfile/v1/validation_test.go
@@ -225,12 +225,17 @@ func TestValidateFunctionName(t *testing.T) {
 			"Foo/FarB",
 			false,
 		},
+		{
+			"example.com/foo/generate-folders@sha256:3434a5299f8fcb2c2ade9975e56ca5a622427b9d5a9a971640765e830fb90a0e",
+		true,
+		},
+
 	}
 
 	for _, n := range inputs {
 		n := n
 		t.Run(n.Name, func(t *testing.T) {
-			err := validateFunctionName(n.Name)
+			err := ValidateFunctionName(n.Name)
 			if n.Valid && err != nil {
 				t.Fatalf("function name %s should be valid", n.Name)
 			}

--- a/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
+++ b/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
@@ -15,6 +15,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/pkgutil"
+	kptfile "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/GoogleContainerTools/kpt/thirdparty/cmdconfig/commands/runner"
 	"github.com/GoogleContainerTools/kpt/thirdparty/kyaml/runfn"
 	"github.com/google/shlex"
@@ -161,6 +162,9 @@ func (r *EvalFnRunner) getFunctionSpec() (*runtimeutil.FunctionSpec, []string, e
 	fn := &runtimeutil.FunctionSpec{}
 	var execArgs []string
 	if r.Image != "" {
+		if err := kptfile.ValidateFunctionName(r.Image); err != nil {
+			return nil, nil, err
+		}
 		fn.Container.Image = r.Image
 	} else if r.Exec != "" {
 		// check the flags that doesn't make sense with exec function

--- a/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
+++ b/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
@@ -162,7 +162,7 @@ func (r *EvalFnRunner) getFunctionSpec() (*runtimeutil.FunctionSpec, []string, e
 	fn := &runtimeutil.FunctionSpec{}
 	var execArgs []string
 	if r.Image != "" {
-		if err := kptfile.ValidateFunctionName(r.Image); err != nil {
+		if err := kptfile.ValidateFunctionImageURL(r.Image); err != nil {
 			return nil, nil, err
 		}
 		fn.Container.Image = r.Image


### PR DESCRIPTION
fixes https://github.com/GoogleContainerTools/kpt/issues/2322, and makes validation consistent for `fn render` and `fn eval`
