### PR TITLE
added debugging info to pre-hook

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -6,7 +6,7 @@ diff=`git diff`
 
 if [[ $diff != "" ]];
 then 
-        echo "Found unstaged changes. Make sure to run `make generate` for updating the docs before you commit the changes."
+        echo "Found unstaged changes [$diff]. Make sure to run `make generate` for updating the docs before you commit the changes."
         exit 1
 else 
         exit 0

--- a/Makefile
+++ b/Makefile
@@ -58,13 +58,13 @@ license:
 	GOBIN=$(GOBIN) scripts/update-license.sh
 
 lint:
-	(which golangci-lint || go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.31.0)
+	(which golangci-lint || go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.31.0)
 	$(GOBIN)/golangci-lint run ./...
 
 # TODO: enable this as part of `all` target when it works for go-errors
 # https://github.com/google/go-licenses/issues/15
 license-check:
-	(which go-licensesscs || go get https://github.com/google/go-licenses)
+	(which go-licensesscs || go install https://github.com/google/go-licenses)
 	$(GOBIN)/go-licenses check github.com/GoogleContainerTools/kpt
 
 test:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.0
 	github.com/go-errors/errors v1.4.0
-	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/igorsobreira/titlecase v0.0.0-20140109233139-4156b5b858ac
 	github.com/philopon/go-toposort v0.0.0-20170620085441-9be86dbd762f
 	github.com/posener/complete/v2 v2.0.1-alpha.12


### PR DESCRIPTION
This PR:

- makes the logs for `pre-hook` more informative by showing the the `git diff`
- It also replaced the `go get` to `go install` in relevant Makefile targets to avoid updating the `go.mod` file.
- It also does `go mod tidy` for pkg that was updated recently (shlex).

