### PR TITLE
Don't guard against fnconfig path existence

### DIFF
--- a/internal/pkg/pkg_test.go
+++ b/internal/pkg/pkg_test.go
@@ -775,6 +775,36 @@ func TestFunctionConfigFilePaths(t *testing.T) {
 	}
 }
 
+func TestValidatePipelineWithSubpackageResource(t *testing.T) {
+	subdir := "config"
+	resourceName := "myconfig.yaml"
+	manifest := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: resize
+data:
+  by-path: spec.replicas
+  by-value: "3"
+  put-value: "5"
+`
+	pkgPath := pkgbuilder.NewRootPkg().
+		WithKptfile(
+			pkgbuilder.NewKptfile().
+				WithPipeline(pkgbuilder.NewFunction("functionImage").WithConfigPath(filepath.Join(subdir, resourceName)))).
+		WithSubPackages(pkgbuilder.NewSubPkg(subdir).WithRawResource(resourceName, manifest)).
+		ExpandPkg(t, nil)
+	p, err := New(pkgPath)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+
+	err = p.ValidatePipeline()
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+}
+
 func Chdir(t *testing.T, path string) func() {
 	cwd, err := os.Getwd()
 	if !assert.NoError(t, err) {

--- a/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
+++ b/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
@@ -195,14 +195,6 @@ func toStorageMounts(mounts []string) []runtimeutil.StorageMount {
 	return sms
 }
 
-func checkFnConfigPathExistence(path string) error {
-	// check does fn config file exist
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return fmt.Errorf("missing function config file: %s", path)
-	}
-	return nil
-}
-
 func (r *EvalFnRunner) preRunE(c *cobra.Command, args []string) error {
 	if r.Dest != "" && r.Dest != cmdutil.Stdout && r.Dest != cmdutil.Unwrap {
 		if err := cmdutil.CheckDirectoryNotPresent(r.Dest); err != nil {
@@ -277,13 +269,6 @@ func (r *EvalFnRunner) preRunE(c *cobra.Command, args []string) error {
 
 	// parse mounts to set storageMounts
 	storageMounts := toStorageMounts(r.Mounts)
-
-	if r.FnConfigPath != "" {
-		err = checkFnConfigPathExistence(r.FnConfigPath)
-		if err != nil {
-			return err
-		}
-	}
 
 	r.RunFns = runfn.RunFns{
 		Ctx:                  r.Ctx,

--- a/thirdparty/cmdconfig/commands/cmdeval/cmdeval_test.go
+++ b/thirdparty/cmdconfig/commands/cmdeval/cmdeval_test.go
@@ -288,9 +288,31 @@ apiVersion: v1
 `,
 		},
 		{
-			name: "--fn-config flag",
-			args: []string{"eval", "dir", "--fn-config", "a/b/c", "--image", "foo:bar"},
-			err:  "missing function config file: a/b/c",
+			name:         "--fn-config flag ",
+			args:         []string{"eval", "dir", "--fn-config", "a/b/c", "--image", "foo:bar"},
+			path:         "dir",
+			fnConfigPath: "a/b/c",
+			expectedStruct: &runfn.RunFns{
+				Path:                  "dir",
+				AsCurrentUser:         false,
+				ImagePullPolicy:       fnruntime.AlwaysPull,
+				Env:                   []string{},
+				FnConfigPath:          "a/b/c",
+				ContinueOnEmptyResult: true,
+				Ctx:                   context.TODO(),
+			},
+			expectedFn: &runtimeutil.FunctionSpec{
+				Container: runtimeutil.ContainerSpec{
+					Image: "foo:bar",
+				},
+			},
+			expectedFnConfig: `
+metadata:
+  name: function-input
+data: {}
+kind: ConfigMap
+apiVersion: v1
+`,
 		},
 		{
 			name: "--fn-config with function arguments",

--- a/thirdparty/kyaml/runfn/runfn_test.go
+++ b/thirdparty/kyaml/runfn/runfn_test.go
@@ -407,7 +407,7 @@ func TestCmd_Execute_nonexistentFnConfigPath(t *testing.T) {
 		FnConfig:     fnConfig,
 		fnResults:    fnresult.NewResultList(),
 	}
-	// instance.functionFilterProvider = getFnConfigPathFilterProvider(t, &instance)
+
 	// initialize the defaults
 	assert.NoError(t, instance.init())
 


### PR DESCRIPTION
`kyaml/runfn` already handles missing function config paths.
Fixes https://github.com/GoogleContainerTools/kpt/issues/2346