### PR TITLE
kpt fn render: e2e test for fnconfig in subdir

### DIFF
--- a/e2e/testdata/fn-render/fnconfig-in-subdir/.expected/config.yaml
+++ b/e2e/testdata/fn-render/fnconfig-in-subdir/.expected/config.yaml
@@ -1,0 +1,14 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# 

--- a/e2e/testdata/fn-render/fnconfig-in-subdir/.expected/diff.patch
+++ b/e2e/testdata/fn-render/fnconfig-in-subdir/.expected/diff.patch
@@ -1,0 +1,28 @@
+diff --git a/resources.yaml b/resources.yaml
+index 7a494c9..d22aec8 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -15,12 +15,23 @@ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+   name: nginx-deployment
++  labels:
++    tier: db
+ spec:
+   replicas: 3
++  selector:
++    matchLabels:
++      tier: db
++  template:
++    metadata:
++      labels:
++        tier: db
+ ---
+ apiVersion: custom.io/v1
+ kind: Custom
+ metadata:
+   name: custom
++  labels:
++    tier: db
+ spec:
+   image: nginx:1.2.3

--- a/e2e/testdata/fn-render/fnconfig-in-subdir/.krmignore
+++ b/e2e/testdata/fn-render/fnconfig-in-subdir/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-render/fnconfig-in-subdir/Kptfile
+++ b/e2e/testdata/fn-render/fnconfig-in-subdir/Kptfile
@@ -1,0 +1,8 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: app-with-db
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-labels:v0.1
+      configPath: db/labelconfig.yaml

--- a/e2e/testdata/fn-render/fnconfig-in-subdir/db/labelconfig.yaml
+++ b/e2e/testdata/fn-render/fnconfig-in-subdir/db/labelconfig.yaml
@@ -1,0 +1,19 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: label-config
+data:
+  tier: db

--- a/e2e/testdata/fn-render/fnconfig-in-subdir/resources.yaml
+++ b/e2e/testdata/fn-render/fnconfig-in-subdir/resources.yaml
@@ -1,0 +1,26 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+spec:
+  image: nginx:1.2.3


### PR DESCRIPTION
This PR adds an e2e tests for verifying `kpt fn render` supports:  functionConfig can refer to a file in a subdirectory in the package.