### PR TITLE
Remove the `next` tag from kpt images

### DIFF
--- a/release/tag/goreleaser.yaml
+++ b/release/tag/goreleaser.yaml
@@ -29,11 +29,9 @@ builds:
 dockers:
   - image_templates:
       - "gcr.io/kpt-dev/kpt:{{ .Tag }}"
-      - "gcr.io/kpt-dev/kpt:next"
     dockerfile: "release/images/Dockerfile"
   - image_templates:
       - "gcr.io/kpt-dev/kpt-gcloud:{{ .Tag }}"
-      - "gcr.io/kpt-dev/kpt-gcloud:next"
     dockerfile: "release/images/Dockerfile-gcloud"
 archives:
   - id: archived

--- a/site/installation/README.md
+++ b/site/installation/README.md
@@ -70,7 +70,7 @@ Use one of the kpt docker images.
 ### `kpt`
 
 ```shell
-$ docker run gcr.io/kpt-dev/kpt:next version
+$ docker run gcr.io/kpt-dev/kpt:v1.0.0-beta.1 version
 ```
 
 ### `kpt-gcloud`
@@ -78,7 +78,7 @@ $ docker run gcr.io/kpt-dev/kpt:next version
 An image which includes kpt based upon the Google [cloud-sdk] alpine image.
 
 ```shell
-$ docker run gcr.io/kpt-dev/kpt-gcloud:next version
+$ docker run gcr.io/kpt-dev/kpt-gcloud:v1.0.0-beta.1 version
 ```
 
 ## Source


### PR DESCRIPTION
We should no longer build images with the `next` tag. Releases should only be built using the semver tags. 

We might want to set up a CD pipeline for building images directly from `main` using the `unstable` tag, although I don't think we have actually had any requests for this yet.
