### PR TITLE
Fix issue where live resolver passes the wrong error to the template engine

### DIFF
--- a/internal/errors/resolver/live.go
+++ b/internal/errors/resolver/live.go
@@ -101,28 +101,30 @@ Resource types:
 type liveErrorResolver struct{}
 
 func (*liveErrorResolver) Resolve(err error) (ResolvedResult, bool) {
-	tmplArgs := map[string]interface{}{
-		"err": err,
-	}
-
 	var noInventoryObjError *inventory.NoInventoryObjError
 	if errors.As(err, &noInventoryObjError) {
 		return ResolvedResult{
-			Message: ExecuteTemplate(noInventoryObjErrorMsg, tmplArgs),
+			Message: ExecuteTemplate(noInventoryObjErrorMsg, map[string]interface{}{
+				"err": *noInventoryObjError,
+			}),
 		}, true
 	}
 
 	var multipleInventoryObjError *inventory.MultipleInventoryObjError
 	if errors.As(err, &multipleInventoryObjError) {
 		return ResolvedResult{
-			Message: ExecuteTemplate(multipleInventoryObjErrorMsg, tmplArgs),
+			Message: ExecuteTemplate(multipleInventoryObjErrorMsg, map[string]interface{}{
+				"err": *multipleInventoryObjError,
+			}),
 		}, true
 	}
 
 	var timeoutError *taskrunner.TimeoutError
 	if errors.As(err, &timeoutError) {
 		return ResolvedResult{
-			Message:  ExecuteTemplate(timeoutErrorMsg, tmplArgs),
+			Message: ExecuteTemplate(timeoutErrorMsg, map[string]interface{}{
+				"err": *timeoutError,
+			}),
 			ExitCode: TimeoutErrorExitCode,
 		}, true
 	}
@@ -139,35 +141,45 @@ func (*liveErrorResolver) Resolve(err error) (ResolvedResult, bool) {
 	var noResourceGroupCRDError *cmdutil.NoResourceGroupCRDError
 	if errors.As(err, &noResourceGroupCRDError) {
 		return ResolvedResult{
-			Message: ExecuteTemplate(noResourceGroupCRDMsg, tmplArgs),
+			Message: ExecuteTemplate(noResourceGroupCRDMsg, map[string]interface{}{
+				"err": *noResourceGroupCRDError,
+			}),
 		}, true
 	}
 
 	var invExistsError *cmdliveinit.InvExistsError
 	if errors.As(err, &invExistsError) {
 		return ResolvedResult{
-			Message: ExecuteTemplate(invInfoAlreadyExistsMsg, tmplArgs),
+			Message: ExecuteTemplate(invInfoAlreadyExistsMsg, map[string]interface{}{
+				"err": *invExistsError,
+			}),
 		}, true
 	}
 
 	var multipleInvInfoError *live.MultipleInventoryInfoError
 	if errors.As(err, &multipleInvInfoError) {
 		return ResolvedResult{
-			Message: ExecuteTemplate(multipleInvInfoMsg, tmplArgs),
+			Message: ExecuteTemplate(multipleInvInfoMsg, map[string]interface{}{
+				"err": *multipleInvInfoError,
+			}),
 		}, true
 	}
 
 	var inventoryInfoValidationError *live.InventoryInfoValidationError
 	if errors.As(err, &inventoryInfoValidationError) {
 		return ResolvedResult{
-			Message: ExecuteTemplate(inventoryInfoValidationMsg, tmplArgs),
+			Message: ExecuteTemplate(inventoryInfoValidationMsg, map[string]interface{}{
+				"err": *inventoryInfoValidationError,
+			}),
 		}, true
 	}
 
 	var unknownTypesError *manifestreader.UnknownTypesError
 	if errors.As(err, &unknownTypesError) {
 		return ResolvedResult{
-			Message: ExecuteTemplate(unknownTypesMsg, tmplArgs),
+			Message: ExecuteTemplate(unknownTypesMsg, map[string]interface{}{
+				"err": *unknownTypesError,
+			}),
 		}, true
 	}
 	return ResolvedResult{}, false

--- a/internal/errors/resolver/live_test.go
+++ b/internal/errors/resolver/live_test.go
@@ -1,0 +1,83 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resolver
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoogleContainerTools/kpt/internal/errors"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
+	"sigs.k8s.io/cli-utils/pkg/object"
+)
+
+func TestLiveErrorResolver(t *testing.T) {
+	testCases := map[string]struct {
+		err      error
+		expected string
+	}{
+		"nested timeoutError": {
+			err: &errors.Error{
+				Err: &taskrunner.TimeoutError{
+					Identifiers: []object.ObjMetadata{
+						{
+							GroupKind: schema.GroupKind{
+								Group: "apps",
+								Kind:  "Deployment",
+							},
+							Name:      "test",
+							Namespace: "test-ns",
+						},
+					},
+					Condition: taskrunner.AllCurrent,
+					Timeout:   3 * time.Second,
+					TimedOutResources: []taskrunner.TimedOutResource{
+						{
+							Identifier: object.ObjMetadata{
+								GroupKind: schema.GroupKind{
+									Group: "apps",
+									Kind:  "Deployment",
+								},
+								Name:      "test",
+								Namespace: "test-ns",
+							},
+							Status:  status.InProgressStatus,
+							Message: "this is a test",
+						},
+					},
+				},
+			},
+			expected: `
+Error: Timeout after 3 seconds waiting for 1 out of 1 resources to reach condition AllCurrent:
+
+Deployment/test InProgress this is a test
+`,
+		},
+	}
+
+	for tn, tc := range testCases {
+		t.Run(tn, func(t *testing.T) {
+			res, ok := (&liveErrorResolver{}).Resolve(tc.err)
+			if !ok {
+				t.Error("expected error to be resolved, but it wasn't")
+			}
+			assert.Equal(t, strings.TrimSpace(tc.expected), strings.TrimSpace(res.Message))
+		})
+	}
+}

--- a/pkg/api/kptfile/v1/validation_test.go
+++ b/pkg/api/kptfile/v1/validation_test.go
@@ -227,9 +227,8 @@ func TestValidateFunctionName(t *testing.T) {
 		},
 		{
 			"example.com/foo/generate-folders@sha256:3434a5299f8fcb2c2ade9975e56ca5a622427b9d5a9a971640765e830fb90a0e",
-		true,
+			true,
 		},
-
 	}
 
 	for _, n := range inputs {


### PR DESCRIPTION
The live error resolver has a bug where the top-level error is passed to the template engine instead of the specific type needed by the template.