### PR TITLE
Update kind and k8s for e2e tests

### DIFF
--- a/.github/workflows/e2eEnvironment.yml
+++ b/.github/workflows/e2eEnvironment.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        version: [1.18, 1.19]
+        version: [1.19, 1.20]
     steps:
       - name: Set up Go
         uses: actions/setup-go@v2
@@ -40,7 +40,7 @@ jobs:
       - name: Install KinD
         uses: engineerd/setup-kind@aa272fe2a7309878ffc2a81c56cfe3ef108ae7d0 # v0.5.0
         with:
-          version: "v0.9.0"
+          version: "v0.11.1"
           skipClusterCreation: true
       - name: Run Tests
         env:

--- a/e2e/live/end-to-end-test.sh
+++ b/e2e/live/end-to-end-test.sh
@@ -61,15 +61,13 @@
 OPTIND=1
 
 # Kind/Kubernetes versions.
-DEFAULT_KIND_VERSION=0.9.0
-KIND_1_19_VERSION=1.19.1
-KIND_1_18_VERSION=1.18.8
-KIND_1_17_VERSION=1.17.11
+KIND_1_21_VERSION=1.21.1
+KIND_1_20_VERSION=1.20.7
+KIND_1_19_VERSION=1.19.11
+KIND_1_18_VERSION=1.18.19
+KIND_1_17_VERSION=1.17.17
 KIND_1_16_VERSION=1.16.15
-KIND_1_15_VERSION=1.15.12
-KIND_1_14_VERSION=1.14.10
-KIND_1_13_VERSION=1.13.12
-DEFAULT_K8S_VERSION=${KIND_1_17_VERSION}
+DEFAULT_K8S_VERSION=${KIND_1_20_VERSION}
 
 # Change from empty string to build the kpt binary from the downloaded
 # repositories at HEAD, including dependencies cli-utils and kustomize.
@@ -87,12 +85,6 @@ while getopts $options opt; do
 	b)  BUILD_DEPS_AT_HEAD=1;;
 	k)  short_version=$OPTARG
 	    case "$short_version" in
-		1.13) K8S_VERSION=$KIND_1_13_VERSION
-		      ;;
-		1.14) K8S_VERSION=$KIND_1_14_VERSION
-		      ;;
-		1.15) K8S_VERSION=$KIND_1_15_VERSION
-		      ;;
 		1.16) K8S_VERSION=$KIND_1_16_VERSION
 		      ;;
 		1.17) K8S_VERSION=$KIND_1_17_VERSION
@@ -100,6 +92,10 @@ while getopts $options opt; do
 		1.18) K8S_VERSION=$KIND_1_18_VERSION
 		      ;;
 		1.19) K8S_VERSION=$KIND_1_19_VERSION
+		      ;;
+		1.20) K8S_VERSION=$KIND_1_20_VERSION
+		      ;;
+		1.21) K8S_VERSION=$KIND_1_21_VERSION
 		      ;;
 	    esac
 	    ;;
@@ -188,7 +184,8 @@ function buildKpt {
     set +e
 }
 
-# createTestSuite deletes then creates the kind cluster.
+# createTestSuite deletes then creates the kind cluster. We wait for the node
+# to become ready before we run the tests.
 function createTestSuite {
     set -e
     echo "Setting Up Test Suite..."
@@ -199,6 +196,7 @@ function createTestSuite {
     echo "Deleting kind cluster...SUCCESS"
     echo "Creating kind cluster..."
     kind create cluster --image=kindest/node:v${K8S_VERSION} > $OUTPUT_DIR/k8sstartup 2>&1
+    kubectl wait node/kind-control-plane --for condition=ready --timeout=2m
     echo "Creating kind cluster...SUCCESS"
     echo
     echo "Setting Up Test Suite...SUCCESS"


### PR DESCRIPTION
Update to latest version of kind and use new versions of k8s. The current setup doesn't work properly, as the kind node never becomes `Ready`. This hasn't been a problem for the current e2e tests, but will be a problem with the changes included in https://github.com/GoogleContainerTools/kpt/pull/2367