### PR TITLE
Fix issue with multiple RESTMappers for live

### DIFF
--- a/commands/livecmd.go
+++ b/commands/livecmd.go
@@ -34,6 +34,7 @@ import (
 	cluster "k8s.io/kubectl/pkg/cmd/util"
 	"sigs.k8s.io/cli-utils/pkg/manifestreader"
 	"sigs.k8s.io/cli-utils/pkg/provider"
+	"sigs.k8s.io/cli-utils/pkg/util/factory"
 )
 
 func GetLiveCommand(ctx context.Context, _, version string) *cobra.Command {
@@ -79,8 +80,11 @@ func newFactory(cmd *cobra.Command, version string) cluster.Factory {
 	flags := cmd.PersistentFlags()
 	kubeConfigFlags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
 	kubeConfigFlags.AddFlags(flags)
+	cachingConfigFlags := &factory.CachingRESTClientGetter{
+		Delegate: kubeConfigFlags,
+	}
 	userAgentKubeConfigFlags := &cfgflags.UserAgentKubeConfigFlags{
-		Delegate:  kubeConfigFlags,
+		Delegate:  cachingConfigFlags,
 		UserAgent: fmt.Sprintf("kpt/%s", version),
 	}
 	cmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)

--- a/commands/livecmd.go
+++ b/commands/livecmd.go
@@ -80,6 +80,9 @@ func newFactory(cmd *cobra.Command, version string) cluster.Factory {
 	flags := cmd.PersistentFlags()
 	kubeConfigFlags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
 	kubeConfigFlags.AddFlags(flags)
+	// Use the CachingRESTClientGetter to make sure the same RESTMapper is shared
+	// across all kpt live functionality. This is needed to properly invalidate the
+	// RESTMapper cache when CRDs have been installed in the cluster.
 	cachingConfigFlags := &factory.CachingRESTClientGetter{
 		Delegate: kubeConfigFlags,
 	}

--- a/internal/cmdfndoc/cmdfndoc.go
+++ b/internal/cmdfndoc/cmdfndoc.go
@@ -23,8 +23,8 @@ import (
 	"os/exec"
 
 	"github.com/GoogleContainerTools/kpt/internal/docs/generated/fndocs"
-	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"github.com/GoogleContainerTools/kpt/internal/fnruntime"
+	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
 	"github.com/spf13/cobra"
 )


### PR DESCRIPTION
This fixes and issue where multiple RESTMappers are created and invalidation of the RESTMapper cache no longer work as intended. 
