### PR TITLE
Fixes problem reading from stdin for live status command

### DIFF
--- a/e2e/live/end-to-end-test.sh
+++ b/e2e/live/end-to-end-test.sh
@@ -636,11 +636,36 @@ assertPodNotExists "pod-c" "rg-test-namespace"
 assertPodNotExists "pod-d" "rg-test-namespace"
 printResult
 
+# Test: Basic kpt live apply/status/destroy from stdin
+# 
+echo "Testing apply/status/destroy from stdin"
+echo "cat e2e/live/testdata/stdin-test/pods.yaml | kpt live apply -"
+cat e2e/live/testdata/stdin-test/pods.yaml | ${BIN_DIR}/kpt live apply - > $OUTPUT_DIR/status 2>&1
+assertContains "pod/pod-a created"
+assertContains "pod/pod-b created"
+assertContains "pod/pod-c created"
+assertContains "3 resource(s) applied. 3 created, 0 unchanged, 0 configured, 0 failed"
+printResult
+echo "cat e2e/live/testdata/stdin-test/pods.yaml | kpt live status -"
+cat e2e/live/testdata/stdin-test/pods.yaml | ${BIN_DIR}/kpt live status - > $OUTPUT_DIR/status 2>&1
+assertContains "namespace/stdin-test-namespace is Current: Resource is current"
+assertContains "pod/pod-a is Current: Pod is Ready"
+assertContains "pod/pod-b is Current: Pod is Ready"
+assertContains "pod/pod-c is Current: Pod is Ready"
+printResult
+echo "cat e2e/live/testdata/stdin-test/pods.yaml | kpt live destroy -"
+cat e2e/live/testdata/stdin-test/pods.yaml | ${BIN_DIR}/kpt live destroy - > $OUTPUT_DIR/status 2>&1
+assertContains "pod/pod-a deleted"
+assertContains "pod/pod-b deleted"
+assertContains "pod/pod-c deleted"
+assertContains "3 resource(s) deleted, 0 skipped"
+printResult
+
 # Test: kpt live apply continue-on-error
 echo "[ResourceGroup] Testing continue-on-error"
 echo "kpt live apply e2e/live/testdata/continue-on-error"
 cp -f e2e/live/testdata/Kptfile e2e/live/testdata/continue-on-error
-${BIN_DIR}/kpt live init e2e/live/testdata/continue-on-error > $OUTPUT_DIR/status
+${BIN_DIR}/kpt live init e2e/live/testdata/continue-on-error > $OUTPUT_DIR/status 2>&1
 diff e2e/live/testdata/Kptfile e2e/live/testdata/continue-on-error/Kptfile > $OUTPUT_DIR/status 2>&1
 assertContains "namespace: continue-err-namespace"
 ${BIN_DIR}/kpt live apply e2e/live/testdata/continue-on-error > $OUTPUT_DIR/status

--- a/e2e/live/testdata/stdin-test/pods.yaml
+++ b/e2e/live/testdata/stdin-test/pods.yaml
@@ -1,0 +1,69 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: test1
+upstream:
+  type: git
+  git:
+    repo: git@github.com:yuwenma/blueprint-helloworld
+    directory: /
+    ref: master
+inventory:
+  namespace: stdin-test-namespace
+  name: inventory-18030002
+  inventoryID: 4a1bc0b4df68e583e23a7351a0a4d149edc0fa61-1627067858058570061
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-b
+  namespace: stdin-test-namespace
+  labels:
+    name: test-pod-label
+spec:
+  containers:
+  - name: kubernetes-pause
+    image: k8s.gcr.io/pause:2.0
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: stdin-test-namespace
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-c
+  namespace: stdin-test-namespace
+  labels:
+    name: test-pod-label
+spec:
+  containers:
+  - name: kubernetes-pause
+    image: k8s.gcr.io/pause:2.0
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-a
+  namespace: stdin-test-namespace
+  labels:
+    name: test-pod-label
+spec:
+  containers:
+  - name: kubernetes-pause
+    image: k8s.gcr.io/pause:2.0

--- a/thirdparty/cli-utils/status/cmdstatus.go
+++ b/thirdparty/cli-utils/status/cmdstatus.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/slice"
 	"sigs.k8s.io/cli-utils/pkg/apply/poller"
-	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/aggregator"
@@ -112,11 +111,6 @@ func (r *Runner) runE(c *cobra.Command, args []string) error {
 			return err
 		}
 		args = append(args, cwd)
-	}
-
-	_, err := common.DemandOneDirectory(args)
-	if err != nil {
-		return err
 	}
 
 	_, inv, err := live.Load(r.factory, args[0], c.InOrStdin())


### PR DESCRIPTION
* Fixes `kpt live status` to read properly from `stdin` (only removes code).
* Fixes https://github.com/GoogleContainerTools/kpt/issues/2412
* Adds end-to-end tests for `kpt live apply/status/destroy` reading from `stdin`