### PR TITLE
Auto complete function images for eval command

### DIFF
--- a/internal/cmdcomplete/complete.go
+++ b/internal/cmdcomplete/complete.go
@@ -18,6 +18,7 @@ package cmdcomplete
 import (
 	"strings"
 
+	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/posener/complete/v2"
 	"github.com/posener/complete/v2/predict"
@@ -65,6 +66,12 @@ func Complete(cmd *cobra.Command, skipHelp bool, visitFlags VisitFlags) *complet
 		}
 		if flag.Name == "pattern" {
 			cc.Flags[flag.Name] = predict.Options(predict.OptValues("%k_%n.yaml"))
+			return
+		}
+		if flag.Name == "image" || flag.Shorthand == "i" {
+			fnImages := cmdutil.FetchFunctionImages()
+			cc.Flags[flag.Name] = predict.Options(predict.OptValues(fnImages...))
+			cc.Flags[flag.Shorthand] = predict.Options(predict.OptValues(fnImages...))
 			return
 		}
 		cc.Flags[flag.Name] = predict.Nothing

--- a/internal/util/cmdutil/cmdutil_test.go
+++ b/internal/util/cmdutil/cmdutil_test.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -304,4 +305,36 @@ metadata:
 			}
 		})
 	}
+}
+
+func TestListImages(t *testing.T) {
+	result := listImages(`{
+  "apply-setters": {
+    "v0.1": {
+      "apply-setters-simple": {
+        "LocalExamplePath": "/apply-setters/v0.1/apply-setters-simple",
+        "RemoteExamplePath": "https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/apply-setters/v0.1/examples/apply-setters-simple",
+        "RemoteSourcePath": "https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/apply-setters/v0.1/functions/go/apply-setters"
+      }
+    }
+  },
+  "gatekeeper": {
+    "v0.1": {
+      "gatekeeper-warning-only": {
+        "LocalExamplePath": "/gatekeeper/v0.1/gatekeeper-warning-only",
+        "RemoteExamplePath": "https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/gatekeeper/v0.1/examples/gatekeeper-warning-only",
+        "RemoteSourcePath": "https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/gatekeeper/v0.1/functions/go/gatekeeper"
+      }
+    },
+    "v0.2": {
+      "gatekeeper-warning-only": {
+        "LocalExamplePath": "/gatekeeper/v0.2/gatekeeper-warning-only",
+        "RemoteExamplePath": "https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/gatekeeper/v0.2/examples/gatekeeper-warning-only",
+        "RemoteSourcePath": "https://github.com/GoogleContainerTools/kpt-functions-catalog/tree/gatekeeper/v0.2/functions/go/gatekeeper"
+      }
+    }
+  }
+}`)
+	sort.Strings(result)
+	assert.Equal(t, []string{"apply-setters:v0.1", "gatekeeper:v0.2"}, result)
 }

--- a/internal/util/httputil/httputil.go
+++ b/internal/util/httputil/httputil.go
@@ -1,0 +1,24 @@
+package httputil
+
+import (
+	"io/ioutil"
+	"net/http"
+)
+
+// FetchContent fetches the content from the input url
+func FetchContent(url string) (string, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer res.Body.Close()
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}


### PR DESCRIPTION
This PR improves the discoverability of functions by providing tab completion for function images in the catalog available at https://catalog.kpt.dev/ (https://catalog.kpt.dev/catalog.json). Latest version for the image is suggested.

```
$ kpt fn eval -i [tab]
apply-setters:v0.1          fix:v0.2                    list-setters:v0.1           set-labels:v0.1             starlark:v0.2             
create-setters:v0.1         gatekeeper:v0.2             search-replace:v0.2         set-namespace:v0.1          upsert-resource:v0.1      
ensure-name-substring:v0.1  kubeval:v0.1                set-annotations:v0.1        set-project-id:v0.1 
```

```
$ kpt fn doc -i [tab]
apply-setters:v0.1          fix:v0.2                    list-setters:v0.1           set-labels:v0.1             starlark:v0.2             
create-setters:v0.1         gatekeeper:v0.2             search-replace:v0.2         set-namespace:v0.1          upsert-resource:v0.1      
ensure-name-substring:v0.1  kubeval:v0.1                set-annotations:v0.1        set-project-id:v0.1 
```

cc @Pitta @mikebz @grmoon