### PR TITLE
Show timestamp for pipeline execution duration

### DIFF
--- a/e2e/testdata/fn-eval/error-in-pipe/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/error-in-pipe/.expected/config.yaml
@@ -15,7 +15,7 @@
 exitCode: 1
 stdErr: |
   [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3"
-  [FAIL] "gcr.io/kpt-fn/set-namespace:v0.1.3"
+  [FAIL] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s
     Results:
       [ERROR] failed to configure function: input namespace cannot be empty
     Stderr:
@@ -24,5 +24,5 @@ stdErr: |
 
    
   [RUNNING] "gcr.io/kpt-fn/dne"
-  [FAIL] "gcr.io/kpt-fn/dne"
+  [FAIL] "gcr.io/kpt-fn/dne" in 0s
   Error: Function image "gcr.io/kpt-fn/dne" doesn't exist

--- a/e2e/testdata/fn-eval/non-krm-resource/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/non-krm-resource/.expected/config.yaml
@@ -18,5 +18,5 @@ args:
   namespace: staging
 exitCode: 1
 stdErr: |
-  [FAIL] "gcr.io/kpt-fn/set-namespace:v0.1.3"
+  [FAIL] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s
   error: input resource list must contain only KRM resources: nonkrm.yaml: resource must have `apiVersion`

--- a/e2e/testdata/fn-eval/out-of-place-dir/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/out-of-place-dir/.expected/config.yaml
@@ -14,4 +14,4 @@
 
 stdErr: |
   [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3"
-  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3"
+  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s

--- a/e2e/testdata/fn-eval/out-of-place-fnchain-stdout/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/out-of-place-fnchain-stdout/.expected/config.yaml
@@ -1,10 +1,10 @@
 stdErr: |
   [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3"
-  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3"
+  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s
   [RUNNING] "gcr.io/kpt-fn/set-annotations:v0.1.3"
-  [PASS] "gcr.io/kpt-fn/set-annotations:v0.1.3"
+  [PASS] "gcr.io/kpt-fn/set-annotations:v0.1.3" in 0s
   [RUNNING] "gcr.io/kpt-fn/set-labels:v0.1.3"
-  [PASS] "gcr.io/kpt-fn/set-labels:v0.1.3"
+  [PASS] "gcr.io/kpt-fn/set-labels:v0.1.3" in 0s
 stdOut: |
   apiVersion: config.kubernetes.io/v1alpha1
   kind: ResourceList

--- a/e2e/testdata/fn-eval/out-of-place-fnchain-unwrap/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/out-of-place-fnchain-unwrap/.expected/config.yaml
@@ -14,11 +14,11 @@
 
 stdErr: |
   [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3"
-  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3"
+  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s
   [RUNNING] "gcr.io/kpt-fn/set-annotations:v0.1.3"
-  [PASS] "gcr.io/kpt-fn/set-annotations:v0.1.3"
+  [PASS] "gcr.io/kpt-fn/set-annotations:v0.1.3" in 0s
   [RUNNING] "gcr.io/kpt-fn/set-labels:v0.1.3"
-  [PASS] "gcr.io/kpt-fn/set-labels:v0.1.3"
+  [PASS] "gcr.io/kpt-fn/set-labels:v0.1.3" in 0s
 stdOut: |
   # Copyright 2021 Google LLC
   #

--- a/e2e/testdata/fn-eval/short-image-path/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/short-image-path/.expected/config.yaml
@@ -18,4 +18,4 @@ args:
   namespace: staging
 stdErr: |
   [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3"
-  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3"
+  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s

--- a/e2e/testdata/fn-render/fn-failure/.expected/config.yaml
+++ b/e2e/testdata/fn-render/fn-failure/.expected/config.yaml
@@ -17,7 +17,7 @@
 exitCode: 1
 stdErr: |
   [RUNNING] "gcr.io/kpt-fn/starlark:v0.2.1"
-  [FAIL] "gcr.io/kpt-fn/starlark:v0.2.1"
+  [FAIL] "gcr.io/kpt-fn/starlark:v0.2.1" in 0s
     Results:
       [ERROR] httpbin-gen:4:1: got newline, want primary expression
     Stderr:

--- a/e2e/testdata/fn-render/out-of-place-dir/.expected/config.yaml
+++ b/e2e/testdata/fn-render/out-of-place-dir/.expected/config.yaml
@@ -14,4 +14,4 @@
 
 stdErr: |
   [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3"
-  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3"
+  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s

--- a/e2e/testdata/fn-render/out-of-place-fnchain-stdout-results/.expected/config.yaml
+++ b/e2e/testdata/fn-render/out-of-place-fnchain-stdout-results/.expected/config.yaml
@@ -54,6 +54,6 @@ stdOut: |
       image: nginx:1.2.3
 stdErr: |
   [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3"
-  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3"
+  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s
 
   For complete results, see

--- a/e2e/testdata/fn-render/out-of-place-fnchain-stdout/.expected/config.yaml
+++ b/e2e/testdata/fn-render/out-of-place-fnchain-stdout/.expected/config.yaml
@@ -1,11 +1,11 @@
 stdErr: |
   [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3"
-  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3"
+  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s
 
   [RUNNING] "gcr.io/kpt-fn/set-annotations:v0.1.3"
-  [PASS] "gcr.io/kpt-fn/set-annotations:v0.1.3"
+  [PASS] "gcr.io/kpt-fn/set-annotations:v0.1.3" in 0s
   [RUNNING] "gcr.io/kpt-fn/set-labels:v0.1.3"
-  [PASS] "gcr.io/kpt-fn/set-labels:v0.1.3"
+  [PASS] "gcr.io/kpt-fn/set-labels:v0.1.3" in 0s
 
 stdOut: |
   apiVersion: config.kubernetes.io/v1alpha1

--- a/e2e/testdata/fn-render/out-of-place-stdout/.expected/config.yaml
+++ b/e2e/testdata/fn-render/out-of-place-stdout/.expected/config.yaml
@@ -1,6 +1,6 @@
 stdErr: |
   [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3"
-  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3"
+  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s
 
 stdOut: |
   apiVersion: config.kubernetes.io/v1alpha1

--- a/e2e/testdata/fn-render/out-of-place-unwrap/.expected/config.yaml
+++ b/e2e/testdata/fn-render/out-of-place-unwrap/.expected/config.yaml
@@ -14,7 +14,7 @@
 
 stdErr: |
   [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3"
-  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3"
+  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s
 
 stdOut: |
   apiVersion: apps/v1

--- a/e2e/testdata/fn-render/short-image-path/.expected/config.yaml
+++ b/e2e/testdata/fn-render/short-image-path/.expected/config.yaml
@@ -14,6 +14,6 @@
 
 stdErr: |
   [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3"
-  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3"
+  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s
   [RUNNING] "gcr.io/kpt-fn/set-labels:v0.1.4"
-  [PASS] "gcr.io/kpt-fn/set-labels:v0.1.4"
+  [PASS] "gcr.io/kpt-fn/set-labels:v0.1.4" in 0s

--- a/internal/fnruntime/runner.go
+++ b/internal/fnruntime/runner.go
@@ -23,6 +23,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
@@ -111,10 +112,11 @@ func (fr *FunctionRunner) Filter(input []*yaml.RNode) (output []*yaml.RNode, err
 	if !fr.disableCLIOutput {
 		pr.Printf("[RUNNING] %q\n", fr.name)
 	}
+	t0 := time.Now()
 	output, err = fr.do(input)
 	if err != nil {
 		printOpt := printer.NewOpt()
-		pr.OptPrintf(printOpt, "[FAIL] %q\n", fr.name)
+		pr.OptPrintf(printOpt, "[FAIL] %q in %v\n", fr.name, time.Since(t0).Truncate(time.Millisecond*100))
 		printFnResult(fr.ctx, fr.fnResult, printOpt)
 		var fnErr *ExecError
 		if goerrors.As(err, &fnErr) {
@@ -124,7 +126,7 @@ func (fr *FunctionRunner) Filter(input []*yaml.RNode) (output []*yaml.RNode, err
 		return nil, err
 	}
 	if !fr.disableCLIOutput {
-		pr.Printf("[PASS] %q\n", fr.name)
+		pr.Printf("[PASS] %q in %v\n", fr.name, time.Since(t0).Truncate(time.Millisecond*100))
 		printFnResult(fr.ctx, fr.fnResult, printer.NewOpt())
 	}
 	return output, err


### PR DESCRIPTION
This is helpful for debugging and understanding pipeline execution speed. Example output:
```
Package "grafana":
[RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1"
[PASS] "gcr.io/kpt-fn/set-namespace:v0.1" in 4.2s
[RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1"
[PASS] "gcr.io/kpt-fn/set-namespace:v0.1" in 2.9s
[RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1"
[PASS] "gcr.io/kpt-fn/set-namespace:v0.1" in 2.7s

Successfully executed 3 function(s) in 1 package(s).
```