### PR TITLE
feat: improve GitHub pkg get parsing

### DIFF
--- a/internal/util/parse/parse.go
+++ b/internal/util/parse/parse.go
@@ -16,6 +16,7 @@ package parse
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path"
 	"path/filepath"
@@ -39,42 +40,16 @@ func GitParseArgs(ctx context.Context, args []string) (Target, error) {
 
 	// Simple parsing if contains .git
 	if strings.Contains(args[0], ".git") {
-		var repo, dir, version string
-		parts := strings.Split(args[0], ".git")
-		repo = strings.TrimSuffix(parts[0], "/")
-		switch {
-		case len(parts) == 1:
-			// do nothing
-		case strings.Contains(parts[1], "@"):
-			parts := strings.Split(parts[1], "@")
-			version = strings.TrimSuffix(parts[1], "/")
-			dir = parts[0]
-		default:
-			dir = parts[1]
-		}
-		if version == "" {
-			gur, err := gitutil.NewGitUpstreamRepo(ctx, repo)
-			if err != nil {
-				return g, err
-			}
-			defaultRef, err := gur.GetDefaultBranch(ctx)
-			if err != nil {
-				return g, err
-			}
-			version = defaultRef
-		}
-		if dir == "" {
-			dir = "/"
-		}
-		destination, err := getDest(args[1], repo, dir)
+		return getTargetFromPkgURL(ctx, args[0], args[1])
+	}
+
+	// GitHub parsing if contains github.com
+	if strings.Contains(args[0], "github.com") {
+		ghPkgURL, err := pkgURLFromGHURL(args[0])
 		if err != nil {
 			return g, err
 		}
-		g.Ref = version
-		g.Directory = path.Clean(dir)
-		g.Repo = repo
-		g.Destination = filepath.Clean(destination)
-		return g, nil
+		return getTargetFromPkgURL(ctx, ghPkgURL, args[1])
 	}
 
 	uri, version, err := getURIAndVersion(args[0])
@@ -108,6 +83,93 @@ func GitParseArgs(ctx context.Context, args []string) (Target, error) {
 	return g, nil
 }
 
+// getTargetFromPkgURL parses a pkg url and destination into kptfile git info and local destination Target
+func getTargetFromPkgURL(ctx context.Context, pkgUrl, dest string) (Target, error) {
+	g := Target{}
+	var repo, dir, version string
+	parts := strings.Split(pkgUrl, ".git")
+	repo = strings.TrimSuffix(parts[0], "/")
+	switch {
+	case len(parts) == 1:
+		// do nothing
+	case strings.Contains(parts[1], "@"):
+		parts := strings.Split(parts[1], "@")
+		version = strings.TrimSuffix(parts[1], "/")
+		dir = parts[0]
+	default:
+		dir = parts[1]
+	}
+	if version == "" {
+		gur, err := gitutil.NewGitUpstreamRepo(ctx, repo)
+		if err != nil {
+			return g, err
+		}
+		defaultRef, err := gur.GetDefaultBranch(ctx)
+		if err != nil {
+			return g, err
+		}
+		version = defaultRef
+	}
+	if dir == "" {
+		dir = "/"
+	}
+	destination, err := getDest(dest, repo, dir)
+	if err != nil {
+		return g, err
+	}
+	g.Ref = version
+	g.Directory = path.Clean(dir)
+	g.Repo = repo
+	g.Destination = filepath.Clean(destination)
+	return g, nil
+}
+
+// pkgURLFromGHURL converts a GitHub URL into a well formed pkg url
+// by adding a .git suffix after repo URI and version info if available
+func pkgURLFromGHURL(v string) (string, error) {
+	v = strings.TrimSuffix(v, "/")
+	// url should have scheme and host separated by ://
+	parts := strings.SplitN(v, "://", 2)
+	if len(parts) != 2 {
+		return "", errors.Errorf("invalid GitHub url: %s", v)
+	}
+	// host should be github.com
+	if !strings.HasPrefix(parts[1], "github.com") {
+		return "", errors.Errorf("invalid GitHub url: %s", v)
+	}
+
+	ghRepoParts := strings.Split(parts[1], "/")
+	// expect at least github.com/owner/repo
+	if len(ghRepoParts) < 3 {
+		return "", errors.Errorf("invalid GitHub pkg url: %s", v)
+	}
+	// url of form github.com/owner/repo
+	if len(ghRepoParts) == 3 {
+		repoWithPath := path.Join(ghRepoParts...)
+		// return scheme://github.com/owner/repo.git
+		return parts[0] + "://" + path.Join(repoWithPath) + ".git", nil
+	}
+
+	// url of form github.com/owner/repo/tree/ref/<path>
+	if ghRepoParts[3] == "tree" && len(ghRepoParts) > 4 {
+		repo := parts[0] + "://" + path.Join(ghRepoParts[:3]...)
+		version := ghRepoParts[4]
+		dir := path.Join(ghRepoParts[5:]...)
+		if dir != "" {
+			// return scheme://github.com/owner/repo.git/path@ref
+			return fmt.Sprintf("%s.git/%s@%s", repo, dir, version), nil
+		}
+		// return scheme://github.com/owner/repo.git@ref
+		return fmt.Sprintf("%s.git@%s", repo, version), nil
+	}
+	// if no tree, version info is unavailable in url
+	// url of form github.com/owner/repo/<path>
+	repo := parts[0] + "://" + path.Join(ghRepoParts[:3]...)
+	dir := path.Join(ghRepoParts[3:]...)
+	// return scheme://github.com/owner/repo.git/path
+	return repo + path.Join(".git", dir), nil
+}
+
 // getURIAndVersion parses the repo+pkgURI and the version from v
 func getURIAndVersion(v string) (string, string, error) {
 	if strings.Count(v, "://") > 1 {
@@ -128,16 +190,6 @@ func getRepoAndPkg(v string) (string, string, error) {
 	parts := strings.SplitN(v, "://", 2)
 	if len(parts) != 2 {
 		return "", "", errors.Errorf("ambiguous repo/dir@version specify '.git' in argument")
-	}
-
-	if strings.HasPrefix(parts[1], "github.com") {
-		repoSubdir := append(strings.Split(parts[1], "/"), "/")
-		if len(repoSubdir) < 4 {
-			return "", "", errors.Errorf("ambiguous repo/dir@version specify '.git' in argument")
-		}
-		repo := parts[0] + "://" + path.Join(repoSubdir[:3]...)
-		dir := path.Join(repoSubdir[3:]...)
-		return repo, dir, nil
 	}
 
 	if strings.Count(v, ".git/") != 1 && !strings.HasSuffix(v, ".git") {

--- a/internal/util/parse/parse_test.go
+++ b/internal/util/parse/parse_test.go
@@ -1,0 +1,59 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parse
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_pkgURLFromGHURL(t *testing.T) {
+	tests := []struct {
+		name  string
+		ghURL string
+		want  string
+		errS  string
+	}{
+		{"simple", "https://github.com/owner/repo", "https://github.com/owner/repo.git", ""},
+		{"with trailing slash", "https://github.com/owner/repo/", "https://github.com/owner/repo.git", ""},
+		{"with ref", "https://github.com/owner/repo/tree/main", "https://github.com/owner/repo.git@main", ""},
+		{"with ref with nested dir", "https://github.com/owner/repo/tree/foobranch/my/nested/pkg", "https://github.com/owner/repo.git/my/nested/pkg@foobranch", ""},
+		{"with ref trailing slash", "https://github.com/owner/repo/tree/main/", "https://github.com/owner/repo.git@main", ""},
+		{"with tree no ref", "https://github.com/owner/repo/tree", "https://github.com/owner/repo.git/tree", ""},
+		{"with tree no ref trailing slash", "https://github.com/owner/repo/tree/", "https://github.com/owner/repo.git/tree", ""},
+		{"with dir no ref", "https://github.com/owner/repo/my/nested/pkg", "https://github.com/owner/repo.git/my/nested/pkg", ""},
+		{"malformed github url domain", "https://foo.com/github.com", "", "invalid GitHub url"},
+		{"malformed github url no repo", "https://github.com/owner", "", "invalid GitHub pkg url"},
+		{"malformed github url no owner no repo", "https://github.com/owner", "", "invalid GitHub pkg url"},
+		{"malformed github url no scheme", "github.com/owner", "", "invalid GitHub url"},
+		{"not github url", "https://foo.com/bar", "", "invalid GitHub url"},
+		{"empty", "", "", "invalid GitHub url"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := require.New(t)
+			got, err := pkgURLFromGHURL(tt.ghURL)
+			if tt.errS != "" {
+				r.Equal("", got, "url should be empty")
+				r.EqualError(err, fmt.Sprintf("%s: %s", tt.errS, tt.ghURL), "should equal")
+			} else {
+				r.Equal(tt.want, got, "url should be equal")
+				r.NoError(err, "should not return error")
+			}
+		})
+	}
+}

--- a/internal/util/parse/parse_test.go
+++ b/internal/util/parse/parse_test.go
@@ -15,44 +15,168 @@
 package parse
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_pkgURLFromGHURL(t *testing.T) {
 	tests := []struct {
-		name  string
-		ghURL string
-		want  string
-		errS  string
+		name     string
+		ghURL    string
+		want     string
+		errS     string
+		branches []string
 	}{
-		{"simple", "https://github.com/owner/repo", "https://github.com/owner/repo.git", ""},
-		{"with trailing slash", "https://github.com/owner/repo/", "https://github.com/owner/repo.git", ""},
-		{"with ref", "https://github.com/owner/repo/tree/main", "https://github.com/owner/repo.git@main", ""},
-		{"with ref with nested dir", "https://github.com/owner/repo/tree/foobranch/my/nested/pkg", "https://github.com/owner/repo.git/my/nested/pkg@foobranch", ""},
-		{"with ref trailing slash", "https://github.com/owner/repo/tree/main/", "https://github.com/owner/repo.git@main", ""},
-		{"with tree no ref", "https://github.com/owner/repo/tree", "https://github.com/owner/repo.git/tree", ""},
-		{"with tree no ref trailing slash", "https://github.com/owner/repo/tree/", "https://github.com/owner/repo.git/tree", ""},
-		{"with dir no ref", "https://github.com/owner/repo/my/nested/pkg", "https://github.com/owner/repo.git/my/nested/pkg", ""},
-		{"malformed github url domain", "https://foo.com/github.com", "", "invalid GitHub url"},
-		{"malformed github url no repo", "https://github.com/owner", "", "invalid GitHub pkg url"},
-		{"malformed github url no owner no repo", "https://github.com/owner", "", "invalid GitHub pkg url"},
-		{"malformed github url no scheme", "github.com/owner", "", "invalid GitHub url"},
-		{"not github url", "https://foo.com/bar", "", "invalid GitHub url"},
-		{"empty", "", "", "invalid GitHub url"},
+		{
+			name:     "simple",
+			ghURL:    "https://github.com/owner/repo",
+			want:     "https://github.com/owner/repo.git",
+			errS:     "",
+			branches: nil,
+		},
+		{
+			name:     "with trailing slash",
+			ghURL:    "https://github.com/owner/repo/",
+			want:     "https://github.com/owner/repo.git",
+			errS:     "",
+			branches: nil,
+		},
+		{
+			name:     "with ref",
+			ghURL:    "https://github.com/owner/repo/tree/main",
+			want:     "https://github.com/owner/repo.git@main",
+			errS:     "",
+			branches: nil,
+		},
+		{
+			name:     "with commit SHA",
+			ghURL:    "https://github.com/owner/repo/tree/fc0193e5cf7ff836f8208644ff2dc14901ed06c9",
+			want:     "https://github.com/owner/repo.git@fc0193e5cf7ff836f8208644ff2dc14901ed06c9",
+			errS:     "",
+			branches: nil,
+		},
+		{
+			name:     "with ref with branches",
+			ghURL:    "https://github.com/owner/repo/tree/main",
+			want:     "https://github.com/owner/repo.git@main",
+			errS:     "",
+			branches: []string{"test", "main"},
+		},
+		{
+			name:  "with commit SHA with branches",
+			ghURL: "https://github.com/owner/repo/tree/fc0193e5cf7ff836f8208644ff2dc14901ed06c9",
+			want:  "https://github.com/owner/repo.git@fc0193e5cf7ff836f8208644ff2dc14901ed06c9", errS: "", branches: []string{"test", "main"},
+		},
+		{
+			name:     "with ref with branches ambiguous",
+			ghURL:    "https://github.com/owner/repo/tree/main/foo/bar",
+			want:     "",
+			errS:     "ambiguous repo/dir@version specify '.git' in argument",
+			branches: []string{"test", "main", "main/foo"},
+		},
+		{
+			name:  "with ref with nested dir",
+			ghURL: "https://github.com/owner/repo/tree/foobranch/my/nested/pkg",
+			want:  "https://github.com/owner/repo.git/my/nested/pkg@foobranch",
+			errS:  "", branches: []string{"test", "main", "foobranch"},
+		},
+		{
+			name:     "with ref with nested dir ambiguous",
+			ghURL:    "https://github.com/owner/repo/tree/foobranch/my/nested/pkg",
+			want:     "",
+			errS:     "ambiguous repo/dir@version specify '.git' in argument",
+			branches: []string{"test", "main", "foobranch/bar"},
+		},
+		{
+			name:     "with ref trailing slash",
+			ghURL:    "https://github.com/owner/repo/tree/main/",
+			want:     "https://github.com/owner/repo.git@main",
+			errS:     "",
+			branches: nil,
+		},
+		{
+			name:     "with tree no ref",
+			ghURL:    "https://github.com/owner/repo/tree",
+			want:     "https://github.com/owner/repo.git/tree",
+			errS:     "",
+			branches: []string{"test", "tree/"},
+		},
+		{
+			name:     "with tree no ref trailing slash",
+			ghURL:    "https://github.com/owner/repo/tree/",
+			want:     "https://github.com/owner/repo.git/tree",
+			errS:     "",
+			branches: []string{"test", "tree/"},
+		},
+		{
+			name:     "with dir no ref",
+			ghURL:    "https://github.com/owner/repo/my/nested/pkg",
+			want:     "https://github.com/owner/repo.git/my/nested/pkg",
+			errS:     "",
+			branches: nil,
+		},
+		{
+			name:     "malformed github url domain",
+			ghURL:    "https://foo.com/github.com",
+			want:     "",
+			errS:     "invalid GitHub url",
+			branches: nil,
+		},
+		{
+			name:     "malformed github url no repo",
+			ghURL:    "https://github.com/owner",
+			want:     "",
+			errS:     "invalid GitHub pkg url",
+			branches: nil,
+		},
+		{
+			name:     "malformed github url no owner no repo",
+			ghURL:    "https://github.com/owner",
+			want:     "",
+			errS:     "invalid GitHub pkg url",
+			branches: nil,
+		},
+		{
+			name:     "malformed github url no scheme",
+			ghURL:    "github.com/owner",
+			want:     "",
+			errS:     "invalid GitHub url",
+			branches: nil,
+		},
+		{
+			name:     "not github url",
+			ghURL:    "https://foo.com/bar",
+			want:     "",
+			errS:     "invalid GitHub url",
+			branches: nil,
+		},
+		{
+			name:     "empty",
+			ghURL:    "",
+			want:     "",
+			errS:     "invalid GitHub url",
+			branches: nil,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := require.New(t)
-			got, err := pkgURLFromGHURL(tt.ghURL)
+			ctx := printer.WithContext(context.Background(), printer.New(nil, nil))
+			// getBranches returns test branches slice
+			getBranches := func(ctx context.Context, repo string) ([]string, error) {
+				return tt.branches, nil
+			}
+			got, err := pkgURLFromGHURL(ctx, tt.ghURL, getBranches)
 			if tt.errS != "" {
 				r.Equal("", got, "url should be empty")
 				r.EqualError(err, fmt.Sprintf("%s: %s", tt.errS, tt.ghURL), "should equal")
 			} else {
-				r.Equal(tt.want, got, "url should be equal")
 				r.NoError(err, "should not return error")
+				r.Equal(tt.want, got, "url should be equal")
 			}
 		})
 	}


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/kpt/issues/2444

Improves handling of GitHub URLs for `pkg get` by parsing a GitHub URL (displayed in the web browser) into a well formed package URL. 

This enables users browsing the catalog on GitHub to directly copy a URL and fetch the package as opposed to manually transforming it.

Example:

```
kpt pkg get https://github.com/GoogleCloudPlatform/blueprints/tree/main/catalog/networking
Package "networking":
Fetching https://github.com/GoogleCloudPlatform/blueprints@main
From https://github.com/GoogleCloudPlatform/blueprints
 * branch            main       -> FETCH_HEAD
Adding package "catalog/networking".

Fetched 1 package(s).
```

```
kpt pkg get https://github.com/GoogleCloudPlatform/blueprints/tree/2b93fd6d4f1a3eabdf4dfce05b93ccb1f9f671c5/catalog/project
Package "project":
Fetching https://github.com/GoogleCloudPlatform/blueprints@2b93fd6d4f1a3eabdf4dfce05b93ccb1f9f671c5
From https://github.com/GoogleCloudPlatform/blueprints
 * branch            2b93fd6d4f1a3eabdf4dfce05b93ccb1f9f671c5 -> FETCH_HEAD
Adding package "catalog/project".

Fetched 1 package(s).
```
