### PR TITLE
Fix missing kptfile URL.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,29 +15,23 @@
 name: Go
 on:
   pull_request:
-    paths-ignore:
-      - "docs/**"
-      - "site/**"
   push:
-    paths-ignore:
-      - "docs/**"
-      - "site/**"
 
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.16
-      uses: actions/setup-go@v1
-      with:
-        go-version: 1.16
-      id: go
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
-    - name: Build, Test, Lint
-      run: |
-        git config --global user.email you@example.com
-        git config --global user.name Your Name
-        make all
-        make test-docker
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.16
+        id: go
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v1
+      - name: Build, Test, Lint
+        run: |
+          git config --global user.email you@example.com
+          git config --global user.name Your Name
+          make all
+          make test-docker

--- a/site/reference/schema/kptfile/README.md
+++ b/site/reference/schema/kptfile/README.md
@@ -1,4 +1,4 @@
 # Kptfile
 
 Grab the OpenAPI
-[schema here](https://kpt.dev/reference/schema/kptfile/kptfile.yaml)
+[schema here](https://raw.githubusercontent.com/GoogleContainerTools/kpt/main/site/reference/schema/kptfile/kptfile.yaml).


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/kpt/issues/2464
Also unblocks builds for site PRs.