### PR TITLE
Update base image for kpt-gcloud to use gcloud 355

### DIFF
--- a/release/images/Dockerfile-gcloud
+++ b/release/images/Dockerfile-gcloud
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/google.com/cloudsdktool/cloud-sdk:338.0.0-alpine
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:355.0.0-alpine
 RUN apk update && apk upgrade && \
     apk add --no-cache git less diffutils bash openssh docker-cli && \
     rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
Base the kpt-gcloud image on the latest gcloud base image.