### PR TITLE
Fix small grammatical issue

### DIFF
--- a/site/book/02-concepts/00.md
+++ b/site/book/02-concepts/00.md
@@ -18,7 +18,7 @@ That's a pretty terse description, so let's break it down:
 
   In contrast, many configuration tools today interleave data and code, for example by embedding a
   templating language in YAML. As configuration becomes complex, it becomes hard to read and
-  understand. Furthermore, this prevent external tooling from easily consuming such configuration
+  understand. Furthermore, this prevents external tooling from easily consuming such configuration
   leading to a closed ecosystem.
 
 - **Extensible**: kpt provides a small core machinery and powerful extension mechanisms. There are


### PR DESCRIPTION
Just a tiny change here. The sentence currently reads 

>Furthermore, this prevent external tooling from easily consuming such configuration leading to a closed ecosystem.

Now it reads:

> Furthermore, this **prevents** external tooling from easily consuming such configuration leading to a closed ecosystem.
