### PR TITLE
feat: subpkg update porcelain

### DIFF
--- a/internal/util/update/update.go
+++ b/internal/util/update/update.go
@@ -187,13 +187,13 @@ func (u Command) Run(ctx context.Context) error {
 }
 
 // updateSubKf updates subpackage with given ref and update strategy
-func updateSubKf(subKf *kptfilev1.KptFile, ref string, strat kptfilev1.UpdateStrategyType) {
+func updateSubKf(subKf *kptfilev1.KptFile, ref string, strategy kptfilev1.UpdateStrategyType) {
 	// check if explicit ref provided
 	if ref != "" {
 		subKf.Upstream.Git.Ref = ref
 	}
-	if strat != "" {
-		subKf.Upstream.UpdateStrategy = strat
+	if strategy != "" {
+		subKf.Upstream.UpdateStrategy = strategy
 	}
 }
 

--- a/internal/util/update/update_test.go
+++ b/internal/util/update/update_test.go
@@ -652,7 +652,7 @@ func TestCommand_Run_toBranchRefWithSubpkgs(t *testing.T) {
 							pkgbuilder.SetFieldPath("42", "spec", "replicas")),
 				),
 		},
-		"update strat with single subpkg from same repo": {
+		"update strategy with single subpkg from same repo": {
 			strategy:  kptfilev1.FastForward,
 			updateRef: "subpkg-update",
 			reposChanges: map[string][]testutil.Content{


### PR DESCRIPTION
fixes #2379 

This extends `kpt pkg update pkg@ref` porcelain to update `upstream` of any local sub pkg kptfiles IFF the local sub package has same ref as root pkg and is

- sub package of the root package in the upstream repo
- same as root pkg

We determine if a local sub pkg is a sub pkg/same pkg upstream by matching repo and confirming sub pkg `upstream.git.directory` is within or same as root pkg dir. 

