### PR TITLE
chore: updated node version for site-check job

### DIFF
--- a/.github/workflows/checkSite.yml
+++ b/.github/workflows/checkSite.yml
@@ -32,7 +32,7 @@ jobs:
           path: href-checker
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '12'
       - name: Install Site Checker
         run: yarn install
         working-directory: href-checker

--- a/.github/workflows/checkSite.yml
+++ b/.github/workflows/checkSite.yml
@@ -32,7 +32,7 @@ jobs:
           path: href-checker
       - uses: actions/setup-node@v2
         with:
-          node-version: '12'
+          node-version: '16'
       - name: Install Site Checker
         run: yarn install
         working-directory: href-checker

--- a/.github/workflows/checkSite.yml
+++ b/.github/workflows/checkSite.yml
@@ -36,9 +36,9 @@ jobs:
       - name: Install Site Checker
         run: yarn install
         working-directory: href-checker
-      - name: Lint site content
-        run: npm i && npm run lint-check
-        working-directory: site
+#      - name: Lint site content
+#        run: npm i && npm run lint-check
+#        working-directory: site
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Run Site Checker

--- a/.github/workflows/checkSite.yml
+++ b/.github/workflows/checkSite.yml
@@ -33,12 +33,12 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '16'
+      - name: Lint site content
+        run: npm i && npm run lint-check
+        working-directory: site
       - name: Install Site Checker
         run: yarn install
         working-directory: href-checker
-#      - name: Lint site content
-#        run: npm i && npm run lint-check
-#        working-directory: site
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Run Site Checker

--- a/.github/workflows/checkSite.yml
+++ b/.github/workflows/checkSite.yml
@@ -33,12 +33,12 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '14'
-      - name: Lint site content
-        run: npm i && npm run lint-check
-        working-directory: site
       - name: Install Site Checker
         run: yarn install
         working-directory: href-checker
+      - name: Lint site content
+        run: npm i && npm run lint-check
+        working-directory: site
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Run Site Checker

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -25,6 +25,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
       - name: Generate Site
         run: make site-run-server
       - name: Generate sitemap

--- a/scripts/check-site.sh
+++ b/scripts/check-site.sh
@@ -23,8 +23,8 @@ echo "Starting check."
 # Convert them to valid URLs
 # Check each link for Docsify 404s
 
-find . -name README.md -printf "%P\n" | grep -v node_modules | grep -v themes |
+find . -name README.md -printf "%P\n" | grep -v node_modules |
     sed "s/README.md//" | sed "s/^/http:\/\/localhost:3000\//" |
-    xargs -n1 sh -c '! (npx href-checker $0 --bad-content="404 - Not found" --silent --no-off-site -c=15 | grep .) || exit 255'
+    xargs -n1 sh -c '! (echo Checking $0 && npx href-checker $0 --bad-content="404 - Not found" --silent --no-off-site -c=15 | grep .) || exit 255'
 
 echo "Success."

--- a/site/book/06-deploying-packages/01-initializing-a-package-for-apply.md
+++ b/site/book/06-deploying-packages/01-initializing-a-package-for-apply.md
@@ -30,7 +30,7 @@ and namespace of the `ResourceGroup` resource.
 ?> Refer to the [init command reference][init-doc] for usage.
 
 !> Once a package is applied to the cluster, you do not want to change the
-metadata in the `inventory` section as it severs the association between the
-package and the `ResourceGroup` leading to destructive operations.
+metadata in the `inventory` section; doing so severs the association between the
+package and the `ResourceGroup`, leading to destructive operations.
 
 [init-doc]: /reference/cli/live/init/


### PR DESCRIPTION
This is a clone of https://github.com/GoogleContainerTools/kpt/pull/2500 with rebase to incorporate fix in Go tests.