### PR TITLE
feature: Added entrypoint support in `fn` commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ test-docker: build
 # KPT_E2E_UPDATE_EXPECTED=true (if expected output to be updated)
 # target to run e2e tests for "kpt fn render" command
 test-fn-render: build
-	PATH=$(GOBIN):$(PATH) go test -v --tags=docker --run=TestFnRender/testdata/fn-render/$(T) ./e2e/
+	PATH=$(GOBIN):$(PATH) go test -count=1 -v --tags=docker --run=TestFnRender/testdata/fn-render/$(T) ./e2e/
 
 # target to run e2e tests for "kpt fn eval" command
 test-fn-eval: build

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ test-fn-render: build
 
 # target to run e2e tests for "kpt fn eval" command
 test-fn-eval: build
-	PATH=$(GOBIN):$(PATH) go test -v --tags=docker --run=TestFnEval/testdata/fn-eval/$(T)  ./e2e/
+	PATH=$(GOBIN):$(PATH) go test -count=1 -v --tags=docker --run=TestFnEval/testdata/fn-eval/$(T)  ./e2e/
 
 # target to run e2e tests for "kpt fn eval" command
 test-live-apply: build

--- a/e2e/testdata/fn-eval/entrypoint-failure/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/entrypoint-failure/.expected/config.yaml
@@ -1,0 +1,23 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exitCode: 1
+testType: eval
+image: gcr.io/kpt-fn/set-namespace:v0.1.3
+entrypoint: function1
+args:
+  namespace: staging
+stdErr: |
+  [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3[function1]"
+  [FAIL] "gcr.io/kpt-fn/set-namespace:v0.1.3[function1]" in 0s

--- a/e2e/testdata/fn-eval/entrypoint-failure/.krmignore
+++ b/e2e/testdata/fn-eval/entrypoint-failure/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-eval/entrypoint-failure/resources.yaml
+++ b/e2e/testdata/fn-eval/entrypoint-failure/resources.yaml
@@ -1,0 +1,26 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+spec:
+  image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/entrypoint-success/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/entrypoint-success/.expected/config.yaml
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 testType: eval
-image: gcr.io/kpt-fn/set-namespace:v0.1.3
-entrypoint: function
+image: gcr.io/kpt-fn-demo/all_fns:v0.0.1
+entrypoint: set-namespace
 args:
   namespace: staging
 stdErr: |
-  [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3[function]"
-  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3[function]" in 0s
+  [RUNNING] "gcr.io/kpt-fn-demo/all_fns:v0.0.1[set-namespace]"
+  [PASS] "gcr.io/kpt-fn-demo/all_fns:v0.0.1[set-namespace]" in 0s

--- a/e2e/testdata/fn-eval/entrypoint-success/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/entrypoint-success/.expected/config.yaml
@@ -1,0 +1,22 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+testType: eval
+image: gcr.io/kpt-fn/set-namespace:v0.1.3
+entrypoint: function
+args:
+  namespace: staging
+stdErr: |
+  [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3[function]"
+  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3[function]" in 0s

--- a/e2e/testdata/fn-eval/entrypoint-success/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/entrypoint-success/.expected/diff.patch
@@ -1,0 +1,19 @@
+diff --git a/resources.yaml b/resources.yaml
+index 7a494c9..254b9cd 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -15,6 +15,7 @@ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+   name: nginx-deployment
++  namespace: staging
+ spec:
+   replicas: 3
+ ---
+@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
+ kind: Custom
+ metadata:
+   name: custom
++  namespace: staging
+ spec:
+   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/entrypoint-success/.krmignore
+++ b/e2e/testdata/fn-eval/entrypoint-success/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-eval/entrypoint-success/resources.yaml
+++ b/e2e/testdata/fn-eval/entrypoint-success/resources.yaml
@@ -1,0 +1,26 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+spec:
+  image: nginx:1.2.3

--- a/e2e/testdata/fn-render/entrypoint-failure/.expected/config.yaml
+++ b/e2e/testdata/fn-render/entrypoint-failure/.expected/config.yaml
@@ -16,9 +16,6 @@
 # non-zero exit code and no changes in the resources.
 exitCode: 1
 stdErr: |
-  [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3"
-  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s
-  [RUNNING] "gcr.io/kpt-fn/set-labels:v0.1.4[function1]"
   [FAIL] "gcr.io/kpt-fn/set-labels:v0.1.4[function1]" in 0s
     Stderr:
       "docker: Error response from daemon: OCI runtime create failed: container_linux.go:370: starting container process caused: exec: \"function1\": executable file not found in $PATH: unknown."

--- a/e2e/testdata/fn-render/entrypoint-failure/.expected/config.yaml
+++ b/e2e/testdata/fn-render/entrypoint-failure/.expected/config.yaml
@@ -1,0 +1,24 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# One of the functions in the pipeline fails resulting in
+# non-zero exit code and no changes in the resources.
+exitCode: 1
+stdErr: |
+  [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3"
+  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s
+  [RUNNING] "gcr.io/kpt-fn/set-labels:v0.1.4[function1]"
+  [FAIL] "gcr.io/kpt-fn/set-labels:v0.1.4[function1]" in 0s
+    Stderr:
+      "docker: Error response from daemon: OCI runtime create failed: container_linux.go:370: starting container process caused: exec: \"function1\": executable file not found in $PATH: unknown."

--- a/e2e/testdata/fn-render/entrypoint-failure/.expected/config.yaml
+++ b/e2e/testdata/fn-render/entrypoint-failure/.expected/config.yaml
@@ -15,7 +15,3 @@
 # One of the functions in the pipeline fails resulting in
 # non-zero exit code and no changes in the resources.
 exitCode: 1
-stdErr: |
-  [FAIL] "gcr.io/kpt-fn/set-labels:v0.1.4[function1]" in 0s
-    Stderr:
-      "docker: Error response from daemon: OCI runtime create failed: container_linux.go:370: starting container process caused: exec: \"function1\": executable file not found in $PATH: unknown."

--- a/e2e/testdata/fn-render/entrypoint-failure/.krmignore
+++ b/e2e/testdata/fn-render/entrypoint-failure/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-render/entrypoint-failure/Kptfile
+++ b/e2e/testdata/fn-render/entrypoint-failure/Kptfile
@@ -1,0 +1,13 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: app
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-namespace:v0.1.3
+      configMap:
+        namespace: staging
+    - image: gcr.io/kpt-fn/set-labels:v0.1.4
+      entrypoint: function1
+      configMap:
+        tier: backend

--- a/e2e/testdata/fn-render/entrypoint-failure/resources.yaml
+++ b/e2e/testdata/fn-render/entrypoint-failure/resources.yaml
@@ -1,0 +1,26 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+spec:
+  image: nginx:1.2.3

--- a/e2e/testdata/fn-render/entrypoint-success/.expected/config.yaml
+++ b/e2e/testdata/fn-render/entrypoint-success/.expected/config.yaml
@@ -1,0 +1,19 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+stdErr: |
+  [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3"
+  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s
+  [RUNNING] "gcr.io/kpt-fn/set-labels:v0.1.4[function]"
+  [PASS] "gcr.io/kpt-fn/set-labels:v0.1.4[function]" in 0s

--- a/e2e/testdata/fn-render/entrypoint-success/.expected/config.yaml
+++ b/e2e/testdata/fn-render/entrypoint-success/.expected/config.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 stdErr: |
-  [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3"
-  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s
-  [RUNNING] "gcr.io/kpt-fn/set-labels:v0.1.4[function]"
-  [PASS] "gcr.io/kpt-fn/set-labels:v0.1.4[function]" in 0s
+  [RUNNING] "gcr.io/kpt-fn-demo/all_fns:v0.0.1[set-namespace]"
+  [PASS] "gcr.io/kpt-fn-demo/all_fns:v0.0.1[set-namespace]" in 0s
+  [RUNNING] "gcr.io/kpt-fn-demo/all_fns:v0.0.1[set-labels]"
+  [PASS] "gcr.io/kpt-fn-demo/all_fns:v0.0.1[set-labels]" in 0s

--- a/e2e/testdata/fn-render/entrypoint-success/.expected/diff.patch
+++ b/e2e/testdata/fn-render/entrypoint-success/.expected/diff.patch
@@ -1,0 +1,30 @@
+diff --git a/resources.yaml b/resources.yaml
+index 7a494c9..a9dd224 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -15,12 +15,25 @@ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+   name: nginx-deployment
++  namespace: staging
++  labels:
++    tier: backend
+ spec:
+   replicas: 3
++  selector:
++    matchLabels:
++      tier: backend
++  template:
++    metadata:
++      labels:
++        tier: backend
+ ---
+ apiVersion: custom.io/v1
+ kind: Custom
+ metadata:
+   name: custom
++  namespace: staging
++  labels:
++    tier: backend
+ spec:
+   image: nginx:1.2.3

--- a/e2e/testdata/fn-render/entrypoint-success/.krmignore
+++ b/e2e/testdata/fn-render/entrypoint-success/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-render/entrypoint-success/Kptfile
+++ b/e2e/testdata/fn-render/entrypoint-success/Kptfile
@@ -4,10 +4,11 @@ metadata:
   name: app
 pipeline:
   mutators:
-    - image: gcr.io/kpt-fn/set-namespace:v0.1.3
+    - image: gcr.io/kpt-fn-demo/all_fns:v0.0.1
+      entrypoint: set-namespace
       configMap:
         namespace: staging
-    - image: gcr.io/kpt-fn/set-labels:v0.1.4
-      entrypoint: function
+    - image: gcr.io/kpt-fn-demo/all_fns:v0.0.1
+      entrypoint: set-labels
       configMap:
         tier: backend

--- a/e2e/testdata/fn-render/entrypoint-success/Kptfile
+++ b/e2e/testdata/fn-render/entrypoint-success/Kptfile
@@ -1,0 +1,13 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: app
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-namespace:v0.1.3
+      configMap:
+        namespace: staging
+    - image: gcr.io/kpt-fn/set-labels:v0.1.4
+      entrypoint: function
+      configMap:
+        tier: backend

--- a/e2e/testdata/fn-render/entrypoint-success/resources.yaml
+++ b/e2e/testdata/fn-render/entrypoint-success/resources.yaml
@@ -1,0 +1,26 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+spec:
+  image: nginx:1.2.3

--- a/internal/docs/generated/fndocs/docs.go
+++ b/internal/docs/generated/fndocs/docs.go
@@ -80,6 +80,9 @@ Flags:
     e.g. instead of passing ` + "`" + `gcr.io/kpt-fn/set-namespace:v0.1` + "`" + ` you can pass ` + "`" + `set-namespace:v0.1` + "`" + `.
     ` + "`" + `eval` + "`" + ` executes only one function, so do not use ` + "`" + `--exec-path` + "`" + ` flag with this flag.
   
+  --entrypoint:
+    Executable in the container image to run.
+  
   --image-pull-policy:
     If the image should be pulled before rendering the package(s). It can be set
     to one of always, ifNotPresent, never. If unspecified, always will be the
@@ -130,6 +133,9 @@ var EvalExamples = `
 
   # execute container my-fn with an input ConfigMap containing ` + "`" + `data: {foo: bar}` + "`" + `
   $ kpt fn eval DIR -i gcr.io/example.com/my-fn:v1.0.0 -- foo=bar
+
+  # execute /fn-bin executable in container my-fn
+  $ kpt fn eval DIR -i gcr.io/example.com/my-fn:v1.0.0 --entrypoint /fn-bin
 
   # execute executable my-fn on the resources in DIR directory and
   # write output back to DIR

--- a/internal/docs/generated/fndocs/docs.go
+++ b/internal/docs/generated/fndocs/docs.go
@@ -81,7 +81,7 @@ Flags:
     ` + "`" + `eval` + "`" + ` executes only one function, so do not use ` + "`" + `--exec-path` + "`" + ` flag with this flag.
   
   --entrypoint:
-    Executable in the container image to run.
+    Overwrite the default entrypoint set by the function image.
   
   --image-pull-policy:
     If the image should be pulled before rendering the package(s). It can be set

--- a/internal/fnruntime/container.go
+++ b/internal/fnruntime/container.go
@@ -59,8 +59,10 @@ type ContainerFnPermission struct {
 type ContainerFn struct {
 	Ctx  context.Context
 	Path types.UniquePath
-	// Image is the container image to run
+	// Image is the container image to run.
 	Image string
+	// Entrypoint is the executable to run when container starts.
+	Entrypoint string
 	// ImagePullPolicy controls the image pulling behavior.
 	ImagePullPolicy ImagePullPolicy
 	// Container function will be killed after this timeour.
@@ -134,6 +136,9 @@ func (f *ContainerFn) getDockerCmd() (*exec.Cmd, context.CancelFunc) {
 		"--network", string(network),
 		"--user", uidgid,
 		"--security-opt=no-new-privileges",
+	}
+	if f.Entrypoint != "" {
+		args = append(args, "--entrypoint", f.Entrypoint)
 	}
 	if f.ImagePullPolicy == NeverPull {
 		args = append(args, "--pull", "never")

--- a/pkg/api/fnresult/v1/types.go
+++ b/pkg/api/fnresult/v1/types.go
@@ -25,6 +25,8 @@ type Result struct {
 	// Image is the full name of the image that generates this result
 	// Image and Exec are mutually exclusive
 	Image string `yaml:"image,omitempty"`
+	// Entrypoint is the executable that was used to run the function
+	Entrypoint string `yaml:"entrypoint,omitempty"`
 	// ExecPath is the the absolute os-specific path to the executable file
 	// If user provides an executable file with commands, ExecPath should
 	// contain the entire input string.

--- a/pkg/api/kptfile/v1/types.go
+++ b/pkg/api/kptfile/v1/types.go
@@ -268,6 +268,11 @@ type Function struct {
 	//	image: set-labels
 	Image string `yaml:"image,omitempty"`
 
+	// `Entrypoint` specifies the executable to run when the container starts.
+	// For more details, refer to:
+	// https://docs.docker.com/engine/reference/run/#entrypoint-default-command-to-execute-at-runtime
+	Entrypoint string `yaml:"entrypoint,omitempty"`
+
 	// `ConfigPath` specifies a slash-delimited relative path to a file in the current directory
 	// containing a KRM resource used as the function config. This resource is
 	// excluded when resolving 'sources', and as a result cannot be operated on

--- a/pkg/test/runner/config.go
+++ b/pkg/test/runner/config.go
@@ -36,6 +36,8 @@ type EvalTestCaseConfig struct {
 	execUniquePath types.UniquePath
 	// Image is the image name for the function
 	Image string `json:"image,omitempty" yaml:"image,omitempty"`
+	// Entrypoint is the executable to run when container starts
+	Entrypoint string `json:"entrypoint,omitempty" yaml:"entrypoint,omitempty"`
 	// Args are the arguments that will be passed into function.
 	// Args will be passed as 'key=value' format after the '--' in command.
 	Args map[string]string `json:"args,omitempty" yaml:"args,omitempty"`

--- a/pkg/test/runner/runner.go
+++ b/pkg/test/runner/runner.go
@@ -199,6 +199,9 @@ func (r *Runner) runFnEval() error {
 			}
 			if r.testCase.Config.EvalConfig.Image != "" {
 				kptArgs = append(kptArgs, "--image", r.testCase.Config.EvalConfig.Image)
+				if r.testCase.Config.EvalConfig.Entrypoint != "" {
+					kptArgs = append(kptArgs, "--entrypoint", r.testCase.Config.EvalConfig.Entrypoint)
+				}
 			} else if !r.testCase.Config.EvalConfig.execUniquePath.Empty() {
 				kptArgs = append(kptArgs, "--exec", string(r.testCase.Config.EvalConfig.execUniquePath))
 			}

--- a/scripts/uber-fn/Dockerfile
+++ b/scripts/uber-fn/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.13
+COPY set-namespace /usr/local/bin/set-namespace
+COPY set-labels /usr/local/bin/set-labels
+ENTRYPOINT ["set-namespace"]
+

--- a/scripts/uber-fn/build-uber-fn.sh
+++ b/scripts/uber-fn/build-uber-fn.sh
@@ -1,3 +1,17 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 #!/usr/bin/env bash
 
 set_labels_image=gcr.io/kpt-fn/set-labels:v0.1.4

--- a/scripts/uber-fn/build-uber-fn.sh
+++ b/scripts/uber-fn/build-uber-fn.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set_labels_image=gcr.io/kpt-fn/set-labels:v0.1.4
+set_namespace_image=gcr.io/kpt-fn/set-namespace:v0.1.3
+
+# extract set-labels binary
+container_id=`docker create $set_labels_image`
+docker cp $container_id:/usr/local/bin/function ./set-labels
+docker rm $container_id
+
+# extract set-namespace binary
+container_id=`docker create $set_namespace_image`
+docker cp $container_id:/usr/local/bin/function ./set-namespace
+docker rm $container_id
+
+# package extracted binaries in a new container image
+docker build -t gcr.io/kpt-fn-demo/all_fns:v0.0.1 .
+
+# clean if up
+rm -f ./set-namespace ./set-labels

--- a/site/reference/cli/fn/eval/README.md
+++ b/site/reference/cli/fn/eval/README.md
@@ -81,7 +81,7 @@ fn-args:
   `eval` executes only one function, so do not use `--exec-path` flag with this flag.
 
 --entrypoint:
-  Executable in the container image to run.
+  Overwrite the default entrypoint set by the function image.
 
 --image-pull-policy:
   If the image should be pulled before rendering the package(s). It can be set

--- a/site/reference/cli/fn/eval/README.md
+++ b/site/reference/cli/fn/eval/README.md
@@ -80,6 +80,9 @@ fn-args:
   e.g. instead of passing `gcr.io/kpt-fn/set-namespace:v0.1` you can pass `set-namespace:v0.1`.
   `eval` executes only one function, so do not use `--exec-path` flag with this flag.
 
+--entrypoint:
+  Executable in the container image to run.
+
 --image-pull-policy:
   If the image should be pulled before rendering the package(s). It can be set
   to one of always, ifNotPresent, never. If unspecified, always will be the
@@ -141,6 +144,11 @@ $ kpt fn eval DIR -i gcr.io/example.com/my-fn --fn-config my-fn-config
 ```shell
 # execute container my-fn with an input ConfigMap containing `data: {foo: bar}`
 $ kpt fn eval DIR -i gcr.io/example.com/my-fn:v1.0.0 -- foo=bar
+```
+
+```shell
+# execute /fn-bin executable in container my-fn
+$ kpt fn eval DIR -i gcr.io/example.com/my-fn:v1.0.0 --entrypoint /fn-bin
 ```
 
 ```shell

--- a/thirdparty/kyaml/runfn/runfn.go
+++ b/thirdparty/kyaml/runfn/runfn.go
@@ -310,6 +310,7 @@ func (r *RunFns) defaultFnFilterProvider(spec runtimeutil.FunctionSpec, fnConfig
 		}
 	}
 	var fltr *runtimeutil.FunctionFilter
+	var fnDisplayName string
 	fnResult := &fnresult.Result{
 		// TODO(droot): This is required for making structured results subpackage aware.
 		// Enable this once test harness supports filepath based assertions.
@@ -342,6 +343,7 @@ func (r *RunFns) defaultFnFilterProvider(spec runtimeutil.FunctionSpec, fnConfig
 			DeferFailure:   spec.DeferFailure,
 		}
 		fnResult.Image = spec.Container.Image
+		fnDisplayName = spec.Container.Image
 	}
 
 	if spec.Exec.Path != "" {
@@ -356,7 +358,7 @@ func (r *RunFns) defaultFnFilterProvider(spec runtimeutil.FunctionSpec, fnConfig
 			DeferFailure:   spec.DeferFailure,
 		}
 		fnResult.ExecPath = r.OriginalExec
-
+		fnDisplayName = r.OriginalExec
 	}
-	return fnruntime.NewFunctionRunner(r.Ctx, fltr, "", fnResult, r.fnResults, false)
+	return fnruntime.NewFunctionRunner(r.Ctx, fltr, fnDisplayName, "", fnResult, r.fnResults, false)
 }

--- a/thirdparty/kyaml/runfn/runfn.go
+++ b/thirdparty/kyaml/runfn/runfn.go
@@ -46,6 +46,9 @@ type RunFns struct {
 	// Function is an function to run against the input.
 	Function *runtimeutil.FunctionSpec
 
+	// Executable to run when the function containers start.
+	Entrypoint string
+
 	// FnConfig is the configurations passed from command line
 	FnConfig *yaml.RNode
 
@@ -325,6 +328,7 @@ func (r *RunFns) defaultFnFilterProvider(spec runtimeutil.FunctionSpec, fnConfig
 		c := &fnruntime.ContainerFn{
 			Path:            r.uniquePath,
 			Image:           spec.Container.Image,
+			Entrypoint:      r.Entrypoint,
 			ImagePullPolicy: r.ImagePullPolicy,
 			UIDGID:          uidgid,
 			StorageMounts:   r.StorageMounts,
@@ -344,6 +348,9 @@ func (r *RunFns) defaultFnFilterProvider(spec runtimeutil.FunctionSpec, fnConfig
 		}
 		fnResult.Image = spec.Container.Image
 		fnDisplayName = spec.Container.Image
+		if r.Entrypoint != "" {
+			fnDisplayName += fmt.Sprintf("[%s]", r.Entrypoint)
+		}
 	}
 
 	if spec.Exec.Path != "" {


### PR DESCRIPTION
In some cases, users have bundled multiple kpt functions into single container image to simply packaging/versioning/distribution. This PR enables the use-case by supporting running an executable container using `entrypoint` flag.

Here is an example:
```
apiVersion: kpt.dev/v1
kind: Kptfile
metadata:
  name: app
pipeline:
  mutators:
    - image: gcr.io/kpt-fn/all-functions:v0.1
      entrypoint: set-labels # execute the binary name `set-labels`
      configMap:
        tier: backend
```

Example for running imperatively:

```
# execute fn1 in function image my-uber-fn-image
kpt fn eval -i my-uber-fn-image --entrypoint fn1
```