### PR TITLE
Do not error out while adding merge comments

### DIFF
--- a/internal/util/addmergecomment/addmergecomment_test.go
+++ b/internal/util/addmergecomment/addmergecomment_test.go
@@ -28,7 +28,6 @@ func TestAddMetadataComment(t *testing.T) {
 		name     string
 		input    string
 		expected string
-		errMsg   string
 	}{
 		{
 			name: "Add kpt merge annotation with name and namespace",
@@ -111,7 +110,7 @@ spec:
  `,
 		},
 		{
-			name: "Skip adding kpt merge comment if already present",
+			name: "Skip adding kpt merge comment if no metadata field",
 			input: `
 apiVersion: apps/v1
 kind: MyKind
@@ -123,6 +122,19 @@ apiVersion: apps/v1
 kind: MyKind
 spec:
   replicas: 3
+ `,
+		},
+		{
+			name: "Skip adding kpt merge comment if non-KRM resource",
+			input: `- op: replace
+  path: /spec
+  value:
+    group: kubeflow.org
+ `,
+			expected: `- op: replace
+  path: /spec
+  value:
+    group: kubeflow.org
  `,
 		},
 	}
@@ -144,19 +156,7 @@ spec:
 				t.FailNow()
 			}
 
-			err = Process(baseDir)
-			if test.errMsg != "" {
-				if !assert.NotNil(t, err) {
-					t.FailNow()
-				}
-				if !assert.Contains(t, err.Error(), test.errMsg) {
-					t.FailNow()
-				}
-			}
-
-			if test.errMsg == "" && !assert.NoError(t, err) {
-				t.FailNow()
-			}
+			Process(baseDir)
 
 			actualResources, err := ioutil.ReadFile(r.Name())
 			if !assert.NoError(t, err) {

--- a/internal/util/diff/diff.go
+++ b/internal/util/diff/diff.go
@@ -271,9 +271,7 @@ type defaultPkgDiffer struct {
 
 func (d *defaultPkgDiffer) Diff(pkgs ...string) error {
 	// add merge comments before comparing so that there are no unwanted diffs
-	if err := addmergecomment.Process(pkgs...); err != nil {
-		return err
-	}
+	addmergecomment.Process(pkgs...)
 	for _, pkg := range pkgs {
 		if err := d.prepareForDiff(pkg); err != nil {
 			return err

--- a/internal/util/get/get.go
+++ b/internal/util/get/get.go
@@ -98,9 +98,7 @@ func (c Command) Run(ctx context.Context) error {
 		return cleanUpDirAndError(c.Destination, err)
 	}
 
-	if err := addmergecomment.Process(c.Destination); err != nil {
-		return cleanUpDirAndError(c.Destination, err)
-	}
+	addmergecomment.Process(c.Destination)
 	return nil
 }
 

--- a/internal/util/update/update.go
+++ b/internal/util/update/update.go
@@ -170,9 +170,7 @@ func (u Command) Run(ctx context.Context) error {
 	pr.Printf("\nUpdated %d package(s).\n", packageCount)
 
 	// finally, make sure that the merge comments are added to all resources in the updated package
-	if err := addmergecomment.Process(string(u.Pkg.UniquePath)); err != nil {
-		return errors.E(op, u.Pkg.UniquePath, err)
-	}
+	addmergecomment.Process(string(u.Pkg.UniquePath))
 	return nil
 }
 
@@ -400,10 +398,7 @@ func (u Command) mergePackage(ctx context.Context, localPath, updatedPath, origi
 	pr := printer.FromContextOrDie(ctx)
 	// at this point, the localPath, updatedPath and originPath exists and are about to be merged
 	// make sure that the merge comments are added to all of them so that they are merged accurately
-	if err := addmergecomment.Process(localPath, updatedPath, originPath); err != nil {
-		return errors.E(op, types.UniquePath(localPath),
-			fmt.Errorf("failed to add merge comments %q", err.Error()))
-	}
+	addmergecomment.Process(localPath, updatedPath, originPath)
 	updatedUnfetched, err := pkg.IsPackageUnfetched(updatedPath)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) || !isRootPkg {


### PR DESCRIPTION
This PR makes sure that addmergecomment logic is just a best effort and doesn't error out in any case. Addresses https://github.com/GoogleContainerTools/kpt/issues/2506

cc @zijianjoy