### PR TITLE
Wrap Bare Sequence Nodes to avoid parsing errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,5 +24,5 @@ require (
 	k8s.io/utils v0.0.0-20210707171843-4b05e18ac7d9
 	sigs.k8s.io/cli-utils v0.25.1-0.20210702190410-c1a7c2d0409d
 	sigs.k8s.io/kustomize/api v0.8.10
-	sigs.k8s.io/kustomize/kyaml v0.11.2-0.20210920184024-1cb93123fc3f
+	sigs.k8s.io/kustomize/kyaml v0.11.2-0.20210920224623-c47fc4860720
 )

--- a/go.mod
+++ b/go.mod
@@ -24,5 +24,5 @@ require (
 	k8s.io/utils v0.0.0-20210707171843-4b05e18ac7d9
 	sigs.k8s.io/cli-utils v0.25.1-0.20210702190410-c1a7c2d0409d
 	sigs.k8s.io/kustomize/api v0.8.10
-	sigs.k8s.io/kustomize/kyaml v0.11.2-0.20210908182956-2b8a39373e88
+	sigs.k8s.io/kustomize/kyaml v0.11.2-0.20210920184024-1cb93123fc3f
 )

--- a/go.sum
+++ b/go.sum
@@ -996,6 +996,8 @@ sigs.k8s.io/kustomize/kyaml v0.11.1-0.20210715213702-35d1c3f9b418 h1:aFl1EFMI4TN
 sigs.k8s.io/kustomize/kyaml v0.11.1-0.20210715213702-35d1c3f9b418/go.mod h1:FTJxEZ86ScK184NpGSAQcfEqee0nul8oLCK30D47m4E=
 sigs.k8s.io/kustomize/kyaml v0.11.2-0.20210908182956-2b8a39373e88 h1:oAFCwINXUpDfmRrof559WnkAMIVQl6gTTrMaXsYAOrc=
 sigs.k8s.io/kustomize/kyaml v0.11.2-0.20210908182956-2b8a39373e88/go.mod h1:FTJxEZ86ScK184NpGSAQcfEqee0nul8oLCK30D47m4E=
+sigs.k8s.io/kustomize/kyaml v0.11.2-0.20210920184024-1cb93123fc3f h1:qXVD5h5HHQLrhjijxnEamdibvj7do0ZLyxueB9blxEE=
+sigs.k8s.io/kustomize/kyaml v0.11.2-0.20210920184024-1cb93123fc3f/go.mod h1:FTJxEZ86ScK184NpGSAQcfEqee0nul8oLCK30D47m4E=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.0 h1:C4r9BgJ98vrKnnVCjwCSXcWjWe0NKcUQkmzDXZXGwH8=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.0/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=

--- a/go.sum
+++ b/go.sum
@@ -998,6 +998,8 @@ sigs.k8s.io/kustomize/kyaml v0.11.2-0.20210908182956-2b8a39373e88 h1:oAFCwINXUpD
 sigs.k8s.io/kustomize/kyaml v0.11.2-0.20210908182956-2b8a39373e88/go.mod h1:FTJxEZ86ScK184NpGSAQcfEqee0nul8oLCK30D47m4E=
 sigs.k8s.io/kustomize/kyaml v0.11.2-0.20210920184024-1cb93123fc3f h1:qXVD5h5HHQLrhjijxnEamdibvj7do0ZLyxueB9blxEE=
 sigs.k8s.io/kustomize/kyaml v0.11.2-0.20210920184024-1cb93123fc3f/go.mod h1:FTJxEZ86ScK184NpGSAQcfEqee0nul8oLCK30D47m4E=
+sigs.k8s.io/kustomize/kyaml v0.11.2-0.20210920224623-c47fc4860720 h1:pL/hMigoxtZ9THfFBXvwtHUeoy93h3INK/VC6oR9QwA=
+sigs.k8s.io/kustomize/kyaml v0.11.2-0.20210920224623-c47fc4860720/go.mod h1:FTJxEZ86ScK184NpGSAQcfEqee0nul8oLCK30D47m4E=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.0 h1:C4r9BgJ98vrKnnVCjwCSXcWjWe0NKcUQkmzDXZXGwH8=
 sigs.k8s.io/structured-merge-diff/v4 v4.1.0/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=

--- a/internal/cmdrender/executor.go
+++ b/internal/cmdrender/executor.go
@@ -88,6 +88,7 @@ func (e *Executor) Execute(ctx context.Context) error {
 			PreserveSeqIndent:  true,
 			PackageFileName:    kptfilev1.KptFileName,
 			IncludeSubpackages: true,
+			WrapBareSeqNode:    true,
 		}
 		err = pkgWriter.Write(hctx.root.resources)
 		if err != nil {

--- a/internal/fnruntime/runner_test.go
+++ b/internal/fnruntime/runner_test.go
@@ -412,6 +412,7 @@ spec:
 			Writer:                out,
 			KeepReaderAnnotations: true,
 			OmitReaderAnnotations: true,
+			WrapBareSeqNode:       true,
 		}
 		n, err := r.Read()
 		if err != nil {

--- a/internal/pkg/pkg.go
+++ b/internal/pkg/pkg.go
@@ -491,6 +491,7 @@ func (p *Pkg) LocalResources(includeMetaResources bool) (resources []*yaml.RNode
 		SetAnnotations: map[string]string{
 			pkgPathAnnotation: string(p.UniquePath),
 		},
+		WrapBareSeqNode: true,
 	}
 	resources, err = pkgReader.Read()
 	if err != nil {

--- a/internal/util/addmergecomment/addmergecomment.go
+++ b/internal/util/addmergecomment/addmergecomment.go
@@ -33,7 +33,7 @@ type AddMergeComment struct{}
 // Process invokes AddMergeComment kyaml filter on the resources in input packages paths
 func Process(paths ...string) error {
 	for _, path := range paths {
-		inout := &kio.LocalPackageReadWriter{PackagePath: path, PreserveSeqIndent: true}
+		inout := &kio.LocalPackageReadWriter{PackagePath: path, PreserveSeqIndent: true, WrapBareSeqNode: true}
 		amc := &AddMergeComment{}
 		err := kio.Pipeline{
 			Inputs:  []kio.Reader{inout},

--- a/internal/util/addmergecomment/addmergecomment_test.go
+++ b/internal/util/addmergecomment/addmergecomment_test.go
@@ -125,6 +125,19 @@ spec:
   replicas: 3
  `,
 		},
+		{
+			name: "Skip adding kpt merge comment if non-KRM resource",
+			input: `- op: replace
+  path: /spec
+  value:
+    group: kubeflow.org
+ `,
+			expected: `- op: replace
+  path: /spec
+  value:
+    group: kubeflow.org
+ `,
+		},
 	}
 	for i := range tests {
 		test := tests[i]

--- a/internal/util/cmdutil/cmdutil.go
+++ b/internal/util/cmdutil/cmdutil.go
@@ -166,7 +166,7 @@ func WriteToOutput(r io.Reader, w io.Writer, outDir string) error {
 	}
 
 	return kio.Pipeline{
-		Inputs:  []kio.Reader{&kio.ByteReader{Reader: r, PreserveSeqIndent: true}},
+		Inputs:  []kio.Reader{&kio.ByteReader{Reader: r, PreserveSeqIndent: true, WrapBareSeqNode: true}},
 		Outputs: outputs}.Execute()
 }
 

--- a/internal/util/cmdutil/cmdutil_test.go
+++ b/internal/util/cmdutil/cmdutil_test.go
@@ -287,6 +287,7 @@ metadata:
 			in := &kio.LocalPackageReader{
 				PackagePath:       baseDir,
 				PreserveSeqIndent: true,
+				WrapBareSeqNode:   true,
 			}
 			out := &bytes.Buffer{}
 

--- a/internal/util/get/get_test.go
+++ b/internal/util/get/get_test.go
@@ -1342,6 +1342,7 @@ func TestCommand_Run_subpackages(t *testing.T) {
 				PackagePath:       w.FullPackagePath(),
 				MatchFilesGlob:    []string{kptfilev1.KptFileName},
 				PreserveSeqIndent: true,
+				WrapBareSeqNode:   true,
 			}
 			err = kio.Pipeline{
 				Inputs:  []kio.Reader{rw},

--- a/internal/util/merge/merge3.go
+++ b/internal/util/merge/merge3.go
@@ -70,6 +70,7 @@ func (m Merge3) Merge() error {
 		IncludeSubpackages: m.IncludeSubPackages,
 		PackageFileName:    kptfilev1.KptFileName,
 		PreserveSeqIndent:  true,
+		WrapBareSeqNode:    true,
 	}
 	inputs = append(inputs, dest)
 
@@ -82,6 +83,7 @@ func (m Merge3) Merge() error {
 			IncludeSubpackages: m.IncludeSubPackages,
 			PackageFileName:    kptfilev1.KptFileName,
 			PreserveSeqIndent:  true,
+			WrapBareSeqNode:    true,
 		},
 		Exclusions: relPaths,
 	})
@@ -95,6 +97,7 @@ func (m Merge3) Merge() error {
 			IncludeSubpackages: m.IncludeSubPackages,
 			PackageFileName:    kptfilev1.KptFileName,
 			PreserveSeqIndent:  true,
+			WrapBareSeqNode:    true,
 		},
 		Exclusions: relPaths,
 	})

--- a/internal/util/pkgutil/pkgutil.go
+++ b/internal/util/pkgutil/pkgutil.go
@@ -287,6 +287,7 @@ func FormatPackage(pkgPath string) {
 		PackagePath:       pkgPath,
 		MatchFilesGlob:    append(kio.DefaultMatch, kptfilev1.KptFileName),
 		PreserveSeqIndent: true,
+		WrapBareSeqNode:   true,
 	}
 	f := &filters.FormatFilter{
 		UseSchema: true,

--- a/internal/util/update/update_test.go
+++ b/internal/util/update/update_test.go
@@ -2150,6 +2150,7 @@ func TestCommand_Run_local_subpackages(t *testing.T) {
 					PackagePath:       g.LocalWorkspace.FullPackagePath(),
 					MatchFilesGlob:    []string{kptfilev1.KptFileName},
 					PreserveSeqIndent: true,
+					WrapBareSeqNode:   true,
 				}
 				err = kio.Pipeline{
 					Inputs:  []kio.Reader{rw},
@@ -3683,6 +3684,7 @@ func TestRun_remote_subpackages(t *testing.T) {
 				PackagePath:       g.LocalWorkspace.FullPackagePath(),
 				MatchFilesGlob:    []string{kptfilev1.KptFileName},
 				PreserveSeqIndent: true,
+				WrapBareSeqNode:   true,
 			}
 			err = kio.Pipeline{
 				Inputs:  []kio.Reader{rw},

--- a/pkg/api/kptfile/v1/validation.go
+++ b/pkg/api/kptfile/v1/validation.go
@@ -162,7 +162,7 @@ func GetValidatedFnConfigFromPath(pkgPath types.UniquePath, configPath string) (
 	if err != nil {
 		return nil, fmt.Errorf("functionConfig must exist in the current package")
 	}
-	reader := kio.ByteReader{Reader: file, PreserveSeqIndent: true}
+	reader := kio.ByteReader{Reader: file, PreserveSeqIndent: true, WrapBareSeqNode: true}
 	nodes, err := reader.Read()
 	if err != nil {
 		return nil, fmt.Errorf("failed to read functionConfig %q: %w", configPath, err)

--- a/pkg/live/load.go
+++ b/pkg/live/load.go
@@ -99,7 +99,8 @@ func readInvInfoFromStream(in io.Reader) (kptfilev1.Inventory, error) {
 	if err := (&kio.Pipeline{
 		Inputs: []kio.Reader{
 			&kio.ByteReader{
-				Reader: in,
+				Reader:          in,
+				WrapBareSeqNode: true,
 			},
 		},
 		Filters: []kio.Filter{

--- a/pkg/live/load_test.go
+++ b/pkg/live/load_test.go
@@ -319,6 +319,7 @@ func TestLoad_StdIn(t *testing.T) {
 						OmitReaderAnnotations: true,
 						MatchFilesGlob:        append([]string{kptfile.KptFileName}, kio.DefaultMatch...),
 						IncludeSubpackages:    true,
+						WrapBareSeqNode:       true,
 					},
 				},
 				Outputs: []kio.Writer{

--- a/pkg/live/rgpath.go
+++ b/pkg/live/rgpath.go
@@ -41,7 +41,8 @@ func (r *ResourceGroupPathManifestReader) Read() ([]*unstructured.Unstructured, 
 
 	var objs []*unstructured.Unstructured
 	nodes, err := (&kio.LocalPackageReader{
-		PackagePath: r.PkgPath,
+		PackagePath:     r.PkgPath,
+		WrapBareSeqNode: true,
 	}).Read()
 	if err != nil {
 		return objs, err

--- a/pkg/live/rgstream.go
+++ b/pkg/live/rgstream.go
@@ -43,7 +43,8 @@ type ResourceGroupStreamManifestReader struct {
 func (p *ResourceGroupStreamManifestReader) Read() ([]*unstructured.Unstructured, error) {
 	var objs []*unstructured.Unstructured
 	nodes, err := (&kio.ByteReader{
-		Reader: p.Reader,
+		Reader:          p.Reader,
+		WrapBareSeqNode: true,
 	}).Read()
 	if err != nil {
 		return objs, err

--- a/thirdparty/cmdconfig/commands/cmdsource/cmdsource.go
+++ b/thirdparty/cmdconfig/commands/cmdsource/cmdsource.go
@@ -74,7 +74,7 @@ func (r *SourceRunner) runE(c *cobra.Command, args []string) error {
 	// if there is a function-config specified, emit it
 	var functionConfig *yaml.RNode
 	if r.FunctionConfig != "" {
-		configs, err := kio.LocalPackageReader{PackagePath: r.FunctionConfig, PreserveSeqIndent: true}.Read()
+		configs, err := kio.LocalPackageReader{PackagePath: r.FunctionConfig, PreserveSeqIndent: true, WrapBareSeqNode: true}.Read()
 		if err != nil {
 			return err
 		}
@@ -109,6 +109,7 @@ func (r *SourceRunner) runE(c *cobra.Command, args []string) error {
 			PreserveSeqIndent:  true,
 			PackageFileName:    kptfile.KptFileName,
 			IncludeSubpackages: true,
+			WrapBareSeqNode:    true,
 		})
 	}
 

--- a/thirdparty/cmdconfig/commands/cmdtree/cmdtree.go
+++ b/thirdparty/cmdconfig/commands/cmdtree/cmdtree.go
@@ -59,6 +59,7 @@ func (r *TreeRunner) runE(c *cobra.Command, args []string) error {
 		PackagePath:       resolvedPath,
 		MatchFilesGlob:    r.getMatchFilesGlob(),
 		PreserveSeqIndent: true,
+		WrapBareSeqNode:   true,
 	}
 	fltrs := []kio.Filter{&filters.IsLocalConfig{
 		IncludeLocalConfig: true,

--- a/thirdparty/kyaml/runfn/runfn.go
+++ b/thirdparty/kyaml/runfn/runfn.go
@@ -134,13 +134,14 @@ func (r RunFns) getNodesAndFilters() (
 			PreserveSeqIndent:  true,
 			PackageFileName:    kptfile.KptFileName,
 			IncludeSubpackages: true,
+			WrapBareSeqNode:    true,
 		}
 	}
 
 	if r.Input == nil {
 		p.Inputs = []kio.Reader{outputPkg}
 	} else {
-		p.Inputs = []kio.Reader{&kio.ByteReader{Reader: r.Input, PreserveSeqIndent: true}}
+		p.Inputs = []kio.Reader{&kio.ByteReader{Reader: r.Input, PreserveSeqIndent: true, WrapBareSeqNode: true}}
 	}
 	if err := p.Execute(); err != nil {
 		return nil, nil, outputPkg, err


### PR DESCRIPTION
Wrap bare sequence nodes while reading resources. Upstream change corresponding to https://github.com/kubernetes-sigs/kustomize/pull/4189