### PR TITLE
update sidebar

### DIFF
--- a/scripts/generate_site_sidebar/sidebar_template.md.tmpl
+++ b/scripts/generate_site_sidebar/sidebar_template.md.tmpl
@@ -27,5 +27,7 @@
     - [ResourceList](reference/schema/resource-list/)
     - [CRD Status Convention](reference/schema/crd-status-convention/)
 - [Functions Catalog](https://catalog.kpt.dev/ ":target=_self")
+  - [Curated](https://catalog.kpt.dev/ ":target=_self")
+  - [Contrib](https://catalog.kpt.dev/contrib/ ":target=_self")
 - [FAQ](faq/)
 - [Contact](contact/)

--- a/site/index.html
+++ b/site/index.html
@@ -15,7 +15,7 @@
     />
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/docsify-themeable@0/dist/css/theme-simple.css"
+      href="https://cdn.jsdelivr.net/npm/docsify-themeable@0.8.4/dist/css/theme-simple.css"
     />
     <link
       href="https://fonts.googleapis.com/icon?family=Material+Icons+Outlined"

--- a/site/sidebar.md
+++ b/site/sidebar.md
@@ -55,5 +55,7 @@
     - [ResourceList](reference/schema/resource-list/)
     - [CRD Status Convention](reference/schema/crd-status-convention/)
 - [Functions Catalog](https://catalog.kpt.dev/ ":target=_self")
+  - [Curated](https://catalog.kpt.dev/ ":target=_self")
+  - [Contrib](https://catalog.kpt.dev/contrib/ ":target=_self")
 - [FAQ](faq/)
 - [Contact](contact/)


### PR DESCRIPTION
We ping docsify-themeable to 0.8.4 to avoid picking up the change related
to "expand/collapse icons" in 0.8.5+. See:
https://jhildenbiddle.github.io/docsify-themeable/#/changelog?id=_085
