### PR TITLE
Avoid printing the error twice

### DIFF
--- a/site/book/05-developing-functions/02-developing-in-Go.md
+++ b/site/book/05-developing-functions/02-developing-in-Go.md
@@ -31,7 +31,6 @@ provided value:
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"sigs.k8s.io/kustomize/kyaml/fn/framework"
@@ -61,7 +60,6 @@ func main() {
   command.AddGenerateDockerfile(cmd)
 
 	if err := cmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
We set  the 3rd argument `noPrintError` to `false` in `cmd := command.Build(p, command.StandaloneDisabled, false)`. We don't need to do `fmt.Println`


