### PR TITLE
use k8s casing for flag --image-pull-policy

### DIFF
--- a/e2e/fn_test.go
+++ b/e2e/fn_test.go
@@ -1,3 +1,4 @@
+//go:build docker
 // +build docker
 
 // Copyright 2021 Google LLC

--- a/e2e/testdata/fn-eval/image-pull-policy-always/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/image-pull-policy-always/.expected/config.yaml
@@ -15,6 +15,6 @@
 testType: eval
 image: gcr.io/kpt-fn-demo/foo:v0.1
 sequential: true
-imagePullPolicy: always
+imagePullPolicy: Always
 exitCode: 1
 stdErr: foo

--- a/e2e/testdata/fn-eval/image-pull-policy-if-not-present/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/image-pull-policy-if-not-present/.expected/config.yaml
@@ -15,6 +15,6 @@
 testType: eval
 image: gcr.io/kpt-fn-demo/bar:v0.1
 sequential: true
-imagePullPolicy: ifNotPresent
+imagePullPolicy: IfNotPresent
 exitCode: 1
 stdErr: foo

--- a/e2e/testdata/fn-eval/image-pull-policy-never/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/image-pull-policy-never/.expected/config.yaml
@@ -14,6 +14,6 @@
 
 testType: eval
 image: gcr.io/kpt-fn/not-exist:v0.1
-imagePullPolicy: never
+imagePullPolicy: Never
 exitCode: 1
 stdErr: "No such image"

--- a/e2e/testdata/fn-render/image-pull-policy-always/.expected/config.yaml
+++ b/e2e/testdata/fn-render/image-pull-policy-always/.expected/config.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-imagePullPolicy: always
+imagePullPolicy: Always
 sequential: true
 exitCode: 1
 stdErr: foo

--- a/e2e/testdata/fn-render/image-pull-policy-if-not-present/.expected/config.yaml
+++ b/e2e/testdata/fn-render/image-pull-policy-if-not-present/.expected/config.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-imagePullPolicy: ifNotPresent
+imagePullPolicy: IfNotPresent
 sequential: true
 exitCode: 1
 stdErr: foo

--- a/e2e/testdata/fn-render/image-pull-policy-never/.expected/config.yaml
+++ b/e2e/testdata/fn-render/image-pull-policy-never/.expected/config.yaml
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-imagePullPolicy: never
+imagePullPolicy: Never
 exitCode: 1
 stdErr: "No such image"

--- a/internal/cmdrender/cmdrender.go
+++ b/internal/cmdrender/cmdrender.go
@@ -23,6 +23,7 @@ import (
 	"os"
 
 	docs "github.com/GoogleContainerTools/kpt/internal/docs/generated/fndocs"
+	"github.com/GoogleContainerTools/kpt/internal/fnruntime"
 	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"github.com/GoogleContainerTools/kpt/internal/util/argutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
@@ -44,8 +45,8 @@ func NewRunner(ctx context.Context, parent string) *Runner {
 		"path to a directory to save function results")
 	c.Flags().StringVarP(&r.dest, "output", "o", "",
 		fmt.Sprintf("output resources are written to provided location. Allowed values: %s|%s|<OUT_DIR_PATH>", cmdutil.Stdout, cmdutil.Unwrap))
-	c.Flags().StringVar(&r.imagePullPolicy, "image-pull-policy", "always",
-		"pull image before running the container. It should be one of always, ifNotPresent and never.")
+	c.Flags().StringVar(&r.imagePullPolicy, "image-pull-policy", string(fnruntime.AlwaysPull),
+		fmt.Sprintf("pull image before running the container. It must be one of %s, %s and %s.", fnruntime.AlwaysPull, fnruntime.IfNotPresentPull, fnruntime.NeverPull))
 	cmdutil.FixDocs("kpt", parent, c)
 	r.Command = c
 	return r

--- a/internal/fnruntime/container.go
+++ b/internal/fnruntime/container.go
@@ -40,9 +40,9 @@ const (
 	defaultShortTimeout time.Duration        = 5 * time.Second
 	dockerBin           string               = "docker"
 
-	AlwaysPull       ImagePullPolicy = "always"
-	IfNotPresentPull ImagePullPolicy = "ifNotPresent"
-	NeverPull        ImagePullPolicy = "never"
+	AlwaysPull       ImagePullPolicy = "Always"
+	IfNotPresentPull ImagePullPolicy = "IfNotPresent"
+	NeverPull        ImagePullPolicy = "Never"
 )
 
 type ImagePullPolicy string

--- a/internal/util/cmdutil/cmdutil.go
+++ b/internal/util/cmdutil/cmdutil.go
@@ -107,17 +107,20 @@ To install docker, follow the instructions at https://docs.docker.com/get-docker
 }
 
 func ValidateImagePullPolicyValue(v string) error {
-	if v != string(fnruntime.AlwaysPull) && v != string(fnruntime.IfNotPresentPull) && v != string(fnruntime.NeverPull) {
+	v = strings.ToLower(v)
+	if v != strings.ToLower(string(fnruntime.AlwaysPull)) &&
+		v != strings.ToLower(string(fnruntime.IfNotPresentPull)) &&
+		v != strings.ToLower(string(fnruntime.NeverPull)) {
 		return fmt.Errorf("image pull policy must be one of %s, %s and %s", fnruntime.AlwaysPull, fnruntime.IfNotPresentPull, fnruntime.NeverPull)
 	}
 	return nil
 }
 
 func StringToImagePullPolicy(v string) fnruntime.ImagePullPolicy {
-	switch v {
-	case string(fnruntime.NeverPull):
+	switch strings.ToLower(v) {
+	case strings.ToLower(string(fnruntime.NeverPull)):
 		return fnruntime.NeverPull
-	case string(fnruntime.IfNotPresentPull):
+	case strings.ToLower(string(fnruntime.IfNotPresentPull)):
 		return fnruntime.IfNotPresentPull
 	default:
 		return fnruntime.AlwaysPull

--- a/pkg/test/runner/README.md
+++ b/pkg/test/runner/README.md
@@ -24,7 +24,7 @@ in `.expected`:
   - `skip`: Runner will skip the test if `skip` is set to true. Default: false.
   - `sequential`: This test case should be run sequentially. Default: false.
   - `imagePullPolicy`: The image pull policy to be used. It can be set to one of
-    `always`, `ifNotPresent` and `never`. Default value is inherited from the
+    `Always`, `IfNotPresent` and `Never`. Default value is inherited from the
     CLI flag.
   - `notIdempotent`: The functions and commands should be idempotent, but in
     some cases it's not doable. The runner will not run the command twice to

--- a/pkg/test/runner/config.go
+++ b/pkg/test/runner/config.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/GoogleContainerTools/kpt/internal/fnruntime"
 	"github.com/GoogleContainerTools/kpt/internal/types"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
@@ -68,9 +67,9 @@ type TestCaseConfig struct {
 	Sequential bool `json:"sequential,omitempty" yaml:"sequential,omitempty"`
 
 	// ImagePullPolicy controls the image pulling behavior. It can be set to one
-	// of always, ifNotPresent and never. If unspecified, the default will be
-	// the same as the CLI flag.
-	ImagePullPolicy fnruntime.ImagePullPolicy `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
+	// of `Always`, `IfNotPresent` and `Never`. If unspecified, the default will
+	// be the same as the CLI flag.
+	ImagePullPolicy string `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
 
 	// Skip means should this test case be skipped. Default: false
 	Skip bool `json:"skip,omitempty" yaml:"skip,omitempty"`

--- a/pkg/test/runner/runner.go
+++ b/pkg/test/runner/runner.go
@@ -192,7 +192,7 @@ func (r *Runner) runFnEval() error {
 				kptArgs = append(kptArgs, "-o", destDir)
 			}
 			if r.testCase.Config.ImagePullPolicy != "" {
-				kptArgs = append(kptArgs, "--image-pull-policy", string(r.testCase.Config.ImagePullPolicy))
+				kptArgs = append(kptArgs, "--image-pull-policy", r.testCase.Config.ImagePullPolicy)
 			}
 			if r.testCase.Config.EvalConfig.Network {
 				kptArgs = append(kptArgs, "--network")
@@ -346,7 +346,7 @@ func (r *Runner) runFnRender() error {
 			}
 
 			if r.testCase.Config.ImagePullPolicy != "" {
-				kptArgs = append(kptArgs, "--image-pull-policy", string(r.testCase.Config.ImagePullPolicy))
+				kptArgs = append(kptArgs, "--image-pull-policy", r.testCase.Config.ImagePullPolicy)
 			}
 
 			if r.testCase.Config.DisableOutputTruncate {

--- a/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
+++ b/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
@@ -61,8 +61,8 @@ func GetEvalFnRunner(ctx context.Context, parent string) *EvalFnRunner {
 		"a list of environment variables to be used by functions")
 	r.Command.Flags().BoolVar(
 		&r.AsCurrentUser, "as-current-user", false, "use the uid and gid that kpt is running with to run the function in the container")
-	r.Command.Flags().StringVar(&r.ImagePullPolicy, "image-pull-policy", "always",
-		"pull image before running the container. It should be one of always, ifNotPresent and never.")
+	r.Command.Flags().StringVar(&r.ImagePullPolicy, "image-pull-policy", string(fnruntime.AlwaysPull),
+		fmt.Sprintf("pull image before running the container. It must be one of %s, %s and %s.", fnruntime.AlwaysPull, fnruntime.IfNotPresentPull, fnruntime.NeverPull))
 	r.Command.Flags().StringVar(
 		&r.Selector.APIVersion, "api-version", "", "select the resources with apiVersion to run the function on")
 	r.Command.Flags().StringVar(


### PR DESCRIPTION
We always convert it to lower cases before comparing them. This is not a breaking change.

fixes: https://github.com/GoogleContainerTools/kpt/issues/2468