### PR TITLE
Update should accept empty path with version

### DIFF
--- a/internal/util/argutil/argutil.go
+++ b/internal/util/argutil/argutil.go
@@ -94,11 +94,13 @@ func ParseFieldPath(path string) ([]string, error) {
 func ResolveSymlink(ctx context.Context, path string) (string, error) {
 	isSymlink := false
 	f, err := os.Lstat(path)
-	if err != nil {
-		return "", err
-	}
-	if f.Mode().Type() == os.ModeSymlink {
-		isSymlink = true
+	if err == nil {
+		// this step only helps with printing WARN message by checking if the input
+		// path has symlink, so do not error out at this phase and let
+		// filepath.EvalSymlinks(path) handle the cases
+		if f.Mode().Type() == os.ModeSymlink {
+			isSymlink = true
+		}
 	}
 	rp, err := filepath.EvalSymlinks(path)
 	if err != nil {

--- a/internal/util/argutil/argutil_test.go
+++ b/internal/util/argutil/argutil_test.go
@@ -144,6 +144,10 @@ func TestResolveSymlink(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "foo", actual2)
 
+	actual3, err := ResolveSymlink(fake.CtxWithDefaultPrinter(), ".")
+	assert.NoError(t, err)
+	assert.Equal(t, ".", actual3)
+
 	_, err = ResolveSymlink(fake.CtxWithDefaultPrinter(), "baz")
 	assert.Error(t, err)
 	assert.Equal(t, "lstat baz: no such file or directory", err.Error())


### PR DESCRIPTION
This PR addresses regression during symlinks check and allows empty path with version for `kpt pkg update`.