### PR TITLE
fix: Use KptFileKind variable instead of KptFileName for GVR

### DIFF
--- a/internal/cmdget/cmdget_test.go
+++ b/internal/cmdget/cmdget_test.go
@@ -68,7 +68,7 @@ func TestCmd_execute(t *testing.T) {
 			},
 			TypeMeta: yaml.TypeMeta{
 				APIVersion: kptfilev1.KptFileAPIVersion,
-				Kind:       kptfilev1.KptFileName},
+				Kind:       kptfilev1.KptFileKind},
 		},
 		Upstream: &kptfilev1.Upstream{
 			Type: kptfilev1.GitOrigin,
@@ -128,7 +128,7 @@ func TestCmdMainBranch_execute(t *testing.T) {
 			},
 			TypeMeta: yaml.TypeMeta{
 				APIVersion: kptfilev1.KptFileAPIVersion,
-				Kind:       kptfilev1.KptFileName},
+				Kind:       kptfilev1.KptFileKind},
 		},
 		Upstream: &kptfilev1.Upstream{
 			Type: kptfilev1.GitOrigin,

--- a/internal/util/fetch/fetch_test.go
+++ b/internal/util/fetch/fetch_test.go
@@ -196,7 +196,7 @@ func TestCommand_Run(t *testing.T) {
 			},
 			TypeMeta: yaml.TypeMeta{
 				APIVersion: kptfilev1.KptFileAPIVersion,
-				Kind:       kptfilev1.KptFileName},
+				Kind:       kptfilev1.KptFileKind},
 		},
 		Upstream: &kptfilev1.Upstream{
 			Type: "git",
@@ -258,7 +258,7 @@ func TestCommand_Run_subdir(t *testing.T) {
 			},
 			TypeMeta: yaml.TypeMeta{
 				APIVersion: kptfilev1.KptFileAPIVersion,
-				Kind:       kptfilev1.KptFileName},
+				Kind:       kptfilev1.KptFileKind},
 		},
 		Upstream: &kptfilev1.Upstream{
 			Type: kptfilev1.GitOrigin,
@@ -334,7 +334,7 @@ func TestCommand_Run_branch(t *testing.T) {
 			},
 			TypeMeta: yaml.TypeMeta{
 				APIVersion: kptfilev1.KptFileAPIVersion,
-				Kind:       kptfilev1.KptFileName},
+				Kind:       kptfilev1.KptFileKind},
 		},
 		Upstream: &kptfilev1.Upstream{
 			Type: kptfilev1.GitOrigin,
@@ -415,7 +415,7 @@ func TestCommand_Run_tag(t *testing.T) {
 			},
 			TypeMeta: yaml.TypeMeta{
 				APIVersion: kptfilev1.KptFileAPIVersion,
-				Kind:       kptfilev1.KptFileName},
+				Kind:       kptfilev1.KptFileKind},
 		},
 		Upstream: &kptfilev1.Upstream{
 			Type: "git",

--- a/pkg/api/kptfile/v1/types.go
+++ b/pkg/api/kptfile/v1/types.go
@@ -35,7 +35,7 @@ const (
 var TypeMeta = yaml.ResourceMeta{
 	TypeMeta: yaml.TypeMeta{
 		APIVersion: KptFileAPIVersion,
-		Kind:       KptFileName,
+		Kind:       KptFileKind,
 	},
 }
 

--- a/pkg/live/load.go
+++ b/pkg/live/load.go
@@ -175,7 +175,7 @@ type InventoryFilter struct {
 
 func (i *InventoryFilter) Filter(object *yaml.RNode) (*yaml.RNode, error) {
 	if object.GetApiVersion() != kptfilev1.KptFileAPIVersion ||
-		object.GetKind() != kptfilev1.KptFileName {
+		object.GetKind() != kptfilev1.KptFileKind {
 		return object, nil
 	}
 


### PR DESCRIPTION
When specifying the Kptfile resource kind, some code were using the KptFileName variable instead of KptFileKind. Both variables currently contain the same value: "Kptfile", but this will be an issue in the future should the KptFileName and KptFileKind variables have different values.