### PR TITLE
[WIP] Update cli-utils to v0.27.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	k8s.io/klog/v2 v2.10.0
 	k8s.io/kubectl v0.22.2
 	k8s.io/utils v0.0.0-20210820185131-d34e5cb4466e
-	sigs.k8s.io/cli-utils v0.26.1-0.20211020064957-d62b5c62002d
+	sigs.k8s.io/cli-utils v0.26.1-0.20211111225114-39f77432ba99
 	sigs.k8s.io/kustomize/api v0.8.11
 	sigs.k8s.io/kustomize/kyaml v0.12.1-0.20211012224254-55ac9ca88db9
 )

--- a/go.sum
+++ b/go.sum
@@ -1022,8 +1022,8 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
-sigs.k8s.io/cli-utils v0.26.1-0.20211020064957-d62b5c62002d h1:yxJZ6HujyxXTLuHuZ8/HkzWy6g+eTpslhUzAzPpA9dE=
-sigs.k8s.io/cli-utils v0.26.1-0.20211020064957-d62b5c62002d/go.mod h1:8ll2fyx+bzjbwmwUnKBQU+2LDbMDsxy44DiDZ+drALg=
+sigs.k8s.io/cli-utils v0.26.1-0.20211111225114-39f77432ba99 h1:XXjbg+pG8zO2oWcH/UtF2wJwEpy6sYOkPOAaIR1N4qM=
+sigs.k8s.io/cli-utils v0.26.1-0.20211111225114-39f77432ba99/go.mod h1:8ll2fyx+bzjbwmwUnKBQU+2LDbMDsxy44DiDZ+drALg=
 sigs.k8s.io/controller-runtime v0.10.1 h1:+eLHgY/VrJWnfg6iXUqhCUqNXgPH1NZeP9drNAAgWlg=
 sigs.k8s.io/controller-runtime v0.10.1/go.mod h1:CQp8eyUQZ/Q7PJvnIrB6/hgfTC1kBkGylwsLgOQi1WY=
 sigs.k8s.io/kustomize/api v0.8.11 h1:LzQzlq6Z023b+mBtc6v72N2mSHYmN8x7ssgbf/hv0H8=

--- a/internal/cmdapply/cmdapply.go
+++ b/internal/cmdapply/cmdapply.go
@@ -35,7 +35,6 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/apply"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
-	status "sigs.k8s.io/cli-utils/pkg/util/factory"
 )
 
 // NewRunner returns a command runner
@@ -208,15 +207,11 @@ func runApply(r *Runner, invInfo inventory.InventoryInfo, objs []*unstructured.U
 
 	// Run the applier. It will return a channel where we can receive updates
 	// to keep track of progress and any issues.
-	poller, err := status.NewStatusPoller(r.factory)
-	if err != nil {
-		return err
-	}
 	invClient, err := inventory.NewInventoryClient(r.factory, live.WrapInventoryObj, live.InvToUnstructuredFunc)
 	if err != nil {
 		return err
 	}
-	applier, err := apply.NewApplier(r.factory, invClient, poller)
+	applier, err := apply.NewApplier(r.factory, invClient)
 	if err != nil {
 		return err
 	}

--- a/internal/cmddestroy/cmddestroy.go
+++ b/internal/cmddestroy/cmddestroy.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/apply"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
-	status "sigs.k8s.io/cli-utils/pkg/util/factory"
 )
 
 func NewRunner(ctx context.Context, factory util.Factory,
@@ -154,15 +153,11 @@ func (r *Runner) runE(c *cobra.Command, args []string) error {
 func runDestroy(r *Runner, inv inventory.InventoryInfo, dryRunStrategy common.DryRunStrategy) error {
 	// Run the destroyer. It will return a channel where we can receive updates
 	// to keep track of progress and any issues.
-	poller, err := status.NewStatusPoller(r.factory)
-	if err != nil {
-		return err
-	}
 	invClient, err := inventory.NewInventoryClient(r.factory, live.WrapInventoryObj, live.InvToUnstructuredFunc)
 	if err != nil {
 		return err
 	}
-	destroyer, err := apply.NewDestroyer(r.factory, invClient, poller)
+	destroyer, err := apply.NewDestroyer(r.factory, invClient)
 	if err != nil {
 		return err
 	}

--- a/pkg/live/apply-crd-task.go
+++ b/pkg/live/apply-crd-task.go
@@ -89,4 +89,6 @@ func (a *ApplyCRDTask) Start(taskContext *taskrunner.TaskContext) {
 	}()
 }
 
-func (a *ApplyCRDTask) ClearTimeout() {}
+func (a *ApplyCRDTask) Cancel(_ *taskrunner.TaskContext) {}
+
+func (a *ApplyCRDTask) StatusUpdate(_ *taskrunner.TaskContext, _ object.ObjMetadata) {}

--- a/pkg/live/rgpath_test.go
+++ b/pkg/live/rgpath_test.go
@@ -151,7 +151,7 @@ func TestPathManifestReader_Read(t *testing.T) {
 				"cr.yaml": cr,
 			},
 			namespace:      "test-namespace",
-			expectedErrMsg: "unknown resource types: Custom.custom.io",
+			expectedErrMsg: "unknown resource types: custom.io/v1, Kind=Custom",
 		},
 		"local-config is filtered out": {
 			manifests: map[string]string{

--- a/pkg/live/rgstream_test.go
+++ b/pkg/live/rgstream_test.go
@@ -99,7 +99,7 @@ func TestResourceStreamManifestReader_Read(t *testing.T) {
 				"cr.yaml": cr,
 			},
 			namespace:      "test-namespace",
-			expectedErrMsg: "unknown resource types: Custom.custom.io",
+			expectedErrMsg: "unknown resource types: custom.io/v1, Kind=Custom",
 		},
 	}
 


### PR DESCRIPTION
This is a test to make sure kpt can adopt the latest cli-utils. Version `v0.27.0` is not out yet, but we can release it soon if all goes well here.

Major changes: 
- No default reconcile timeout (wait until cancelled)
- No default prune/delete timeout (wait until cancelled)
- Always wait for reconciliation after apply/prune/delete (previously only waited if there were dependencies, causing more than one apply task)
- Send WaitEvent for every object
- Added deletion prevention annotations
- Context cancel/timeout now sends an error and event
- Update K8s libs to v0.22.2
- Update kyaml to v0.12.0
- Printers moved from cmd to pkg

This will most notably change the output and behavior of kpt live apply/status/destroy.