### PR TITLE
add tests to exercise modify path annotation

### DIFF
--- a/e2e/testdata/fn-eval/modify-legacy-path-annotation/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/modify-legacy-path-annotation/.expected/config.yaml
@@ -1,0 +1,17 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+testType: eval
+image: gcr.io/kpt-fn/starlark:v0.3
+fnConfig: ../starlark-fn.yaml

--- a/e2e/testdata/fn-eval/modify-legacy-path-annotation/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/modify-legacy-path-annotation/.expected/diff.patch
@@ -1,0 +1,4 @@
+diff --git a/deployment.yaml b/newfilename.yaml
+similarity index 100%
+rename from deployment.yaml
+rename to newfilename.yaml

--- a/e2e/testdata/fn-eval/modify-legacy-path-annotation/.krmignore
+++ b/e2e/testdata/fn-eval/modify-legacy-path-annotation/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-eval/modify-legacy-path-annotation/deployment.yaml
+++ b/e2e/testdata/fn-eval/modify-legacy-path-annotation/deployment.yaml
@@ -1,0 +1,35 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    foo: bar
+  name: my-nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - image: nginx:1.14.2
+          name: nginx
+          ports:
+            - containerPort: 80
+              protocol: TCP

--- a/e2e/testdata/fn-eval/modify-legacy-path-annotation/starlark-fn.yaml
+++ b/e2e/testdata/fn-eval/modify-legacy-path-annotation/starlark-fn.yaml
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: fn.kpt.dev/v1alpha1
+kind: StarlarkRun
+metadata:
+  name: update-path
+source: |
+  for r in ctx.resource_list["items"]:
+    if r["kind"] == "Deployment":
+      r["metadata"]["annotations"]["config.kubernetes.io/path"] = "newfilename.yaml"

--- a/e2e/testdata/fn-eval/modify-path-annotation/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/modify-path-annotation/.expected/config.yaml
@@ -1,0 +1,17 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+testType: eval
+image: gcr.io/kpt-fn/starlark:v0.3
+fnConfig: ../starlark-fn.yaml

--- a/e2e/testdata/fn-eval/modify-path-annotation/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/modify-path-annotation/.expected/diff.patch
@@ -1,0 +1,4 @@
+diff --git a/deployment.yaml b/newfilename.yaml
+similarity index 100%
+rename from deployment.yaml
+rename to newfilename.yaml

--- a/e2e/testdata/fn-eval/modify-path-annotation/.krmignore
+++ b/e2e/testdata/fn-eval/modify-path-annotation/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-eval/modify-path-annotation/deployment.yaml
+++ b/e2e/testdata/fn-eval/modify-path-annotation/deployment.yaml
@@ -1,0 +1,35 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    foo: bar
+  name: my-nginx
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      containers:
+        - image: nginx:1.14.2
+          name: nginx
+          ports:
+            - containerPort: 80
+              protocol: TCP

--- a/e2e/testdata/fn-eval/modify-path-annotation/starlark-fn.yaml
+++ b/e2e/testdata/fn-eval/modify-path-annotation/starlark-fn.yaml
@@ -1,0 +1,21 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: fn.kpt.dev/v1alpha1
+kind: StarlarkRun
+metadata:
+  name: update-path
+source: |
+  for r in ctx.resource_list["items"]:
+    if r["kind"] == "Deployment":
+      r["metadata"]["annotations"]["internal.config.kubernetes.io/path"] = "newfilename.yaml"

--- a/e2e/testdata/fn-render/modify-legacy-path-annotation/.expected/diff.patch
+++ b/e2e/testdata/fn-render/modify-legacy-path-annotation/.expected/diff.patch
@@ -1,0 +1,4 @@
+diff --git a/deployment.yaml b/newfilename.yaml
+similarity index 100%
+rename from deployment.yaml
+rename to newfilename.yaml

--- a/e2e/testdata/fn-render/modify-legacy-path-annotation/.krmignore
+++ b/e2e/testdata/fn-render/modify-legacy-path-annotation/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-render/modify-legacy-path-annotation/Kptfile
+++ b/e2e/testdata/fn-render/modify-legacy-path-annotation/Kptfile
@@ -1,0 +1,8 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: app
+pipeline:
+  mutators:
+  - image: gcr.io/kpt-fn/starlark:v0.3.0
+    configPath: starlark-fn.yaml

--- a/e2e/testdata/fn-render/modify-legacy-path-annotation/deployment.yaml
+++ b/e2e/testdata/fn-render/modify-legacy-path-annotation/deployment.yaml
@@ -1,0 +1,19 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3

--- a/e2e/testdata/fn-render/modify-legacy-path-annotation/starlark-fn.yaml
+++ b/e2e/testdata/fn-render/modify-legacy-path-annotation/starlark-fn.yaml
@@ -1,0 +1,22 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: fn.kpt.dev/v1alpha1
+kind: StarlarkRun
+metadata:
+  name: update-path
+source: |
+  for r in ctx.resource_list["items"]:
+    if r["kind"] == "Deployment":
+      r["metadata"]["annotations"]["config.kubernetes.io/path"] = "newfilename.yaml"

--- a/e2e/testdata/fn-render/modify-path-annotation/.expected/diff.patch
+++ b/e2e/testdata/fn-render/modify-path-annotation/.expected/diff.patch
@@ -1,0 +1,4 @@
+diff --git a/deployment.yaml b/newfilename.yaml
+similarity index 100%
+rename from deployment.yaml
+rename to newfilename.yaml

--- a/e2e/testdata/fn-render/modify-path-annotation/.krmignore
+++ b/e2e/testdata/fn-render/modify-path-annotation/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-render/modify-path-annotation/Kptfile
+++ b/e2e/testdata/fn-render/modify-path-annotation/Kptfile
@@ -1,0 +1,8 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: app
+pipeline:
+  mutators:
+  - image: gcr.io/kpt-fn/starlark:v0.3.0
+    configPath: starlark-fn.yaml

--- a/e2e/testdata/fn-render/modify-path-annotation/deployment.yaml
+++ b/e2e/testdata/fn-render/modify-path-annotation/deployment.yaml
@@ -1,0 +1,19 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3

--- a/e2e/testdata/fn-render/modify-path-annotation/starlark-fn.yaml
+++ b/e2e/testdata/fn-render/modify-path-annotation/starlark-fn.yaml
@@ -1,0 +1,22 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: fn.kpt.dev/v1alpha1
+kind: StarlarkRun
+metadata:
+  name: update-path
+source: |
+  for r in ctx.resource_list["items"]:
+    if r["kind"] == "Deployment":
+      r["metadata"]["annotations"]["internal.config.kubernetes.io/path"] = "newfilename.yaml"


### PR DESCRIPTION
Added tests for render and eval to ensure a function can modify the legacy|new path annotation and it should be reflected.