### PR TITLE
fn render supports function binary executables

### DIFF
--- a/e2e/testdata/fn-render/exec-function-with-args/.expected/config.yaml
+++ b/e2e/testdata/fn-render/exec-function-with-args/.expected/config.yaml
@@ -1,0 +1,15 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+allowExec: true

--- a/e2e/testdata/fn-render/exec-function-with-args/.expected/diff.patch
+++ b/e2e/testdata/fn-render/exec-function-with-args/.expected/diff.patch
@@ -1,0 +1,21 @@
+diff --git a/resources.yaml b/resources.yaml
+index e8ae6bb..297b99f 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -15,7 +15,7 @@ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+   name: nginx-deployment
+-  namespace: foo
++  namespace: bar
+ spec:
+   replicas: 3
+ ---
+@@ -23,6 +23,6 @@ apiVersion: custom.io/v1
+ kind: Custom
+ metadata:
+   name: custom
+-  namespace: foo
++  namespace: bar
+ spec:
+   image: nginx:1.2.3

--- a/e2e/testdata/fn-render/exec-function-with-args/.krmignore
+++ b/e2e/testdata/fn-render/exec-function-with-args/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-render/exec-function-with-args/Kptfile
+++ b/e2e/testdata/fn-render/exec-function-with-args/Kptfile
@@ -1,0 +1,7 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: app
+pipeline:
+  mutators:
+    - exec: "sed -e 's/foo/bar/'"

--- a/e2e/testdata/fn-render/exec-function-with-args/resources.yaml
+++ b/e2e/testdata/fn-render/exec-function-with-args/resources.yaml
@@ -1,0 +1,28 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: foo
+spec:
+  replicas: 3
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+  namespace: foo
+spec:
+  image: nginx:1.2.3

--- a/e2e/testdata/fn-render/exec-without-permissions/.expected/config.yaml
+++ b/e2e/testdata/fn-render/exec-without-permissions/.expected/config.yaml
@@ -1,0 +1,16 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+exitCode: 1
+stdErr: 'Error: must run with `--allow-exec` option to allow running function binaries'

--- a/e2e/testdata/fn-render/exec-without-permissions/.krmignore
+++ b/e2e/testdata/fn-render/exec-without-permissions/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-render/exec-without-permissions/Kptfile
+++ b/e2e/testdata/fn-render/exec-without-permissions/Kptfile
@@ -1,0 +1,7 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: app
+pipeline:
+  mutators:
+    - exec: "sed -e 's/foo/bar/'"

--- a/e2e/testdata/fn-render/exec-without-permissions/resources.yaml
+++ b/e2e/testdata/fn-render/exec-without-permissions/resources.yaml
@@ -1,0 +1,28 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: foo
+spec:
+  replicas: 3
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+  namespace: foo
+spec:
+  image: nginx:1.2.3

--- a/internal/cmdrender/cmdrender.go
+++ b/internal/cmdrender/cmdrender.go
@@ -101,12 +101,6 @@ func (r *Runner) preRunE(c *cobra.Command, args []string) error {
 }
 
 func (r *Runner) runE(c *cobra.Command, _ []string) error {
-	// TODO(droot): check for docker availability only if the pipeline
-	// uses container functions.
-	err := cmdutil.DockerCmdAvailable()
-	if err != nil {
-		return err
-	}
 	var output io.Writer
 	outContent := bytes.Buffer{}
 	if r.dest != "" {
@@ -121,8 +115,7 @@ func (r *Runner) runE(c *cobra.Command, _ []string) error {
 		ImagePullPolicy: cmdutil.StringToImagePullPolicy(r.imagePullPolicy),
 		AllowExec:       r.allowExec,
 	}
-	err = executor.Execute(r.ctx)
-	if err != nil {
+	if err := executor.Execute(r.ctx); err != nil {
 		return err
 	}
 

--- a/internal/cmdrender/cmdrender.go
+++ b/internal/cmdrender/cmdrender.go
@@ -47,6 +47,8 @@ func NewRunner(ctx context.Context, parent string) *Runner {
 		fmt.Sprintf("output resources are written to provided location. Allowed values: %s|%s|<OUT_DIR_PATH>", cmdutil.Stdout, cmdutil.Unwrap))
 	c.Flags().StringVar(&r.imagePullPolicy, "image-pull-policy", string(fnruntime.IfNotPresentPull),
 		fmt.Sprintf("pull image before running the container. It must be one of %s, %s and %s.", fnruntime.AlwaysPull, fnruntime.IfNotPresentPull, fnruntime.NeverPull))
+	c.Flags().BoolVar(&r.allowExec, "allow-exec", false,
+		"allow binary executable to be run during pipeline execution.")
 	cmdutil.FixDocs("kpt", parent, c)
 	r.Command = c
 	return r
@@ -61,6 +63,7 @@ type Runner struct {
 	pkgPath         string
 	resultsDirPath  string
 	imagePullPolicy string
+	allowExec       bool
 	dest            string
 	Command         *cobra.Command
 	ctx             context.Context
@@ -98,6 +101,8 @@ func (r *Runner) preRunE(c *cobra.Command, args []string) error {
 }
 
 func (r *Runner) runE(c *cobra.Command, _ []string) error {
+	// TODO(droot): check for docker availability only if the pipeline
+	// uses container functions.
 	err := cmdutil.DockerCmdAvailable()
 	if err != nil {
 		return err
@@ -114,6 +119,7 @@ func (r *Runner) runE(c *cobra.Command, _ []string) error {
 		ResultsDirPath:  r.resultsDirPath,
 		Output:          output,
 		ImagePullPolicy: cmdutil.StringToImagePullPolicy(r.imagePullPolicy),
+		AllowExec:       r.allowExec,
 	}
 	err = executor.Execute(r.ctx)
 	if err != nil {

--- a/internal/cmdrender/executor.go
+++ b/internal/cmdrender/executor.go
@@ -38,7 +38,7 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
-var errAllowedExecNotSpecified error = fmt.Errorf("must run with `--allow-exec` option to allow running function binaries.")
+var errAllowedExecNotSpecified error = fmt.Errorf("must run with `--allow-exec` option to allow running function binaries")
 
 // Executor hydrates a given pkg.
 type Executor struct {

--- a/internal/fnruntime/container.go
+++ b/internal/fnruntime/container.go
@@ -128,6 +128,7 @@ func (f *ContainerFn) getDockerCmd() (*exec.Cmd, context.CancelFunc) {
 		"--user", uidgid,
 		"--security-opt=no-new-privileges",
 	}
+
 	switch f.ImagePullPolicy {
 	case NeverPull:
 		args = append(args, "--pull", "never")

--- a/internal/fnruntime/runner.go
+++ b/internal/fnruntime/runner.go
@@ -38,64 +38,48 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
-// NewContainerRunner returns a kio.Filter given a specification of a container function
+// NewRunner returns a kio.Filter given a specification of a function
 // and it's config.
-func NewContainerRunner(
+func NewRunner(
 	ctx context.Context, f *kptfilev1.Function,
 	pkgPath types.UniquePath, fnResults *fnresult.ResultList,
 	imagePullPolicy ImagePullPolicy, displayResourceCount bool) (kio.Filter, error) {
+
 	config, err := newFnConfig(f, pkgPath)
 	if err != nil {
 		return nil, err
 	}
 
 	fnResult := &fnresult.Result{
-		Image: f.Image,
+		Image:    f.Image,
+		ExecPath: f.Exec,
 		// TODO(droot): This is required for making structured results subpackage aware.
 		// Enable this once test harness supports filepath based assertions.
 		// Pkg: string(pkgPath),
 	}
-	cfn := &ContainerFn{
-		Path:            pkgPath,
-		Image:           f.Image,
-		ImagePullPolicy: imagePullPolicy,
-		Ctx:             ctx,
-		FnResult:        fnResult,
-	}
-	fltr := &runtimeutil.FunctionFilter{
-		Run:            cfn.Run,
-		FunctionConfig: config,
+
+	fltr := &runtimeutil.FunctionFilter{FunctionConfig: config}
+	if f.Image != "" {
+		f.Image = AddDefaultImagePathPrefix(f.Image)
+		cfn := &ContainerFn{
+			Path:            pkgPath,
+			Image:           f.Image,
+			ImagePullPolicy: imagePullPolicy,
+			Ctx:             ctx,
+			FnResult:        fnResult,
+		}
+		fltr.Run = cfn.Run
+	} else if f.Exec != "" {
+		// assuming exec here
+		eFn := &ExecFn{
+			Path:     f.Exec,
+			FnResult: fnResult,
+		}
+		fltr.Run = eFn.Run
+	} else {
+		return nil, fmt.Errorf("must specify `exec` or `image` to execute a function")
 	}
 	return NewFunctionRunner(ctx, fltr, pkgPath, fnResult, fnResults, true, displayResourceCount)
-}
-
-// NewExecRunner returns a kio.Filter given a specification of a exec function and it's config.
-func NewExecRunner(
-	ctx context.Context, f *kptfilev1.Function,
-	pkgPath types.UniquePath, fnResults *fnresult.ResultList,
-	imagePullPolicy ImagePullPolicy, displayResourceCount bool) (kio.Filter, error) {
-
-	fnResult := &fnresult.Result{
-		// TODO(droot): This is required for making structured results subpackage aware.
-		// Enable this once test harness supports filepath based assertions.
-		// Pkg: string(r.uniquePath),
-		ExecPath: f.Exec,
-	}
-	fnConfig, err := newFnConfig(f, pkgPath)
-	if err != nil {
-		return nil, err
-	}
-	// assuming exec here
-	e := &ExecFn{
-		Path:     f.Exec,
-		FnResult: fnResult,
-	}
-	fltr := &runtimeutil.FunctionFilter{
-		Run:            e.Run,
-		FunctionConfig: fnConfig,
-		// DeferFailure:   spec.DeferFailure,
-	}
-	return NewFunctionRunner(ctx, fltr, "", fnResult, fnResults, false, displayResourceCount)
 }
 
 // NewFunctionRunner returns a kio.Filter given a specification of a function

--- a/internal/fnruntime/runner.go
+++ b/internal/fnruntime/runner.go
@@ -52,15 +52,6 @@ func NewRunner(
 	}
 	if f.Image != "" {
 		f.Image = AddDefaultImagePathPrefix(f.Image)
-	} else {
-		s, err := shlex.Split(f.Exec)
-		if err != nil {
-			return nil, fmt.Errorf("exec command %q must be valid: %w", f.Exec, err)
-		}
-		if len(s) > 0 {
-			f.Exec = s[0]
-			f.ExecArgs = s[1:]
-		}
 	}
 
 	fnResult := &fnresult.Result{
@@ -83,10 +74,22 @@ func NewRunner(
 		}
 		fltr.Run = cfn.Run
 	case f.Exec != "":
+		var execArgs []string
 		// assuming exec here
+		s, err := shlex.Split(f.Exec)
+		if err != nil {
+			return nil, fmt.Errorf("exec command %q must be valid: %w", f.Exec, err)
+		}
+		execPath := f.Exec
+		if len(s) > 0 {
+			execPath = s[0]
+		}
+		if len(s) > 1 {
+			execArgs = s[1:]
+		}
 		eFn := &ExecFn{
-			Path:     f.Exec,
-			Args:     f.ExecArgs,
+			Path:     execPath,
+			Args:     execArgs,
 			FnResult: fnResult,
 		}
 		fltr.Run = eFn.Run

--- a/internal/fnruntime/runner.go
+++ b/internal/fnruntime/runner.go
@@ -59,7 +59,9 @@ func NewRunner(
 	}
 
 	fltr := &runtimeutil.FunctionFilter{FunctionConfig: config}
-	if f.Image != "" {
+	switch {
+
+	case f.Image != "":
 		f.Image = AddDefaultImagePathPrefix(f.Image)
 		cfn := &ContainerFn{
 			Path:            pkgPath,
@@ -69,14 +71,14 @@ func NewRunner(
 			FnResult:        fnResult,
 		}
 		fltr.Run = cfn.Run
-	} else if f.Exec != "" {
+	case f.Exec != "":
 		// assuming exec here
 		eFn := &ExecFn{
 			Path:     f.Exec,
 			FnResult: fnResult,
 		}
 		fltr.Run = eFn.Run
-	} else {
+	default:
 		return nil, fmt.Errorf("must specify `exec` or `image` to execute a function")
 	}
 	return NewFunctionRunner(ctx, fltr, pkgPath, fnResult, fnResults, true, displayResourceCount)

--- a/internal/fnruntime/runner.go
+++ b/internal/fnruntime/runner.go
@@ -69,6 +69,35 @@ func NewContainerRunner(
 	return NewFunctionRunner(ctx, fltr, pkgPath, fnResult, fnResults, true, displayResourceCount)
 }
 
+// NewExecRunner returns a kio.Filter given a specification of a exec function and it's config.
+func NewExecRunner(
+	ctx context.Context, f *kptfilev1.Function,
+	pkgPath types.UniquePath, fnResults *fnresult.ResultList,
+	imagePullPolicy ImagePullPolicy, displayResourceCount bool) (kio.Filter, error) {
+
+	fnResult := &fnresult.Result{
+		// TODO(droot): This is required for making structured results subpackage aware.
+		// Enable this once test harness supports filepath based assertions.
+		// Pkg: string(r.uniquePath),
+		ExecPath: f.Exec,
+	}
+	fnConfig, err := newFnConfig(f, pkgPath)
+	if err != nil {
+		return nil, err
+	}
+	// assuming exec here
+	e := &ExecFn{
+		Path:     f.Exec,
+		FnResult: fnResult,
+	}
+	fltr := &runtimeutil.FunctionFilter{
+		Run:            e.Run,
+		FunctionConfig: fnConfig,
+		// DeferFailure:   spec.DeferFailure,
+	}
+	return NewFunctionRunner(ctx, fltr, "", fnResult, fnResults, false, displayResourceCount)
+}
+
 // NewFunctionRunner returns a kio.Filter given a specification of a function
 // and it's config.
 func NewFunctionRunner(ctx context.Context,

--- a/internal/fnruntime/runner.go
+++ b/internal/fnruntime/runner.go
@@ -49,6 +49,9 @@ func NewRunner(
 	if err != nil {
 		return nil, err
 	}
+	if f.Image != "" {
+		f.Image = AddDefaultImagePathPrefix(f.Image)
+	}
 
 	fnResult := &fnresult.Result{
 		Image:    f.Image,
@@ -60,9 +63,7 @@ func NewRunner(
 
 	fltr := &runtimeutil.FunctionFilter{FunctionConfig: config}
 	switch {
-
 	case f.Image != "":
-		f.Image = AddDefaultImagePathPrefix(f.Image)
 		cfn := &ContainerFn{
 			Path:            pkgPath,
 			Image:           f.Image,

--- a/pkg/api/kptfile/v1/types.go
+++ b/pkg/api/kptfile/v1/types.go
@@ -268,6 +268,10 @@ type Function struct {
 	//	image: set-labels
 	Image string `yaml:"image,omitempty" json:"image,omitempty"`
 
+	// Exec specifies the function binary executable.
+	// The executable needs to be in the $PATH.
+	Exec string `yaml:"exec,omitempty" json:"exec,omitempty"`
+
 	// `ConfigPath` specifies a slash-delimited relative path to a file in the current directory
 	// containing a KRM resource used as the function config. This resource is
 	// excluded when resolving 'sources', and as a result cannot be operated on

--- a/pkg/api/kptfile/v1/types.go
+++ b/pkg/api/kptfile/v1/types.go
@@ -269,7 +269,10 @@ type Function struct {
 	Image string `yaml:"image,omitempty" json:"image,omitempty"`
 
 	// Exec specifies the function binary executable.
-	// The executable needs to be in the $PATH.
+	// The executable can be fully qualified or it must exists in the $PATH e.g:
+	//
+	// 	 exec: set-namespace
+	// 	 exec: /usr/local/bin/my-custom-fn
 	Exec string `yaml:"exec,omitempty" json:"exec,omitempty"`
 
 	// `ConfigPath` specifies a slash-delimited relative path to a file in the current directory

--- a/pkg/api/kptfile/v1/types.go
+++ b/pkg/api/kptfile/v1/types.go
@@ -275,8 +275,6 @@ type Function struct {
 	// 	 exec: /usr/local/bin/my-custom-fn
 	Exec string `yaml:"exec,omitempty" json:"exec,omitempty"`
 
-	ExecArgs []string `yaml:"-" json:"-"`
-
 	// `ConfigPath` specifies a slash-delimited relative path to a file in the current directory
 	// containing a KRM resource used as the function config. This resource is
 	// excluded when resolving 'sources', and as a result cannot be operated on

--- a/pkg/api/kptfile/v1/types.go
+++ b/pkg/api/kptfile/v1/types.go
@@ -275,6 +275,8 @@ type Function struct {
 	// 	 exec: /usr/local/bin/my-custom-fn
 	Exec string `yaml:"exec,omitempty" json:"exec,omitempty"`
 
+	ExecArgs []string `yaml:"-" json:"-"`
+
 	// `ConfigPath` specifies a slash-delimited relative path to a file in the current directory
 	// containing a KRM resource used as the function config. This resource is
 	// excluded when resolving 'sources', and as a result cannot be operated on

--- a/pkg/api/kptfile/v1/validation.go
+++ b/pkg/api/kptfile/v1/validation.go
@@ -70,13 +70,13 @@ func (f *Function) validate(fnType string, idx int, pkgPath types.UniquePath) er
 	if f.Image == "" && f.Exec == "" {
 		return &ValidateError{
 			Field:  fmt.Sprintf("pipeline.%s[%d]", fnType, idx),
-			Reason: "must specifiy a functon (`image` or `exec`) to execute",
+			Reason: "must specify a functon (`image` or `exec`) to execute",
 		}
 	}
 	if f.Image != "" && f.Exec != "" {
 		return &ValidateError{
 			Field:  fmt.Sprintf("pipeline.%s[%d]", fnType, idx),
-			Reason: "must not specifiy both `image` and `exec` at the same time",
+			Reason: "must not specify both `image` and `exec` at the same time",
 		}
 	}
 	if f.Image != "" {

--- a/pkg/api/kptfile/v1/validation.go
+++ b/pkg/api/kptfile/v1/validation.go
@@ -67,6 +67,7 @@ func (p *Pipeline) validate(pkgPath types.UniquePath) error {
 }
 
 func (f *Function) validate(fnType string, idx int, pkgPath types.UniquePath) error {
+	return nil
 	err := ValidateFunctionImageURL(f.Image)
 	if err != nil {
 		return &ValidateError{

--- a/pkg/api/kptfile/v1/validation.go
+++ b/pkg/api/kptfile/v1/validation.go
@@ -67,15 +67,29 @@ func (p *Pipeline) validate(pkgPath types.UniquePath) error {
 }
 
 func (f *Function) validate(fnType string, idx int, pkgPath types.UniquePath) error {
-	return nil
-	err := ValidateFunctionImageURL(f.Image)
-	if err != nil {
+	if f.Image == "" && f.Exec == "" {
 		return &ValidateError{
-			Field:  fmt.Sprintf("pipeline.%s[%d].image", fnType, idx),
-			Value:  f.Image,
-			Reason: err.Error(),
+			Field:  fmt.Sprintf("pipeline.%s[%d]", fnType, idx),
+			Reason: "must specifiy a functon (`image` or `exec`) to execute",
 		}
 	}
+	if f.Image != "" && f.Exec != "" {
+		return &ValidateError{
+			Field:  fmt.Sprintf("pipeline.%s[%d]", fnType, idx),
+			Reason: "must not specifiy both `image` and `exec` at the same time",
+		}
+	}
+	if f.Image != "" {
+		err := ValidateFunctionImageURL(f.Image)
+		if err != nil {
+			return &ValidateError{
+				Field:  fmt.Sprintf("pipeline.%s[%d].image", fnType, idx),
+				Value:  f.Image,
+				Reason: err.Error(),
+			}
+		}
+	}
+	// TODO(droot): validate the exec
 
 	if len(f.ConfigMap) != 0 && f.ConfigPath != "" {
 		return &ValidateError{

--- a/pkg/test/runner/config.go
+++ b/pkg/test/runner/config.go
@@ -71,6 +71,9 @@ type TestCaseConfig struct {
 	// be the same as the CLI flag.
 	ImagePullPolicy string `json:"imagePullPolicy,omitempty" yaml:"imagePullPolicy,omitempty"`
 
+	// AllowExec determines if `fn render` needs to be invoked with `--allow-exec` flag
+	AllowExec bool `json:"allowExec,omitempty" yaml:"allowExec,omitempty"`
+
 	// Skip means should this test case be skipped. Default: false
 	Skip bool `json:"skip,omitempty" yaml:"skip,omitempty"`
 

--- a/pkg/test/runner/runner.go
+++ b/pkg/test/runner/runner.go
@@ -349,6 +349,10 @@ func (r *Runner) runFnRender() error {
 				kptArgs = append(kptArgs, "--image-pull-policy", r.testCase.Config.ImagePullPolicy)
 			}
 
+			if r.testCase.Config.AllowExec {
+				kptArgs = append(kptArgs, "--allow-exec")
+			}
+
 			if r.testCase.Config.DisableOutputTruncate {
 				kptArgs = append(kptArgs, "--truncate-output=false")
 			}


### PR DESCRIPTION
This PR adds support for executing binaries (as function) in `fn render`.

An example of kptfile that uses binary executable as declarative function:

```yaml
apiVersion: kpt.dev/v1
kind: Kptfile
metadata:
  name: app
pipeline:
  mutators:
    - exec: "sed -e 's/foo/bar/'"
```

`render` needs to be executed with `allow-exec` flag for it to run binary executables as functions.

```sh
$ kpt fn render --allow-exec
```

##  Alternatives considered for exec support:

### Overloading the `image` field to support other runtimes where prefix of the image value can be used to derive the runtime as shown below:

```
apiVersion: kpt.dev/v1
kind: Kptfile
metadata:
  name: app
pipeline:
  mutators:
    - image: "exec: sed -e 's/foo/bar/'"

```

This is very confusing from UX perspective where `image` field could mean many things, so ruled it out.

### Using an explicit discriminator field `type` to determine different runtimes

```
apiVersion: kpt.dev/v1
kind: Kptfile
metadata:
  name: app
pipeline:
  mutators:
    - type: container
      image: gcr.io/kpt-fn/set-namespace:v0.1.1
    - type: exec
      exec: "sed -e `s/foo/bar`"
    - type: remote
      url: https://my-fn
```

The discriminator `type` increases the verbosity of the configuration. As we were exploring patterns for more runtimes, we realized there is a primary required field for these runtimes such as `exec`, `image`, `url` that can serve the purpose of discriminator field and decided to go with that.



