### PR TITLE
Add missing json annotation to KptFile

### DIFF
--- a/pkg/api/kptfile/v1/types.go
+++ b/pkg/api/kptfile/v1/types.go
@@ -42,7 +42,7 @@ var TypeMeta = yaml.ResourceMeta{
 // KptFile contains information about a package managed with kpt.
 // swagger:model kptfile
 type KptFile struct {
-	yaml.ResourceMeta `yaml:",inline"`
+	yaml.ResourceMeta `yaml:",inline" json:",inline"`
 
 	Upstream *Upstream `yaml:"upstream,omitempty" json:"upstream,omitempty"`
 


### PR DESCRIPTION
Add missing `json` annotation to KptFile

The json annotations are required by tools such as k8s `controller-gen`.
