### PR TITLE
changed default image pull policy to if-not-present

### DIFF
--- a/e2e/testdata/fn-eval/error-in-pipe/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/error-in-pipe/.expected/config.yaml
@@ -21,8 +21,11 @@ stdErr: |
     Stderr:
       "[error] /// : failed to configure function: input namespace cannot be empty"
     Exit code: 1
-
+  
    
   [RUNNING] "gcr.io/kpt-fn/dne"
   [FAIL] "gcr.io/kpt-fn/dne" in 0s
-  Error: Function image "gcr.io/kpt-fn/dne" doesn't exist
+    Stderr:
+      "docker: Error response from daemon: manifest for gcr.io/kpt-fn/dne:latest not found: manifest unknown: Failed to fetch \"latest\" from request \"/v2/kpt-fn/dne/manifests/latest\"."
+      "See 'docker run --help'."
+    Exit code: 125

--- a/e2e/testdata/fn-eval/error-in-pipe/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/error-in-pipe/.expected/exec.sh
@@ -16,6 +16,6 @@
 set -eo pipefail
 
 kpt fn source \
-| kpt fn eval - --image gcr.io/kpt-fn/set-namespace:v0.1.3 \
-| kpt fn eval - --image gcr.io/kpt-fn/dne -- foo=bar \
-| kpt fn sink
+|kpt fn eval - --image gcr.io/kpt-fn/set-namespace:v0.1.3\
+|kpt fn eval - --image gcr.io/kpt-fn/dne -- foo=bar\
+|kpt fn sink

--- a/e2e/testdata/fn-eval/error-in-pipe/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/error-in-pipe/.expected/exec.sh
@@ -16,6 +16,6 @@
 set -eo pipefail
 
 kpt fn source \
-|kpt fn eval - --image gcr.io/kpt-fn/set-namespace:v0.1.3\
-|kpt fn eval - --image gcr.io/kpt-fn/dne -- foo=bar\
-|kpt fn sink
+| kpt fn eval - --image gcr.io/kpt-fn/set-namespace:v0.1.3 \
+| kpt fn eval - --image gcr.io/kpt-fn/dne -- foo=bar \
+| kpt fn sink

--- a/e2e/testdata/fn-eval/fn-success-with-stderr/pkg/.expected/results.yaml
+++ b/e2e/testdata/fn-eval/fn-success-with-stderr/pkg/.expected/results.yaml
@@ -5,6 +5,5 @@ metadata:
 exitCode: 0
 items:
   - image: gcr.io/kpt-fn/starlark:v0.2
-    stderr: |
-      function succeeded, reporting it on stderr
+    stderr: function succeeded, reporting it on stderr
     exitCode: 0

--- a/e2e/testdata/fn-eval/missing-fn-image/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/missing-fn-image/.expected/config.yaml
@@ -17,4 +17,4 @@ exitCode: 1
 image: gcr.io/kpt-fn/dne # non-existing image
 args:
   namespace: staging
-stdErr: 'Function image "gcr.io/kpt-fn/dne" doesn''t exist'
+stdErr: 'gcr.io/kpt-fn/dne:latest not found'

--- a/e2e/testdata/fn-render/fn-success-with-stderr/.expected/results.yaml
+++ b/e2e/testdata/fn-render/fn-success-with-stderr/.expected/results.yaml
@@ -5,6 +5,5 @@ metadata:
 exitCode: 0
 items:
   - image: gcr.io/kpt-fn/starlark:v0.2
-    stderr: |
-      function succeeded, reporting it on stderr
+    stderr: function succeeded, reporting it on stderr
     exitCode: 0

--- a/e2e/testdata/fn-render/missing-fn-image/.expected/config.yaml
+++ b/e2e/testdata/fn-render/missing-fn-image/.expected/config.yaml
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 exitCode: 1
-stdErr: 'Error: Function image "gcr.io/kpt-fn/dne" doesn''t exist'
+stdErr: 'gcr.io/kpt-fn/dne:latest not found'

--- a/internal/cmdrender/cmdrender.go
+++ b/internal/cmdrender/cmdrender.go
@@ -45,7 +45,7 @@ func NewRunner(ctx context.Context, parent string) *Runner {
 		"path to a directory to save function results")
 	c.Flags().StringVarP(&r.dest, "output", "o", "",
 		fmt.Sprintf("output resources are written to provided location. Allowed values: %s|%s|<OUT_DIR_PATH>", cmdutil.Stdout, cmdutil.Unwrap))
-	c.Flags().StringVar(&r.imagePullPolicy, "image-pull-policy", string(fnruntime.AlwaysPull),
+	c.Flags().StringVar(&r.imagePullPolicy, "image-pull-policy", string(fnruntime.IfNotPresentPull),
 		fmt.Sprintf("pull image before running the container. It must be one of %s, %s and %s.", fnruntime.AlwaysPull, fnruntime.IfNotPresentPull, fnruntime.NeverPull))
 	cmdutil.FixDocs("kpt", parent, c)
 	r.Command = c

--- a/internal/fnruntime/container.go
+++ b/internal/fnruntime/container.go
@@ -232,8 +232,8 @@ func isdockerCLIoutput(s string) bool {
 		strings.Contains(s, ": Pulling from") ||
 		strings.Contains(s, ": Waiting") ||
 		strings.Contains(s, ": Pull complete") ||
-		strings.Contains(s, ": Digest: sha256") ||
-		strings.Contains(s, ": Status: Downloaded newer image") ||
+		strings.Contains(s, "Digest: sha256") ||
+		strings.Contains(s, "Status: Downloaded newer image") ||
 		strings.Contains(s, "Unable to find image") {
 		return true
 	}

--- a/internal/fnruntime/container.go
+++ b/internal/fnruntime/container.go
@@ -209,7 +209,7 @@ func (e *ContainerImageError) Error() string {
 
 // filterDockerCLIOutput filters out docker CLI messages
 // from the given buffer.
-func filterDockerCLIOutput(in *bytes.Buffer) string {
+func filterDockerCLIOutput(in io.Reader) string {
 	out := strings.Builder{}
 
 	s := bufio.NewScanner(in)

--- a/internal/fnruntime/container.go
+++ b/internal/fnruntime/container.go
@@ -195,18 +195,6 @@ func (e *ContainerImageError) Error() string {
 		e.Image, e.Output)
 }
 
-/*
-	"Unable to find image 'gcr.io/kpt-fn/starlark:v0.3' locally"
-    "v0.3: Pulling from kpt-fn/starlark"
-    "4e9f2cdf4387: Already exists"
-    "aafbf7df3ddf: Pulling fs layer"
-    "aafbf7df3ddf: Verifying Checksum"
-    "aafbf7df3ddf: Download complete"
-    "aafbf7df3ddf: Pull complete"
-    "Digest: sha256:c347e28606fa1a608e8e02e03541a5a46e4a0152005df4a11e44f6c4ab1edd9a"
-    "Status: Downloaded newer image for gcr.io/kpt-fn/starlark:v0.3"
-*/
-
 // filterDockerCLIOutput filters out docker CLI messages
 // from the given buffer.
 func filterDockerCLIOutput(in io.Reader) string {
@@ -224,12 +212,25 @@ func filterDockerCLIOutput(in io.Reader) string {
 
 // isdockerCLIoutput is helper method to determine if
 // the given string is a docker CLI output message.
+// Example docker output:
+//	"Unable to find image 'gcr.io/kpt-fn/starlark:v0.3' locally"
+//  "v0.3: Pulling from kpt-fn/starlark"
+//  "4e9f2cdf4387: Already exists"
+//  "aafbf7df3ddf: Pulling fs layer"
+//  "aafbf7df3ddf: Verifying Checksum"
+//  "aafbf7df3ddf: Download complete"
+//  "6b759ab96cb2: Waiting"
+//  "aafbf7df3ddf: Pull complete"
+//  "Digest: sha256:c347e28606fa1a608e8e02e03541a5a46e4a0152005df4a11e44f6c4ab1edd9a"
+//  "Status: Downloaded newer image for gcr.io/kpt-fn/starlark:v0.3"
+//
 func isdockerCLIoutput(s string) bool {
 	if strings.Contains(s, "Already exists") ||
 		strings.Contains(s, "Pulling fs layer") ||
 		strings.Contains(s, "Verifying Checksum") ||
 		strings.Contains(s, "Download complete") ||
 		strings.Contains(s, "Pulling from") ||
+		strings.Contains(s, "Waiting") ||
 		strings.Contains(s, "Pull complete") ||
 		strings.Contains(s, "Digest: sha256") ||
 		strings.Contains(s, "Status: Downloaded newer image") ||

--- a/internal/fnruntime/container.go
+++ b/internal/fnruntime/container.go
@@ -218,7 +218,6 @@ func filterDockerCLIOutput(in io.Reader) string {
 		txt := s.Text()
 		if !isdockerCLIoutput(txt) {
 			out.WriteString(txt)
-			out.WriteString("\n")
 		}
 	}
 	return out.String()

--- a/internal/fnruntime/container.go
+++ b/internal/fnruntime/container.go
@@ -225,15 +225,15 @@ func filterDockerCLIOutput(in io.Reader) string {
 //  "Status: Downloaded newer image for gcr.io/kpt-fn/starlark:v0.3"
 //
 func isdockerCLIoutput(s string) bool {
-	if strings.Contains(s, "Already exists") ||
-		strings.Contains(s, "Pulling fs layer") ||
-		strings.Contains(s, "Verifying Checksum") ||
-		strings.Contains(s, "Download complete") ||
-		strings.Contains(s, "Pulling from") ||
-		strings.Contains(s, "Waiting") ||
-		strings.Contains(s, "Pull complete") ||
-		strings.Contains(s, "Digest: sha256") ||
-		strings.Contains(s, "Status: Downloaded newer image") ||
+	if strings.Contains(s, ": Already exists") ||
+		strings.Contains(s, ": Pulling fs layer") ||
+		strings.Contains(s, ": Verifying Checksum") ||
+		strings.Contains(s, ": Download complete") ||
+		strings.Contains(s, ": Pulling from") ||
+		strings.Contains(s, ": Waiting") ||
+		strings.Contains(s, ": Pull complete") ||
+		strings.Contains(s, ": Digest: sha256") ||
+		strings.Contains(s, ": Status: Downloaded newer image") ||
 		strings.Contains(s, "Unable to find image") {
 		return true
 	}

--- a/internal/fnruntime/container.go
+++ b/internal/fnruntime/container.go
@@ -210,17 +210,16 @@ func (e *ContainerImageError) Error() string {
 // filterDockerCLIOutput filters out docker CLI messages
 // from the given buffer.
 func filterDockerCLIOutput(in io.Reader) string {
-	out := strings.Builder{}
-
 	s := bufio.NewScanner(in)
+	var lines []string
 
 	for s.Scan() {
 		txt := s.Text()
 		if !isdockerCLIoutput(txt) {
-			out.WriteString(txt)
+			lines = append(lines, txt)
 		}
 	}
-	return out.String()
+	return strings.Join(lines, "\n")
 }
 
 // isdockerCLIoutput is helper method to determine if

--- a/internal/fnruntime/container.go
+++ b/internal/fnruntime/container.go
@@ -106,7 +106,7 @@ func (f *ContainerFn) Run(reader io.Reader, writer io.Writer) error {
 	}
 
 	if errSink.Len() > 0 {
-		f.FnResult.Stderr = errSink.String()
+		f.FnResult.Stderr = filterDockerCLIOutput(&errSink)
 	}
 	return nil
 }

--- a/internal/fnruntime/container_test.go
+++ b/internal/fnruntime/container_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/GoogleContainerTools/kpt/internal/fnruntime"
 	"github.com/GoogleContainerTools/kpt/internal/printer"
+	fnresult "github.com/GoogleContainerTools/kpt/pkg/api/fnresult/v1"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -54,6 +55,9 @@ func TestContainerFn(t *testing.T) {
 			instance := fnruntime.ContainerFn{
 				Ctx:   printer.WithContext(ctx, printer.New(nil, errBuff)),
 				Image: tt.image,
+				FnResult: &fnresult.Result{
+					Image: tt.image,
+				},
 			}
 			input := bytes.NewBufferString(tt.input)
 			output := &bytes.Buffer{}

--- a/internal/fnruntime/fnerrors_test.go
+++ b/internal/fnruntime/fnerrors_test.go
@@ -15,6 +15,7 @@
 package fnruntime
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -135,6 +136,39 @@ error message`,
 			tc.fnExecError.TruncateOutput = tc.truncate
 			s := tc.fnExecError.String()
 			assert.EqualValues(t, tc.expected, s)
+		})
+	}
+}
+
+func TestDockerCLIOutputFilter(t *testing.T) {
+
+	testcases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name: "should filter docker CLI output successfully",
+			input: `Unable to find image 'gcr.io/kpt-fn/starlark:v0.3' locally
+v0.3: Pulling from kpt-fn/starlark
+4e9f2cdf4387: Already exists
+aafbf7df3ddf: Pulling fs layer
+aafbf7df3ddf: Verifying Checksum
+aafbf7df3ddf: Download complete
+aafbf7df3ddf: Pull complete
+6b759ab96cb2: Waiting
+Digest: sha256:c347e28606fa1a608e8e02e03541a5a46e4a0152005df4a11e44f6c4ab1edd9a
+Status: Downloaded newer image for gcr.io/kpt-fn/starlark:v0.3
+`,
+			expected: "",
+		},
+	}
+
+	for _, tc := range testcases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			s := filterDockerCLIOutput(bytes.NewBufferString(tc.input))
+			assert.Equal(t, tc.expected, s)
 		})
 	}
 }

--- a/internal/fnruntime/fnerrors_test.go
+++ b/internal/fnruntime/fnerrors_test.go
@@ -162,6 +162,46 @@ Status: Downloaded newer image for gcr.io/kpt-fn/starlark:v0.3
 `,
 			expected: "",
 		},
+		{
+			name: "should filter docker messages and shouldn't truncate trailing lines",
+			input: `Unable to find image 'gcr.io/kpt-fn/starlark:v0.3' locally
+v0.3: Pulling from kpt-fn/starlark
+4e9f2cdf4387: Already exists
+aafbf7df3ddf: Pulling fs layer
+aafbf7df3ddf: Verifying Checksum
+aafbf7df3ddf: Download complete
+aafbf7df3ddf: Pull complete
+6b759ab96cb2: Waiting
+Digest: sha256:c347e28606fa1a608e8e02e03541a5a46e4a0152005df4a11e44f6c4ab1edd9a
+Status: Downloaded newer image for gcr.io/kpt-fn/starlark:v0.3
+line before last line
+lastline
+
+`,
+			expected: `line before last line
+lastline
+`,
+		},
+		{
+			name: "should filter interleaved docker messages",
+			input: `firstline
+Unable to find image 'gcr.io/kpt-fn/starlark:v0.3' locally
+v0.3: Pulling from kpt-fn/starlark
+4e9f2cdf4387: Already exists
+aafbf7df3ddf: Pulling fs layer
+aafbf7df3ddf: Verifying Checksum
+line in the middle
+aafbf7df3ddf: Download complete
+aafbf7df3ddf: Pull complete
+6b759ab96cb2: Waiting
+Digest: sha256:c347e28606fa1a608e8e02e03541a5a46e4a0152005df4a11e44f6c4ab1edd9a
+Status: Downloaded newer image for gcr.io/kpt-fn/starlark:v0.3
+lastline
+`,
+			expected: `firstline
+line in the middle
+lastline`,
+		},
 	}
 
 	for _, tc := range testcases {

--- a/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
+++ b/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
@@ -61,7 +61,7 @@ func GetEvalFnRunner(ctx context.Context, parent string) *EvalFnRunner {
 		"a list of environment variables to be used by functions")
 	r.Command.Flags().BoolVar(
 		&r.AsCurrentUser, "as-current-user", false, "use the uid and gid that kpt is running with to run the function in the container")
-	r.Command.Flags().StringVar(&r.ImagePullPolicy, "image-pull-policy", string(fnruntime.AlwaysPull),
+	r.Command.Flags().StringVar(&r.ImagePullPolicy, "image-pull-policy", string(fnruntime.IfNotPresentPull),
 		fmt.Sprintf("pull image before running the container. It must be one of %s, %s and %s.", fnruntime.AlwaysPull, fnruntime.IfNotPresentPull, fnruntime.NeverPull))
 	r.Command.Flags().StringVar(
 		&r.Selector.APIVersion, "match-api-version", "", "select resources matching the given apiVersion")

--- a/thirdparty/cmdconfig/commands/cmdeval/cmdeval_test.go
+++ b/thirdparty/cmdconfig/commands/cmdeval/cmdeval_test.go
@@ -219,7 +219,7 @@ apiVersion: v1
 			expectedStruct: &runfn.RunFns{
 				Path:                  dir,
 				ResultsDir:            "foo/",
-				ImagePullPolicy:       fnruntime.AlwaysPull,
+				ImagePullPolicy:       fnruntime.IfNotPresentPull,
 				Env:                   []string{},
 				ContinueOnEmptyResult: true,
 				Ctx:                   context.TODO(),
@@ -258,7 +258,7 @@ apiVersion: v1
 			path: dir,
 			expectedStruct: &runfn.RunFns{
 				Path:                  dir,
-				ImagePullPolicy:       fnruntime.AlwaysPull,
+				ImagePullPolicy:       fnruntime.IfNotPresentPull,
 				Env:                   []string{"FOO=BAR", "BAR"},
 				ContinueOnEmptyResult: true,
 				Ctx:                   context.TODO(),
@@ -283,7 +283,7 @@ apiVersion: v1
 			expectedStruct: &runfn.RunFns{
 				Path:                  dir,
 				AsCurrentUser:         true,
-				ImagePullPolicy:       fnruntime.AlwaysPull,
+				ImagePullPolicy:       fnruntime.IfNotPresentPull,
 				Env:                   []string{},
 				ContinueOnEmptyResult: true,
 				Ctx:                   context.TODO(),


### PR DESCRIPTION
`kpt fn` commands support command flag called `image-pull-policy` that determines image fetch behavior for KRM functions. Current default value is `AlwaysPull` which means `kpt` will always try to pull the image using `docker pull` even if the function image is present locally. In addition, current code also calls `docker inspect` to check if the image is present locally for `ifnotpresent`.

This PR does the following:
 - Changes the default value for `image-pull-policy` to `if-not-present` i.e. pull image only if it doesn't exists locally.
 - Removes the `docker pull` and `docker image inspect` calls instead relays the `image-pull-policy` flag to `docker run` command as is. This will eliminate two docker calls and thus, make the `fn render` and `fn eval` faster.
 - To support the above implementation, we had to filter out docker CLI command  (especially progress messages). This was needed because output from executing KRM function and `docker run` will be emitted on same `stderr` output stream.

 