### PR TITLE
--image flag typo fix

### DIFF
--- a/internal/docs/generated/fndocs/docs.go
+++ b/internal/docs/generated/fndocs/docs.go
@@ -90,7 +90,7 @@ Flags:
     Container image of the function to execute e.g. ` + "`" + `gcr.io/kpt-fn/set-namespace:v0.1` + "`" + `.
     For convenience, if full image path is not specified, ` + "`" + `gcr.io/kpt-fn/` + "`" + ` is added as default prefix.
     e.g. instead of passing ` + "`" + `gcr.io/kpt-fn/set-namespace:v0.1` + "`" + ` you can pass ` + "`" + `set-namespace:v0.1` + "`" + `.
-    ` + "`" + `eval` + "`" + ` executes only one function, so do not use ` + "`" + `--exec-path` + "`" + ` flag with this flag.
+    ` + "`" + `eval` + "`" + ` executes only one function, so do not use ` + "`" + `--exec` + "`" + ` flag with this flag.
   
   --image-pull-policy:
     If the image should be pulled before rendering the package(s). It can be set

--- a/site/reference/cli/fn/eval/README.md
+++ b/site/reference/cli/fn/eval/README.md
@@ -90,7 +90,7 @@ fn-args:
   Container image of the function to execute e.g. `gcr.io/kpt-fn/set-namespace:v0.1`.
   For convenience, if full image path is not specified, `gcr.io/kpt-fn/` is added as default prefix.
   e.g. instead of passing `gcr.io/kpt-fn/set-namespace:v0.1` you can pass `set-namespace:v0.1`.
-  `eval` executes only one function, so do not use `--exec-path` flag with this flag.
+  `eval` executes only one function, so do not use `--exec` flag with this flag.
 
 --image-pull-policy:
   If the image should be pulled before rendering the package(s). It can be set


### PR DESCRIPTION
Fix typo in `kpt fn eval`'s --image flag description