### PR TITLE
Simplify and speed up "kpt live" e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ test-fn-eval: build
 
 # target to run e2e tests for "kpt fn eval" command
 test-live-apply: build
-	PATH=$(GOBIN):$(PATH) go test -v -timeout=20m --tags=kind --run=TestLiveApply/testdata/live-apply/$(T)  ./e2e/
+	PATH=$(GOBIN):$(PATH) go test -v -timeout=20m --tags=kind -p 2 --run=TestLiveApply/testdata/live-apply/$(T)  ./e2e/
 
 vet:
 	go vet ./...

--- a/e2e/testdata/live-apply/apply-depends-on/resources/first.yaml
+++ b/e2e/testdata/live-apply/apply-depends-on/resources/first.yaml
@@ -18,7 +18,7 @@ metadata:
   name: first-nginx
   namespace: apply-depends-on
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: first-nginx

--- a/e2e/testdata/live-apply/apply-depends-on/resources/second.yaml
+++ b/e2e/testdata/live-apply/apply-depends-on/resources/second.yaml
@@ -20,7 +20,7 @@ metadata:
   annotations:
     config.kubernetes.io/depends-on: apps/namespaces/apply-depends-on/Deployment/first-nginx
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: second-nginx

--- a/e2e/testdata/live-apply/crd-and-cr/config.yaml
+++ b/e2e/testdata/live-apply/crd-and-cr/config.yaml
@@ -12,21 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-requiresCleanCluster: true
-preinstallResourceGroup: true
-output:
-  events:
-    stdOut: |
-      customresourcedefinition.apiextensions.k8s.io/customs.kpt.dev created
-      1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed
-      custom.kpt.dev/cr created
-      1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed
-  json:
-    stdOut: |
-      {"eventType":"resourceApplied","group":"apiextensions.k8s.io","kind":"CustomResourceDefinition","name":"customs.kpt.dev","namespace":"","operation":"Created","timestamp":"<TIMESTAMP>","type":"apply"}
-      {"configuredCount":0,"count":1,"createdCount":1,"eventType":"completed","failedCount":0,"serverSideCount":0,"timestamp":"<TIMESTAMP>","type":"apply","unchangedCount":0}
-      {"eventType":"resourceApplied","group":"kpt.dev","kind":"Custom","name":"cr","namespace":"","operation":"Created","timestamp":"<TIMESTAMP>","type":"apply"}
-      {"configuredCount":0,"count":1,"createdCount":1,"eventType":"completed","failedCount":0,"serverSideCount":0,"timestamp":"<TIMESTAMP>","type":"apply","unchangedCount":0}
+parallel: true
+stdOut: |
+  customresourcedefinition.apiextensions.k8s.io/customs.kpt.dev created
+  1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed
+  custom.kpt.dev/cr created
+  1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed
 inventory:
   - group: apiextensions.k8s.io
     kind: CustomResourceDefinition

--- a/e2e/testdata/live-apply/dry-run-with-install-rg/config.yaml
+++ b/e2e/testdata/live-apply/dry-run-with-install-rg/config.yaml
@@ -12,21 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-requiresCleanCluster: true
+parallel: false
+noResourceGroup: true
 kptArgs:
   - "--dry-run"
   - "--install-resource-group"
-output:
-  events:
-    stdOut: |
-      deployment.apps/nginx-deployment created (dry-run)
-      1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed (dry-run)
-    stdErr: |
-      installing inventory ResourceGroup CRD.
-  json:
-    stdOut: |
-      {"eventType":"resourceApplied","group":"apps","kind":"Deployment","name":"nginx-deployment","namespace":"dry-run-with-install-rg","operation":"Created","timestamp":"<TIMESTAMP>","type":"apply"}
-      {"configuredCount":0,"count":1,"createdCount":1,"eventType":"completed","failedCount":0,"serverSideCount":0,"timestamp":"<TIMESTAMP>","type":"apply","unchangedCount":0}
-    stdErr: |
-      installing inventory ResourceGroup CRD.
+stdOut: |
+  deployment.apps/nginx-deployment created (dry-run)
+  1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed (dry-run)
+stdErr: |
+  installing inventory ResourceGroup CRD.
 exitCode: 0

--- a/e2e/testdata/live-apply/dry-run-with-install-rg/resources/deployment.yaml
+++ b/e2e/testdata/live-apply/dry-run-with-install-rg/resources/deployment.yaml
@@ -24,7 +24,7 @@ spec:
     rollingUpdate:
       maxUnavailable: 1
       maxSurge: 0
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: nginx-deployment

--- a/e2e/testdata/live-apply/dry-run-without-rg/config.yaml
+++ b/e2e/testdata/live-apply/dry-run-without-rg/config.yaml
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-requiresCleanCluster: true
+parallel: false
+noResourceGroup: true
 kptArgs:
   - "--dry-run"
-output:
-  events:
-    stdErr: |
-      Error: The ResourceGroup CRD was not found in the cluster. Please install it either by using the '--install-resource-group' flag or the 'kpt live install-resource-group' command.
+stdErr: |
+  Error: The ResourceGroup CRD was not found in the cluster. Please install it either by using the '--install-resource-group' flag or the 'kpt live install-resource-group' command.
 exitCode: 1

--- a/e2e/testdata/live-apply/install-rg-on-apply/config.yaml
+++ b/e2e/testdata/live-apply/install-rg-on-apply/config.yaml
@@ -12,20 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-requiresCleanCluster: true
-output:
-  events:
-    stdOut: |
-      deployment.apps/nginx-deployment created
-      1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed
-    stdErr: |
-      installing inventory ResourceGroup CRD.
-  json:
-    stdOut: |
-      {"eventType":"resourceApplied","group":"apps","kind":"Deployment","name":"nginx-deployment","namespace":"install-rg-on-apply","operation":"Created","timestamp":"<TIMESTAMP>","type":"apply"}
-      {"configuredCount":0,"count":1,"createdCount":1,"eventType":"completed","failedCount":0,"serverSideCount":0,"timestamp":"<TIMESTAMP>","type":"apply","unchangedCount":0}
-    stdErr: |
-      installing inventory ResourceGroup CRD.
+parallel: false
+noResourceGroup: true
+stdOut: |
+  deployment.apps/nginx-deployment created
+  1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed
+stdErr: |
+  installing inventory ResourceGroup CRD.
 inventory:
   - group: apps
     kind: Deployment

--- a/e2e/testdata/live-apply/install-rg-on-apply/resources/deployment.yaml
+++ b/e2e/testdata/live-apply/install-rg-on-apply/resources/deployment.yaml
@@ -24,7 +24,7 @@ spec:
     rollingUpdate:
       maxUnavailable: 1
       maxSurge: 0
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: nginx-deployment

--- a/e2e/testdata/live-apply/json-output/config.yaml
+++ b/e2e/testdata/live-apply/json-output/config.yaml
@@ -1,0 +1,39 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+parallel: true
+kptArgs:
+  - "--output=json"
+stdOut: |
+  {"eventType":"resourceApplied","group":"","kind":"ConfigMap","name":"cm","namespace":"json-output","operation":"Created","timestamp":"<TIMESTAMP>","type":"apply"}
+  {"eventType":"resourceApplied","group":"apps","kind":"Deployment","name":"third-nginx","namespace":"json-output","operation":"Created","timestamp":"<TIMESTAMP>","type":"apply"}
+  {"configuredCount":0,"count":2,"createdCount":2,"eventType":"completed","failedCount":0,"serverSideCount":0,"timestamp":"<TIMESTAMP>","type":"apply","unchangedCount":0}
+  {"eventType":"resourceApplied","group":"apps","kind":"Deployment","name":"fourth-nginx","namespace":"json-output","operation":"Created","timestamp":"<TIMESTAMP>","type":"apply"}
+  {"configuredCount":0,"count":1,"createdCount":1,"eventType":"completed","failedCount":0,"serverSideCount":0,"timestamp":"<TIMESTAMP>","type":"apply","unchangedCount":0}
+  {"eventType":"resourcePruned","group":"apps","kind":"Deployment","name":"second-nginx","namespace":"json-output","operation":"Pruned","timestamp":"<TIMESTAMP>","type":"prune"}
+  {"eventType":"completed","pruned":1,"skipped":0,"timestamp":"<TIMESTAMP>","type":"prune"}
+  {"eventType":"resourcePruned","group":"apps","kind":"Deployment","name":"first-nginx","namespace":"json-output","operation":"Pruned","timestamp":"<TIMESTAMP>","type":"prune"}
+  {"eventType":"completed","pruned":1,"skipped":0,"timestamp":"<TIMESTAMP>","type":"prune"}
+inventory:
+  - kind: ConfigMap
+    name: cm
+    namespace: json-output
+  - group: apps
+    kind: Deployment
+    name: third-nginx
+    namespace: json-output
+  - group: apps
+    kind: Deployment
+    name: fourth-nginx
+    namespace: json-output

--- a/e2e/testdata/live-apply/json-output/pre-apply/first.yaml
+++ b/e2e/testdata/live-apply/json-output/pre-apply/first.yaml
@@ -12,20 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-parallel: true
-
-stdOut: |
-  deployment.apps/first-nginx created
-  1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed
-  deployment.apps/second-nginx created
-  1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed
-
-inventory:
-  - group: apps
-    kind: Deployment
-    name: first-nginx
-    namespace: apply-depends-on
-  - group: apps
-    kind: Deployment
-    name: second-nginx
-    namespace: apply-depends-on
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: first-nginx
+  namespace: json-output
+  annotations:
+    config.k8s.io/owning-inventory: json-output
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: first-nginx
+  template:
+    metadata:
+      labels:
+        app: first-nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80

--- a/e2e/testdata/live-apply/json-output/pre-apply/rg.yaml
+++ b/e2e/testdata/live-apply/json-output/pre-apply/rg.yaml
@@ -12,20 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-parallel: true
-
-stdOut: |
-  deployment.apps/first-nginx created
-  1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed
-  deployment.apps/second-nginx created
-  1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed
-
-inventory:
-  - group: apps
-    kind: Deployment
-    name: first-nginx
-    namespace: apply-depends-on
-  - group: apps
-    kind: Deployment
-    name: second-nginx
-    namespace: apply-depends-on
+apiVersion: kpt.dev/v1alpha1
+kind: ResourceGroup
+metadata:
+  labels:
+    cli-utils.sigs.k8s.io/inventory-id: json-output
+  name: json-output
+  namespace: json-output
+spec:
+  resources:
+    - group: apps
+      kind: Deployment
+      name: first-nginx
+      namespace: json-output
+    - group: apps
+      kind: Deployment
+      name: second-nginx
+      namespace: json-output

--- a/e2e/testdata/live-apply/json-output/pre-apply/second.yaml
+++ b/e2e/testdata/live-apply/json-output/pre-apply/second.yaml
@@ -12,20 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-parallel: true
-
-stdOut: |
-  deployment.apps/first-nginx created
-  1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed
-  deployment.apps/second-nginx created
-  1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed
-
-inventory:
-  - group: apps
-    kind: Deployment
-    name: first-nginx
-    namespace: apply-depends-on
-  - group: apps
-    kind: Deployment
-    name: second-nginx
-    namespace: apply-depends-on
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: second-nginx
+  namespace: json-output
+  annotations:
+    config.k8s.io/owning-inventory: json-output
+    config.kubernetes.io/depends-on: apps/namespaces/json-output/Deployment/first-nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: second-nginx
+  template:
+    metadata:
+      labels:
+        app: second-nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80

--- a/e2e/testdata/live-apply/json-output/resources/Kptfile
+++ b/e2e/testdata/live-apply/json-output/resources/Kptfile
@@ -1,0 +1,8 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: json-output
+inventory:
+  namespace: json-output
+  name: json-output
+  inventoryID: json-output

--- a/e2e/testdata/live-apply/json-output/resources/cm.yaml
+++ b/e2e/testdata/live-apply/json-output/resources/cm.yaml
@@ -12,20 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-parallel: true
-
-stdOut: |
-  deployment.apps/first-nginx created
-  1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed
-  deployment.apps/second-nginx created
-  1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed
-
-inventory:
-  - group: apps
-    kind: Deployment
-    name: first-nginx
-    namespace: apply-depends-on
-  - group: apps
-    kind: Deployment
-    name: second-nginx
-    namespace: apply-depends-on
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cm
+  namespace: json-output
+data:
+  foo: bar

--- a/e2e/testdata/live-apply/json-output/resources/fourth.yaml
+++ b/e2e/testdata/live-apply/json-output/resources/fourth.yaml
@@ -12,20 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-parallel: true
-
-stdOut: |
-  deployment.apps/first-nginx created
-  1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed
-  deployment.apps/second-nginx created
-  1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed
-
-inventory:
-  - group: apps
-    kind: Deployment
-    name: first-nginx
-    namespace: apply-depends-on
-  - group: apps
-    kind: Deployment
-    name: second-nginx
-    namespace: apply-depends-on
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fourth-nginx
+  namespace: json-output
+  annotations:
+    config.k8s.io/owning-inventory: json-output
+    config.kubernetes.io/depends-on: apps/namespaces/json-output/Deployment/third-nginx
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: fourth-nginx
+  template:
+    metadata:
+      labels:
+        app: fourth-nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80

--- a/e2e/testdata/live-apply/json-output/resources/third.yaml
+++ b/e2e/testdata/live-apply/json-output/resources/third.yaml
@@ -12,20 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-parallel: true
-
-stdOut: |
-  deployment.apps/first-nginx created
-  1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed
-  deployment.apps/second-nginx created
-  1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed
-
-inventory:
-  - group: apps
-    kind: Deployment
-    name: first-nginx
-    namespace: apply-depends-on
-  - group: apps
-    kind: Deployment
-    name: second-nginx
-    namespace: apply-depends-on
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: third-nginx
+  namespace: json-output
+  annotations:
+    config.k8s.io/owning-inventory: json-output
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: third-nginx
+  template:
+    metadata:
+      labels:
+        app: third-nginx
+    spec:
+      containers:
+        - name: nginx
+          image: nginx:1.14.2
+          ports:
+            - containerPort: 80

--- a/e2e/testdata/live-apply/prune-depends-on/config.yaml
+++ b/e2e/testdata/live-apply/prune-depends-on/config.yaml
@@ -12,24 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-preinstallResourceGroup: true
-output:
-  events:
-    stdOut: |
-      configmap/cm created
-      1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed
-      deployment.apps/second-nginx pruned
-      1 resource(s) pruned, 0 skipped, 0 failed
-      deployment.apps/first-nginx pruned
-      1 resource(s) pruned, 0 skipped, 0 failed
-  json:
-    stdOut: |
-      {"eventType":"resourceApplied","group":"","kind":"ConfigMap","name":"cm","namespace":"prune-depends-on","operation":"Created","timestamp":"<TIMESTAMP>","type":"apply"}
-      {"configuredCount":0,"count":1,"createdCount":1,"eventType":"completed","failedCount":0,"serverSideCount":0,"timestamp":"<TIMESTAMP>","type":"apply","unchangedCount":0}
-      {"eventType":"resourcePruned","group":"apps","kind":"Deployment","name":"second-nginx","namespace":"prune-depends-on","operation":"Pruned","timestamp":"<TIMESTAMP>","type":"prune"}
-      {"eventType":"completed","pruned":1,"skipped":0,"timestamp":"<TIMESTAMP>","type":"prune"}
-      {"eventType":"resourcePruned","group":"apps","kind":"Deployment","name":"first-nginx","namespace":"prune-depends-on","operation":"Pruned","timestamp":"<TIMESTAMP>","type":"prune"}
-      {"eventType":"completed","pruned":1,"skipped":0,"timestamp":"<TIMESTAMP>","type":"prune"}
+parallel: true
+stdOut: |
+  configmap/cm created
+  1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed
+  deployment.apps/second-nginx pruned
+  1 resource(s) pruned, 0 skipped, 0 failed
+  deployment.apps/first-nginx pruned
+  1 resource(s) pruned, 0 skipped, 0 failed
 inventory:
   - kind: ConfigMap
     name: cm

--- a/e2e/testdata/live-apply/prune-depends-on/pre-apply/first.yaml
+++ b/e2e/testdata/live-apply/prune-depends-on/pre-apply/first.yaml
@@ -20,7 +20,7 @@ metadata:
   annotations:
     config.k8s.io/owning-inventory: prune-depends-on
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: first-nginx

--- a/e2e/testdata/live-apply/prune-depends-on/pre-apply/second.yaml
+++ b/e2e/testdata/live-apply/prune-depends-on/pre-apply/second.yaml
@@ -21,7 +21,7 @@ metadata:
     config.k8s.io/owning-inventory: prune-depends-on
     config.kubernetes.io/depends-on: apps/namespaces/prune-depends-on/Deployment/first-nginx
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: second-nginx

--- a/go.sum
+++ b/go.sum
@@ -1037,8 +1037,6 @@ sigs.k8s.io/kustomize/cmd/config v0.9.13/go.mod h1:7547FLF8W/lTaDf0BDqFTbZxM9zqw
 sigs.k8s.io/kustomize/kustomize/v4 v4.2.0/go.mod h1:MOkR6fmhwG7hEDRXBYELTi5GSFcLwfqwzTRHW3kv5go=
 sigs.k8s.io/kustomize/kyaml v0.11.0/go.mod h1:GNMwjim4Ypgp/MueD3zXHLRJEjz7RvtPae0AwlvEMFM=
 sigs.k8s.io/kustomize/kyaml v0.12.0/go.mod h1:FTJxEZ86ScK184NpGSAQcfEqee0nul8oLCK30D47m4E=
-sigs.k8s.io/kustomize/kyaml v0.13.1-0.20211122190718-01420768c8ef h1:+S4oQAuqVk4Nmy28fALpv93AgW0UKQWjmqUwSNmIWpE=
-sigs.k8s.io/kustomize/kyaml v0.13.1-0.20211122190718-01420768c8ef/go.mod h1:FTJxEZ86ScK184NpGSAQcfEqee0nul8oLCK30D47m4E=
 sigs.k8s.io/kustomize/kyaml v0.13.1-0.20211203194734-cd2c6a1ad117 h1:4ePwpEnROoPqjaY6WC98EiRpYrmJjDHV6KA7PGDmpdQ=
 sigs.k8s.io/kustomize/kyaml v0.13.1-0.20211203194734-cd2c6a1ad117/go.mod h1:FTJxEZ86ScK184NpGSAQcfEqee0nul8oLCK30D47m4E=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=

--- a/pkg/test/live/config.go
+++ b/pkg/test/live/config.go
@@ -36,11 +36,13 @@ type TestCaseConfig struct {
 	// Inventory is the expected list of resource present in the inventory.
 	Inventory []InventoryEntry `yaml:"inventory,omitempty"`
 
-	// PreinstallResourceGroup causes the test framework to verify that the
-	// ResourceGroup CRD is available in the cluster before running the test.
+	// NoResourceGroup defines whether the RG CRD should be present in the cluster
+	// when the test starts.
 	NoResourceGroup bool `yaml:"noResourceGroup,omitempty"`
 
-	
+	// Parallel defines whether the test can be run in parallel with other
+	// tests. The primary requirement here is that the test doesn't create,
+	// update, or delete any cluster-scoped resources.
 	Parallel bool `yaml:"parallel,omitempty"`
 
 	// KptArgs is a list of args that will be provided to the kpt command

--- a/pkg/test/live/config.go
+++ b/pkg/test/live/config.go
@@ -26,31 +26,26 @@ type TestCaseConfig struct {
 	// ExitCode is the expected exit code from the kpt commands. Default: 0
 	ExitCode int `yaml:"exitCode,omitempty"`
 
-	Output map[string]Output `yaml:"output,omitempty"`
-
-	// Inventory is the expected list of resource present in the inventory.
-	Inventory []InventoryEntry `yaml:"inventory,omitempty"`
-
-	// RequiresCleanCluster tells the test framework that a new cluster must
-	// be created for running this test.
-	RequiresCleanCluster bool `yaml:"requiresCleanCluster,omitempty"`
-
-	// PreinstallResourceGroup causes the test framework to verify that the
-	// ResourceGroup CRD is available in the cluster before running the test.
-	PreinstallResourceGroup bool `yaml:"preinstallResourceGroup,omitempty"`
-
-	// KptArgs is a list of args that will be provided to the kpt command
-	// when running the test.
-	KptArgs []string `yaml:"kptArgs,omitempty"`
-}
-
-type Output struct {
 	// StdErr is the expected standard error output. Default: ""
 	StdErr string `yaml:"stdErr,omitempty"`
 
 	// StdOut is the expected standard output from running the command.
 	// Default: ""
 	StdOut string `yaml:"stdOut,omitempty"`
+
+	// Inventory is the expected list of resource present in the inventory.
+	Inventory []InventoryEntry `yaml:"inventory,omitempty"`
+
+	// PreinstallResourceGroup causes the test framework to verify that the
+	// ResourceGroup CRD is available in the cluster before running the test.
+	NoResourceGroup bool `yaml:"noResourceGroup,omitempty"`
+
+	
+	Parallel bool `yaml:"parallel,omitempty"`
+
+	// KptArgs is a list of args that will be provided to the kpt command
+	// when running the test.
+	KptArgs []string `yaml:"kptArgs,omitempty"`
 }
 
 // InventoryEntry defines an entry in an inventory list.

--- a/pkg/test/live/kind.go
+++ b/pkg/test/live/kind.go
@@ -1,0 +1,111 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package live
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+const (
+	KindClusterName   = "live-e2e-test"
+	K8sVersionEnvName = "K8S_VERSION"
+)
+
+func InstallResourceGroup(t *testing.T) {
+	cmd := exec.Command("kpt", "live", "install-resource-group")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("error installing ResourceGroup CRD: %v", err)
+	}
+}
+
+func RemoveResourceGroup(t *testing.T) {
+	cmd := exec.Command("kubectl", "delete", "crd", "resourcegroups.kpt.dev")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("error removing ResourceGroup CRD: %v", err)
+	}
+	if CheckIfResourceGroupInstalled(t) {
+		t.Fatalf("couldn't remove ResourceGroup CRD")
+	}
+}
+
+func CheckIfResourceGroupInstalled(t *testing.T) bool {
+	cmd := exec.Command("kubectl", "get", "resourcegroups.kpt.dev")
+	output, err := cmd.CombinedOutput()
+	if strings.Contains(string(output), "the server doesn't have a resource type") {
+		return false
+	}
+	if err != nil {
+		t.Fatalf("error checking for ResourceGroup CRD: %v", err)
+	}
+	return true
+}
+
+func CheckKindClusterAvailable(t *testing.T) bool {
+	cmd := exec.Command("kind", "get", "clusters")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to check for kind cluster: %v", err)
+	}
+
+	sc := bufio.NewScanner(bytes.NewReader(output))
+	for sc.Scan() {
+		if strings.TrimSpace(sc.Text()) == KindClusterName {
+			return true
+		}
+	}
+	if err := sc.Err(); err != nil {
+		t.Fatalf("error parsing output from 'kind get cluster': %v", err)
+	}
+	return false
+}
+
+func CreateKindCluster(t *testing.T) {
+	args := []string{"create", "cluster", fmt.Sprintf("--name=%s", KindClusterName)}
+	if k8sVersion := os.Getenv(K8sVersionEnvName); k8sVersion != "" {
+		t.Logf("Using version %s", k8sVersion)
+		args = append(args, fmt.Sprintf("--image=kindest/node:v%s", k8sVersion))
+	}
+	cmd := exec.Command("kind", args...)
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to create new kind cluster: %v", err)
+	}
+}
+
+func RemoveKindCluster(t *testing.T) {
+	cmd := exec.Command("kind", "delete", "cluster", fmt.Sprintf("--name=%s", KindClusterName))
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("failed to remove existing cluster: %v", err)
+	}
+}
+
+func CreateNamespace(t *testing.T, namespace string) {
+	cmd := exec.Command("kubectl", "create", "ns", namespace)
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("error creating namespace %s: %v", namespace, err)
+	}
+}
+
+func RemoveNamespace(t *testing.T, namespace string) {
+	cmd := exec.Command("kubectl", "delete", "ns", namespace, "--wait=false")
+	if err := cmd.Run(); err != nil {
+		t.Logf("error deleting namespace %s: %v", namespace, err)
+	}
+}


### PR DESCRIPTION
Simplifies the test config and schedules tests to avoid having to recreate the kind cluster (which is very slow).