### PR TITLE
Update cli-utils to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20211109043139-026bd182f079 // indirect
 	k8s.io/kubectl v0.22.2
 	k8s.io/utils v0.0.0-20210820185131-d34e5cb4466e
-	sigs.k8s.io/cli-utils v0.26.1-0.20211020064957-d62b5c62002d
+	sigs.k8s.io/cli-utils v0.26.1-0.20220108032703-d7d63f4b6289
 	sigs.k8s.io/kustomize/api v0.8.11
 	sigs.k8s.io/kustomize/kyaml v0.13.1-0.20211203194734-cd2c6a1ad117
 )

--- a/go.sum
+++ b/go.sum
@@ -1022,8 +1022,8 @@ rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.0.22/go.mod h1:LEScyzhFmoF5pso/YSeBstl57mOzx9xlU9n85RGrDQg=
-sigs.k8s.io/cli-utils v0.26.1-0.20211020064957-d62b5c62002d h1:yxJZ6HujyxXTLuHuZ8/HkzWy6g+eTpslhUzAzPpA9dE=
-sigs.k8s.io/cli-utils v0.26.1-0.20211020064957-d62b5c62002d/go.mod h1:8ll2fyx+bzjbwmwUnKBQU+2LDbMDsxy44DiDZ+drALg=
+sigs.k8s.io/cli-utils v0.26.1-0.20220108032703-d7d63f4b6289 h1:4kv1Ge3sdzNPT96uRa5zU+vNczErzkoQYanbQmRgn60=
+sigs.k8s.io/cli-utils v0.26.1-0.20220108032703-d7d63f4b6289/go.mod h1:8ll2fyx+bzjbwmwUnKBQU+2LDbMDsxy44DiDZ+drALg=
 sigs.k8s.io/controller-runtime v0.10.1 h1:+eLHgY/VrJWnfg6iXUqhCUqNXgPH1NZeP9drNAAgWlg=
 sigs.k8s.io/controller-runtime v0.10.1/go.mod h1:CQp8eyUQZ/Q7PJvnIrB6/hgfTC1kBkGylwsLgOQi1WY=
 sigs.k8s.io/kustomize/api v0.8.11 h1:LzQzlq6Z023b+mBtc6v72N2mSHYmN8x7ssgbf/hv0H8=

--- a/internal/cmddestroy/cmddestroy.go
+++ b/internal/cmddestroy/cmddestroy.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/apply"
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
-	status "sigs.k8s.io/cli-utils/pkg/util/factory"
 )
 
 func NewRunner(ctx context.Context, factory util.Factory,
@@ -154,21 +153,18 @@ func (r *Runner) runE(c *cobra.Command, args []string) error {
 func runDestroy(r *Runner, inv inventory.InventoryInfo, dryRunStrategy common.DryRunStrategy) error {
 	// Run the destroyer. It will return a channel where we can receive updates
 	// to keep track of progress and any issues.
-	poller, err := status.NewStatusPoller(r.factory)
-	if err != nil {
-		return err
-	}
 	invClient, err := inventory.NewInventoryClient(r.factory, live.WrapInventoryObj, live.InvToUnstructuredFunc)
 	if err != nil {
 		return err
 	}
-	destroyer, err := apply.NewDestroyer(r.factory, invClient, poller)
+	destroyer, err := apply.NewDestroyer(r.factory, invClient)
 	if err != nil {
 		return err
 	}
 	options := apply.DestroyerOptions{
-		InventoryPolicy: r.inventoryPolicy,
-		DryRunStrategy:  dryRunStrategy,
+		InventoryPolicy:  r.inventoryPolicy,
+		DryRunStrategy:   dryRunStrategy,
+		EmitStatusEvents: true,
 	}
 	ch := destroyer.Run(context.Background(), inv, options)
 

--- a/internal/cmdmigrate/migratecmd_test.go
+++ b/internal/cmdmigrate/migratecmd_test.go
@@ -286,14 +286,14 @@ func TestKptMigrate_migrateObjs(t *testing.T) {
 		},
 		"One migrate object is valid": {
 			invObj:  kptfileStr,
-			objs:    []object.ObjMetadata{object.UnstructuredToObjMetaOrDie(pod1)},
+			objs:    []object.ObjMetadata{object.UnstructuredToObjMetadata(pod1)},
 			isError: false,
 		},
 		"Multiple migrate objects are valid": {
 			invObj: kptfileStr,
 			objs: []object.ObjMetadata{
-				object.UnstructuredToObjMetaOrDie(pod1),
-				object.UnstructuredToObjMetaOrDie(pod2),
+				object.UnstructuredToObjMetadata(pod1),
+				object.UnstructuredToObjMetadata(pod2),
 			},
 			isError: false,
 		},

--- a/internal/errors/resolver/live.go
+++ b/internal/errors/resolver/live.go
@@ -19,7 +19,6 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/cmdutil"
 	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/pkg/live"
-	"sigs.k8s.io/cli-utils/pkg/apply/taskrunner"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/manifestreader"
 )
@@ -42,14 +41,6 @@ package or automatically deleting omitted resources (pruning).
 Error: Package has multiple inventory object templates.
 
 The package should have one and only one inventory object template.
-`
-	//nolint:lll
-	timeoutErrorMsg = `
-Error: Timeout after {{printf "%.0f" .err.Timeout.Seconds}} seconds waiting for {{printf "%d" (len .err.TimedOutResources)}} out of {{printf "%d" (len .err.Identifiers)}} resources to reach condition {{ .err.Condition}}:{{ printf "\n" }}
-
-{{- range .err.TimedOutResources}}
-{{printf "%s/%s %s %s" .Identifier.GroupKind.Kind .Identifier.Name .Status .Message }}
-{{- end}}
 `
 
 	resourceGroupCRDInstallErrorMsg = `
@@ -85,15 +76,13 @@ Details:
 `
 
 	unknownTypesMsg = `
-Error: {{ printf "%d" (len .err.GroupKinds) }} resource types could not be found in the cluster or as CRDs among the applied resources.
+Error: {{ printf "%d" (len .err.GroupVersionKinds) }} resource types could not be found in the cluster or as CRDs among the applied resources.
 
 Resource types:
-{{- range .err.GroupKinds}}
+{{- range .err.GroupVersionKinds}}
 {{ printf "%s" .String }}
 {{- end}}
 `
-
-	TimeoutErrorExitCode = 3
 )
 
 // liveErrorResolver is an implementation of the ErrorResolver interface
@@ -116,16 +105,6 @@ func (*liveErrorResolver) Resolve(err error) (ResolvedResult, bool) {
 			Message: ExecuteTemplate(multipleInventoryObjErrorMsg, map[string]interface{}{
 				"err": *multipleInventoryObjError,
 			}),
-		}, true
-	}
-
-	var timeoutError *taskrunner.TimeoutError
-	if errors.As(err, &timeoutError) {
-		return ResolvedResult{
-			Message: ExecuteTemplate(timeoutErrorMsg, map[string]interface{}{
-				"err": *timeoutError,
-			}),
-			ExitCode: TimeoutErrorExitCode,
 		}, true
 	}
 

--- a/internal/util/cmdutil/cmdutil.go
+++ b/internal/util/cmdutil/cmdutil.go
@@ -198,7 +198,7 @@ func FetchFunctionImages() []string {
 }
 
 // fnName -> v<major>.<minor> -> catalogEntry
-type catalogV2 map[string]map[string]struct{
+type catalogV2 map[string]map[string]struct {
 	LatestPatchVersion string
 	Examples           interface{}
 }

--- a/pkg/live/apply-crd-task.go
+++ b/pkg/live/apply-crd-task.go
@@ -41,7 +41,7 @@ func (a *ApplyCRDTask) Action() event.ResourceAction {
 }
 
 func (a *ApplyCRDTask) Identifiers() object.ObjMetadataSet {
-	return object.UnstructuredsToObjMetasOrDie([]*unstructured.Unstructured{a.crd})
+	return object.UnstructuredSetToObjMetadataSet([]*unstructured.Unstructured{a.crd})
 }
 
 // NewApplyCRDTask returns a pointer to an ApplyCRDTask struct,
@@ -89,4 +89,6 @@ func (a *ApplyCRDTask) Start(taskContext *taskrunner.TaskContext) {
 	}()
 }
 
-func (a *ApplyCRDTask) ClearTimeout() {}
+func (a *ApplyCRDTask) Cancel(_ *taskrunner.TaskContext) {}
+
+func (a *ApplyCRDTask) StatusUpdate(_ *taskrunner.TaskContext, _ object.ObjMetadata) {}

--- a/pkg/live/load_test.go
+++ b/pkg/live/load_test.go
@@ -34,7 +34,7 @@ func TestLoad_LocalDisk(t *testing.T) {
 	testCases := map[string]struct {
 		pkg            *pkgbuilder.RootPkg
 		namespace      string
-		expectedObjs   []object.ObjMetadata
+		expectedObjs   object.ObjMetadataSet
 		expectedInv    kptfile.Inventory
 		expectedErrMsg string
 	}{
@@ -184,7 +184,7 @@ func TestLoad_LocalDisk(t *testing.T) {
 			}
 			assert.NoError(t, err)
 
-			objMetas := object.UnstructuredsToObjMetasOrDie(objs)
+			objMetas := object.UnstructuredSetToObjMetadataSet(objs)
 			sort.Slice(objMetas, func(i, j int) bool {
 				return objMetas[i].String() < objMetas[j].String()
 			})
@@ -199,7 +199,7 @@ func TestLoad_StdIn(t *testing.T) {
 	testCases := map[string]struct {
 		pkg            *pkgbuilder.RootPkg
 		namespace      string
-		expectedObjs   []object.ObjMetadata
+		expectedObjs   object.ObjMetadataSet
 		expectedInv    kptfile.Inventory
 		expectedErrMsg string
 	}{
@@ -343,7 +343,7 @@ func TestLoad_StdIn(t *testing.T) {
 			}
 			assert.NoError(t, err)
 
-			objMetas := object.UnstructuredsToObjMetasOrDie(objs)
+			objMetas := object.UnstructuredSetToObjMetadataSet(objs)
 			sort.Slice(objMetas, func(i, j int) bool {
 				return objMetas[i].String() < objMetas[j].String()
 			})

--- a/pkg/live/rgpath_test.go
+++ b/pkg/live/rgpath_test.go
@@ -23,7 +23,7 @@ func TestPathManifestReader_Read(t *testing.T) {
 	testCases := map[string]struct {
 		manifests      map[string]string
 		namespace      string
-		expectedObjs   []object.ObjMetadata
+		expectedObjs   object.ObjMetadataSet
 		expectedErrMsg string
 	}{
 		"Empty package is ok": {
@@ -151,7 +151,7 @@ func TestPathManifestReader_Read(t *testing.T) {
 				"cr.yaml": cr,
 			},
 			namespace:      "test-namespace",
-			expectedErrMsg: "unknown resource types: Custom.custom.io",
+			expectedErrMsg: "unknown resource types: custom.io/v1/Custom",
 		},
 		"local-config is filtered out": {
 			manifests: map[string]string{
@@ -211,7 +211,7 @@ func TestPathManifestReader_Read(t *testing.T) {
 			}
 			assert.NoError(t, err)
 
-			readObjMetas := object.UnstructuredsToObjMetasOrDie(readObjs)
+			readObjMetas := object.UnstructuredSetToObjMetadataSet(readObjs)
 
 			sort.Slice(readObjMetas, func(i, j int) bool {
 				return readObjMetas[i].String() < readObjMetas[j].String()

--- a/pkg/live/rgstream_test.go
+++ b/pkg/live/rgstream_test.go
@@ -22,7 +22,7 @@ func TestResourceStreamManifestReader_Read(t *testing.T) {
 	testCases := map[string]struct {
 		manifests      map[string]string
 		namespace      string
-		expectedObjs   []object.ObjMetadata
+		expectedObjs   object.ObjMetadataSet
 		expectedErrMsg string
 	}{
 		"Kptfile is excluded": {
@@ -99,7 +99,7 @@ func TestResourceStreamManifestReader_Read(t *testing.T) {
 				"cr.yaml": cr,
 			},
 			namespace:      "test-namespace",
-			expectedErrMsg: "unknown resource types: Custom.custom.io",
+			expectedErrMsg: "unknown resource types: custom.io/v1/Custom",
 		},
 	}
 
@@ -137,7 +137,7 @@ func TestResourceStreamManifestReader_Read(t *testing.T) {
 			}
 			assert.NoError(t, err)
 
-			readObjMetas := object.UnstructuredsToObjMetasOrDie(readObjs)
+			readObjMetas := object.UnstructuredSetToObjMetadataSet(readObjs)
 
 			sort.Slice(readObjMetas, func(i, j int) bool {
 				return readObjMetas[i].String() < readObjMetas[j].String()

--- a/thirdparty/cli-utils/status/cmdstatus.go
+++ b/thirdparty/cli-utils/status/cmdstatus.go
@@ -27,9 +27,9 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/aggregator"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/collector"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/engine"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/event"
 	kstatus "sigs.k8s.io/cli-utils/pkg/kstatus/status"
-	status "sigs.k8s.io/cli-utils/pkg/util/factory"
 )
 
 const (
@@ -234,7 +234,7 @@ func allKnownNotifierFunc(cancelFunc context.CancelFunc) collector.ObserverFunc 
 }
 
 func pollerFactoryFunc(f util.Factory) (poller.Poller, error) {
-	return status.NewStatusPoller(f)
+	return polling.NewStatusPollerFromFactory(f, []engine.StatusReader{})
 }
 
 func invClient(f util.Factory) (inventory.InventoryClient, error) {


### PR DESCRIPTION
Update to the latest version of cli-utils in preparation for updating to a new cli-utils release.

The underlying library have several important changes:
- No default reconcile timeout (wait until cancelled)
- No default prune/delete timeout (wait until cancelled)
- Always wait for reconciliation after apply/prune/delete (previously only waited if there were dependencies, causing more than one apply task)
- Send WaitEvent for every object
- Added deletion prevention annotations
- Context cancel/timeout now sends an error and event
- Update K8s libs to v0.22.2
- Update kyaml to v0.12.0
- Printers moved from cmd to pkg

In kpt, this has the following important consequences:
- The default behavior when no reconcile or prune timeout is provided has changed. It previously resulted in no waiting at all, now the behavior is that kpt will wait until cancelled.


The new `Wait` events are not currently exposed through the kpt cli. We can consider changing this, but we should see if we can align the kpt UX with the behavior of the printers from cli-utils.

Replaces https://github.com/GoogleContainerTools/kpt/pull/2581