### PR TITLE
Use reconcile-timeout for live apply tests

### DIFF
--- a/e2e/testdata/live-apply/apply-depends-on/config.yaml
+++ b/e2e/testdata/live-apply/apply-depends-on/config.yaml
@@ -14,6 +14,9 @@
 
 parallel: true
 
+kptArgs:
+  - "--reconcile-timeout=1m"
+
 stdOut: |
   deployment.apps/first-nginx created
   1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed

--- a/e2e/testdata/live-apply/crd-and-cr/config.yaml
+++ b/e2e/testdata/live-apply/crd-and-cr/config.yaml
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 parallel: true
+
+kptArgs:
+  - "--reconcile-timeout=1m"
+
 stdOut: |
   customresourcedefinition.apiextensions.k8s.io/customs.kpt.dev created
   1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed

--- a/e2e/testdata/live-apply/install-rg-on-apply/config.yaml
+++ b/e2e/testdata/live-apply/install-rg-on-apply/config.yaml
@@ -14,6 +14,8 @@
 
 parallel: false
 noResourceGroup: true
+kptArgs:
+  - "--reconcile-timeout=1m"
 stdOut: |
   deployment.apps/nginx-deployment created
   1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed

--- a/e2e/testdata/live-apply/json-output/config.yaml
+++ b/e2e/testdata/live-apply/json-output/config.yaml
@@ -15,6 +15,7 @@
 parallel: true
 kptArgs:
   - "--output=json"
+  - "--reconcile-timeout=1m"
 stdOut: |
   {"eventType":"resourceApplied","group":"","kind":"ConfigMap","name":"cm","namespace":"json-output","operation":"Created","timestamp":"<TIMESTAMP>","type":"apply"}
   {"eventType":"resourceApplied","group":"apps","kind":"Deployment","name":"third-nginx","namespace":"json-output","operation":"Created","timestamp":"<TIMESTAMP>","type":"apply"}

--- a/e2e/testdata/live-apply/prune-depends-on/config.yaml
+++ b/e2e/testdata/live-apply/prune-depends-on/config.yaml
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 parallel: true
+
+kptArgs:
+  - "--reconcile-timeout=1m"
+
 stdOut: |
   configmap/cm created
   1 resource(s) applied. 1 created, 0 unchanged, 0 configured, 0 failed

--- a/pkg/test/live/runner.go
+++ b/pkg/test/live/runner.go
@@ -15,6 +15,7 @@
 package live
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"os"
@@ -26,6 +27,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
@@ -96,11 +98,15 @@ func (r *Runner) VerifyExitCode(t *testing.T, err error) {
 }
 
 func (r *Runner) VerifyStdout(t *testing.T, stdout string) {
-	assert.Equal(t, strings.TrimSpace(r.Config.StdOut), strings.TrimSpace(substituteTimestamps(stdout)))
+	assert.Equal(t, strings.TrimSpace(r.Config.StdOut), prepOutput(t, stdout))
 }
 
 func (r *Runner) VerifyStderr(t *testing.T, stderr string) {
-	assert.Equal(t, strings.TrimSpace(r.Config.StdErr), strings.TrimSpace(substituteTimestamps(stderr)))
+	assert.Equal(t, strings.TrimSpace(r.Config.StdErr), prepOutput(t, stderr))
+}
+
+func prepOutput(t *testing.T, s string) string {
+	return strings.TrimSpace(substituteTimestamps(removeStatusEvents(t, s)))
 }
 
 func (r *Runner) VerifyInventory(t *testing.T, name, namespace string) {
@@ -172,4 +178,33 @@ var timestampRegexp = regexp.MustCompile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z`)
 
 func substituteTimestamps(text string) string {
 	return timestampRegexp.ReplaceAllString(text, "<TIMESTAMP>")
+}
+
+var statuses = []status.Status{
+	status.InProgressStatus,
+	status.CurrentStatus,
+	status.FailedStatus,
+	status.TerminatingStatus,
+	status.UnknownStatus,
+	status.NotFoundStatus,
+}
+
+func removeStatusEvents(t *testing.T, text string) string {
+	scanner := bufio.NewScanner(strings.NewReader(text))
+	var lines []string
+
+scan:
+	for scanner.Scan() {
+		line := scanner.Text()
+		for _, s := range statuses {
+			if strings.Contains(line, s.String()) {
+				continue scan
+			}
+		}
+		lines = append(lines, line)
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("error scanning output: %v", err)
+	}
+	return strings.Join(lines, "\n")
 }


### PR DESCRIPTION
Updates the test runner to remove status events from the output before we compare the output to the expected results. This is because the status events does not have consistent ordering.
