### PR TITLE
fix: bash auto completion for CLI flags

### DIFF
--- a/run/run.go
+++ b/run/run.go
@@ -89,6 +89,7 @@ func GetMain(ctx context.Context) *cobra.Command {
 			// Complete exits if it is called in completion mode, otherwise it is a no-op
 			cmdcomplete.Complete(cmd.Parent(), false, nil).Complete("kpt")
 		},
+		DisableFlagParsing: true,
 	})
 
 	// find the pager if one exists


### PR DESCRIPTION
This kpt subcommand is invoked by bash shell completion, which
previously returned an error when attempting to perform
auto completion for flag values. The actual subcommands and their
associated flags are registered with the root Command but not
this subcommand, which results in flag validation returning an
error for this subcommand.

Disabling flag validation fixes this issue and enables auto
completion for flags in bash.