### PR TITLE
POST-RELEASE: add autocompletion to installation guide

### DIFF
--- a/site/installation/README.md
+++ b/site/installation/README.md
@@ -27,6 +27,47 @@ Verify the version:
 $ kpt version
 ```
 
+## (Optional) enable shell auto-completion
+
+kpt provides auto-completion support for several of the common shells.
+To see the options for enabling shell auto-completion:
+```shell
+kpt completion -h
+```
+
+### Prerequisites
+`kpt` depends on `bash-completion` in order to support auto-completion for the
+bash shell. If you are using bash as your shell, you will need to install
+`bash-completion` in order to use kpt's auto-completion feature.
+`bash-completion` is provided by many package managers
+(see [here][bash-completion]).
+
+### Enable kpt auto-completion
+The kpt completion script for a shell can be generated with the commands
+`kpt completion bash`, `kpt completion zsh`, etc. Sourcing the completion script
+in your shell enables auto-completion.
+
+#### Enable auto-completion for your current shell
+bash:
+```shell
+source <(kpt completion bash)
+```
+zsh:
+```shell
+source <(kpt completion zsh)
+```
+etc.
+#### Enable kpt completion for all your shell sessions
+bash:
+```shell
+echo 'source <(kpt completion bash)' >> ~/.bashrc
+```
+zsh:
+```shell
+echo 'source <(kpt completion zsh)' >> ~/.zshrc
+```
+etc.
+
 <!-- gcloud and homebrew are not yet available for builds from the main branch.
 ## gcloud
 
@@ -105,3 +146,4 @@ $ kpt version
 [darwin]:
   https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.10/kpt_darwin_amd64
 [migration guide]: /installation/migration
+[bash-completion]: https://github.com/scop/bash-completion#installation


### PR DESCRIPTION
Add autocompletion to installation guide.

Follow-up to https://github.com/GoogleContainerTools/kpt/pull/2631