### PR TITLE
docs: fix book hyperlink for depends-on

### DIFF
--- a/site/book/06-deploying-packages/03-handling-dependencies.md
+++ b/site/book/06-deploying-packages/03-handling-dependencies.md
@@ -83,4 +83,4 @@ service/wordpress-mysql deleted
 See [depends-on] for more information.
 
 [depends-on]:
-  /reference/annotations/depends-on
+  /reference/annotations/depends-on/


### PR DESCRIPTION
The hyperlink was missing a trailing / which was leading to a 404 for
the redirected page.
