### PR TITLE
Added docs for using exec in fn render

### DIFF
--- a/internal/docs/generated/fndocs/docs.go
+++ b/internal/docs/generated/fndocs/docs.go
@@ -239,6 +239,11 @@ Args:
 
 Flags:
 
+  --allow-exec:
+    Allow executable binaries to run as function. Note that executable binaries
+    can perform privileged operations on your system, so ensure that binaries
+    referred in the pipeline are trusted and safe to execute.
+  
   --image-pull-policy:
     If the image should be pulled before rendering the package(s). It can be set
     to one of always, ifNotPresent, never. If unspecified, always will be the

--- a/site/book/04-using-functions/01-declarative-function-execution.md
+++ b/site/book/04-using-functions/01-declarative-function-execution.md
@@ -122,8 +122,21 @@ For example, `set-labels:v0.1` is automatically expanded to `gcr.io/kpt-fn/set-l
 ### `exec`
 
 The `exec` field specifies the executable command for the function. You can specify
-an executable with arguments. For example, specifying `"sed -e 's/foo/bar/'"` will
-replace all occurances of `foo` with `bar` in the package resources.
+an executable with arguments.
+
+Example below uses `sed` executable to replace all occurances of `foo` with `bar`
+in the package resources.
+
+```yaml
+# PKG_DIR/Kptfile (Excerpt)
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: app
+pipeline:
+  mutators:
+    - exec: "sed -e 's/foo/bar/'"
+```
 
 Note that you must render the package by allowing executables by specifying `--allow-exec`
 command line flag as shown below.

--- a/site/book/04-using-functions/01-declarative-function-execution.md
+++ b/site/book/04-using-functions/01-declarative-function-execution.md
@@ -110,12 +110,34 @@ The end result is that:
 If any of the functions in the pipeline fails for whatever reason, then the
 entire pipeline is aborted and the local filesystem is left intact.
 
-## Specifying `image`
+## Specifying `function`
+
+### `image`
 
 The `image` field specifies the container image for the function. You can specify
 an image from any container registry. If the registry is omitted, the default
 container registry for functions catalog (`gcr.io/kpt-fn`) is prepended automatically.
 For example, `set-labels:v0.1` is automatically expanded to `gcr.io/kpt-fn/set-labels:v0.1`.
+
+### `exec`
+
+The `exec` field specifies the executable command for the function. You can specify
+an executable with arguments. For example, specifying `"sed -e 's/foo/bar/'"` will
+replace all occurances of `foo` with `bar` in the package resources.
+
+Note that you must render the package by allowing executables by specifying `--allow-exec`
+command line flag as shown below.
+
+```shell
+$ kpt fn render [PKG_DIR] --allow-exec
+```
+
+Using `exec` is not recommended for two reasons:
+
+- It makes the package non-portable since rendering the package requires the
+  executables to be present on the system.
+- Executing binaries is not very secure since they can perform privileged operations
+  on the system.
 
 ## Specifying `functionConfig`
 

--- a/site/reference/cli/fn/render/README.md
+++ b/site/reference/cli/fn/render/README.md
@@ -48,6 +48,11 @@ PKG_PATH:
 #### Flags
 
 ```
+--allow-exec:
+  Allow executable binaries to run as function. Note that executable binaries
+  can perform privileged operations on your system, so ensure that binaries
+  referred in the pipeline are trusted and safe to execute.
+
 --image-pull-policy:
   If the image should be pulled before rendering the package(s). It can be set
   to one of always, ifNotPresent, never. If unspecified, always will be the


### PR DESCRIPTION
This PR adds end-user documentation for running executable binaries as functions during `fn render`.