### PR TITLE
fix: check correct docker version is installed

### DIFF
--- a/internal/util/cmdutil/cmdutil_test.go
+++ b/internal/util/cmdutil/cmdutil_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 )
 
@@ -351,4 +352,44 @@ func TestListImages(t *testing.T) {
 }`)
 	sort.Strings(result)
 	assert.Equal(t, []string{"apply-setters:v0.1.1", "gatekeeper:v0.2.1"}, result)
+}
+
+func TestIsSupportedDockerVersion(t *testing.T) {
+	tests := []struct {
+		name   string
+		inputV string
+		errMsg string
+	}{
+		{
+			name:   "greater than min version",
+			inputV: "20.10.1",
+		},
+		{
+			name:   "equal to min version",
+			inputV: "20.10.0",
+		},
+		{
+			name:   "less than min version",
+			inputV: "20.9.1",
+			errMsg: "docker client version must be v20.10.0 or greater: found v20.9.1",
+		},
+		{
+			name:   "invalid semver",
+			inputV: "20..12.1",
+			errMsg: "docker client version must be v20.10.0 or greater: found invalid version v20..12.1",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			require := require.New(t)
+			err := isSupportedDockerVersion(tt.inputV)
+			if tt.errMsg != "" {
+				require.NotNil(err)
+				require.Contains(err.Error(), tt.errMsg)
+			} else {
+				require.NoError(err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Previously if docker client was less than [20.10.0](https://docs.docker.com/engine/release-notes/#client-7), kpt would error out with ` "unknown flag: --pull"`. This improves the error message by validating that docker version is >= `20.10.0` before proceeding with any fn executions.