### PR TITLE
docs: update kpt completion docs

### DIFF
--- a/site/installation/README.md
+++ b/site/installation/README.md
@@ -32,41 +32,23 @@ $ kpt version
 kpt provides auto-completion support for several of the common shells.
 To see the options for enabling shell auto-completion:
 ```shell
-kpt completion -h
+$ kpt completion -h
 ```
 
 ### Prerequisites
-`kpt` depends on `bash-completion` in order to support auto-completion for the
-bash shell. If you are using bash as your shell, you will need to install
-`bash-completion` in order to use kpt's auto-completion feature.
-`bash-completion` is provided by many package managers
-(see [here][bash-completion]).
+Previous installations of kpt completion may have added the following line to
+the shell's config file (e.g. `.bashrc`, `.zshrc`, etc.):
+```shell
+complete -C <KPT_PATH> kpt
+```
+This line needs to be removed for kpt's completion implementation to function
+properly.
 
 ### Enable kpt auto-completion
 The kpt completion script for a shell can be generated with the commands
-`kpt completion bash`, `kpt completion zsh`, etc. Sourcing the completion script
-in your shell enables auto-completion.
-
-#### Enable auto-completion for your current shell
-bash:
-```shell
-source <(kpt completion bash)
-```
-zsh:
-```shell
-source <(kpt completion zsh)
-```
-etc.
-#### Enable kpt completion for all your shell sessions
-bash:
-```shell
-echo 'source <(kpt completion bash)' >> ~/.bashrc
-```
-zsh:
-```shell
-echo 'source <(kpt completion zsh)' >> ~/.zshrc
-```
-etc.
+`kpt completion bash`, `kpt completion zsh`, etc.
+For instructions on how to enable the script for the given shell, see the help
+page with the commands `kpt completion bash -h`, `kpt completion zsh -h`, etc.
 
 <!-- gcloud and homebrew are not yet available for builds from the main branch.
 ## gcloud


### PR DESCRIPTION
This change makes two key updates to the completion docs:
- Provide instructions to remove an artifact of previous installations
which breaks kpt completion functionality. This issue was reported by a
user of kpt.
- Direct the user to the help command for per-shell instructions to
enable kpt completion. Since the completion functionality is provided by
a third party library (cobra), this ensures the user is provided with
accurate and up to date instructions.
