### PR TITLE
PackageDraft interface should not inherit from Package

### DIFF
--- a/porch/repository/pkg/repository/repository.go
+++ b/porch/repository/pkg/repository/repository.go
@@ -39,8 +39,7 @@ type PackageRevision interface {
 }
 
 type PackageDraft interface {
-	PackageRevision
-	UpdateResources(ctx context.Context, new *v1alpha1.PackageRevisionResources, change *v1alpha1.Task) error
+	UpdateResources(ctx context.Context, new *v1alpha1.PackageRevisionResources, task *v1alpha1.Task) error
 	// Finish round of updates.
 	Close(ctx context.Context) (PackageRevision, error)
 }


### PR DESCRIPTION
In particular, some of the methods such as GetResources are ambiguous until we finish the draft (do we want the in-progress resources or the upstream resources?)