### PR TITLE
Minor fixups to better surface errors

### DIFF
--- a/porch/README.md
+++ b/porch/README.md
@@ -161,7 +161,7 @@ kubectl api-resources
 kubectl get packagerevisions --namespace default
 ```
 
-Follow the instructions above on how to register repositories and discover packges.
+Follow the instructions above on how to register repositories and discover packages.
 
 ### Running Locally
 

--- a/porch/engine/pkg/engine/clone.go
+++ b/porch/engine/pkg/engine/clone.go
@@ -76,7 +76,7 @@ func (m *clonePackageMutation) cloneFromGit(ctx context.Context, gitPackage *api
 
 	revision, lock, err := r.GetPackage(gitPackage.Ref, gitPackage.Directory)
 	if err != nil {
-		return repository.PackageResources{}, fmt.Errorf("cannot find packge %s@%s: %w", gitPackage.Directory, gitPackage.Ref, err)
+		return repository.PackageResources{}, fmt.Errorf("cannot find package %s@%s: %w", gitPackage.Directory, gitPackage.Ref, err)
 	}
 
 	resources, err := revision.GetResources(ctx)

--- a/porch/repository/pkg/git/git.go
+++ b/porch/repository/pkg/git/git.go
@@ -72,7 +72,7 @@ func OpenRepository(name, namespace string, spec *configapi.GitRepository, authO
 		repo = r
 	} else if !fi.IsDir() {
 		// Internal error - corrupted cache.
-		return nil, fmt.Errorf("cannot clone git repository: %q", spec.Repo)
+		return nil, fmt.Errorf("cannot clone git repository %q: %w", spec.Repo, err)
 	} else {
 		r, err := gogit.PlainOpen(dir)
 		if err != nil {
@@ -81,7 +81,7 @@ func OpenRepository(name, namespace string, spec *configapi.GitRepository, authO
 
 		remotes, err := r.Remotes()
 		if err != nil {
-			return nil, fmt.Errorf("cannot list remotes in %q", spec.Repo)
+			return nil, fmt.Errorf("cannot list remotes in %q: %w", spec.Repo, err)
 		}
 
 		found := false
@@ -97,7 +97,7 @@ func OpenRepository(name, namespace string, spec *configapi.GitRepository, authO
 		}
 		if !found {
 			// TODO: add remote?
-			return nil, fmt.Errorf("cannot clone git repository: %q", spec.Repo)
+			return nil, fmt.Errorf("cannot clone git repository (remote not found): %q", spec.Repo)
 		}
 		repo = r
 	}


### PR DESCRIPTION
In general, we should always return the error, unless we actually want
to mask it e.g. for security reasons (and in that case, we would
normally expect to log the underlying error instead of wrapping).
