### PR TITLE
Ensure release license file exists

### DIFF
--- a/scripts/create-licenses.sh
+++ b/scripts/create-licenses.sh
@@ -237,8 +237,12 @@ done >> ${TMP_LICENSE_FILE}
 
 cat ${TMP_LICENSE_FILE} > ${VENDOR_LICENSE_FILE}
 
+# initialize zip file to ensure existence (downstream builds depend on libs.zip)
+README="${KUBE_ROOT}/scripts/docs/create-licenses/README.md"
+zip -q "${ZIP_FILENAME}" "${README}"
+
 # Create a package of Mozilla repository source code (only go code).
-[ -n "$mozilla_repos" ] && zip -qr $ZIP_FILENAME $mozilla_repos -i '*.go'
+[ -n "$mozilla_repos" ] && zip -qur $ZIP_FILENAME $mozilla_repos -i '*.go'
 
 # Cleanup vendor directory
 rm -rf vendor

--- a/scripts/create-licenses.sh
+++ b/scripts/create-licenses.sh
@@ -168,7 +168,7 @@ V2_LICENSE_DIR="vendor/github.com/cpuguy83/go-md2man"
 mv ${V2_LICENSE_DIR}/v2/LICENSE ${V2_LICENSE_DIR}
 
 # Loop through every vendored package
-mozilla_repos=""
+mozilla_repos=()
 for PACKAGE in $(go list -mod=mod -m -json all | jq -r .Path | sort -f); do
   if [[ -e "staging/src/${PACKAGE}" ]]; then
     # echo "$PACKAGE is a staging package, skipping" > /dev/stderr
@@ -224,7 +224,7 @@ __EOF__
   license=$(cat "${file}")
   if [[ "$license" == *"Mozilla"* ]]
   then
-    mozilla_repos+=" ${DEPS_DIR}/${PACKAGE}"
+    mozilla_repos+=("${DEPS_DIR}/${PACKAGE}")
   fi
 
   cat ${file}
@@ -242,7 +242,7 @@ README="${KUBE_ROOT}/scripts/docs/create-licenses/README.md"
 zip -q "${ZIP_FILENAME}" "${README}"
 
 # Create a package of Mozilla repository source code (only go code).
-[ -n "$mozilla_repos" ] && zip -qur $ZIP_FILENAME $mozilla_repos -i '*.go'
+[ ${#mozilla_repos[@]} != 0 ] && zip -qur "${ZIP_FILENAME}" "${mozilla_repos[@]}" -i '*.go'
 
 # Cleanup vendor directory
 rm -rf vendor

--- a/scripts/docs/create-licenses/README.md
+++ b/scripts/docs/create-licenses/README.md
@@ -1,0 +1,5 @@
+# create-licenses
+
+This file is intended to be included with the `libs.zip` file that is
+distributed with each `kpt` release. The `libs.zip` file contains a packaging of
+source files necessary to satisfy the Mozilla license.


### PR DESCRIPTION
* ci: ensure existence of lib.zip for releases
ensure existence of the lib.zip file for downstream releases. This is
done by creating an empty zip file and updating it with mozilla_repos if
mozilla_repos is not empty.

* ci: use array for mozilla_repos
Update mozilla_repos to use an array rather than a string with space
delimited elements. This is intended to provide a more straightforward
type for storing a list of elements as well as provide more explicit
word splitting in line with SC2086.


I am open to feedback for alternatives to an empty zip file, e.g. the base zip file contains a README or a dummy go file