### PR TITLE
Expose Renderer api with FileSystem abstraction

### DIFF
--- a/internal/cmddiff/cmddiff.go
+++ b/internal/cmddiff/cmddiff.go
@@ -25,7 +25,9 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/util/argutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/diff"
+	"github.com/GoogleContainerTools/kpt/internal/util/pathutil"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 // NewRunner returns a command runner.
@@ -100,7 +102,12 @@ func (r *Runner) preRunE(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	p, err := pkg.New(resolvedPath)
+	absResolvedPath, _, err := pathutil.ResolveAbsAndRelPaths(resolvedPath)
+	if err != nil {
+		return err
+	}
+
+	p, err := pkg.New(filesys.FileSystemOrOnDisk{}, absResolvedPath)
 	if err != nil {
 		return err
 	}

--- a/internal/cmdget/cmdget.go
+++ b/internal/cmdget/cmdget.go
@@ -28,9 +28,11 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/get"
 	"github.com/GoogleContainerTools/kpt/internal/util/parse"
+	"github.com/GoogleContainerTools/kpt/internal/util/pathutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/remote"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 // NewRunner returns a command runner
@@ -100,7 +102,12 @@ func (r *Runner) preRunE(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	p, err := pkg.New(destination)
+	absDestPath, _, err := pathutil.ResolveAbsAndRelPaths(destination)
+	if err != nil {
+		return err
+	}
+
+	p, err := pkg.New(filesys.FileSystemOrOnDisk{}, absDestPath)
 	if err != nil {
 		return errors.E(op, types.UniquePath(destination), err)
 	}

--- a/internal/cmdinit/cmdinit.go
+++ b/internal/cmdinit/cmdinit.go
@@ -29,9 +29,11 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/man"
+	"github.com/GoogleContainerTools/kpt/internal/util/pathutil"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/kyaml/errors"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
@@ -75,7 +77,12 @@ func (r *Runner) runE(c *cobra.Command, args []string) error {
 	if len(args) == 0 {
 		args = append(args, pkg.CurDir)
 	}
-	p, err := pkg.New(args[0])
+
+	absPath, _, err := pathutil.ResolveAbsAndRelPaths(args[0])
+	if err != nil {
+		return err
+	}
+	p, err := pkg.New(filesys.FileSystemOrOnDisk{}, absPath)
 	if err != nil {
 		return err
 	}

--- a/internal/cmdliveinit/cmdliveinit_test.go
+++ b/internal/cmdliveinit/cmdliveinit_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 var (
@@ -225,7 +226,7 @@ func TestCmd_Run(t *testing.T) {
 
 			// Otherwise, validate the kptfile values
 			assert.NoError(t, err)
-			kf, err := pkg.ReadKptfile(w.WorkspaceDirectory)
+			kf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, w.WorkspaceDirectory)
 			assert.NoError(t, err)
 			if !assert.NotNil(t, kf.Inventory) {
 				t.FailNow()

--- a/internal/cmdmigrate/migratecmd.go
+++ b/internal/cmdmigrate/migratecmd.go
@@ -16,6 +16,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/docs/generated/livedocs"
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	"github.com/GoogleContainerTools/kpt/internal/util/argutil"
+	"github.com/GoogleContainerTools/kpt/internal/util/pathutil"
 	"github.com/GoogleContainerTools/kpt/pkg/live"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -27,6 +28,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/manifestreader"
 	"sigs.k8s.io/cli-utils/pkg/object"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 // MigrateRunner encapsulates fields for the kpt migrate command.
@@ -194,7 +196,11 @@ func (mr *MigrateRunner) applyCRD() error {
 func (mr *MigrateRunner) updateKptfile(ctx context.Context, args []string, prevID string) error {
 	fmt.Fprint(mr.ioStreams.Out, "  updating Kptfile inventory values...")
 	if !mr.dryRun {
-		p, err := pkg.New(args[0])
+		absPath, _, err := pathutil.ResolveAbsAndRelPaths(args[0])
+		if err != nil {
+			return err
+		}
+		p, err := pkg.New(filesys.FileSystemOrOnDisk{}, absPath)
 		if err != nil {
 			return err
 		}

--- a/internal/cmdmigrate/migratecmd_test.go
+++ b/internal/cmdmigrate/migratecmd_test.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/manifestreader"
 	"sigs.k8s.io/cli-utils/pkg/object"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 var testNamespace = "test-inventory-namespace"
@@ -157,7 +158,7 @@ func TestKptMigrate_updateKptfile(t *testing.T) {
 				return
 			}
 			assert.NoError(t, err)
-			kf, err := pkg.ReadKptfile(dir)
+			kf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, dir)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/internal/cmdpull/cmdpull.go
+++ b/internal/cmdpull/cmdpull.go
@@ -25,10 +25,12 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/util/argutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/parse"
+	"github.com/GoogleContainerTools/kpt/internal/util/pathutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/pull"
 	"github.com/GoogleContainerTools/kpt/internal/util/remote"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 // NewRunner returns a command runner
@@ -89,7 +91,12 @@ func (r *Runner) preRunE(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	p, err := pkg.New(destination)
+	absDestPath, _, err := pathutil.ResolveAbsAndRelPaths(destination)
+	if err != nil {
+		return err
+	}
+
+	p, err := pkg.New(filesys.FileSystemOrOnDisk{}, absDestPath)
 	if err != nil {
 		return errors.E(op, types.UniquePath(destination), err)
 	}

--- a/internal/cmdpush/cmdpush.go
+++ b/internal/cmdpush/cmdpush.go
@@ -28,10 +28,12 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/util/argutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/parse"
+	"github.com/GoogleContainerTools/kpt/internal/util/pathutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/push"
 	"github.com/GoogleContainerTools/kpt/internal/util/remote"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 // NewRunner returns a command runner
@@ -107,8 +109,11 @@ func (r *Runner) preRunE(_ *cobra.Command, args []string) error {
 	}
 
 	r.Push.Increment = r.Increment
-
-	r.Push.Pkg, err = pkg.New(resolvedPath)
+	absResolvedPath, _, err := pathutil.ResolveAbsAndRelPaths(resolvedPath)
+	if err != nil {
+		return err
+	}
+	r.Push.Pkg, err = pkg.New(filesys.FileSystemOrOnDisk{}, absResolvedPath)
 	if err != nil {
 		return errors.E(op, err)
 	}

--- a/internal/cmdrender/cmdrender.go
+++ b/internal/cmdrender/cmdrender.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/util/argutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/pathutil"
+	"github.com/GoogleContainerTools/kpt/internal/util/render"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
@@ -114,7 +115,7 @@ func (r *Runner) runE(c *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	executor := Render{
+	executor := render.Render{
 		PkgPath:         absPkgPath,
 		ResultsDirPath:  r.resultsDirPath,
 		Output:          output,

--- a/internal/cmdrender/cmdrender.go
+++ b/internal/cmdrender/cmdrender.go
@@ -114,7 +114,7 @@ func (r *Runner) runE(c *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	executor := Renderer{
+	executor := Render{
 		PkgPath:         absPkgPath,
 		ResultsDirPath:  r.resultsDirPath,
 		Output:          output,

--- a/internal/cmdrender/cmdrender.go
+++ b/internal/cmdrender/cmdrender.go
@@ -108,7 +108,7 @@ func (r *Runner) runE(c *cobra.Command, _ []string) error {
 		// capture the content to be written
 		output = &outContent
 	}
-	executor := Executor{
+	executor := Renderer{
 		PkgPath:         r.pkgPath,
 		ResultsDirPath:  r.resultsDirPath,
 		Output:          output,

--- a/internal/cmdrender/cmdrender.go
+++ b/internal/cmdrender/cmdrender.go
@@ -27,7 +27,9 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"github.com/GoogleContainerTools/kpt/internal/util/argutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
+	"github.com/GoogleContainerTools/kpt/internal/util/pathutil"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 // NewRunner returns a command runner
@@ -108,12 +110,17 @@ func (r *Runner) runE(c *cobra.Command, _ []string) error {
 		// capture the content to be written
 		output = &outContent
 	}
+	absPkgPath, _, err := pathutil.ResolveAbsAndRelPaths(r.pkgPath)
+	if err != nil {
+		return err
+	}
 	executor := Renderer{
-		PkgPath:         r.pkgPath,
+		PkgPath:         absPkgPath,
 		ResultsDirPath:  r.resultsDirPath,
 		Output:          output,
 		ImagePullPolicy: cmdutil.StringToImagePullPolicy(r.imagePullPolicy),
 		AllowExec:       r.allowExec,
+		FileSystem:      filesys.FileSystemOrOnDisk{},
 	}
 	if err := executor.Execute(r.ctx); err != nil {
 		return err

--- a/internal/cmdrender/cmdrender.go
+++ b/internal/cmdrender/cmdrender.go
@@ -115,7 +115,7 @@ func (r *Runner) runE(c *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
-	executor := render.Render{
+	executor := render.Renderer{
 		PkgPath:         absPkgPath,
 		ResultsDirPath:  r.resultsDirPath,
 		Output:          output,

--- a/internal/cmdrender/executor.go
+++ b/internal/cmdrender/executor.go
@@ -32,6 +32,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/util/printerutil"
 	fnresult "github.com/GoogleContainerTools/kpt/pkg/api/fnresult/v1"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 	"sigs.k8s.io/kustomize/kyaml/sets"
@@ -40,22 +41,35 @@ import (
 
 var errAllowedExecNotSpecified error = fmt.Errorf("must run with `--allow-exec` option to allow running function binaries")
 
-// Executor hydrates a given pkg.
-type Executor struct {
-	PkgPath         string
-	ResultsDirPath  string
-	Output          io.Writer
+// Renderer hydrates a given pkg by running the functions in the input pipeline
+type Renderer struct {
+	// PkgPath is the absolute path to the root package
+	PkgPath string
+
+	// ResultsDirPath is absolute path to the directory to write results
+	ResultsDirPath string
+
+	// Output is the writer to which the output resources are written
+	Output io.Writer
+
+	// ImagePullPolicy pull image before running the container.
+	// It must be one of fnruntime.AlwaysPull, fnruntime.IfNotPresentPull, fnruntime.NeverPull
 	ImagePullPolicy fnruntime.ImagePullPolicy
-	AllowExec       bool
+
+	// AllowExec allow binary executable to be run during pipeline execution
+	AllowExec bool
+
+	// FileSystem is the input filesystem to operate on
+	FileSystem filesys.FileSystem
 }
 
 // Execute runs a pipeline.
-func (e *Executor) Execute(ctx context.Context) error {
+func (e *Renderer) Execute(ctx context.Context) error {
 	const op errors.Op = "fn.render"
 
 	pr := printer.FromContextOrDie(ctx)
 
-	root, err := newPkgNode(e.PkgPath, nil)
+	root, err := newPkgNode(e.PkgPath, nil, e.FileSystem)
 	if err != nil {
 		return errors.E(op, types.UniquePath(e.PkgPath), err)
 	}
@@ -67,6 +81,7 @@ func (e *Executor) Execute(ctx context.Context) error {
 		fnResults:       fnresult.NewResultList(),
 		imagePullPolicy: e.ImagePullPolicy,
 		allowExec:       e.AllowExec,
+		fileSystem:      e.FileSystem,
 	}
 
 	if _, err = hydrate(ctx, root, hctx); err != nil {
@@ -100,6 +115,7 @@ func (e *Executor) Execute(ctx context.Context) error {
 			PackageFileName:    kptfilev1.KptFileName,
 			IncludeSubpackages: true,
 			WrapBareSeqNode:    true,
+			FileSystem:         filesys.FileSystemOrOnDisk{FileSystem: e.FileSystem},
 		}
 		err = pkgWriter.Write(hctx.root.resources)
 		if err != nil {
@@ -128,8 +144,8 @@ func (e *Executor) Execute(ctx context.Context) error {
 	return e.saveFnResults(ctx, hctx.fnResults)
 }
 
-func (e *Executor) saveFnResults(ctx context.Context, fnResults *fnresult.ResultList) error {
-	resultsFile, err := fnruntime.SaveResults(e.ResultsDirPath, fnResults)
+func (e *Renderer) saveFnResults(ctx context.Context, fnResults *fnresult.ResultList) error {
+	resultsFile, err := fnruntime.SaveResults(e.ResultsDirPath, fnResults, e.FileSystem)
 	if err != nil {
 		return fmt.Errorf("failed to save function results: %w", err)
 	}
@@ -176,6 +192,8 @@ type hydrationContext struct {
 	// bookkeeping to ensure docker command availability check is done once
 	// during rendering
 	dockerCheckDone bool
+
+	fileSystem filesys.FileSystem
 }
 
 //
@@ -193,14 +211,19 @@ type pkgNode struct {
 }
 
 // newPkgNode returns a pkgNode instance given a path or pkg.
-func newPkgNode(path string, p *pkg.Pkg) (pn *pkgNode, err error) {
+func newPkgNode(path string, p *pkg.Pkg, fs filesys.FileSystem) (pn *pkgNode, err error) {
 	const op errors.Op = "pkg.read"
 
 	if path == "" && p == nil {
 		return pn, fmt.Errorf("missing package path %s or package", path)
 	}
 	if path != "" {
-		p, err = pkg.New(path)
+		if fs == nil {
+			p, err = pkg.New(path)
+		} else {
+			// should take fs
+			p, err = pkg.NewWithFs(path, fs)
+		}
 		if err != nil {
 			return pn, errors.E(op, p.UniquePath, err)
 		}
@@ -280,7 +303,7 @@ func hydrate(ctx context.Context, pn *pkgNode, hctx *hydrationContext) (output [
 		var transitiveResources []*yaml.RNode
 		var subPkgNode *pkgNode
 
-		if subPkgNode, err = newPkgNode("", subpkg); err != nil {
+		if subPkgNode, err = newPkgNode("", subpkg, hctx.fileSystem); err != nil {
 			return output, errors.E(op, subpkg.UniquePath, err)
 		}
 

--- a/internal/cmdrender/executor.go
+++ b/internal/cmdrender/executor.go
@@ -218,12 +218,7 @@ func newPkgNode(path string, p *pkg.Pkg, fs filesys.FileSystem) (pn *pkgNode, er
 		return pn, fmt.Errorf("missing package path %s or package", path)
 	}
 	if path != "" {
-		if fs == nil {
-			p, err = pkg.New(path)
-		} else {
-			// should take fs
-			p, err = pkg.NewWithFs(path, fs)
-		}
+		p, err = pkg.New(fs, path)
 		if err != nil {
 			return pn, errors.E(op, p.UniquePath, err)
 		}

--- a/internal/cmdrender/executor.go
+++ b/internal/cmdrender/executor.go
@@ -41,8 +41,8 @@ import (
 
 var errAllowedExecNotSpecified error = fmt.Errorf("must run with `--allow-exec` option to allow running function binaries")
 
-// Renderer hydrates a given pkg by running the functions in the input pipeline
-type Renderer struct {
+// Render hydrates a given pkg by running the functions in the input pipeline
+type Render struct {
 	// PkgPath is the absolute path to the root package
 	PkgPath string
 
@@ -64,7 +64,7 @@ type Renderer struct {
 }
 
 // Execute runs a pipeline.
-func (e *Renderer) Execute(ctx context.Context) error {
+func (e *Render) Execute(ctx context.Context) error {
 	const op errors.Op = "fn.render"
 
 	pr := printer.FromContextOrDie(ctx)
@@ -144,7 +144,7 @@ func (e *Renderer) Execute(ctx context.Context) error {
 	return e.saveFnResults(ctx, hctx.fnResults)
 }
 
-func (e *Renderer) saveFnResults(ctx context.Context, fnResults *fnresult.ResultList) error {
+func (e *Render) saveFnResults(ctx context.Context, fnResults *fnresult.ResultList) error {
 	resultsFile, err := fnruntime.SaveResults(e.ResultsDirPath, fnResults, e.FileSystem)
 	if err != nil {
 		return fmt.Errorf("failed to save function results: %w", err)

--- a/internal/cmdupdate/cmdupdate.go
+++ b/internal/cmdupdate/cmdupdate.go
@@ -28,9 +28,11 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/types"
 	"github.com/GoogleContainerTools/kpt/internal/util/argutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
+	"github.com/GoogleContainerTools/kpt/internal/util/pathutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/update"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 // NewRunner returns a command runner.
@@ -94,8 +96,11 @@ func (r *Runner) preRunE(_ *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-
-	p, err := pkg.New(resolvedPath)
+	absResolvedPath, _, err := pathutil.ResolveAbsAndRelPaths(resolvedPath)
+	if err != nil {
+		return err
+	}
+	p, err := pkg.New(filesys.FileSystemOrOnDisk{}, absResolvedPath)
 	if err != nil {
 		return errors.E(op, err)
 	}

--- a/internal/fnruntime/utils.go
+++ b/internal/fnruntime/utils.go
@@ -17,7 +17,6 @@ package fnruntime
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"path/filepath"
 
 	"github.com/GoogleContainerTools/kpt/internal/types"
@@ -47,11 +46,7 @@ func SaveResults(resultsDir string, fnResults *fnresult.ResultList, fsys filesys
 		return "", err
 	}
 
-	if fsys == nil {
-		err = ioutil.WriteFile(filePath, out.Bytes(), 0744)
-	} else {
-		err = fsys.WriteFile(filePath, out.Bytes())
-	}
+	err = fsys.WriteFile(filePath, out.Bytes())
 	if err != nil {
 		return "", err
 	}

--- a/internal/fnruntime/utils.go
+++ b/internal/fnruntime/utils.go
@@ -23,6 +23,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/types"
 	fnresult "github.com/GoogleContainerTools/kpt/pkg/api/fnresult/v1"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
@@ -32,7 +33,7 @@ import (
 const ResourceIDAnnotation = "internal.config.k8s.io/kpt-resource-id"
 
 // SaveResults saves results gathered from running the pipeline at specified dir.
-func SaveResults(resultsDir string, fnResults *fnresult.ResultList) (string, error) {
+func SaveResults(resultsDir string, fnResults *fnresult.ResultList, fsys filesys.FileSystem) (string, error) {
 	if resultsDir == "" {
 		return "", nil
 	}
@@ -46,7 +47,11 @@ func SaveResults(resultsDir string, fnResults *fnresult.ResultList) (string, err
 		return "", err
 	}
 
-	err = ioutil.WriteFile(filePath, out.Bytes(), 0744)
+	if fsys == nil {
+		err = ioutil.WriteFile(filePath, out.Bytes(), 0744)
+	} else {
+		err = fsys.WriteFile(filePath, out.Bytes())
+	}
 	if err != nil {
 		return "", err
 	}

--- a/internal/fnruntime/utils.go
+++ b/internal/fnruntime/utils.go
@@ -31,8 +31,8 @@ import (
 // kpt during round trip and should be deleted after that
 const ResourceIDAnnotation = "internal.config.k8s.io/kpt-resource-id"
 
-// SaveResults saves results gathered from running the pipeline at specified dir.
-func SaveResults(resultsDir string, fnResults *fnresult.ResultList, fsys filesys.FileSystem) (string, error) {
+// SaveResults saves results gathered from running the pipeline at specified dir in the input FileSystem.
+func SaveResults(fsys filesys.FileSystem, resultsDir string, fnResults *fnresult.ResultList) (string, error) {
 	if resultsDir == "" {
 		return "", nil
 	}

--- a/internal/pkg/pkg_test.go
+++ b/internal/pkg/pkg_test.go
@@ -25,8 +25,10 @@ import (
 
 	"github.com/GoogleContainerTools/kpt/internal/testutil/pkgbuilder"
 	"github.com/GoogleContainerTools/kpt/internal/types"
+	"github.com/GoogleContainerTools/kpt/internal/util/pathutil"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
@@ -82,7 +84,9 @@ func TestNewPkg(t *testing.T) {
 			assert.NoError(t, err)
 			revert := Chdir(t, filepath.Join(dir, test.workingDir))
 			defer revert()
-			p, err := New(test.inputPath)
+			absInputPath, _, err := pathutil.ResolveAbsAndRelPaths(test.inputPath)
+			assert.NoError(t, err)
+			p, err := New(filesys.FileSystemOrOnDisk{}, absInputPath)
 			assert.NoError(t, err)
 			assert.Equal(t, test.displayPath, string(p.DisplayPath))
 		})
@@ -166,14 +170,20 @@ func TestAdjustDisplayPathForSubpkg(t *testing.T) {
 			assert.NoError(t, err)
 			revert := Chdir(t, filepath.Join(dir, "rootPkgParentDir", test.workingDir))
 			defer revert()
-			parent, err := New(test.pkgPath)
+			absPkgPath, _, err := pathutil.ResolveAbsAndRelPaths(test.pkgPath)
+			assert.NoError(t, err)
+			parent, err := New(filesys.FileSystemOrOnDisk{}, absPkgPath)
 			assert.NoError(t, err)
 			if test.rootPkgParentDirPath != "" {
-				rootPkg, err := New(test.rootPkgParentDirPath)
+				absRootPkgPath, _, err := pathutil.ResolveAbsAndRelPaths(test.rootPkgParentDirPath)
+				assert.NoError(t, err)
+				rootPkg, err := New(filesys.FileSystemOrOnDisk{}, absRootPkgPath)
 				assert.NoError(t, err)
 				parent.rootPkgParentDirPath = string(rootPkg.UniquePath)
 			}
-			subPkg, err := New(test.subPkgPath)
+			absSubPkgPath, _, err := pathutil.ResolveAbsAndRelPaths(test.subPkgPath)
+			assert.NoError(t, err)
+			subPkg, err := New(filesys.FileSystemOrOnDisk{}, absSubPkgPath)
 			assert.NoError(t, err)
 			err = parent.adjustDisplayPathForSubpkg(subPkg)
 			assert.NoError(t, err)
@@ -407,7 +417,11 @@ func TestDirectSubpackages(t *testing.T) {
 		t.Run(tn, func(t *testing.T) {
 			pkgPath := tc.pkg.ExpandPkg(t, nil)
 			defer os.RemoveAll(pkgPath)
-			p, err := New(pkgPath)
+			absPkgPath, _, err := pathutil.ResolveAbsAndRelPaths(pkgPath)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+			p, err := New(filesys.FileSystemOrOnDisk{}, absPkgPath)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}
@@ -593,7 +607,7 @@ func TestSubpackages(t *testing.T) {
 				for _, matcher := range v.matcher {
 					for _, recursive := range v.recursive {
 						t.Run(fmt.Sprintf("matcher:%s-recursive:%t", matcher, recursive), func(t *testing.T) {
-							paths, err := Subpackages(pkgPath, matcher, recursive)
+							paths, err := Subpackages(filesys.FileSystemOrOnDisk{}, pkgPath, matcher, recursive)
 							if !assert.NoError(t, err) {
 								t.FailNow()
 							}
@@ -636,7 +650,7 @@ func TestSubpackages_symlinks(t *testing.T) {
 		t.FailNow()
 	}
 
-	paths, err := Subpackages(pkgPath, All, true)
+	paths, err := Subpackages(filesys.FileSystemOrOnDisk{}, pkgPath, All, true)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/internal/pkg/pkg_test.go
+++ b/internal/pkg/pkg_test.go
@@ -773,7 +773,7 @@ func TestFunctionConfigFilePaths(t *testing.T) {
 			for _, v := range tc.cases {
 				v := v
 				t.Run(fmt.Sprintf("recursive:%t", v.recursive), func(t *testing.T) {
-					paths, err := FunctionConfigFilePaths(types.UniquePath(pkgPath), v.recursive)
+					paths, err := FunctionConfigFilePaths(filesys.FileSystemOrOnDisk{}, types.UniquePath(pkgPath), v.recursive)
 					if !assert.NoError(t, err) {
 						t.FailNow()
 					}

--- a/internal/pkg/testing/helpers.go
+++ b/internal/pkg/testing/helpers.go
@@ -18,13 +18,19 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
+	"github.com/GoogleContainerTools/kpt/internal/util/pathutil"
 	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 // CreatePkgOrFail creates a new package from the provided path. Unlike the
 // pkg.New function, it fails the test instead of returning an error.
 func CreatePkgOrFail(t *testing.T, path string) *pkg.Pkg {
-	p, err := pkg.New(path)
+	absPath, _, err := pathutil.ResolveAbsAndRelPaths(path)
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	p, err := pkg.New(filesys.FileSystemOrOnDisk{}, absPath)
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -38,6 +38,7 @@ import (
 	assertnow "gotest.tools/assert"
 	"sigs.k8s.io/kustomize/kyaml/copyutil"
 	"sigs.k8s.io/kustomize/kyaml/errors"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/sets"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
@@ -129,11 +130,11 @@ func KptfileAwarePkgEqual(t *testing.T, pkg1, pkg2 string, addMergeCommentsToSou
 
 		// Read the Kptfiles and set the Commit field to an empty
 		// string before we compare.
-		pkg1kf, err := pkg.ReadKptfile(filepath.Dir(pkg1Path))
+		pkg1kf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Dir(pkg1Path))
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}
-		pkg2kf, err := pkg.ReadKptfile(filepath.Dir(pkg2Path))
+		pkg2kf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Dir(pkg2Path))
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}
@@ -641,12 +642,12 @@ func replaceData(repo, data string) error {
 		// For Kptfiles we want to keep the Upstream section if the Kptfile
 		// in the data directory doesn't already include one.
 		if filepath.Base(path) == "Kptfile" {
-			dataKptfile, err := pkg.ReadKptfile(filepath.Dir(path))
+			dataKptfile, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Dir(path))
 			if err != nil {
 				return err
 			}
 			repoKptfileDir := filepath.Dir(filepath.Join(repo, rel))
-			repoKptfile, err := pkg.ReadKptfile(repoKptfileDir)
+			repoKptfile, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, repoKptfileDir)
 			if err != nil {
 				return err
 			}

--- a/internal/util/cmdutil/cmdutil.go
+++ b/internal/util/cmdutil/cmdutil.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -62,32 +61,6 @@ func PrintErrorStacktrace() bool {
 
 // StackOnError if true, will print a stack trace on failure.
 var StackOnError bool
-
-func ResolveAbsAndRelPaths(path string) (string, string, error) {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return "", "", err
-	}
-
-	var relPath string
-	var absPath string
-	if filepath.IsAbs(path) {
-		// If the provided path is absolute, we find the relative path by
-		// comparing it to the current working directory.
-		relPath, err = filepath.Rel(cwd, path)
-		if err != nil {
-			return "", "", err
-		}
-		absPath = filepath.Clean(path)
-	} else {
-		// If the provided path is relative, we find the absolute path by
-		// combining the current working directory with the relative path.
-		relPath = filepath.Clean(path)
-		absPath = filepath.Join(cwd, path)
-	}
-
-	return relPath, absPath, nil
-}
 
 // DockerCmdAvailable runs `docker version` to check that the docker command is
 // available and is a supported version. Returns an error with installation

--- a/internal/util/diff/diff.go
+++ b/internal/util/diff/diff.go
@@ -32,6 +32,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/util/remote"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"sigs.k8s.io/kustomize/kyaml/errors"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 // DiffType represents type of comparison to be performed.
@@ -117,7 +118,7 @@ type Command struct {
 func (c *Command) Run(ctx context.Context) error {
 	c.DefaultValues()
 
-	kptFile, err := pkg.ReadKptfile(c.Path)
+	kptFile, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, c.Path)
 	if err != nil {
 		return errors.Errorf("package missing Kptfile at '%s': %v", c.Path, err)
 	}

--- a/internal/util/diff/pkgdiff.go
+++ b/internal/util/diff/pkgdiff.go
@@ -24,6 +24,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/util/attribution"
 	"github.com/GoogleContainerTools/kpt/internal/util/pkgutil"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/sets"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
@@ -79,11 +80,11 @@ func PkgDiff(pkg1, pkg2 string) (sets.String, error) {
 }
 
 func kptfilesEqual(pkg1, pkg2, filePath string) (bool, error) {
-	pkg1Kf, err := pkg.ReadKptfile(filepath.Join(pkg1, filepath.Dir(filePath)))
+	pkg1Kf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Join(pkg1, filepath.Dir(filePath)))
 	if err != nil {
 		return false, err
 	}
-	pkg2Kf, err := pkg.ReadKptfile(filepath.Join(pkg2, filepath.Dir(filePath)))
+	pkg2Kf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Join(pkg2, filepath.Dir(filePath)))
 	if err != nil {
 		return false, err
 	}

--- a/internal/util/fetch/fetch_test.go
+++ b/internal/util/fetch/fetch_test.go
@@ -28,6 +28,7 @@ import (
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
 	"github.com/stretchr/testify/assert"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
@@ -60,7 +61,7 @@ func createKptfile(workspace *testutil.TestWorkspace, git *kptfilev1.Git, strate
 }
 
 func setKptfileName(workspace *testutil.TestWorkspace, name string) error {
-	kf, err := pkg.ReadKptfile(workspace.FullPackagePath())
+	kf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, workspace.FullPackagePath())
 	if err != nil {
 		return err
 	}

--- a/internal/util/get/get.go
+++ b/internal/util/get/get.go
@@ -29,10 +29,12 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/util/addmergecomment"
 	"github.com/GoogleContainerTools/kpt/internal/util/attribution"
 	"github.com/GoogleContainerTools/kpt/internal/util/fetch"
+	"github.com/GoogleContainerTools/kpt/internal/util/pathutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/remote"
 	"github.com/GoogleContainerTools/kpt/internal/util/stack"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 )
 
@@ -84,7 +86,11 @@ func (c Command) Run(ctx context.Context) error {
 		return cleanUpDirAndError(c.Destination, err)
 	}
 
-	p, err := pkg.New(c.Destination)
+	absDestPath, _, err := pathutil.ResolveAbsAndRelPaths(c.Destination)
+	if err != nil {
+		return err
+	}
+	p, err := pkg.New(filesys.FileSystemOrOnDisk{}, absDestPath)
 	if err != nil {
 		return cleanUpDirAndError(c.Destination, err)
 	}

--- a/internal/util/man/man.go
+++ b/internal/util/man/man.go
@@ -29,6 +29,7 @@ import (
 	v1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/cpuguy83/go-md2man/v2/md2man"
 	"sigs.k8s.io/kustomize/kyaml/errors"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 // Command displays local package documentation as man pages.
@@ -58,7 +59,7 @@ func (m Command) Run() error {
 	}
 
 	// lookup the path to the man page
-	k, err := pkg.ReadKptfile(m.Path)
+	k, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, m.Path)
 	if err != nil {
 		return err
 	}

--- a/internal/util/pathutil/pathutil.go
+++ b/internal/util/pathutil/pathutil.go
@@ -1,0 +1,33 @@
+package pathutil
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// ResolveAbsAndRelPaths returns absolute and relative paths for input path
+func ResolveAbsAndRelPaths(path string) (string, string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", "", err
+	}
+
+	var relPath string
+	var absPath string
+	if filepath.IsAbs(path) {
+		// If the provided path is absolute, we find the relative path by
+		// comparing it to the current working directory.
+		relPath, err = filepath.Rel(cwd, path)
+		if err != nil {
+			return "", "", err
+		}
+		absPath = filepath.Clean(path)
+	} else {
+		// If the provided path is relative, we find the absolute path by
+		// combining the current working directory with the relative path.
+		relPath = filepath.Clean(path)
+		absPath = filepath.Join(cwd, path)
+	}
+
+	return absPath, relPath, nil
+}

--- a/internal/util/pkgutil/pkgutil.go
+++ b/internal/util/pkgutil/pkgutil.go
@@ -327,7 +327,7 @@ func RoundTripKptfilesInPkg(pkgPath string) error {
 	pkgsPaths = append(pkgsPaths, pkgPath)
 
 	for _, pkgPath := range pkgsPaths {
-		kf, err := pkg.ReadKptfile(pkgPath)
+		kf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, pkgPath)
 		if err != nil {
 			// do not throw error if formatting fails
 			return err

--- a/internal/util/pkgutil/pkgutil.go
+++ b/internal/util/pkgutil/pkgutil.go
@@ -26,6 +26,7 @@ import (
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
 	"sigs.k8s.io/kustomize/kyaml/copyutil"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/filters"
 )
@@ -69,7 +70,7 @@ func WalkPackage(src string, c func(string, os.FileInfo, error) error) error {
 // CopyPackage copies the content of a single package from src to dst. If includeSubpackages
 // is true, it will copy resources belonging to any subpackages.
 func CopyPackage(src, dst string, copyRootKptfile bool, matcher pkg.SubpackageMatcher) error {
-	subpackagesToCopy, err := pkg.Subpackages(src, matcher, true)
+	subpackagesToCopy, err := pkg.Subpackages(filesys.FileSystemOrOnDisk{}, src, matcher, true)
 	if err != nil {
 		return err
 	}
@@ -265,7 +266,7 @@ func SubPkgFirstSorter(paths []string) func(i, j int) bool {
 func FindSubpackagesForPaths(matcher pkg.SubpackageMatcher, recurse bool, pkgPaths ...string) ([]string, error) {
 	uniquePaths := make(map[string]bool)
 	for _, path := range pkgPaths {
-		paths, err := pkg.Subpackages(path, matcher, recurse)
+		paths, err := pkg.Subpackages(filesys.FileSystemOrOnDisk{}, path, matcher, recurse)
 		if err != nil {
 			return []string{}, err
 		}
@@ -312,7 +313,7 @@ func FormatPackage(pkgPath string) {
 // subpackages. This is used to format Kptfiles in the order of go structures
 // TODO: phanimarupaka remove this method after addressing https://github.com/GoogleContainerTools/kpt/issues/2052
 func RoundTripKptfilesInPkg(pkgPath string) error {
-	paths, err := pkg.Subpackages(pkgPath, pkg.All, true)
+	paths, err := pkg.Subpackages(filesys.FileSystemOrOnDisk{}, pkgPath, pkg.All, true)
 	if err != nil {
 		return err
 	}

--- a/internal/util/pull/pull.go
+++ b/internal/util/pull/pull.go
@@ -28,6 +28,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/types"
 	"github.com/GoogleContainerTools/kpt/internal/util/remote"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 // Command fetches a package from a git repository, copies it to a local
@@ -69,7 +70,7 @@ func (c Command) Run(ctx context.Context) error {
 
 	pr.Printf("Pulled digest %s\n", digest)
 
-	kf, err := pkg.ReadKptfile(c.Destination)
+	kf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, c.Destination)
 	if err != nil {
 		return errors.E(op, types.UniquePath(c.Destination), err)
 	}

--- a/internal/util/remote/git.go
+++ b/internal/util/remote/git.go
@@ -33,6 +33,7 @@ import (
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
 	"github.com/otiai10/copy"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 type gitUpstream struct {
@@ -356,7 +357,7 @@ func ClonerUsingGitExec(ctx context.Context, repoSpec *git.RepoSpec) error {
 
 	// Verify that if a Kptfile exists in the package, it contains the correct
 	// version of the Kptfile.
-	_, err = pkg.ReadKptfile(pkgPath)
+	_, err = pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, pkgPath)
 	if err != nil {
 		// A Kptfile isn't required, so it is fine if there is no Kptfile.
 		if errors.Is(err, os.ErrNotExist) {

--- a/internal/util/render/executor.go
+++ b/internal/util/render/executor.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmdrender
+package render
 
 import (
 	"context"

--- a/internal/util/render/executor_test.go
+++ b/internal/util/render/executor_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmdrender
+package render
 
 import (
 	"fmt"

--- a/internal/util/update/common.go
+++ b/internal/util/update/common.go
@@ -20,18 +20,19 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	"github.com/GoogleContainerTools/kpt/internal/types"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 // PkgHasUpdatedUpstream checks if the the local package has different
 // upstream information than origin.
 func PkgHasUpdatedUpstream(local, origin string) (bool, error) {
 	const op errors.Op = "update.PkgHasUpdatedUpstream"
-	originKf, err := pkg.ReadKptfile(origin)
+	originKf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, origin)
 	if err != nil {
 		return false, errors.E(op, types.UniquePath(local), err)
 	}
 
-	localKf, err := pkg.ReadKptfile(local)
+	localKf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, local)
 	if err != nil {
 		return false, errors.E(op, types.UniquePath(local), err)
 	}

--- a/internal/util/update/fastforward.go
+++ b/internal/util/update/fastforward.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/util/pkgutil"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/sets"
 )
 
@@ -116,7 +117,7 @@ func (u FastForwardUpdater) checkForLocalChanges(localPath, originalPath string)
 
 func hasKfDiff(localPath, orgPath string) (bool, error) {
 	const op errors.Op = "update.hasKfDiff"
-	localKf, err := pkg.ReadKptfile(localPath)
+	localKf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, localPath)
 	if err != nil {
 		return false, errors.E(op, types.UniquePath(localPath), err)
 	}
@@ -137,7 +138,7 @@ func hasKfDiff(localPath, orgPath string) (bool, error) {
 		}
 		return false, errors.E(op, types.UniquePath(localPath), err)
 	}
-	orgKf, err := pkg.ReadKptfile(orgPath)
+	orgKf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, orgPath)
 	if err != nil {
 		return false, errors.E(op, types.UniquePath(localPath), err)
 	}

--- a/internal/util/update/update.go
+++ b/internal/util/update/update.go
@@ -413,7 +413,7 @@ func (u Command) mergePackage(ctx context.Context, localPath, updatedPath, origi
 		// Both exists, so just go ahead as normal.
 	}
 
-	pkgKf, err := pkg.ReadKptfile(localPath)
+	pkgKf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, localPath)
 	if err != nil {
 		return errors.E(op, types.UniquePath(localPath), err)
 	}

--- a/internal/util/update/update.go
+++ b/internal/util/update/update.go
@@ -32,6 +32,7 @@ import (
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
 	"sigs.k8s.io/kustomize/kyaml/copyutil"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 // PkgNotGitRepoError is the error type returned if the package being updated is not inside
@@ -286,7 +287,7 @@ func (u Command) updatePackage(ctx context.Context, subPkgPath, localPath, updat
 	const op errors.Op = "update.updatePackage"
 	pr := printer.FromContextOrDie(ctx)
 
-	localExists, err := pkg.IsPackageDir(localPath)
+	localExists, err := pkg.IsPackageDir(filesys.FileSystemOrOnDisk{}, localPath)
 	if err != nil {
 		return errors.E(op, types.UniquePath(localPath), err)
 	}
@@ -295,7 +296,7 @@ func (u Command) updatePackage(ctx context.Context, subPkgPath, localPath, updat
 	// from updated and origin might not have a Kptfile at the root.
 	updatedExists := isRootPkg
 	if !isRootPkg {
-		updatedExists, err = pkg.IsPackageDir(updatedPath)
+		updatedExists, err = pkg.IsPackageDir(filesys.FileSystemOrOnDisk{}, updatedPath)
 		if err != nil {
 			return errors.E(op, types.UniquePath(localPath), err)
 		}
@@ -303,7 +304,7 @@ func (u Command) updatePackage(ctx context.Context, subPkgPath, localPath, updat
 
 	originExists := isRootPkg
 	if !isRootPkg {
-		originExists, err = pkg.IsPackageDir(originPath)
+		originExists, err = pkg.IsPackageDir(filesys.FileSystemOrOnDisk{}, originPath)
 		if err != nil {
 			return errors.E(op, types.UniquePath(localPath), err)
 		}

--- a/internal/util/update/update_test.go
+++ b/internal/util/update/update_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/kyaml/copyutil"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/filters"
 )
@@ -259,7 +260,7 @@ func TestCommand_Run_localPackageChanges(t *testing.T) {
 			expectedErr: "local package files have been modified",
 			expectedCommit: func(writer *testutil.TestSetupManager) (string, error) {
 				upstreamRepo := writer.Repos[testutil.Upstream]
-				f, err := pkg.ReadKptfile(filepath.Join(writer.LocalWorkspace.WorkspaceDirectory, upstreamRepo.RepoName))
+				f, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Join(writer.LocalWorkspace.WorkspaceDirectory, upstreamRepo.RepoName))
 				if err != nil {
 					return "", err
 				}
@@ -2037,7 +2038,7 @@ func TestCommand_Run_local_subpackages(t *testing.T) {
 
 				expectedPath := result.expectedLocal.ExpandPkgWithName(t,
 					g.LocalWorkspace.PackageDir, testutil.ToReposInfo(g.Repos))
-				kf, err := pkg.ReadKptfile(expectedPath)
+				kf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, expectedPath)
 				if !assert.NoError(t, err) {
 					t.FailNow()
 				}

--- a/pkg/kptfile/kptfileutil/util.go
+++ b/pkg/kptfile/kptfileutil/util.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/types"
 	"github.com/GoogleContainerTools/kpt/internal/util/git"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/sets"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 	"sigs.k8s.io/kustomize/kyaml/yaml/merge3"
@@ -131,7 +132,7 @@ func DefaultKptfile(name string) *kptfilev1.KptFile {
 // sections will also be copied into local.
 func UpdateKptfileWithoutOrigin(localPath, updatedPath string, updateUpstream bool) error {
 	const op errors.Op = "kptfileutil.UpdateKptfileWithoutOrigin"
-	localKf, err := pkg.ReadKptfile(localPath)
+	localKf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, localPath)
 	if err != nil {
 		if !goerrors.Is(err, os.ErrNotExist) {
 			return errors.E(op, types.UniquePath(localPath), err)
@@ -139,7 +140,7 @@ func UpdateKptfileWithoutOrigin(localPath, updatedPath string, updateUpstream bo
 		localKf = &kptfilev1.KptFile{}
 	}
 
-	updatedKf, err := pkg.ReadKptfile(updatedPath)
+	updatedKf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, updatedPath)
 	if err != nil {
 		if !goerrors.Is(err, os.ErrNotExist) {
 			return errors.E(op, types.UniquePath(updatedPath), err)
@@ -170,7 +171,7 @@ func UpdateKptfileWithoutOrigin(localPath, updatedPath string, updateUpstream bo
 // sections will also be copied into local.
 func UpdateKptfile(localPath, updatedPath, originPath string, updateUpstream bool) error {
 	const op errors.Op = "kptfileutil.UpdateKptfile"
-	localKf, err := pkg.ReadKptfile(localPath)
+	localKf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, localPath)
 	if err != nil {
 		if !goerrors.Is(err, os.ErrNotExist) {
 			return errors.E(op, types.UniquePath(localPath), err)
@@ -178,7 +179,7 @@ func UpdateKptfile(localPath, updatedPath, originPath string, updateUpstream boo
 		localKf = &kptfilev1.KptFile{}
 	}
 
-	updatedKf, err := pkg.ReadKptfile(updatedPath)
+	updatedKf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, updatedPath)
 	if err != nil {
 		if !goerrors.Is(err, os.ErrNotExist) {
 			return errors.E(op, types.UniquePath(localPath), err)
@@ -186,7 +187,7 @@ func UpdateKptfile(localPath, updatedPath, originPath string, updateUpstream boo
 		updatedKf = &kptfilev1.KptFile{}
 	}
 
-	originKf, err := pkg.ReadKptfile(originPath)
+	originKf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, originPath)
 	if err != nil {
 		if !goerrors.Is(err, os.ErrNotExist) {
 			return errors.E(op, types.UniquePath(localPath), err)
@@ -213,7 +214,7 @@ func UpdateKptfile(localPath, updatedPath, originPath string, updateUpstream boo
 func UpdateUpstreamLock(path string, upstreamLock *kptfilev1.UpstreamLock) error {
 	const op errors.Op = "kptfileutil.UpdateUpstreamLock"
 	// read KptFile cloned with the package if it exists
-	kptfile, err := pkg.ReadKptfile(path)
+	kptfile, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, path)
 	if err != nil {
 		return errors.E(op, types.UniquePath(path), err)
 	}

--- a/pkg/live/load.go
+++ b/pkg/live/load.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
+	"github.com/GoogleContainerTools/kpt/internal/util/pathutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/strings"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -29,6 +30,7 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/common"
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/manifestreader"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
@@ -147,7 +149,11 @@ func loadFromDisk(f util.Factory, path string) ([]*unstructured.Unstructured, kp
 }
 
 func readInvInfoFromDisk(path string) (kptfilev1.Inventory, error) {
-	p, err := pkg.New(path)
+	absPath, _, err := pathutil.ResolveAbsAndRelPaths(path)
+	if err != nil {
+		return kptfilev1.Inventory{}, err
+	}
+	p, err := pkg.New(filesys.FileSystemOrOnDisk{}, absPath)
 	if err != nil {
 		return kptfilev1.Inventory{}, err
 	}

--- a/pkg/live/rgpath.go
+++ b/pkg/live/rgpath.go
@@ -40,7 +40,7 @@ func (r *ResourceGroupPathManifestReader) Read() ([]*unstructured.Unstructured, 
 	}
 
 	// Lookup all files referenced by all subpackages.
-	fcPaths, err := pkg.FunctionConfigFilePaths(p.UniquePath, true)
+	fcPaths, err := pkg.FunctionConfigFilePaths(filesys.FileSystemOrOnDisk{}, p.UniquePath, true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/live/rgpath.go
+++ b/pkg/live/rgpath.go
@@ -7,8 +7,10 @@ import (
 	"encoding/json"
 
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
+	"github.com/GoogleContainerTools/kpt/internal/util/pathutil"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/cli-utils/pkg/manifestreader"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/filters"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
@@ -28,7 +30,11 @@ type ResourceGroupPathManifestReader struct {
 // Kptfile data. If unable to generate the ResourceGroup inventory
 // object from the Kptfile, it is NOT an error.
 func (r *ResourceGroupPathManifestReader) Read() ([]*unstructured.Unstructured, error) {
-	p, err := pkg.New(r.PkgPath)
+	absPkgPath, _, err := pathutil.ResolveAbsAndRelPaths(r.PkgPath)
+	if err != nil {
+		return nil, err
+	}
+	p, err := pkg.New(filesys.FileSystemOrOnDisk{}, absPkgPath)
 	if err != nil {
 		return nil, err
 	}

--- a/porch/apiserver/go.sum
+++ b/porch/apiserver/go.sum
@@ -520,6 +520,7 @@ github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -1104,6 +1105,7 @@ golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.5.0/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
+golang.org/x/mod v0.5.1 h1:OJxoQ/rynoF0dcCdI7cLPktw/hR2cueqYfjm43oqK38=
 golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/porch/engine/go.mod
+++ b/porch/engine/go.mod
@@ -46,7 +46,9 @@ require (
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/go-containerregistry v0.8.0 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -64,6 +66,8 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
+	github.com/spf13/cobra v1.3.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.7.0 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
@@ -72,6 +76,7 @@ require (
 	go.opentelemetry.io/otel/metric v0.20.0 // indirect
 	go.opentelemetry.io/otel/trace v0.20.0 // indirect
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
+	golang.org/x/mod v0.5.1 // indirect
 	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect

--- a/porch/engine/go.sum
+++ b/porch/engine/go.sum
@@ -496,6 +496,7 @@ github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -1031,6 +1032,7 @@ golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.5.0/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
+golang.org/x/mod v0.5.1 h1:OJxoQ/rynoF0dcCdI7cLPktw/hR2cueqYfjm43oqK38=
 golang.org/x/mod v0.5.1/go.mod h1:5OXOZSfqPIIbmVBIIKWRFfZjPR0E5r58TLhUjH0a2Ro=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/porch/engine/pkg/kpt/fs_test.go
+++ b/porch/engine/pkg/kpt/fs_test.go
@@ -124,6 +124,7 @@ spec:
 	}
 }
 
+// TODO: Make this test work by uncommenting the portions
 func TestMemFSRenderSubpkgs(t *testing.T) {
 	appResources := `apiVersion: apps/v1
 kind: Deployment

--- a/porch/engine/pkg/kpt/fs_test.go
+++ b/porch/engine/pkg/kpt/fs_test.go
@@ -14,7 +14,13 @@
 
 package kpt
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/GoogleContainerTools/kpt/internal/fnruntime"
+	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
+	"github.com/GoogleContainerTools/kpt/internal/util/render"
+)
 
 func TestMemFS(t *testing.T) {
 	fs := &memfs{}
@@ -33,4 +39,223 @@ func TestMemFS(t *testing.T) {
 	} else if got, want := string(res), "Hello World"; got != want {
 		t.Errorf("unexpected file contents: got %q, want %q", got, want)
 	}
+}
+
+func TestMemFSRenderBasicPipeline(t *testing.T) {
+	resources := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+spec:
+  image: nginx:1.2.3`
+
+	kptfile := `apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: app
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-namespace:v0.1.3
+      configMap:
+        namespace: staging
+    - image: gcr.io/kpt-fn/set-labels:v0.1.4
+      configMap:
+        tier: backend`
+
+	expectedResources := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: staging
+  labels:
+    tier: backend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      tier: backend
+  template:
+    metadata:
+      labels:
+        tier: backend
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+  namespace: staging
+  labels:
+    tier: backend
+spec:
+  image: nginx:1.2.3
+`
+
+	fs := &memfs{}
+	if err := fs.MkdirAll("a/b/c"); err != nil {
+		t.Errorf(`MkdirAll("a") failed %v`, err)
+	}
+	if err := fs.WriteFile("/a/b/c/resources.yaml", []byte(resources)); err != nil {
+		t.Errorf("Failed to write file: %v", err)
+	}
+	if err := fs.WriteFile("/a/b/c/Kptfile", []byte(kptfile)); err != nil {
+		t.Errorf("Failed to write file: %v", err)
+	}
+	r := render.Render{
+		PkgPath:         "/a/b/c",
+		ImagePullPolicy: fnruntime.IfNotPresentPull,
+		FileSystem:      fs,
+	}
+	err := r.Execute(fake.CtxWithDefaultPrinter())
+	if err != nil {
+		t.Errorf("Failed to render: %v", err)
+	}
+
+	if res, err := fs.ReadFile("/a/b/c/resources.yaml"); err != nil {
+		t.Errorf("Failed to read file: %v", err)
+	} else if got, want := string(res), expectedResources; got != want {
+		t.Errorf("unexpected file contents: got %q, want %q", got, want)
+	}
+}
+
+func TestMemFSRenderSubpkgs(t *testing.T) {
+	appResources := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+spec:
+  image: nginx:1.2.3`
+
+	appKptfile := `apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: app-with-db
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-namespace:v0.1.3
+      configMap:
+        namespace: staging
+    - image: gcr.io/kpt-fn/set-labels:v0.1.4
+      configMap:
+        tier: db`
+
+	/*dbResources := `apiVersion: apps/v1
+	kind: StatefulSet
+	metadata:
+	  name: db
+	spec:
+	  replicas: 3`
+
+		dbKptfile := `apiVersion: kpt.dev/v1
+	kind: Kptfile
+	metadata:
+	  name: db
+	pipeline:
+	  mutators:
+	    - image: gcr.io/kpt-fn/set-namespace:v0.1.3
+	      configMap:
+	        namespace: db
+	    - image: gcr.io/kpt-fn/set-labels:v0.1.4
+	      configMap:
+	        app: backend`*/
+
+	expectedAppResources := `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: staging
+  labels:
+    tier: db
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      tier: db
+  template:
+    metadata:
+      labels:
+        tier: db
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+  namespace: staging
+  labels:
+    tier: db
+spec:
+  image: nginx:1.2.3
+`
+	/*expectedDbResources := `apiVersion: apps/v1
+	kind: StatefulSet
+	metadata:
+	  name: db
+	  namespace: staging
+	  labels:
+	    tier: db
+	spec:
+	  replicas: 3
+	  selector:
+	    matchLabels:
+	      tier: db
+	  template:
+	    metadata:
+	      labels:
+	        tier: db
+	`*/
+
+	fs := &memfs{}
+	if err := fs.MkdirAll("app"); err != nil {
+		t.Errorf(`MkdirAll("a") failed %v`, err)
+	}
+	if err := fs.WriteFile("/app/resources.yaml", []byte(appResources)); err != nil {
+		t.Errorf("Failed to write file: %v", err)
+	}
+	if err := fs.WriteFile("/app/Kptfile", []byte(appKptfile)); err != nil {
+		t.Errorf("Failed to write file: %v", err)
+	}
+	/*if err := fs.WriteFile("/app/db/resources.yaml", []byte(dbResources)); err != nil {
+		t.Errorf("Failed to write file: %v", err)
+	}
+	if err := fs.WriteFile("/app/db/Kptfile", []byte(dbKptfile)); err != nil {
+		t.Errorf("Failed to write file: %v", err)
+	}*/
+
+	r := render.Render{
+		PkgPath:         "/app",
+		ImagePullPolicy: fnruntime.IfNotPresentPull,
+		FileSystem:      fs,
+	}
+	err := r.Execute(fake.CtxWithDefaultPrinter())
+	if err != nil {
+		t.Errorf("Failed to render: %v", err)
+	}
+
+	rr, _ := fs.ReadFile("/app/resources.yaml")
+	println(string(rr))
+
+	if res, err := fs.ReadFile("/app/resources.yaml"); err != nil {
+		t.Errorf("Failed to read file: %v", err)
+	} else if got, want := string(res), expectedAppResources; got != want {
+		t.Errorf("unexpected file contents: got %q, want %q", got, want)
+	}
+
+	/*if res, err := fs.ReadFile("/app/db/resources.yaml"); err != nil {
+		t.Errorf("Failed to read file: %v", err)
+	} else if got, want := string(res), expectedDbResources; got != want {
+		t.Errorf("unexpected file contents: got %q, want %q", got, want)
+	}*/
 }

--- a/porch/engine/pkg/kpt/fs_test.go
+++ b/porch/engine/pkg/kpt/fs_test.go
@@ -99,7 +99,7 @@ spec:
 
 	fs := &memfs{}
 	if err := fs.MkdirAll("a/b/c"); err != nil {
-		t.Errorf(`MkdirAll("a") failed %v`, err)
+		t.Errorf(`MkdirAll("a/b/c") failed %v`, err)
 	}
 	if err := fs.WriteFile("/a/b/c/resources.yaml", []byte(resources)); err != nil {
 		t.Errorf("Failed to write file: %v", err)
@@ -107,7 +107,7 @@ spec:
 	if err := fs.WriteFile("/a/b/c/Kptfile", []byte(kptfile)); err != nil {
 		t.Errorf("Failed to write file: %v", err)
 	}
-	r := render.Render{
+	r := render.Renderer{
 		PkgPath:         "/a/b/c",
 		ImagePullPolicy: fnruntime.IfNotPresentPull,
 		FileSystem:      fs,
@@ -220,7 +220,7 @@ spec:
 
 	fs := &memfs{}
 	if err := fs.MkdirAll("app"); err != nil {
-		t.Errorf(`MkdirAll("a") failed %v`, err)
+		t.Errorf(`MkdirAll("a/b/c") failed %v`, err)
 	}
 	if err := fs.WriteFile("/app/resources.yaml", []byte(appResources)); err != nil {
 		t.Errorf("Failed to write file: %v", err)
@@ -235,7 +235,7 @@ spec:
 		t.Errorf("Failed to write file: %v", err)
 	}*/
 
-	r := render.Render{
+	r := render.Renderer{
 		PkgPath:         "/app",
 		ImagePullPolicy: fnruntime.IfNotPresentPull,
 		FileSystem:      fs,

--- a/thirdparty/cmdconfig/commands/cmdsource/cmdsource.go
+++ b/thirdparty/cmdconfig/commands/cmdsource/cmdsource.go
@@ -17,6 +17,7 @@ import (
 	kptfile "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/GoogleContainerTools/kpt/thirdparty/cmdconfig/commands/runner"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/kioutil"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
@@ -98,7 +99,7 @@ func (r *SourceRunner) runE(c *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		functionConfigFilter, err := pkg.FunctionConfigFilterFunc(types.UniquePath(resolvedPath), r.IncludeMetaResources)
+		functionConfigFilter, err := pkg.FunctionConfigFilterFunc(filesys.FileSystemOrOnDisk{}, types.UniquePath(resolvedPath), r.IncludeMetaResources)
 		if err != nil {
 			return err
 		}

--- a/thirdparty/kyaml/runfn/runfn.go
+++ b/thirdparty/kyaml/runfn/runfn.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"sigs.k8s.io/kustomize/kyaml/errors"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
@@ -240,7 +241,7 @@ func (r RunFns) runFunctions(input kio.Reader, output kio.Writer, fltrs []kio.Fi
 			return writeErr
 		}
 	}
-	resultsFile, resultErr := fnruntime.SaveResults(r.ResultsDir, r.fnResults, nil)
+	resultsFile, resultErr := fnruntime.SaveResults(r.ResultsDir, r.fnResults, filesys.FileSystemOrOnDisk{})
 	if err != nil {
 		// function fails
 		if resultErr == nil {

--- a/thirdparty/kyaml/runfn/runfn.go
+++ b/thirdparty/kyaml/runfn/runfn.go
@@ -240,7 +240,7 @@ func (r RunFns) runFunctions(input kio.Reader, output kio.Writer, fltrs []kio.Fi
 			return writeErr
 		}
 	}
-	resultsFile, resultErr := fnruntime.SaveResults(r.ResultsDir, r.fnResults)
+	resultsFile, resultErr := fnruntime.SaveResults(r.ResultsDir, r.fnResults, nil)
 	if err != nil {
 		// function fails
 		if resultErr == nil {

--- a/thirdparty/kyaml/runfn/runfn.go
+++ b/thirdparty/kyaml/runfn/runfn.go
@@ -126,7 +126,7 @@ func (r RunFns) getNodesAndFilters() (
 		matchFilesGlob = append(matchFilesGlob, kptfile.KptFileName)
 	}
 	if r.Path != "" {
-		functionConfigFilter, err := pkg.FunctionConfigFilterFunc(r.uniquePath, r.IncludeMetaResources)
+		functionConfigFilter, err := pkg.FunctionConfigFilterFunc(filesys.FileSystemOrOnDisk{}, r.uniquePath, r.IncludeMetaResources)
 		if err != nil {
 			return nil, nil, outputPkg, err
 		}
@@ -241,7 +241,7 @@ func (r RunFns) runFunctions(input kio.Reader, output kio.Writer, fltrs []kio.Fi
 			return writeErr
 		}
 	}
-	resultsFile, resultErr := fnruntime.SaveResults(r.ResultsDir, r.fnResults, filesys.FileSystemOrOnDisk{})
+	resultsFile, resultErr := fnruntime.SaveResults(filesys.FileSystemOrOnDisk{}, r.ResultsDir, r.fnResults)
 	if err != nil {
 		// function fails
 		if resultErr == nil {


### PR DESCRIPTION
@martinmaly @droot Here is the PR for exposing Renderer api with FileSystem abstraction. I have tested it manually using fs.FS. I can add automated tests leveraging the FileSystem implementation from Martin. This implementation will not disturb the current flow which makes it less invasive and helps incremental development.