### PR TITLE
Kpt location parsing

### DIFF
--- a/demos/demo-location/main.go
+++ b/demos/demo-location/main.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/demos/demo-location/main.go
+++ b/demos/demo-location/main.go
@@ -156,9 +156,8 @@ type CustomLocation struct {
 }
 
 type CustomLocationLock struct {
-	WhereItIs            string
-	LabelOrVersionString string
-	UniqueIDString       string
+	CustomLocation
+	UniqueIDString string
 }
 
 // compile-time check that duck types are correct
@@ -170,6 +169,14 @@ var _ mutate.LockSetter = CustomLocation{}
 // string when reference appears in console and log messages
 func (ref CustomLocation) String() string {
 	return fmt.Sprint(" WhereItIs:", ref.WhereItIs, " LabelOrVersionString:", ref.LabelOrVersionString)
+}
+
+func (ref CustomLocation) Type() string {
+	return "custom"
+}
+
+func (ref CustomLocation) Validate() error {
+	return nil
 }
 
 // string when reference appears in console and log messages
@@ -190,8 +197,10 @@ func (ref CustomLocation) SetIdentifier(labelOrVersion string) (location.Referen
 // depending on location, the exact meaning may be commit-id, image-digest, url-query parameter, exact resource name, etc.
 func (ref CustomLocation) SetLock(uniqueID string) (location.ReferenceLock, error) {
 	return CustomLocationLock{
-		WhereItIs:            ref.WhereItIs,
-		LabelOrVersionString: ref.LabelOrVersionString,
-		UniqueIDString:       uniqueID,
+		CustomLocation: CustomLocation{
+			WhereItIs:            ref.WhereItIs,
+			LabelOrVersionString: ref.LabelOrVersionString,
+		},
+		UniqueIDString: uniqueID,
 	}, nil
 }

--- a/demos/demo-location/main.go
+++ b/demos/demo-location/main.go
@@ -158,7 +158,7 @@ type CustomLocation struct {
 type CustomLocationLock struct {
 	WhereItIs            string
 	LabelOrVersionString string
-	UniqueIdString       string
+	UniqueIDString       string
 }
 
 // compile-time check that duck types are correct
@@ -174,24 +174,24 @@ func (ref CustomLocation) String() string {
 
 // string when reference appears in console and log messages
 func (ref CustomLocationLock) String() string {
-	return fmt.Sprint(" WhereItIs:", ref.WhereItIs, " LabelOrVersionString:", ref.LabelOrVersionString, " UniqueIdString:", ref.UniqueIdString)
+	return fmt.Sprint(" WhereItIs:", ref.WhereItIs, " LabelOrVersionString:", ref.LabelOrVersionString, " UniqueIDString:", ref.UniqueIDString)
 }
 
 // return location with only the identifier changed
 // depending on location, the exact meaning may be branch/label/version/tag/etc
-func (ref CustomLocation) SetIdentifier(name string) (location.Reference, error) {
+func (ref CustomLocation) SetIdentifier(labelOrVersion string) (location.Reference, error) {
 	return CustomLocation{
 		WhereItIs:            ref.WhereItIs,
-		LabelOrVersionString: name,
+		LabelOrVersionString: labelOrVersion,
 	}, nil
 }
 
 // return the locked form of the location
 // depending on location, the exact meaning may be commit-id, image-digest, url-query parameter, exact resource name, etc.
-func (ref CustomLocation) SetLock(uniqueId string) (location.ReferenceLock, error) {
+func (ref CustomLocation) SetLock(uniqueID string) (location.ReferenceLock, error) {
 	return CustomLocationLock{
 		WhereItIs:            ref.WhereItIs,
 		LabelOrVersionString: ref.LabelOrVersionString,
-		UniqueIdString:       uniqueId,
+		UniqueIDString:       uniqueID,
 	}, nil
 }

--- a/demos/demo-location/main.go
+++ b/demos/demo-location/main.go
@@ -149,15 +149,15 @@ func main() {
 
 }
 
-func example(caption string, arg string, identifier string, hash string, opts ...location.Option) {
+func example(caption string, arg string, identifier string, lock string, opts ...location.Option) {
 	fmt.Printf("%s %q\n", caption, arg)
-	if err := run(arg, identifier, hash, opts...); err != nil {
+	if err := run(arg, identifier, lock, opts...); err != nil {
 		fmt.Printf("example error: %v\n", err)
 	}
 	fmt.Println()
 }
 
-func run(arg string, identifier string, hash string, opts ...location.Option) error {
+func run(arg string, identifier string, lock string, opts ...location.Option) error {
 	// parse arg to a reference
 	parsed, err := location.ParseReference(arg, opts...)
 	if err != nil {
@@ -177,9 +177,9 @@ func run(arg string, identifier string, hash string, opts ...location.Option) er
 		changed = parsed
 	}
 
-	if hash != "" {
+	if lock != "" {
 		// making a locked reference with the unique value field for that reference type
-		locked, err := mutate.Lock(changed, hash)
+		locked, err := mutate.Lock(changed, lock)
 		if err != nil {
 			return err
 		}

--- a/demos/demo-location/main.go
+++ b/demos/demo-location/main.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/GoogleContainerTools/kpt/pkg/location"
+	"github.com/GoogleContainerTools/kpt/pkg/location/mutate"
+)
+
+func main() {
+	ctx := context.Background()
+
+	fmt.Println("- parsing argument to location")
+	fmt.Println()
+
+	example(
+		"oci example",
+		"oci://us-docker.pkg.dev/my-project-id/my-repo-name/my-blueprint:draft",
+		"example",
+		"sha256:9f6ca9562c5e7bd8bb53d736a2869adc27529eb202996dfefb804ec2c95237ba",
+		location.WithContext(ctx),
+	)
+
+	example(
+		"git example",
+		"https://github.com/GoogleCloudPlatform/blueprints.git/catalog/gke@gke-blueprint-v0.4.0",
+		"main",
+		"2b8afca2ef0662cf5ea39c797832ac9c5ea67c7e",
+		location.WithContext(ctx),
+	)
+
+	example(
+		"dir example",
+		"path/to/dir",
+		"qa",
+		"",
+		location.WithContext(ctx),
+	)
+
+	example(
+		"stdin example",
+		"-",
+		"",
+		"",
+		location.WithContext(ctx),
+		location.WithStdin(os.Stdin),
+	)
+
+	example(
+		"stdout example",
+		"-",
+		"",
+		"",
+		location.WithContext(ctx),
+		location.WithStdout(os.Stdout),
+	)
+
+	example(
+		"stdin/out example",
+		"-",
+		"",
+		"",
+		location.WithContext(ctx),
+		location.WithStdin(os.Stdin),
+		location.WithStdout(os.Stdout),
+	)
+
+	fmt.Println("- creating locations directly")
+	fmt.Println()
+
+	fmt.Println("stdio example")
+	in := location.InputStream{
+		Reader: os.Stdin,
+	}
+	out := location.OutputStream{
+		Writer: os.Stdout,
+	}
+	fmt.Printf("stdio in %v\n", in)
+	fmt.Printf("stdio out %v\n", out)
+	fmt.Println()
+
+	fmt.Println("bytes example")
+	buf := bytes.NewBuffer([]byte("hello world"))
+	in = location.InputStream{
+		Reader: buf,
+	}
+	out = location.OutputStream{
+		Writer: buf,
+	}
+	fmt.Printf("buffer in %v\n", in)
+	fmt.Printf("buffer out %v\n", out)
+	fmt.Println()
+
+	fmt.Println("custom location example")
+
+	ref := CustomLocation{
+		WhereItIs:            "http://127.0.0.1:8001/my-package",
+		LabelOrVersionString: "draft",
+	}
+	fmt.Printf("ref: %v\n", ref)
+
+	updated, _ := mutate.Identifier(ref, "preview")
+	fmt.Printf("updated: %v\n", updated)
+
+	locked, _ := mutate.Lock(updated, "98510723450981325098375013")
+	fmt.Printf("locked: %v\n", locked)
+	fmt.Println()
+
+}
+
+func example(caption string, arg string, identifier string, hash string, opts ...location.Option) {
+	fmt.Printf("%s %q\n", caption, arg)
+	if err := run(arg, identifier, hash, opts...); err != nil {
+		fmt.Printf("example error: %v\n", err)
+	}
+	fmt.Println()
+}
+
+func run(arg string, identifier string, hash string, opts ...location.Option) error {
+	parsed, err := location.ParseReference(arg, opts...)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("parsed: {%v}\n", parsed)
+
+	if identifier != "" {
+		changed, err := mutate.Identifier(parsed, identifier)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("changed: {%v}\n", changed)
+
+		if hash != "" {
+			locked, err := mutate.Lock(changed, hash)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("locked: {%v}\n", locked)
+		}
+	}
+
+	return nil
+}
+
+// example of providing a custom location that supports branch/tag identifier and locking to a unique id.
+// the meaning of the fields in the struct are entirely specific to the location type.
+
+type CustomLocation struct {
+	WhereItIs            string
+	LabelOrVersionString string
+}
+
+type CustomLocationLock struct {
+	WhereItIs            string
+	LabelOrVersionString string
+	UniqueIdString       string
+}
+
+// compile-time check that duck types are correct
+var _ location.Reference = CustomLocation{}
+var _ location.ReferenceLock = CustomLocationLock{}
+var _ mutate.IdentifierSetter = CustomLocation{}
+var _ mutate.LockSetter = CustomLocation{}
+
+// string when reference appears in console and log messages
+func (ref CustomLocation) String() string {
+	return fmt.Sprint(" WhereItIs:", ref.WhereItIs, " LabelOrVersionString:", ref.LabelOrVersionString)
+}
+
+// string when reference appears in console and log messages
+func (ref CustomLocationLock) String() string {
+	return fmt.Sprint(" WhereItIs:", ref.WhereItIs, " LabelOrVersionString:", ref.LabelOrVersionString, " UniqueIdString:", ref.UniqueIdString)
+}
+
+// return location with only the identifier changed
+// depending on location, the exact meaning may be branch/label/version/tag/etc
+func (ref CustomLocation) SetIdentifier(name string) (location.Reference, error) {
+	return CustomLocation{
+		WhereItIs:            ref.WhereItIs,
+		LabelOrVersionString: name,
+	}, nil
+}
+
+// return the locked form of the location
+// depending on location, the exact meaning may be commit-id, image-digest, url-query parameter, exact resource name, etc.
+func (ref CustomLocation) SetLock(uniqueId string) (location.ReferenceLock, error) {
+	return CustomLocationLock{
+		WhereItIs:            ref.WhereItIs,
+		LabelOrVersionString: ref.LabelOrVersionString,
+		UniqueIdString:       uniqueId,
+	}, nil
+}

--- a/demos/demo-location/main.go
+++ b/demos/demo-location/main.go
@@ -13,6 +13,10 @@ import (
 func main() {
 	ctx := context.Background()
 
+	opts := []location.Option{
+		location.WithContext(ctx),
+	}
+
 	fmt.Println("- parsing argument to location")
 	fmt.Println()
 
@@ -21,7 +25,7 @@ func main() {
 		"oci://us-docker.pkg.dev/my-project-id/my-repo-name/my-blueprint:draft",
 		"example",
 		"sha256:9f6ca9562c5e7bd8bb53d736a2869adc27529eb202996dfefb804ec2c95237ba",
-		location.WithContext(ctx),
+		opts...,
 	)
 
 	example(
@@ -29,7 +33,7 @@ func main() {
 		"https://github.com/GoogleCloudPlatform/blueprints.git/catalog/gke@gke-blueprint-v0.4.0",
 		"main",
 		"2b8afca2ef0662cf5ea39c797832ac9c5ea67c7e",
-		location.WithContext(ctx),
+		opts...,
 	)
 
 	example(
@@ -37,16 +41,17 @@ func main() {
 		"path/to/dir",
 		"qa",
 		"",
-		location.WithContext(ctx),
+		opts...,
 	)
 
+	// stdin and stdout options are added on individual calls to parse, because
+	// only the caller knows if "-" in an argument means read from stdin or write to stdout
 	example(
 		"stdin example",
 		"-",
 		"",
 		"",
-		location.WithContext(ctx),
-		location.WithStdin(os.Stdin),
+		append(opts, location.WithStdin(os.Stdin))...,
 	)
 
 	example(
@@ -54,18 +59,15 @@ func main() {
 		"-",
 		"",
 		"",
-		location.WithContext(ctx),
-		location.WithStdout(os.Stdout),
+		append(opts, location.WithStdin(os.Stdin))...,
 	)
 
 	example(
-		"stdin/out example",
+		"duplex example",
 		"-",
 		"",
 		"",
-		location.WithContext(ctx),
-		location.WithStdin(os.Stdin),
-		location.WithStdout(os.Stdout),
+		append(opts, location.WithStdin(os.Stdin), location.WithStdout(os.Stdout))...,
 	)
 
 	fmt.Println("- creating locations directly")

--- a/pkg/api/kptfile/v1/types.go
+++ b/pkg/api/kptfile/v1/types.go
@@ -155,7 +155,7 @@ type Oci struct {
 	Image string `yaml:"image,omitempty" json:"image,omitempty"`
 
 	// Directory is the sub-package of the image.
-	Directory string `yaml:"path,omitempty" json:"path,omitempty"`
+	Directory string `yaml:"directory,omitempty" json:"directory,omitempty"`
 }
 
 // UpstreamLock is a resolved locator for the last fetch of the package.
@@ -208,7 +208,7 @@ type OciLock struct {
 	Image string `yaml:"image,omitempty" json:"image,omitempty"`
 
 	// Directory is the sub-package of the image.
-	Directory string `yaml:"path,omitempty" json:"path,omitempty"`
+	Directory string `yaml:"directory,omitempty" json:"directory,omitempty"`
 
 	// Digest is the unique sha of the image when it was last pulled.
 	Digest string `yaml:"digest,omitempty" json:"digest,omitempty"`

--- a/pkg/kptfile/kptfileutil/util.go
+++ b/pkg/kptfile/kptfileutil/util.go
@@ -249,14 +249,14 @@ func UpdateUpstreamLockFromGit(path string, spec *git.RepoSpec) error {
 // NewUpstreamFromReference creates kptfilev1.Upstream structures from supported
 // location types. The kptfile upstream supports specific, well-known types.
 func NewUpstreamFromReference(ref location.Reference) (*kptfilev1.Upstream, error) {
-	const op errors.Op = "kptfileutil.UpdateUpstreamLock"
+	const op errors.Op = "kptfileutil.NewUpstreamFromReference"
 	switch ref := ref.(type) {
 	case location.Git:
 		return &kptfilev1.Upstream{
 			Type: kptfilev1.GitOrigin,
 			Git: &kptfilev1.Git{
 				Repo:      ref.Repo,
-				Directory: toDirectory(ref.Directory),
+				Directory: toDirectory(ref.Directory, false),
 				Ref:       ref.Ref,
 			},
 		}, nil
@@ -265,7 +265,7 @@ func NewUpstreamFromReference(ref location.Reference) (*kptfilev1.Upstream, erro
 			Type: kptfilev1.OciOrigin,
 			Oci: &kptfilev1.Oci{
 				Image:     ref.Image.Name(),
-				Directory: toDirectory(ref.Directory),
+				Directory: toDirectory(ref.Directory, true),
 			},
 		}, nil
 	}
@@ -276,14 +276,14 @@ func NewUpstreamFromReference(ref location.Reference) (*kptfilev1.Upstream, erro
 // NewUpstreamLockFromReferenceLock creates kptfilev1.UpstreamLock structures from supported
 // location types. The kptfile upstream supports specific, well-known types.
 func NewUpstreamLockFromReferenceLock(ref location.ReferenceLock) (*kptfilev1.UpstreamLock, error) {
-	const op errors.Op = "kptfileutil.UpdateUpstreamLock"
+	const op errors.Op = "kptfileutil.NewUpstreamLockFromReferenceLock"
 	switch ref := ref.(type) {
 	case location.GitLock:
 		return &kptfilev1.UpstreamLock{
 			Type: kptfilev1.GitOrigin,
 			Git: &kptfilev1.GitLock{
 				Repo:      ref.Repo,
-				Directory: toDirectory(ref.Directory),
+				Directory: toDirectory(ref.Directory, false),
 				Ref:       ref.Ref,
 				Commit:    ref.Commit,
 			},
@@ -293,7 +293,7 @@ func NewUpstreamLockFromReferenceLock(ref location.ReferenceLock) (*kptfilev1.Up
 			Type: kptfilev1.OciOrigin,
 			Oci: &kptfilev1.OciLock{
 				Image:     ref.Image.Name(),
-				Directory: toDirectory(ref.Directory),
+				Directory: toDirectory(ref.Directory, true),
 				Digest:    ref.Digest.Name(),
 			},
 		}, nil
@@ -304,8 +304,8 @@ func NewUpstreamLockFromReferenceLock(ref location.ReferenceLock) (*kptfilev1.Up
 
 // toDirectory convert relative Reference sub-package locations to
 // the kptfilev1 absolute-within-repo conventions.
-func toDirectory(relPath string) string {
-	if absPath := filepath.Join("/", relPath); absPath != "/" {
+func toDirectory(relPath string, omitDefault bool) string {
+	if absPath := filepath.Join("/", relPath); absPath != "/" || !omitDefault {
 		return absPath
 	}
 	// root location is default in kptfilev1

--- a/pkg/location/defaultdir.go
+++ b/pkg/location/defaultdir.go
@@ -1,14 +1,19 @@
 package location
 
-import "fmt"
-
+// DirectoryNameDefaulter is present on Reference types that
+// suggest a default local folder name
 type DirectoryNameDefaulter interface {
-	GetDefaultDirectoryName() (string, error)
+	// GetDefaultDirectoryName implements the location.DefaultDirectoryName() method
+	GetDefaultDirectoryName() (string, bool)
 }
 
-func DefaultDirectoryName(ref Reference) (string, error) {
+// DefaultDirectoryName returns the suggested local directory name to
+// create when a package from a remove reference is cloned or pulled.
+// Returns an empty string and false if the Reference type does not have
+// anything path-like to suggest from.
+func DefaultDirectoryName(ref Reference) (string, bool) {
 	if ref, ok := ref.(DirectoryNameDefaulter); ok {
 		return ref.GetDefaultDirectoryName()
 	}
-	return "", fmt.Errorf("default directory not supported for reference: %v", ref)
+	return "", false
 }

--- a/pkg/location/defaultdir.go
+++ b/pkg/location/defaultdir.go
@@ -1,0 +1,14 @@
+package location
+
+import "fmt"
+
+type DirectoryNameDefaulter interface {
+	GetDefaultDirectoryName() (string, error)
+}
+
+func DefaultDirectoryName(ref Reference) (string, error) {
+	if ref, ok := ref.(DirectoryNameDefaulter); ok {
+		return ref.GetDefaultDirectoryName()
+	}
+	return "", fmt.Errorf("default directory not supported for reference: %v", ref)
+}

--- a/pkg/location/defaultdir.go
+++ b/pkg/location/defaultdir.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package location
 
 // DirectoryNameDefaulter is present on Reference types that

--- a/pkg/location/mutate/mutations.go
+++ b/pkg/location/mutate/mutations.go
@@ -42,7 +42,7 @@ func Identifier(ref location.Reference, identifier string) (location.Reference, 
 // LockSetter is implemented by location.Reference types that
 // support mutate.Log
 type LockSetter interface {
-	SetLock(hash string) (location.ReferenceLock, error)
+	SetLock(lock string) (location.ReferenceLock, error)
 }
 
 // Lock returns a new ReferenceLock where the property that identifies the
@@ -50,9 +50,9 @@ type LockSetter interface {
 // The exact meaning of the value depends on the type of reference, and
 // is typically returned from the remote storage system as part of sending or
 // receiving content.
-func Lock(ref location.Reference, hash string) (location.ReferenceLock, error) {
+func Lock(ref location.Reference, lock string) (location.ReferenceLock, error) {
 	if ref, ok := ref.(LockSetter); ok {
-		return ref.SetLock(hash)
+		return ref.SetLock(lock)
 	}
 	return nil, fmt.Errorf("locked reference not support for reference: %v", ref)
 }

--- a/pkg/location/mutate/mutations.go
+++ b/pkg/location/mutate/mutations.go
@@ -11,8 +11,7 @@ type IdentifierSetter interface {
 }
 
 func Identifier(ref location.Reference, identifier string) (location.Reference, error) {
-	switch ref := ref.(type) {
-	case IdentifierSetter:
+	if ref, ok := ref.(IdentifierSetter); ok {
 		return ref.SetIdentifier(identifier)
 	}
 	return nil, fmt.Errorf("changing identifier not supported for reference: %v", ref)
@@ -23,8 +22,7 @@ type LockSetter interface {
 }
 
 func Lock(ref location.Reference, hash string) (location.ReferenceLock, error) {
-	switch ref := ref.(type) {
-	case LockSetter:
+	if ref, ok := ref.(LockSetter); ok {
 		return ref.SetLock(hash)
 	}
 	return nil, fmt.Errorf("locked reference not support for reference: %v", ref)

--- a/pkg/location/mutate/mutations.go
+++ b/pkg/location/mutate/mutations.go
@@ -1,0 +1,31 @@
+package mutate
+
+import (
+	"fmt"
+
+	"github.com/GoogleContainerTools/kpt/pkg/location"
+)
+
+type IdentifierSetter interface {
+	SetIdentifier(identifier string) (location.Reference, error)
+}
+
+func Identifier(ref location.Reference, identifier string) (location.Reference, error) {
+	switch ref := ref.(type) {
+	case IdentifierSetter:
+		return ref.SetIdentifier(identifier)
+	}
+	return nil, fmt.Errorf("identifier not supported for reference: %v", ref)
+}
+
+type LockSetter interface {
+	SetLock(hash string) (location.ReferenceLock, error)
+}
+
+func Lock(ref location.Reference, hash string) (location.ReferenceLock, error) {
+	switch ref := ref.(type) {
+	case LockSetter:
+		return ref.SetLock(hash)
+	}
+	return nil, fmt.Errorf("locked reference not support for reference: %v", ref)
+}

--- a/pkg/location/mutate/mutations.go
+++ b/pkg/location/mutate/mutations.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mutate
 
 import (

--- a/pkg/location/mutate/mutations.go
+++ b/pkg/location/mutate/mutations.go
@@ -6,10 +6,18 @@ import (
 	"github.com/GoogleContainerTools/kpt/pkg/location"
 )
 
+// IdentifierSetter is implemented by location.Reference types that
+// support mutate.Identifier
 type IdentifierSetter interface {
+	// SetIdentifier is called by mutate.Identifier
 	SetIdentifier(identifier string) (location.Reference, error)
 }
 
+// Identifier returns a new Reference where the property that
+// identifies the branch, tag, or label has been replaced with value given.
+// Typical identifier values are often a semantic name like 'draft', 'main', 'prod', or a
+// string representation of a version. The specifics of how the identifier is
+// mapped to storage depends on the type of reference.
 func Identifier(ref location.Reference, identifier string) (location.Reference, error) {
 	if ref, ok := ref.(IdentifierSetter); ok {
 		return ref.SetIdentifier(identifier)
@@ -17,10 +25,17 @@ func Identifier(ref location.Reference, identifier string) (location.Reference, 
 	return nil, fmt.Errorf("changing identifier not supported for reference: %v", ref)
 }
 
+// LockSetter is implemented by location.Reference types that
+// support mutate.Log
 type LockSetter interface {
 	SetLock(hash string) (location.ReferenceLock, error)
 }
 
+// Lock returns a new ReferenceLock where the property that identifies the
+// unique commit or digest has been replaced with the value given.
+// The exact meaning of the value depends on the type of reference, and
+// is typically returned from the remote storage system as part of sending or
+// receiving content.
 func Lock(ref location.Reference, hash string) (location.ReferenceLock, error) {
 	if ref, ok := ref.(LockSetter); ok {
 		return ref.SetLock(hash)

--- a/pkg/location/mutate/mutations.go
+++ b/pkg/location/mutate/mutations.go
@@ -15,7 +15,7 @@ func Identifier(ref location.Reference, identifier string) (location.Reference, 
 	case IdentifierSetter:
 		return ref.SetIdentifier(identifier)
 	}
-	return nil, fmt.Errorf("identifier not supported for reference: %v", ref)
+	return nil, fmt.Errorf("changing identifier not supported for reference: %v", ref)
 }
 
 type LockSetter interface {

--- a/pkg/location/mutate/mutations_test.go
+++ b/pkg/location/mutate/mutations_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mutate
 
 import (

--- a/pkg/location/mutate/mutations_test.go
+++ b/pkg/location/mutate/mutations_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 )
 
+//nolint:scopelint
 func TestSetIdentifier(t *testing.T) {
 	type args struct {
 		ref        location.Reference
@@ -82,6 +83,7 @@ func TestSetIdentifier(t *testing.T) {
 	}
 }
 
+//nolint:scopelint
 func TestSetLock(t *testing.T) {
 	type args struct {
 		ref  location.Reference

--- a/pkg/location/mutate/mutations_test.go
+++ b/pkg/location/mutate/mutations_test.go
@@ -180,6 +180,14 @@ func (ref custom) String() string {
 	return fmt.Sprintf("place:%s label:%s", ref.Place, ref.Label)
 }
 
+func (ref custom) Type() string {
+	return "custom"
+}
+
+func (ref custom) Validate() error {
+	return nil
+}
+
 func (ref custom) SetIdentifier(identifier string) (location.Reference, error) {
 	return custom{
 		Place: ref.Place,

--- a/pkg/location/mutate/mutations_test.go
+++ b/pkg/location/mutate/mutations_test.go
@@ -209,9 +209,9 @@ func (ref custom) SetIdentifier(identifier string) (location.Reference, error) {
 	}, nil
 }
 
-func (ref custom) SetLock(hash string) (location.ReferenceLock, error) {
+func (ref custom) SetLock(lock string) (location.ReferenceLock, error) {
 	return customLock{
 		custom: ref,
-		Lock:   hash,
+		Lock:   lock,
 	}, nil
 }

--- a/pkg/location/mutate/mutations_test.go
+++ b/pkg/location/mutate/mutations_test.go
@@ -1,0 +1,193 @@
+package mutate
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/GoogleContainerTools/kpt/pkg/location"
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+func TestSetIdentifier(t *testing.T) {
+	type args struct {
+		ref        location.Reference
+		identifier string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    location.Reference
+		wantErr bool
+	}{
+		{
+			name: "OciWithIdentifier",
+			args: args{
+				ref: location.Oci{
+					Image:     name.MustParseReference("my-registry.io/name:original"),
+					Directory: "sub/directory",
+				},
+				identifier: "updated",
+			},
+			want: location.Oci{
+				Image:     name.MustParseReference("my-registry.io/name:updated"),
+				Directory: "sub/directory",
+			},
+			wantErr: false,
+		},
+		{
+			name: "GitWithIdentifier",
+			args: args{
+				ref: location.Git{
+					Repo:      "repo",
+					Directory: "sub/directory",
+					Ref:       "original",
+				},
+				identifier: "updated",
+			},
+			want: location.Git{
+				Repo:      "repo",
+				Directory: "sub/directory",
+				Ref:       "updated",
+			},
+			wantErr: false,
+		},
+		{
+			name: "CustomWithIdentifier",
+			args: args{
+				ref: custom{
+					Place: "place",
+					Label: "label",
+				},
+				identifier: "new-label",
+			},
+			want: custom{
+				Place: "place",
+				Label: "new-label",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Identifier(tt.args.ref, tt.args.identifier)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("WithIdentifier() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("WithIdentifier() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetLock(t *testing.T) {
+	type args struct {
+		ref  location.Reference
+		lock string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    location.ReferenceLock
+		wantErr bool
+	}{
+		{
+			name: "OciWithLock",
+			args: args{
+				ref: location.Oci{
+					Image:     name.MustParseReference("my-registry.io/name:original"),
+					Directory: "sub/directory",
+				},
+				lock: "sha256:9f6ca9562c5e7bd8bb53d736a2869adc27529eb202996dfefb804ec2c95237ba",
+			},
+			want: location.OciLock{
+				Oci: location.Oci{
+					Image:     name.MustParseReference("my-registry.io/name:original"),
+					Directory: "sub/directory",
+				},
+				Digest: name.MustParseReference("my-registry.io/name@sha256:9f6ca9562c5e7bd8bb53d736a2869adc27529eb202996dfefb804ec2c95237ba"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "GitWithLock",
+			args: args{
+				ref: location.Git{
+					Repo:      "repo",
+					Directory: "sub/directory",
+					Ref:       "original",
+				},
+				lock: "9f6ca9562c5e7bd8bb53d736a2869adc27529eb202996dfefb804ec2c95237ba",
+			},
+			want: location.GitLock{
+				Git: location.Git{
+					Repo:      "repo",
+					Directory: "sub/directory",
+					Ref:       "original",
+				},
+				Commit: "9f6ca9562c5e7bd8bb53d736a2869adc27529eb202996dfefb804ec2c95237ba",
+			},
+			wantErr: false,
+		},
+		{
+			name: "CustomWithLock",
+			args: args{
+				ref: custom{
+					Place: "place",
+					Label: "label",
+				},
+				lock: "lock",
+			},
+			want: customLock{
+				custom: custom{
+					Place: "place",
+					Label: "label",
+				},
+				Lock: "lock",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Lock(tt.args.ref, tt.args.lock)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("WithLock() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("WithLock() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type custom struct {
+	Place string
+	Label string
+}
+
+type customLock struct {
+	custom
+	Lock string
+}
+
+func (ref custom) String() string {
+	return fmt.Sprintf("place:%s label:%s", ref.Place, ref.Label)
+}
+
+func (ref custom) SetIdentifier(identifier string) (location.Reference, error) {
+	return custom{
+		Place: ref.Place,
+		Label: identifier,
+	}, nil
+}
+
+func (ref custom) SetLock(hash string) (location.ReferenceLock, error) {
+	return customLock{
+		custom: ref,
+		Lock:   hash,
+	}, nil
+}

--- a/pkg/location/options.go
+++ b/pkg/location/options.go
@@ -1,0 +1,44 @@
+package location
+
+import (
+	"context"
+	"io"
+)
+
+type options struct {
+	ctx    context.Context
+	stdin  io.Reader
+	stdout io.Writer
+}
+
+func makeOptions(opts ...Option) options {
+	opt := options{}
+	for _, o := range opts {
+		o(&opt)
+	}
+	return opt
+}
+
+// Option is a functional option for location parsing.
+type Option func(*options)
+
+// WithDefaultTag sets the default tag that will be used if one is not provided.
+func WithContext(ctx context.Context) Option {
+	return func(opts *options) {
+		opts.ctx = ctx
+	}
+}
+
+// WithStdin enables parser to assign "-" location onto an input io.Reader
+func WithStdin(r io.Reader) Option {
+	return func(opts *options) {
+		opts.stdin = r
+	}
+}
+
+// WithStdout enables parser to assign "-" location onto an output io.Writer
+func WithStdout(w io.Writer) Option {
+	return func(opts *options) {
+		opts.stdout = w
+	}
+}

--- a/pkg/location/options.go
+++ b/pkg/location/options.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package location
 
 import (

--- a/pkg/location/parse.go
+++ b/pkg/location/parse.go
@@ -1,0 +1,58 @@
+package location
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+)
+
+func ParseReference(location string, opts ...Option) (Reference, error) {
+	opt := makeOptions(opts...)
+
+	if location == "-" {
+		switch {
+		case opt.stdin != nil && opt.stdout != nil:
+			return InputOutputStream{
+				Reader: opt.stdin,
+				Writer: opt.stdout,
+			}, nil
+		case opt.stdin != nil:
+			return InputStream{
+				Reader: opt.stdin,
+			}, nil
+		case opt.stdout != nil:
+			return OutputStream{
+				Writer: opt.stdout,
+			}, nil
+		}
+	}
+
+	if _, ok := startsWith(location, "oci://"); ok {
+		oci, ociErr := NewOci(location, opts...)
+		return oci, ociErr
+	}
+
+	git, gitErr := NewGit(location, opts...)
+	if gitErr == nil {
+		return git, nil
+	}
+
+	if s, ok := isDir(location); ok {
+		return Dir{
+			Directory: s,
+		}, nil
+	}
+
+	return nil, errors.New("not implemented")
+}
+
+func startsWith(value string, prefix string) (string, bool) {
+	if parts := strings.SplitN(value, prefix, 2); len(parts) == 2 && len(parts[0]) == 0 {
+		return parts[1], true
+	}
+	return prefix, false
+}
+
+func isDir(value string) (string, bool) {
+	return filepath.Clean(value), true
+}

--- a/pkg/location/parse.go
+++ b/pkg/location/parse.go
@@ -15,24 +15,26 @@
 package location
 
 import (
-	"errors"
+	"fmt"
 	"strings"
 )
 
 func ParseReference(location string, opts ...Option) (Reference, error) {
 	opt := makeOptions(opts...)
 
+	var helpText []string
 	for _, parser := range opt.parsers {
-		ref, err := parser(location, opt)
-		if err != nil {
-			return nil, err
+		result := parser(location, opt)
+		if result.err != nil {
+			return nil, result.err
 		}
-		if ref != nil {
-			return ref, nil
+		if result.ref != nil {
+			return result.ref, nil
 		}
+		helpText = append(helpText, result.helpText...)
 	}
 
-	return nil, errors.New("not implemented")
+	return nil, fmt.Errorf("unable to parse location: %v", helpText)
 }
 
 func startsWith(value string, prefix string) (string, bool) {
@@ -40,4 +42,96 @@ func startsWith(value string, prefix string) (string, bool) {
 		return parts[1], true
 	}
 	return prefix, false
+}
+
+// StdioParser enables "-" to resolve as io streams.
+// Use location.WithStdin to provide the io.Reader.
+// Use location.WithStdout to provide the io.Writer.
+var StdioParser parser = func(value string, opt options) result {
+	if value == "-" {
+		switch {
+		case opt.stdin != nil && opt.stdout != nil:
+			return result{
+				ref: DuplexStream{
+					InputStream:  InputStream{Reader: opt.stdin},
+					OutputStream: OutputStream{Writer: opt.stdout},
+				},
+			}
+		case opt.stdin != nil:
+			return result{
+				ref: InputStream{Reader: opt.stdin},
+			}
+		case opt.stdout != nil:
+			return result{
+				ref: OutputStream{Writer: opt.stdout},
+			}
+		}
+	}
+	res := result{}
+	if opt.stdin != nil {
+		res.helpText = append(res.helpText, "Use '-' to read from input stream")
+	}
+	if opt.stdout != nil {
+		res.helpText = append(res.helpText, "Use '-' to write to output stream")
+	}
+	return res
+}
+
+// GitParser enables standard parsing for the location.Git Reference type
+var GitParser parser = func(value string, opt options) result {
+	return result{
+		ref:      parseGit(value, opt),
+		helpText: []string{},
+	}
+}
+
+// OciParser enables standard parsing for the location.Oci Reference type
+var OciParser parser = func(value string, opt options) result {
+	ref, err := parseOci(value)
+	return result{
+		ref: ref,
+		err: err,
+		helpText: []string{
+			"OCI packages use 'oci://' prefix before standard image name",
+		},
+	}
+}
+
+// DirParser enables standard parsing for the location.Dir Reference type
+var DirParser parser = func(value string, opt options) result {
+	return result{
+		ref: parseDir(value),
+	}
+}
+
+// NewParser returns a parser for a custom Reference type.
+// The returned parser is used in the location.WithParser Option
+func NewParser(helpText []string, parser func(parse *Parse)) parser {
+	return func(value string, opt options) result {
+		req := Parse{
+			Value: value,
+			result: result{
+				helpText: helpText,
+			},
+		}
+		parser(&req)
+		return req.result
+	}
+}
+
+type Parse struct {
+	result
+	Value string
+}
+
+func (r *Parse) Result(ref Reference) {
+	r.ref = ref
+}
+
+func (r *Parse) Fail(err error) {
+	r.err = err
+}
+
+func (r *Parse) AddHelpText(helpText string) {
+	r.helpText = append(r.helpText, helpText)
 }

--- a/pkg/location/parse.go
+++ b/pkg/location/parse.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package location
 
 import (

--- a/pkg/location/parse.go
+++ b/pkg/location/parse.go
@@ -25,6 +25,7 @@ func ParseReference(location string, opts ...Option) (Reference, error) {
 				Writer: opt.stdout,
 			}, nil
 		}
+		return nil, errors.New("stdin/stdout not supported here")
 	}
 
 	if _, ok := startsWith(location, "oci://"); ok {

--- a/pkg/location/parse.go
+++ b/pkg/location/parse.go
@@ -2,46 +2,20 @@ package location
 
 import (
 	"errors"
-	"path/filepath"
 	"strings"
 )
 
 func ParseReference(location string, opts ...Option) (Reference, error) {
 	opt := makeOptions(opts...)
 
-	if location == "-" {
-		switch {
-		case opt.stdin != nil && opt.stdout != nil:
-			return InputOutputStream{
-				Reader: opt.stdin,
-				Writer: opt.stdout,
-			}, nil
-		case opt.stdin != nil:
-			return InputStream{
-				Reader: opt.stdin,
-			}, nil
-		case opt.stdout != nil:
-			return OutputStream{
-				Writer: opt.stdout,
-			}, nil
+	for _, parser := range opt.parsers {
+		ref, err := parser(location, opt)
+		if err != nil {
+			return nil, err
 		}
-		return nil, errors.New("stdin/stdout not supported here")
-	}
-
-	if _, ok := startsWith(location, "oci://"); ok {
-		oci, ociErr := NewOci(location, opts...)
-		return oci, ociErr
-	}
-
-	git, gitErr := NewGit(location, opts...)
-	if gitErr == nil {
-		return git, nil
-	}
-
-	if s, ok := isDir(location); ok {
-		return Dir{
-			Directory: s,
-		}, nil
+		if ref != nil {
+			return ref, nil
+		}
 	}
 
 	return nil, errors.New("not implemented")
@@ -52,8 +26,4 @@ func startsWith(value string, prefix string) (string, bool) {
 		return parts[1], true
 	}
 	return prefix, false
-}
-
-func isDir(value string) (string, bool) {
-	return filepath.Clean(value), true
 }

--- a/pkg/location/parse_test.go
+++ b/pkg/location/parse_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	test_reader = &bytes.Buffer{}
-	test_writer = &bytes.Buffer{}
+	testReader = &bytes.Buffer{}
+	testWriter = &bytes.Buffer{}
 )
 
 //nolint:scopelint
@@ -140,10 +140,10 @@ func TestParseReference(t *testing.T) {
 			name: "InputStream",
 			args: args{
 				location: "-",
-				opts:     []Option{WithStdin(test_reader)},
+				opts:     []Option{WithStdin(testReader)},
 			},
 			want: InputStream{
-				Reader: test_reader,
+				Reader: testReader,
 			},
 			wantErr: false,
 		},
@@ -151,10 +151,10 @@ func TestParseReference(t *testing.T) {
 			name: "OutputStream",
 			args: args{
 				location: "-",
-				opts:     []Option{WithStdout(test_writer)},
+				opts:     []Option{WithStdout(testWriter)},
 			},
 			want: OutputStream{
-				Writer: test_writer,
+				Writer: testWriter,
 			},
 			wantErr: false,
 		},
@@ -162,11 +162,11 @@ func TestParseReference(t *testing.T) {
 			name: "DuplexStream",
 			args: args{
 				location: "-",
-				opts:     []Option{WithStdin(test_reader), WithStdout(test_writer)},
+				opts:     []Option{WithStdin(testReader), WithStdout(testWriter)},
 			},
 			want: InputOutputStream{
-				Reader: test_reader,
-				Writer: test_writer,
+				Reader: testReader,
+				Writer: testWriter,
 			},
 			wantErr: false,
 		},

--- a/pkg/location/parse_test.go
+++ b/pkg/location/parse_test.go
@@ -1,0 +1,145 @@
+package location
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+func TestParseReference(t *testing.T) {
+	type args struct {
+		location string
+		opts     []Option
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    Reference
+		wantErr bool
+	}{
+		{
+			name: "OciSimpleName",
+			args: args{
+				location: "oci://ubuntu",
+			},
+			want: Oci{
+				Image:     name.MustParseReference("ubuntu"),
+				Directory: ".",
+			},
+			wantErr: false,
+		},
+		{
+			name: "OciNameWithTag",
+			args: args{
+				location: "oci://my-registry.local/name:tag",
+			},
+			want: Oci{
+				Image:     name.MustParseReference("my-registry.local/name:tag"),
+				Directory: ".",
+			},
+			wantErr: false,
+		},
+		{
+			name: "OciNameWithDigest",
+			args: args{
+				location: "oci://my-registry.local/name@sha256:9f6ca9562c5e7bd8bb53d736a2869adc27529eb202996dfefb804ec2c95237ba",
+			},
+			want: Oci{
+				Image:     name.MustParseReference("my-registry.local/name@sha256:9f6ca9562c5e7bd8bb53d736a2869adc27529eb202996dfefb804ec2c95237ba"),
+				Directory: ".",
+			},
+			wantErr: false,
+		},
+		{
+			name: "OciNameWithDirectory",
+			args: args{
+				location: "oci://my-registry.local/name//sub/directory",
+			},
+			want: Oci{
+				Image:     name.MustParseReference("my-registry.local/name:latest"),
+				Directory: "sub/directory",
+			},
+			wantErr: false,
+		},
+		{
+			name: "OciNameWithDirectoryAndTag",
+			args: args{
+				location: "oci://my-registry.local/name//sub/directory:tag",
+			},
+			want: Oci{
+				Image:     name.MustParseReference("my-registry.local/name:tag"),
+				Directory: "sub/directory",
+			},
+			wantErr: false,
+		},
+		{
+			name: "OciDirectoryExtraSlashes",
+			args: args{
+				location: "oci://my-registry.local/name///sub/directory",
+			},
+			want: Oci{
+				Image:     name.MustParseReference("my-registry.local/name:latest"),
+				Directory: "sub/directory",
+			},
+			wantErr: false,
+		},
+		{
+			name: "OciDirectoryEmptyPath",
+			args: args{
+				location: "oci://my-registry.local/name//",
+			},
+			want: Oci{
+				Image:     name.MustParseReference("my-registry.local/name:latest"),
+				Directory: ".",
+			},
+			wantErr: false,
+		},
+		{
+			name: "GitSimpleRepo",
+			args: args{
+				location: "https://hostname/repo.git@main",
+			},
+			want: Git{
+				Repo:      "https://hostname/repo",
+				Directory: ".",
+				Ref:       "main",
+			},
+			wantErr: false,
+		},
+		{
+			name: "GitWithDirectory",
+			args: args{
+				location: "https://hostname/repo.git/sub/directory@main",
+			},
+			want: Git{
+				Repo:      "https://hostname/repo",
+				Directory: "sub/directory",
+				Ref:       "main",
+			},
+			wantErr: false,
+		},
+		{
+			name: "SimpleDir",
+			args: args{
+				location: "path/to/directory",
+			},
+			want: Dir{
+				Directory: "path/to/directory",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseReference(tt.args.location, tt.args.opts...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Parse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/location/parse_test.go
+++ b/pkg/location/parse_test.go
@@ -1,10 +1,16 @@
 package location
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
+)
+
+var (
+	test_reader = &bytes.Buffer{}
+	test_writer = &bytes.Buffer{}
 )
 
 func TestParseReference(t *testing.T) {
@@ -128,6 +134,48 @@ func TestParseReference(t *testing.T) {
 				Directory: "path/to/directory",
 			},
 			wantErr: false,
+		},
+		{
+			name: "InputStream",
+			args: args{
+				location: "-",
+				opts:     []Option{WithStdin(test_reader)},
+			},
+			want: InputStream{
+				Reader: test_reader,
+			},
+			wantErr: false,
+		},
+		{
+			name: "OutputStream",
+			args: args{
+				location: "-",
+				opts:     []Option{WithStdout(test_writer)},
+			},
+			want: OutputStream{
+				Writer: test_writer,
+			},
+			wantErr: false,
+		},
+		{
+			name: "DuplexStream",
+			args: args{
+				location: "-",
+				opts:     []Option{WithStdin(test_reader), WithStdout(test_writer)},
+			},
+			want: InputOutputStream{
+				Reader: test_reader,
+				Writer: test_writer,
+			},
+			wantErr: false,
+		},
+		{
+			name: "StreamLocationNotExpected",
+			args: args{
+				location: "-",
+			},
+			want:    nil,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/location/parse_test.go
+++ b/pkg/location/parse_test.go
@@ -13,6 +13,7 @@ var (
 	test_writer = &bytes.Buffer{}
 )
 
+//nolint:scopelint
 func TestParseReference(t *testing.T) {
 	type args struct {
 		location string

--- a/pkg/location/parse_test.go
+++ b/pkg/location/parse_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	testReader = &bytes.Buffer{}
-	testWriter = &bytes.Buffer{}
+	testReader  = &bytes.Buffer{}
+	testWriter  = &bytes.Buffer{}
+	testOptions = []Option{WithOci(), WithGit(), WithDir()}
 )
 
 //nolint:scopelint
@@ -159,29 +160,19 @@ func TestParseReference(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "DuplexStream",
-			args: args{
-				location: "-",
-				opts:     []Option{WithStdin(testReader), WithStdout(testWriter)},
-			},
-			want: InputOutputStream{
-				Reader: testReader,
-				Writer: testWriter,
-			},
-			wantErr: false,
-		},
-		{
 			name: "StreamLocationNotExpected",
 			args: args{
 				location: "-",
 			},
-			want:    nil,
-			wantErr: true,
+			want: Dir{
+				Directory: "-",
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseReference(tt.args.location, tt.args.opts...)
+			got, err := ParseReference(tt.args.location, append(tt.args.opts, testOptions...)...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/location/parse_test.go
+++ b/pkg/location/parse_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package location
 
 import (

--- a/pkg/location/reference.go
+++ b/pkg/location/reference.go
@@ -4,6 +4,8 @@ import "fmt"
 
 type Reference interface {
 	fmt.Stringer
+	Type() string
+	Validate() error
 }
 
 type ReferenceLock interface {

--- a/pkg/location/reference.go
+++ b/pkg/location/reference.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package location
 
 import "fmt"

--- a/pkg/location/reference.go
+++ b/pkg/location/reference.go
@@ -1,0 +1,11 @@
+package location
+
+import "fmt"
+
+type Reference interface {
+	fmt.Stringer
+}
+
+type ReferenceLock interface {
+	Reference
+}

--- a/pkg/location/type_dir.go
+++ b/pkg/location/type_dir.go
@@ -2,6 +2,7 @@ package location
 
 import (
 	"fmt"
+	"io/fs"
 )
 
 type Dir struct {
@@ -9,6 +10,15 @@ type Dir struct {
 }
 
 var _ Reference = Dir{}
+
+func parseDir(location string, opt options) (Reference, error) {
+	if fs.ValidPath(location) {
+		return Dir{
+			Directory: location,
+		}, nil
+	}
+	return nil, nil
+}
 
 func (ref Dir) String() string {
 	return fmt.Sprintf("type:dir directory:%q", ref.Directory)

--- a/pkg/location/type_dir.go
+++ b/pkg/location/type_dir.go
@@ -26,16 +26,16 @@ type Dir struct {
 
 var _ Reference = Dir{}
 
-func parseDir(location string, opt options) (Reference, error) {
+func parseDir(location string) Reference {
 	dir := filepath.Clean(location)
 
 	if fs.ValidPath(dir) {
 		return Dir{
 			Directory: dir,
-		}, nil
+		}
 	}
 
-	return nil, nil
+	return nil
 }
 
 // String implements location.Reference

--- a/pkg/location/type_dir.go
+++ b/pkg/location/type_dir.go
@@ -20,14 +20,17 @@ func parseDir(location string, opt options) (Reference, error) {
 	return nil, nil
 }
 
+// String implements location.Reference
 func (ref Dir) String() string {
 	return fmt.Sprintf("type:dir directory:%q", ref.Directory)
 }
 
+// Type implements location.Reference
 func (ref Dir) Type() string {
 	return "dir"
 }
 
+// Validate implements location.Reference
 func (ref Dir) Validate() error {
 	return nil
 }

--- a/pkg/location/type_dir.go
+++ b/pkg/location/type_dir.go
@@ -17,6 +17,7 @@ package location
 import (
 	"fmt"
 	"io/fs"
+	"path/filepath"
 )
 
 type Dir struct {
@@ -26,11 +27,14 @@ type Dir struct {
 var _ Reference = Dir{}
 
 func parseDir(location string, opt options) (Reference, error) {
-	if fs.ValidPath(location) {
+	dir := filepath.Clean(location)
+
+	if fs.ValidPath(dir) {
 		return Dir{
-			Directory: location,
+			Directory: dir,
 		}, nil
 	}
+
 	return nil, nil
 }
 

--- a/pkg/location/type_dir.go
+++ b/pkg/location/type_dir.go
@@ -1,0 +1,13 @@
+package location
+
+import "fmt"
+
+type Dir struct {
+	Directory string
+}
+
+var _ Reference = Dir{}
+
+func (ref Dir) String() string {
+	return fmt.Sprintf("type:dir directory:%q", ref.Directory)
+}

--- a/pkg/location/type_dir.go
+++ b/pkg/location/type_dir.go
@@ -1,6 +1,8 @@
 package location
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type Dir struct {
 	Directory string
@@ -10,4 +12,12 @@ var _ Reference = Dir{}
 
 func (ref Dir) String() string {
 	return fmt.Sprintf("type:dir directory:%q", ref.Directory)
+}
+
+func (ref Dir) Type() string {
+	return "dir"
+}
+
+func (ref Dir) Validate() error {
+	return nil
 }

--- a/pkg/location/type_dir.go
+++ b/pkg/location/type_dir.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package location
 
 import (

--- a/pkg/location/type_git.go
+++ b/pkg/location/type_git.go
@@ -77,16 +77,16 @@ func newGit(location string, opt options) (Git, error) {
 	}, nil
 }
 
-func parseGit(location string, opt options) (Reference, error) {
+func parseGit(location string, opt options) Reference {
 	git, gitErr := newGit(location, opt)
 	var zero Git
 	if gitErr == nil && git != zero {
-		return git, nil
+		return git
 	}
 
 	// TODO - figure out which gitErr must be returned, and which simply mean "it's not a git path"
 
-	return nil, nil
+	return nil
 }
 
 // String implements location.Reference

--- a/pkg/location/type_git.go
+++ b/pkg/location/type_git.go
@@ -2,9 +2,11 @@ package location
 
 import (
 	"fmt"
+	"path"
 	"path/filepath"
 	"strings"
 
+	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/util/parse"
 )
 
@@ -63,6 +65,31 @@ func (ref Git) String() string {
 
 func (ref GitLock) String() string {
 	return fmt.Sprintf("%v commit:%q", ref.Git, ref.Commit)
+}
+
+func (ref Git) Type() string {
+	return "git"
+}
+
+func (ref Git) Validate() error {
+	const op errors.Op = "git.Validate"
+	if len(ref.Repo) == 0 {
+		return errors.E(op, errors.MissingParam, fmt.Errorf("must specify repo"))
+	}
+	if len(ref.Ref) == 0 {
+		return errors.E(op, errors.MissingParam, fmt.Errorf("must specify ref"))
+	}
+	if len(ref.Directory) == 0 {
+		return errors.E(op, errors.MissingParam, fmt.Errorf("must specify directory"))
+	}
+	return nil
+}
+
+func (ref Git) GetDefaultDirectoryName() (string, error) {
+	repo := ref.Repo
+	repo = strings.TrimSuffix(repo, "/")
+	repo = strings.TrimSuffix(repo, ".git")
+	return path.Base(path.Join(path.Clean(repo), path.Clean(ref.Directory))), nil
 }
 
 func (ref Git) SetIdentifier(name string) (Reference, error) {

--- a/pkg/location/type_git.go
+++ b/pkg/location/type_git.go
@@ -36,11 +36,14 @@ type GitLock struct {
 var _ ReferenceLock = GitLock{}
 
 func NewGit(location string, opts ...Option) (Git, error) {
-	opt := makeOptions(opts...)
+	return newGit(location, makeOptions(opts...))
+}
 
+func newGit(location string, opt options) (Git, error) {
 	// args[1] is "" for commands that do not require an output path
 	gitTarget, err := parse.GitParseArgs(opt.ctx, []string{location, ""})
-	if err != nil {
+	var zero parse.GitTarget
+	if err != nil || gitTarget == zero {
 		return Git{}, err
 	}
 
@@ -57,6 +60,18 @@ func NewGit(location string, opts ...Option) (Git, error) {
 		Directory: dir,
 		Ref:       gitTarget.Ref,
 	}, nil
+}
+
+func parseGit(location string, opt options) (Reference, error) {
+	git, gitErr := newGit(location, opt)
+	var zero Git
+	if gitErr == nil && git != zero {
+		return git, nil
+	}
+
+	// TODO - figure out which gitErr must be returned, and which simply mean "it's not a git path"
+
+	return nil, nil
 }
 
 func (ref Git) String() string {

--- a/pkg/location/type_git.go
+++ b/pkg/location/type_git.go
@@ -1,0 +1,81 @@
+package location
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/GoogleContainerTools/kpt/internal/util/parse"
+)
+
+type Git struct {
+	// Repo is the git repository the package.
+	// e.g. 'https://github.com/kubernetes/examples.git'
+	Repo string
+
+	// Directory is the sub directory of the git repository.
+	// e.g. 'staging/cockroachdb'
+	Directory string
+
+	// Ref can be a Git branch, tag, or a commit SHA-1.
+	Ref string
+}
+
+var _ Reference = Git{}
+
+type GitLock struct {
+	Git
+
+	// Commit is the SHA-1 for the last fetch of the package.
+	// This is set by kpt for bookkeeping purposes.
+	Commit string
+}
+
+var _ ReferenceLock = GitLock{}
+
+func NewGit(location string, opts ...Option) (Git, error) {
+	opt := makeOptions(opts...)
+
+	// args[1] is "" for commands that do not require an output path
+	gitTarget, err := parse.GitParseArgs(opt.ctx, []string{location, ""})
+	if err != nil {
+		return Git{}, err
+	}
+
+	dir := gitTarget.Directory
+	if strings.HasPrefix(dir, "/") {
+		dir, err = filepath.Rel("/", gitTarget.Directory)
+		if err != nil {
+			return Git{}, err
+		}
+	}
+
+	return Git{
+		Repo:      gitTarget.Repo,
+		Directory: dir,
+		Ref:       gitTarget.Ref,
+	}, nil
+}
+
+func (ref Git) String() string {
+	return fmt.Sprintf("type:git repo:%q ref:%q directory:%q", ref.Repo, ref.Ref, ref.Directory)
+}
+
+func (ref GitLock) String() string {
+	return fmt.Sprintf("%v commit:%q", ref.Git, ref.Commit)
+}
+
+func (ref Git) SetIdentifier(name string) (Reference, error) {
+	return Git{
+		Repo:      ref.Repo,
+		Directory: ref.Directory,
+		Ref:       name,
+	}, nil
+}
+
+func (ref Git) SetLock(lock string) (ReferenceLock, error) {
+	return GitLock{
+		Git:    ref,
+		Commit: lock,
+	}, nil
+}

--- a/pkg/location/type_git.go
+++ b/pkg/location/type_git.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package location
 
 import (

--- a/pkg/location/type_io.go
+++ b/pkg/location/type_io.go
@@ -1,0 +1,37 @@
+package location
+
+import (
+	"fmt"
+	"io"
+)
+
+type InputStream struct {
+	Reader io.Reader
+}
+
+var _ Reference = InputStream{}
+
+func (ref InputStream) String() string {
+	return fmt.Sprintf("type:io reader:%v", ref.Reader)
+}
+
+type OutputStream struct {
+	Writer io.Writer
+}
+
+var _ Reference = OutputStream{}
+
+func (ref OutputStream) String() string {
+	return fmt.Sprintf("type:io writer:%v", ref.Writer)
+}
+
+type InputOutputStream struct {
+	Reader io.Reader
+	Writer io.Writer
+}
+
+var _ Reference = InputOutputStream{}
+
+func (ref InputOutputStream) String() string {
+	return fmt.Sprintf("type:io reader:%v writer:%v", ref.Reader, ref.Writer)
+}

--- a/pkg/location/type_io.go
+++ b/pkg/location/type_io.go
@@ -15,6 +15,14 @@ func (ref InputStream) String() string {
 	return fmt.Sprintf("type:io reader:%v", ref.Reader)
 }
 
+func (ref InputStream) Type() string {
+	return "io"
+}
+
+func (ref InputStream) Validate() error {
+	return nil
+}
+
 type OutputStream struct {
 	Writer io.Writer
 }
@@ -23,6 +31,14 @@ var _ Reference = OutputStream{}
 
 func (ref OutputStream) String() string {
 	return fmt.Sprintf("type:io writer:%v", ref.Writer)
+}
+
+func (ref OutputStream) Type() string {
+	return "io"
+}
+
+func (ref OutputStream) Validate() error {
+	return nil
 }
 
 type InputOutputStream struct {
@@ -34,4 +50,12 @@ var _ Reference = InputOutputStream{}
 
 func (ref InputOutputStream) String() string {
 	return fmt.Sprintf("type:io reader:%v writer:%v", ref.Reader, ref.Writer)
+}
+
+func (ref InputOutputStream) Type() string {
+	return "io"
+}
+
+func (ref InputOutputStream) Validate() error {
+	return nil
 }

--- a/pkg/location/type_io.go
+++ b/pkg/location/type_io.go
@@ -20,14 +20,17 @@ func stdinParser(value string, opt options) (Reference, error) {
 	return nil, nil
 }
 
+// String implements location.Reference
 func (ref InputStream) String() string {
 	return fmt.Sprintf("type:io reader:%v", ref.Reader)
 }
 
+// Type implements location.Reference
 func (ref InputStream) Type() string {
 	return "io"
 }
 
+// Validate implements location.Reference
 func (ref InputStream) Validate() error {
 	return nil
 }
@@ -47,14 +50,17 @@ func stdoutParser(value string, opt options) (Reference, error) {
 	return nil, nil
 }
 
+// String implements location.Reference
 func (ref OutputStream) String() string {
 	return fmt.Sprintf("type:io writer:%v", ref.Writer)
 }
 
+// Type implements location.Reference
 func (ref OutputStream) Type() string {
 	return "io"
 }
 
+// Validate implements location.Reference
 func (ref OutputStream) Validate() error {
 	return nil
 }

--- a/pkg/location/type_io.go
+++ b/pkg/location/type_io.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package location
 
 import (

--- a/pkg/location/type_io.go
+++ b/pkg/location/type_io.go
@@ -25,15 +25,6 @@ type InputStream struct {
 
 var _ Reference = InputStream{}
 
-func stdinParser(value string, opt options) (Reference, error) {
-	if value == "-" {
-		return InputStream{
-			Reader: opt.stdin,
-		}, nil
-	}
-	return nil, nil
-}
-
 // String implements location.Reference
 func (ref InputStream) String() string {
 	return fmt.Sprintf("type:io reader:%v", ref.Reader)
@@ -55,15 +46,6 @@ type OutputStream struct {
 
 var _ Reference = OutputStream{}
 
-func stdoutParser(value string, opt options) (Reference, error) {
-	if value == "-" {
-		return OutputStream{
-			Writer: opt.stdout,
-		}, nil
-	}
-	return nil, nil
-}
-
 // String implements location.Reference
 func (ref OutputStream) String() string {
 	return fmt.Sprintf("type:io writer:%v", ref.Writer)
@@ -77,4 +59,14 @@ func (ref OutputStream) Type() string {
 // Validate implements location.Reference
 func (ref OutputStream) Validate() error {
 	return nil
+}
+
+type DuplexStream struct {
+	InputStream
+	OutputStream OutputStream
+}
+
+// String implements location.Reference
+func (ref DuplexStream) String() string {
+	return fmt.Sprintf("type:io reader:%v writer:%v", ref.InputStream.Reader, ref.OutputStream.Writer)
 }

--- a/pkg/location/type_io.go
+++ b/pkg/location/type_io.go
@@ -11,6 +11,15 @@ type InputStream struct {
 
 var _ Reference = InputStream{}
 
+func stdinParser(value string, opt options) (Reference, error) {
+	if value == "-" {
+		return InputStream{
+			Reader: opt.stdin,
+		}, nil
+	}
+	return nil, nil
+}
+
 func (ref InputStream) String() string {
 	return fmt.Sprintf("type:io reader:%v", ref.Reader)
 }
@@ -29,6 +38,15 @@ type OutputStream struct {
 
 var _ Reference = OutputStream{}
 
+func stdoutParser(value string, opt options) (Reference, error) {
+	if value == "-" {
+		return OutputStream{
+			Writer: opt.stdout,
+		}, nil
+	}
+	return nil, nil
+}
+
 func (ref OutputStream) String() string {
 	return fmt.Sprintf("type:io writer:%v", ref.Writer)
 }
@@ -38,24 +56,5 @@ func (ref OutputStream) Type() string {
 }
 
 func (ref OutputStream) Validate() error {
-	return nil
-}
-
-type InputOutputStream struct {
-	Reader io.Reader
-	Writer io.Writer
-}
-
-var _ Reference = InputOutputStream{}
-
-func (ref InputOutputStream) String() string {
-	return fmt.Sprintf("type:io reader:%v writer:%v", ref.Reader, ref.Writer)
-}
-
-func (ref InputOutputStream) Type() string {
-	return "io"
-}
-
-func (ref InputOutputStream) Validate() error {
 	return nil
 }

--- a/pkg/location/type_oci.go
+++ b/pkg/location/type_oci.go
@@ -83,7 +83,7 @@ func NewOci(location string, opts ...Option) (Oci, error) {
 	return Oci{}, fmt.Errorf("invalid format")
 }
 
-func parseOci(value string, opt options) (Reference, error) {
+func parseOci(value string) (Reference, error) {
 	if _, ok := startsWith(value, "oci://"); ok {
 		return NewOci(value)
 	}

--- a/pkg/location/type_oci.go
+++ b/pkg/location/type_oci.go
@@ -1,11 +1,12 @@
 package location
 
 import (
-	"errors"
 	"fmt"
+	"path"
 	"path/filepath"
 	"strings"
 
+	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/google/go-containerregistry/pkg/name"
 )
 
@@ -64,7 +65,7 @@ func NewOci(location string, opts ...Option) (Oci, error) {
 		}, nil
 	}
 
-	return Oci{}, errors.New("invalid format")
+	return Oci{}, fmt.Errorf("invalid format")
 }
 
 func (ref Oci) String() string {
@@ -73,6 +74,22 @@ func (ref Oci) String() string {
 
 func (ref OciLock) String() string {
 	return fmt.Sprintf("%v digest:%q", ref.Oci, ref.Digest)
+}
+
+func (ref Oci) Validate() error {
+	const op errors.Op = "oci.Validate"
+	if ref.Image == nil {
+		return errors.E(op, errors.MissingParam, fmt.Errorf("must specify image"))
+	}
+	return nil
+}
+
+func (ref Oci) Type() string {
+	return "oci"
+}
+
+func (ref Oci) GetDefaultDirectoryName() (string, error) {
+	return path.Base(path.Join(path.Clean(ref.Image.Context().Name()), path.Clean(ref.Directory))), nil
 }
 
 func (ref Oci) SetIdentifier(identifier string) (Reference, error) {

--- a/pkg/location/type_oci.go
+++ b/pkg/location/type_oci.go
@@ -1,0 +1,90 @@
+package location
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+type Oci struct {
+	Image     name.Reference
+	Directory string
+}
+
+var _ Reference = Oci{}
+
+type OciLock struct {
+	Oci
+	Digest name.Reference
+}
+
+var _ Reference = OciLock{}
+var _ ReferenceLock = OciLock{}
+
+func NewOci(location string, opts ...Option) (Oci, error) {
+
+	if s, ok := startsWith(location, "oci://"); ok {
+		ref, err := name.ParseReference(s)
+		if err != nil {
+			return Oci{}, err
+		}
+		if parts := strings.SplitN(ref.Context().Name(), "//", 2); len(parts) == 2 {
+			repo, err := name.NewRepository(parts[0])
+			if err != nil {
+				return Oci{}, err
+			}
+
+			dir := filepath.Clean(parts[1])
+			if filepath.IsAbs(dir) {
+				dir, err = filepath.Rel("/", dir)
+				if err != nil {
+					return Oci{}, err
+				}
+			}
+
+			switch ref := ref.(type) {
+			case name.Tag:
+				return Oci{
+					Image:     repo.Tag(ref.TagStr()),
+					Directory: dir,
+				}, nil
+			case name.Digest:
+				return Oci{
+					Image:     repo.Digest(ref.DigestStr()),
+					Directory: dir,
+				}, nil
+			}
+		}
+		return Oci{
+			Image:     ref,
+			Directory: ".",
+		}, nil
+	}
+
+	return Oci{}, errors.New("invalid format")
+}
+
+func (ref Oci) String() string {
+	return fmt.Sprintf("type:oci image:%q directory:%q", ref.Image, ref.Directory)
+}
+
+func (ref OciLock) String() string {
+	return fmt.Sprintf("%v digest:%q", ref.Oci, ref.Digest)
+}
+
+func (ref Oci) SetIdentifier(identifier string) (Reference, error) {
+	return Oci{
+		Image:     ref.Image.Context().Tag(identifier),
+		Directory: ref.Directory,
+	}, nil
+}
+
+func (ref Oci) SetLock(lock string) (ReferenceLock, error) {
+	return OciLock{
+		Oci:    ref,
+		Digest: ref.Image.Context().Digest(lock),
+	}, nil
+}

--- a/pkg/location/type_oci.go
+++ b/pkg/location/type_oci.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package location
 
 import (

--- a/pkg/location/type_oci.go
+++ b/pkg/location/type_oci.go
@@ -68,6 +68,13 @@ func NewOci(location string, opts ...Option) (Oci, error) {
 	return Oci{}, fmt.Errorf("invalid format")
 }
 
+func parseOci(value string, opt options) (Reference, error) {
+	if _, ok := startsWith(value, "oci://"); ok {
+		return NewOci(value)
+	}
+	return nil, nil
+}
+
 func (ref Oci) String() string {
 	return fmt.Sprintf("type:oci image:%q directory:%q", ref.Image, ref.Directory)
 }


### PR DESCRIPTION
`location.ParseReference` returning `location.Reference` for CLI would replace internal git and oci argument parsing in a way that's callable by porch or other clients. 

In the case that the caller already has structured data, where the location type and individual properties are known, the `location.Git{...}` and `location.Oci{...}` should be created directly, rather than creating the string notation to parsing.

The common interface under createable struct types, with a parse to go from a string and options to the common interface, is based on the pattern from gcrane pkg's `name.ParseReference(name, opts...)`.

The ability to mutate/lock references abstractly is intended to be a step towards eliminating methods from the internal remote.Updater and remote.Origin utility interface. The pattern there is taken from the `io.fs` approach where package functions like `mutate.Lock(Reference, string) => (ReferenceLock, error)` make it easy to call optional methods that are not supported on every kind of Reference.

