### PR TITLE
fix: report NotFound status for deleted KCC resources

### DIFF
--- a/pkg/status/configconnector.go
+++ b/pkg/status/configconnector.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -58,6 +59,9 @@ func (c *ConfigConnectorStatusReader) ReadStatus(ctx context.Context, reader eng
 	u.SetGroupVersionKind(gvk)
 	err = reader.Get(ctx, key, &u)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			return newResourceStatus(id, status.NotFoundStatus, &u, "Resource not found")
+		}
 		return newUnknownResourceStatus(id, nil, err)
 	}
 

--- a/pkg/status/configconnector_test.go
+++ b/pkg/status/configconnector_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/polling/testutil"
 	"sigs.k8s.io/cli-utils/pkg/kstatus/status"
@@ -53,6 +54,7 @@ func TestReadStatus(t *testing.T) {
 		resource       string
 		gvk            schema.GroupVersionKind
 		expectedStatus status.Status
+		deleted        bool
 	}{
 		"Resource with deletionTimestap is Terminating": {
 			resource: `
@@ -117,6 +119,22 @@ status:
 			},
 			expectedStatus: status.FailedStatus,
 		},
+
+		"Resource has been deleted": {
+			resource: `
+apiVersion: storage.cnrm.cloud.google.com/v1beta1
+kind: StorageBucket
+metadata:
+  name: fake-bucket
+`,
+			gvk: schema.GroupVersionKind{
+				Group:   "storage.cnrm.cloud.google.com",
+				Version: "v1beta1",
+				Kind:    "StorageBucket",
+			},
+			expectedStatus: status.NotFoundStatus,
+			deleted:        true,
+		},
 	}
 
 	for tn, tc := range testCases {
@@ -126,6 +144,12 @@ status:
 			fakeClusterReader := &fakeClusterReader{
 				getResource: obj,
 			}
+			// Return not found error if we want the resource to be deleted.
+			if tc.deleted {
+				fakeClusterReader.getResource = nil
+				fakeClusterReader.getErr = errors.NewNotFound(schema.GroupResource{tc.gvk.Group, tc.gvk.Kind}, "fake-name")
+			}
+
 			fakeMapper := fakemapper.NewFakeRESTMapper(tc.gvk)
 			statusReader := &ConfigConnectorStatusReader{
 				Mapper: fakeMapper,

--- a/pkg/status/configconnector_test.go
+++ b/pkg/status/configconnector_test.go
@@ -147,7 +147,7 @@ metadata:
 			// Return not found error if we want the resource to be deleted.
 			if tc.deleted {
 				fakeClusterReader.getResource = nil
-				fakeClusterReader.getErr = errors.NewNotFound(schema.GroupResource{tc.gvk.Group, tc.gvk.Kind}, "fake-name")
+				fakeClusterReader.getErr = errors.NewNotFound(schema.GroupResource{Group: tc.gvk.Group, Resource: tc.gvk.Kind}, "fake-name")
 			}
 
 			fakeMapper := fakemapper.NewFakeRESTMapper(tc.gvk)


### PR DESCRIPTION
The current custom StatusReader for Config Connector resources will
report Unknown status when a Config Connector resource is not found (aka
deleted). This causes the `kpt live destroy` reconcile loop to run
forever since it expects a NotFound status to end. This commit ensures
that deleted resources report a NotFound status instead.

A new test case for deleted KCC resource is also added.

Fixes: #2687 
