### PR TITLE
Create fix-all and verify-fix-all

### DIFF
--- a/.github/workflows/porch.yml
+++ b/.github/workflows/porch.yml
@@ -35,6 +35,9 @@ jobs:
           go-version: 1.17.6
       - name: Run Porch Unit Tests
         uses: actions/checkout@v2
+      - name: Verify format / headers etc
+        run: hack/verify-fix-all.sh
+        working-directory: ./porch
       - name: Build
         run: make porch
         working-directory: ./porch

--- a/porch/Makefile
+++ b/porch/Makefile
@@ -104,3 +104,11 @@ run-jaeger:
 .PHONY: porch
 porch:
 	cd apiserver; go build ./cmd/porch
+
+.PHONY: fix-headers
+fix-headers:
+	# TODO: switch to google/addlicense once we have https://github.com/google/addlicense/pull/104
+	go run github.com/justinsb/addlicense@v1.0.1 -c "Google LLC" -l apache --ignore ".build/**" . 2>/dev/null
+
+.PHONY: fix-all
+fix-all: fix-headers fmt tidy

--- a/porch/controllers/remoterootsync/Makefile
+++ b/porch/controllers/remoterootsync/Makefile
@@ -1,3 +1,17 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # GCP project to use for development
 GCP_PROJECT_ID ?= $(shell gcloud config get-value project)
 

--- a/porch/hack/verify-fix-all.sh
+++ b/porch/hack/verify-fix-all.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+
+make -C "${REPO_ROOT}/porch" fix-all
+
+changes=$(git status --porcelain || true)
+if [ -n "${changes}" ]; then
+  echo "ERROR: some files changes, please run `make fixup`"
+  echo "changed files:"
+  printf "%s" "${changes}\n"
+  echo "git diff:"
+  git --no-pager diff
+  exit 1
+fi

--- a/porch/repository/doc.go
+++ b/porch/repository/doc.go
@@ -1,1 +1,15 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package repository


### PR DESCRIPTION
We run all the formatters / header makers etc.

In CI, we run them and make sure that the git checkout is still clean.

Ideally we would also run generate, but it is very slow, and it also
requires GOPATH to be set.  We can do that in CI later.
