### PR TITLE
Enable apply/destroy to use inventory in separate ResourceGroup file 

### DIFF
--- a/internal/cmdapply/cmdapply.go
+++ b/internal/cmdapply/cmdapply.go
@@ -108,6 +108,7 @@ type Runner struct {
 	pruneTimeout                 time.Duration
 	inventoryPolicyString        string
 	dryRun                       bool
+	rgFile                       string
 	printStatusEvents            bool
 
 	inventoryPolicy inventory.InventoryPolicy
@@ -166,7 +167,7 @@ func (r *Runner) runE(c *cobra.Command, args []string) error {
 		}
 	}
 
-	objs, inv, err := live.Load(r.factory, path, c.InOrStdin())
+	objs, inv, err := live.Load(r.factory, path, r.rgFile, c.InOrStdin())
 	if err != nil {
 		return err
 	}

--- a/internal/cmddestroy/cmddestroy.go
+++ b/internal/cmddestroy/cmddestroy.go
@@ -83,6 +83,7 @@ type Runner struct {
 	output                string
 	inventoryPolicyString string
 	dryRun                bool
+	rgFile                string
 	printStatusEvents     bool
 
 	inventoryPolicy inventory.InventoryPolicy
@@ -128,7 +129,7 @@ func (r *Runner) runE(c *cobra.Command, args []string) error {
 		}
 	}
 
-	_, inv, err := live.Load(r.factory, path, c.InOrStdin())
+	_, inv, err := live.Load(r.factory, path, r.rgFile, c.InOrStdin())
 	if err != nil {
 		return err
 	}

--- a/internal/cmdmigrate/migratecmd.go
+++ b/internal/cmdmigrate/migratecmd.go
@@ -301,7 +301,7 @@ func (mr *MigrateRunner) migrateObjs(rgInvClient inventory.InventoryClient,
 		}
 	}
 
-	_, inv, err := live.Load(mr.factory, path, reader)
+	_, inv, err := live.Load(mr.factory, path, mr.rgFile, reader)
 	if err != nil {
 		return err
 	}

--- a/internal/pkg/pkg.go
+++ b/internal/pkg/pkg.go
@@ -741,23 +741,28 @@ func ReadRGFile(path, filename string) (*rgfilev1alpha1.ResourceGroup, error) {
 	}
 	defer f.Close()
 
-	rg := &rgfilev1alpha1.ResourceGroup{}
-	c, err := io.ReadAll(f)
+	rg, err := DecodeRGFile(f)
 	if err != nil {
 		return nil, &RGError{
 			Path: types.UniquePath(path),
 			Err:  err,
 		}
 	}
+	return rg, nil
+}
+
+// DecodeRGFile converts a string reader into structured a ResourceGroup object.
+func DecodeRGFile(in io.Reader) (*rgfilev1alpha1.ResourceGroup, error) {
+	rg := &rgfilev1alpha1.ResourceGroup{}
+	c, err := io.ReadAll(in)
+	if err != nil {
+		return rg, err
+	}
 
 	d := yaml.NewDecoder(bytes.NewBuffer(c))
 	d.KnownFields(true)
 	if err := d.Decode(rg); err != nil {
-		return nil, &RGError{
-			Path: types.UniquePath(path),
-			Err:  err,
-		}
+		return rg, err
 	}
 	return rg, nil
-
 }

--- a/pkg/api/kptfile/v1/types.go
+++ b/pkg/api/kptfile/v1/types.go
@@ -326,3 +326,10 @@ type Inventory struct {
 	Labels      map[string]string `yaml:"labels,omitempty" json:"labels,omitempty"`
 	Annotations map[string]string `yaml:"annotations,omitempty" json:"annotations,omitempty"`
 }
+
+func (i Inventory) IsValid() bool {
+	// Name and Namespace are required inventory fields, so we check these 2 fields.
+	// InventoryID is an optional field since we only store it locally if the user
+	// specifies one.
+	return i.Name != "" && i.Namespace != ""
+}

--- a/pkg/live/rgpath.go
+++ b/pkg/live/rgpath.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
+	rgfilev1alpha1 "github.com/GoogleContainerTools/kpt/pkg/api/resourcegroup/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/cli-utils/pkg/manifestreader"
 	"sigs.k8s.io/kustomize/kyaml/kio"
@@ -63,6 +64,13 @@ func (r *ResourceGroupPathManifestReader) Read() ([]*unstructured.Unstructured, 
 		u, err := kyamlNodeToUnstructured(n)
 		if err != nil {
 			return objs, err
+		}
+
+		// Skip if current file is a ResourceGroup resource. We do not want to apply/delete any ResourceGroup CRs when we
+		// run any `kpt live` commands on a package. Instead, we have specific logic in place for handling ResourceGroups in
+		// the live cluster.
+		if u.GetKind() == rgfilev1alpha1.RGFileKind && u.GetAPIVersion() == rgfilev1alpha1.DefaultMeta.APIVersion {
+			continue
 		}
 		objs = append(objs, u)
 	}

--- a/pkg/live/rgstream.go
+++ b/pkg/live/rgstream.go
@@ -8,6 +8,7 @@ import (
 	"io"
 
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
+	rgfilev1alpha1 "github.com/GoogleContainerTools/kpt/pkg/api/resourcegroup/v1alpha1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/cli-utils/pkg/manifestreader"
@@ -22,6 +23,10 @@ var (
 		{
 			Group: kptfilev1.KptFileGroup,
 			Kind:  kptfilev1.KptFileKind,
+		},
+		{
+			Group: rgfilev1alpha1.RGFileGroup,
+			Kind:  rgfilev1alpha1.RGFileKind,
 		},
 	}
 )

--- a/thirdparty/cli-utils/status/cmdstatus.go
+++ b/thirdparty/cli-utils/status/cmdstatus.go
@@ -85,6 +85,7 @@ type Runner struct {
 	pollUntil string
 	timeout   time.Duration
 	output    string
+	rgFile    string
 
 	pollerFactoryFunc func(util.Factory) (poller.Poller, error)
 }
@@ -124,7 +125,7 @@ func (r *Runner) runE(c *cobra.Command, args []string) error {
 		}
 	}
 
-	_, inv, err := live.Load(r.factory, path, c.InOrStdin())
+	_, inv, err := live.Load(r.factory, path, r.rgFile, c.InOrStdin())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is a PR that implements the `kpt live apply` and `destroy` functionality defined within the kpt live apply from STDIN design doc.

Additions:
* Apply and destroy using inventory stored in resourcegroup.yaml
* Test cases
Note: This is a stacked PR on top of #2705, so some code changes may appear duplicated...

#### Files changed:
```
internal/testutil/pkgbuilder/builder.go
pkg/live/load.go
pkg/live/load_test.go
pkg/live/rgpath.go
pkg/live/rgstream.go
```
Refactoring/splitting code:
```
internal/pkg/pkg.go
```

Small changes (2 lines):
```
internal/cmdapply/cmdapply.go
internal/cmddestroy/cmddestroy.go
internal/cmdmigrate/migratecmd.go
thirdparty/cli-utils/status/cmdstatus.go
```