### PR TITLE
Oci pkg get

### DIFF
--- a/demos/demo-content/main.go
+++ b/demos/demo-content/main.go
@@ -15,23 +15,42 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/fs"
 	"os"
 	"path/filepath"
 
+	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"github.com/GoogleContainerTools/kpt/pkg/content/open"
 	"github.com/GoogleContainerTools/kpt/pkg/location"
 )
 
 func main() {
-	run("temp folder examples", tempFolderExamples)
+	// wire the global printer
+	pr := printer.New(os.Stdout, os.Stderr)
 
-}
+	// create context with associated printer
+	ctx := printer.WithContext(context.Background(), pr)
+	
+	// run through samples on location.Dir{}
+	fmt.Print("\n## Temp folder example\n\n")
+	if err := tempFolderExample(ctx); err != nil {
+		fmt.Printf("error in tempFolderExamples: %v\n", err)
+	}
 
-func run(caption string, example func() error) {
-	if err := example(); err != nil {
-		fmt.Printf("error in %q: %v\n", caption, err)
+	// run through examples on location.Git{}
+	fmt.Print("\n## GitHub blueprint example\n\n")
+	if err := githubBlueprintExample(ctx); err != nil {
+		fmt.Printf("error in githubBlueprintExample: %v\n", err)
+	}
+	
+	if len(os.Args) == 2 {
+		// run through examples on provided location
+		fmt.Print("\n## Parsed location example\n\n")
+		if err := locationExample(ctx, os.Args[1]); err != nil {
+			fmt.Printf("error in locationExample: %v\n", err)
+		}
 	}
 }
 
@@ -44,7 +63,7 @@ spec:
   target: world
 `
 
-func tempFolderExamples() error {
+func tempFolderExample(ctx context.Context) error {
 	// set up temp dir
 	tmp, err := os.MkdirTemp("", "")
 	if err != nil {
@@ -52,7 +71,7 @@ func tempFolderExamples() error {
 	}
 	defer os.RemoveAll(tmp)
 
-	if err := os.WriteFile(filepath.Join(tmp, "hello.txt"), []byte("world"), os.ModePerm); err != nil {
+	if err := os.WriteFile(filepath.Join(tmp, "README.md"), []byte("Hello world"), os.ModePerm); err != nil {
 		return err
 	}
 	if err := os.WriteFile(filepath.Join(tmp, "hello.yaml"), []byte(helloYaml), os.ModePerm); err != nil {
@@ -60,31 +79,56 @@ func tempFolderExamples() error {
 	}
 
 	return runAll(
+		ctx,
 		location.Dir{
 			Directory: tmp,
 		},
 	)
 }
 
-func runAll(ref location.Reference) error {
-	if err := openContent(ref); err != nil {
+func githubBlueprintExample(ctx context.Context) error {
+	return runAll(
+		ctx,
+		location.Git{
+			Repo: "https://github.com/GoogleCloudPlatform/blueprints",
+			Directory: "catalog/gke",
+			Ref: "main",
+		},
+	)
+}
+
+func locationExample(ctx context.Context, arg string) error {
+	ref, err := location.ParseReference(
+		arg,
+		location.WithContext(ctx),
+		location.WithParsers(location.OciParser, location.GitParser, location.DirParser),
+	)
+	if err != nil {
+		return err
+	}
+
+	return runAll(ctx, ref)
+}
+
+func runAll(ctx context.Context, ref location.Reference) error {
+	if err := openContent(ctx, ref); err != nil {
 		return fmt.Errorf("open content: %v", err)
 	}
-	if err := readFromFS(ref); err != nil {
-		return fmt.Errorf("open content as FS: %v", err)
-	}
-	if err := readFromFileSystem(ref); err != nil {
+	if err := readFromFileSystem(ctx, ref); err != nil {
 		return fmt.Errorf("open content as FileSystem: %v", err)
 	}
-	if err := readFromReader(ref); err != nil {
+	if err := readFromReader(ctx, ref); err != nil {
 		return fmt.Errorf("open content as Reader: %v", err)
+	}
+	if err := readFromFS(ctx, ref); err != nil {
+		return fmt.Errorf("open content as FS: %v", err)
 	}
 	return nil
 }
 
-func openContent(ref location.Reference) error {
+func openContent(ctx context.Context, ref location.Reference) error {
 	// open it as content
-	src, err := open.Content(ref)
+	src, err := open.Content(ref, open.WithContext(ctx))
 	if err != nil {
 		return err
 	}
@@ -94,41 +138,48 @@ func openContent(ref location.Reference) error {
 	return nil
 }
 
-func readFromFS(ref location.Reference) error {
+func readFromFS(ctx context.Context, ref location.Reference) error {
 	// open it as content as well as FS
-	src, err := open.FS(ref)
+	src, err := open.FS(ref, open.WithContext(ctx))
 	if err != nil {
 		return err
 	}
 	defer src.Close()
 
-	b, err := fs.ReadFile(src.FS, "hello.txt")
+	b, err := fs.ReadFile(src.FS, "README.md")
 	if err != nil {
 		return err
 	}
-	fmt.Printf("read %q\n", b)
+	fmt.Printf("read %q\n", short(b, 30))
 	return nil
 }
 
-func readFromFileSystem(ref location.Reference) error {
+func readFromFileSystem(ctx context.Context, ref location.Reference) error {
 	// open it as content as well as FS
-	src, err := open.FileSystem(ref)
+	src, err := open.FileSystem(ref, open.WithContext(ctx))
 	if err != nil {
 		return err
 	}
 	defer src.Close()
 
-	b, err := src.FileSystem.ReadFile(filepath.Join(src.Path, "hello.txt"))
+	b, err := src.FileSystem.ReadFile(filepath.Join(src.Path, "README.md"))
 	if err != nil {
 		return err
 	}
-	fmt.Printf("read %q\n", b)
+	fmt.Printf("read %q\n", short(b, 30))
 	return nil
 }
 
-func readFromReader(ref location.Reference) error {
+func short(b []byte, n int) []byte {
+	if len(b) < n {
+		return b
+	}
+	return b[0:n]
+}
+
+func readFromReader(ctx context.Context, ref location.Reference) error {
 	// open it as content as well as FS
-	src, err := open.Reader(ref)
+	src, err := open.Reader(ref, open.WithContext(ctx))
 	if err != nil {
 		return err
 	}
@@ -139,8 +190,10 @@ func readFromReader(ref location.Reference) error {
 		return err
 	}
 	for _, node := range nodes {
-		s, _ := node.String()
-		fmt.Printf("read %v\n", s)
+		//s, _ := node.String()
+		m, _ := node.GetMeta()
+		
+		fmt.Printf("read %v\n", m.GetIdentifier())
 	}
 	return nil
 }

--- a/demos/demo-content/main.go
+++ b/demos/demo-content/main.go
@@ -1,0 +1,146 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"github.com/GoogleContainerTools/kpt/pkg/content/open"
+	"github.com/GoogleContainerTools/kpt/pkg/location"
+)
+
+func main() {
+	run("temp folder examples", tempFolderExamples)
+
+}
+
+func run(caption string, example func() error) {
+	if err := example(); err != nil {
+		fmt.Printf("error in %q: %v\n", caption, err)
+	}
+}
+
+var helloYaml = `
+apiVersion: example.com/v1
+kind: Greeting
+metadata:
+  name: hello
+spec:
+  target: world
+`
+
+func tempFolderExamples() error {
+	// set up temp dir
+	tmp, err := os.MkdirTemp("", "")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmp)
+
+	if err := os.WriteFile(filepath.Join(tmp, "hello.txt"), []byte("world"), os.ModePerm); err != nil {
+		return err
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "hello.yaml"), []byte(helloYaml), os.ModePerm); err != nil {
+		return err
+	}
+
+	return runAll(
+		location.Dir{
+			Directory: tmp,
+		},
+	)
+}
+
+func runAll(ref location.Reference) error {
+	if err := openContent(ref); err != nil {
+		return fmt.Errorf("open content: %v", err)
+	}
+	if err := readFromFS(ref); err != nil {
+		return fmt.Errorf("open content as FS: %v", err)
+	}
+	if err := readFromFileSystem(ref); err != nil {
+		return fmt.Errorf("open content as FileSystem: %v", err)
+	}
+	if err := readFromReader(ref); err != nil {
+		return fmt.Errorf("open content as Reader: %v", err)
+	}
+	return nil
+}
+
+func openContent(ref location.Reference) error {
+	// open it as content
+	src, err := open.Content(ref)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	fmt.Printf("opened %v\n", src.Location)
+	return nil
+}
+
+func readFromFS(ref location.Reference) error {
+	// open it as content as well as FS
+	src, err := open.FS(ref)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	b, err := fs.ReadFile(src.FS, "hello.txt")
+	if err != nil {
+		return err
+	}
+	fmt.Printf("read %q\n", b)
+	return nil
+}
+
+func readFromFileSystem(ref location.Reference) error {
+	// open it as content as well as FS
+	src, err := open.FileSystem(ref)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	b, err := src.FileSystem.ReadFile(filepath.Join(src.Path, "hello.txt"))
+	if err != nil {
+		return err
+	}
+	fmt.Printf("read %q\n", b)
+	return nil
+}
+
+func readFromReader(ref location.Reference) error {
+	// open it as content as well as FS
+	src, err := open.Reader(ref)
+	if err != nil {
+		return err
+	}
+	defer src.Close()
+
+	nodes, err := src.Reader.Read()
+	if err != nil {
+		return err
+	}
+	for _, node := range nodes {
+		s, _ := node.String()
+		fmt.Printf("read %v\n", s)
+	}
+	return nil
+}

--- a/demos/demo-location/main.go
+++ b/demos/demo-location/main.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/demos/demo-location/main.go
+++ b/demos/demo-location/main.go
@@ -156,9 +156,8 @@ type CustomLocation struct {
 }
 
 type CustomLocationLock struct {
-	WhereItIs            string
-	LabelOrVersionString string
-	UniqueIDString       string
+	CustomLocation
+	UniqueIDString string
 }
 
 // compile-time check that duck types are correct
@@ -170,6 +169,14 @@ var _ mutate.LockSetter = CustomLocation{}
 // string when reference appears in console and log messages
 func (ref CustomLocation) String() string {
 	return fmt.Sprint(" WhereItIs:", ref.WhereItIs, " LabelOrVersionString:", ref.LabelOrVersionString)
+}
+
+func (ref CustomLocation) Type() string {
+	return "custom"
+}
+
+func (ref CustomLocation) Validate() error {
+	return nil
 }
 
 // string when reference appears in console and log messages
@@ -190,8 +197,10 @@ func (ref CustomLocation) SetIdentifier(labelOrVersion string) (location.Referen
 // depending on location, the exact meaning may be commit-id, image-digest, url-query parameter, exact resource name, etc.
 func (ref CustomLocation) SetLock(uniqueID string) (location.ReferenceLock, error) {
 	return CustomLocationLock{
-		WhereItIs:            ref.WhereItIs,
-		LabelOrVersionString: ref.LabelOrVersionString,
-		UniqueIDString:       uniqueID,
+		CustomLocation: CustomLocation{
+			WhereItIs:            ref.WhereItIs,
+			LabelOrVersionString: ref.LabelOrVersionString,
+		},
+		UniqueIDString: uniqueID,
 	}, nil
 }

--- a/demos/demo-location/main.go
+++ b/demos/demo-location/main.go
@@ -158,7 +158,7 @@ type CustomLocation struct {
 type CustomLocationLock struct {
 	WhereItIs            string
 	LabelOrVersionString string
-	UniqueIdString       string
+	UniqueIDString       string
 }
 
 // compile-time check that duck types are correct
@@ -174,24 +174,24 @@ func (ref CustomLocation) String() string {
 
 // string when reference appears in console and log messages
 func (ref CustomLocationLock) String() string {
-	return fmt.Sprint(" WhereItIs:", ref.WhereItIs, " LabelOrVersionString:", ref.LabelOrVersionString, " UniqueIdString:", ref.UniqueIdString)
+	return fmt.Sprint(" WhereItIs:", ref.WhereItIs, " LabelOrVersionString:", ref.LabelOrVersionString, " UniqueIDString:", ref.UniqueIDString)
 }
 
 // return location with only the identifier changed
 // depending on location, the exact meaning may be branch/label/version/tag/etc
-func (ref CustomLocation) SetIdentifier(name string) (location.Reference, error) {
+func (ref CustomLocation) SetIdentifier(labelOrVersion string) (location.Reference, error) {
 	return CustomLocation{
 		WhereItIs:            ref.WhereItIs,
-		LabelOrVersionString: name,
+		LabelOrVersionString: labelOrVersion,
 	}, nil
 }
 
 // return the locked form of the location
 // depending on location, the exact meaning may be commit-id, image-digest, url-query parameter, exact resource name, etc.
-func (ref CustomLocation) SetLock(uniqueId string) (location.ReferenceLock, error) {
+func (ref CustomLocation) SetLock(uniqueID string) (location.ReferenceLock, error) {
 	return CustomLocationLock{
 		WhereItIs:            ref.WhereItIs,
 		LabelOrVersionString: ref.LabelOrVersionString,
-		UniqueIdString:       uniqueId,
+		UniqueIDString:       uniqueID,
 	}, nil
 }

--- a/demos/demo-location/main.go
+++ b/demos/demo-location/main.go
@@ -149,15 +149,15 @@ func main() {
 
 }
 
-func example(caption string, arg string, identifier string, hash string, opts ...location.Option) {
+func example(caption string, arg string, identifier string, lock string, opts ...location.Option) {
 	fmt.Printf("%s %q\n", caption, arg)
-	if err := run(arg, identifier, hash, opts...); err != nil {
+	if err := run(arg, identifier, lock, opts...); err != nil {
 		fmt.Printf("example error: %v\n", err)
 	}
 	fmt.Println()
 }
 
-func run(arg string, identifier string, hash string, opts ...location.Option) error {
+func run(arg string, identifier string, lock string, opts ...location.Option) error {
 	// parse arg to a reference
 	parsed, err := location.ParseReference(arg, opts...)
 	if err != nil {
@@ -177,9 +177,9 @@ func run(arg string, identifier string, hash string, opts ...location.Option) er
 		changed = parsed
 	}
 
-	if hash != "" {
+	if lock != "" {
 		// making a locked reference with the unique value field for that reference type
-		locked, err := mutate.Lock(changed, hash)
+		locked, err := mutate.Lock(changed, lock)
 		if err != nil {
 			return err
 		}

--- a/demos/demo-location/main.go
+++ b/demos/demo-location/main.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/GoogleContainerTools/kpt/pkg/location"
+	"github.com/GoogleContainerTools/kpt/pkg/location/mutate"
+)
+
+func main() {
+	ctx := context.Background()
+
+	fmt.Println("- parsing argument to location")
+	fmt.Println()
+
+	example(
+		"oci example",
+		"oci://us-docker.pkg.dev/my-project-id/my-repo-name/my-blueprint:draft",
+		"example",
+		"sha256:9f6ca9562c5e7bd8bb53d736a2869adc27529eb202996dfefb804ec2c95237ba",
+		location.WithContext(ctx),
+	)
+
+	example(
+		"git example",
+		"https://github.com/GoogleCloudPlatform/blueprints.git/catalog/gke@gke-blueprint-v0.4.0",
+		"main",
+		"2b8afca2ef0662cf5ea39c797832ac9c5ea67c7e",
+		location.WithContext(ctx),
+	)
+
+	example(
+		"dir example",
+		"path/to/dir",
+		"qa",
+		"",
+		location.WithContext(ctx),
+	)
+
+	example(
+		"stdin example",
+		"-",
+		"",
+		"",
+		location.WithContext(ctx),
+		location.WithStdin(os.Stdin),
+	)
+
+	example(
+		"stdout example",
+		"-",
+		"",
+		"",
+		location.WithContext(ctx),
+		location.WithStdout(os.Stdout),
+	)
+
+	example(
+		"stdin/out example",
+		"-",
+		"",
+		"",
+		location.WithContext(ctx),
+		location.WithStdin(os.Stdin),
+		location.WithStdout(os.Stdout),
+	)
+
+	fmt.Println("- creating locations directly")
+	fmt.Println()
+
+	fmt.Println("stdio example")
+	in := location.InputStream{
+		Reader: os.Stdin,
+	}
+	out := location.OutputStream{
+		Writer: os.Stdout,
+	}
+	fmt.Printf("stdio in %v\n", in)
+	fmt.Printf("stdio out %v\n", out)
+	fmt.Println()
+
+	fmt.Println("bytes example")
+	buf := bytes.NewBuffer([]byte("hello world"))
+	in = location.InputStream{
+		Reader: buf,
+	}
+	out = location.OutputStream{
+		Writer: buf,
+	}
+	fmt.Printf("buffer in %v\n", in)
+	fmt.Printf("buffer out %v\n", out)
+	fmt.Println()
+
+	fmt.Println("custom location example")
+
+	ref := CustomLocation{
+		WhereItIs:            "http://127.0.0.1:8001/my-package",
+		LabelOrVersionString: "draft",
+	}
+	fmt.Printf("ref: %v\n", ref)
+
+	updated, _ := mutate.Identifier(ref, "preview")
+	fmt.Printf("updated: %v\n", updated)
+
+	locked, _ := mutate.Lock(updated, "98510723450981325098375013")
+	fmt.Printf("locked: %v\n", locked)
+	fmt.Println()
+
+}
+
+func example(caption string, arg string, identifier string, hash string, opts ...location.Option) {
+	fmt.Printf("%s %q\n", caption, arg)
+	if err := run(arg, identifier, hash, opts...); err != nil {
+		fmt.Printf("example error: %v\n", err)
+	}
+	fmt.Println()
+}
+
+func run(arg string, identifier string, hash string, opts ...location.Option) error {
+	parsed, err := location.ParseReference(arg, opts...)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("parsed: {%v}\n", parsed)
+
+	if identifier != "" {
+		changed, err := mutate.Identifier(parsed, identifier)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("changed: {%v}\n", changed)
+
+		if hash != "" {
+			locked, err := mutate.Lock(changed, hash)
+			if err != nil {
+				return err
+			}
+			fmt.Printf("locked: {%v}\n", locked)
+		}
+	}
+
+	return nil
+}
+
+// example of providing a custom location that supports branch/tag identifier and locking to a unique id.
+// the meaning of the fields in the struct are entirely specific to the location type.
+
+type CustomLocation struct {
+	WhereItIs            string
+	LabelOrVersionString string
+}
+
+type CustomLocationLock struct {
+	WhereItIs            string
+	LabelOrVersionString string
+	UniqueIdString       string
+}
+
+// compile-time check that duck types are correct
+var _ location.Reference = CustomLocation{}
+var _ location.ReferenceLock = CustomLocationLock{}
+var _ mutate.IdentifierSetter = CustomLocation{}
+var _ mutate.LockSetter = CustomLocation{}
+
+// string when reference appears in console and log messages
+func (ref CustomLocation) String() string {
+	return fmt.Sprint(" WhereItIs:", ref.WhereItIs, " LabelOrVersionString:", ref.LabelOrVersionString)
+}
+
+// string when reference appears in console and log messages
+func (ref CustomLocationLock) String() string {
+	return fmt.Sprint(" WhereItIs:", ref.WhereItIs, " LabelOrVersionString:", ref.LabelOrVersionString, " UniqueIdString:", ref.UniqueIdString)
+}
+
+// return location with only the identifier changed
+// depending on location, the exact meaning may be branch/label/version/tag/etc
+func (ref CustomLocation) SetIdentifier(name string) (location.Reference, error) {
+	return CustomLocation{
+		WhereItIs:            ref.WhereItIs,
+		LabelOrVersionString: name,
+	}, nil
+}
+
+// return the locked form of the location
+// depending on location, the exact meaning may be commit-id, image-digest, url-query parameter, exact resource name, etc.
+func (ref CustomLocation) SetLock(uniqueId string) (location.ReferenceLock, error) {
+	return CustomLocationLock{
+		WhereItIs:            ref.WhereItIs,
+		LabelOrVersionString: ref.LabelOrVersionString,
+		UniqueIdString:       uniqueId,
+	}, nil
+}

--- a/demos/demo-location/main.go
+++ b/demos/demo-location/main.go
@@ -13,6 +13,10 @@ import (
 func main() {
 	ctx := context.Background()
 
+	opts := []location.Option{
+		location.WithContext(ctx),
+	}
+
 	fmt.Println("- parsing argument to location")
 	fmt.Println()
 
@@ -21,7 +25,7 @@ func main() {
 		"oci://us-docker.pkg.dev/my-project-id/my-repo-name/my-blueprint:draft",
 		"example",
 		"sha256:9f6ca9562c5e7bd8bb53d736a2869adc27529eb202996dfefb804ec2c95237ba",
-		location.WithContext(ctx),
+		opts...,
 	)
 
 	example(
@@ -29,7 +33,7 @@ func main() {
 		"https://github.com/GoogleCloudPlatform/blueprints.git/catalog/gke@gke-blueprint-v0.4.0",
 		"main",
 		"2b8afca2ef0662cf5ea39c797832ac9c5ea67c7e",
-		location.WithContext(ctx),
+		opts...,
 	)
 
 	example(
@@ -37,16 +41,17 @@ func main() {
 		"path/to/dir",
 		"qa",
 		"",
-		location.WithContext(ctx),
+		opts...,
 	)
 
+	// stdin and stdout options are added on individual calls to parse, because
+	// only the caller knows if "-" in an argument means read from stdin or write to stdout
 	example(
 		"stdin example",
 		"-",
 		"",
 		"",
-		location.WithContext(ctx),
-		location.WithStdin(os.Stdin),
+		append(opts, location.WithStdin(os.Stdin))...,
 	)
 
 	example(
@@ -54,18 +59,15 @@ func main() {
 		"-",
 		"",
 		"",
-		location.WithContext(ctx),
-		location.WithStdout(os.Stdout),
+		append(opts, location.WithStdin(os.Stdin))...,
 	)
 
 	example(
-		"stdin/out example",
+		"duplex example",
 		"-",
 		"",
 		"",
-		location.WithContext(ctx),
-		location.WithStdin(os.Stdin),
-		location.WithStdout(os.Stdout),
+		append(opts, location.WithStdin(os.Stdin), location.WithStdout(os.Stdout))...,
 	)
 
 	fmt.Println("- creating locations directly")

--- a/internal/cmdget/cmdget_test.go
+++ b/internal/cmdget/cmdget_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
+	"github.com/GoogleContainerTools/kpt/pkg/location"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
@@ -230,8 +231,8 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 			runE: NoOpRunE,
 			validations: func(_, _ string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "master", r.Get.Git.Ref)
-				assert.Equal(t, "something://foo", r.Get.Git.Repo)
+				assert.Equal(t, "master", r.Get.Upstream.(location.Git).Ref)
+				assert.Equal(t, "something://foo", r.Get.Upstream.(location.Git).Repo)
 				assert.Equal(t, filepath.Join(pathPrefix, w.WorkspaceDirectory, "foo"), r.Get.Destination)
 			},
 		},
@@ -242,9 +243,9 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 			runE: NoOpRunE,
 			validations: func(repo, _ string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
-				assert.Equal(t, "master", r.Get.Git.Ref)
-				assert.Equal(t, "/blueprints/java", r.Get.Git.Directory)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Upstream.(location.Git).Repo)
+				assert.Equal(t, "master", r.Get.Upstream.(location.Git).Ref)
+				assert.Equal(t, "blueprints/java", r.Get.Upstream.(location.Git).Directory)
 				assert.Equal(t, filepath.Join(pathPrefix, w.WorkspaceDirectory, "java"), r.Get.Destination)
 			},
 		},
@@ -255,9 +256,9 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 			runE: NoOpRunE,
 			validations: func(repo, _ string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
-				assert.Equal(t, "master", r.Get.Git.Ref)
-				assert.Equal(t, "/blueprints/java", r.Get.Git.Directory)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Upstream.(location.Git).Repo)
+				assert.Equal(t, "master", r.Get.Upstream.(location.Git).Ref)
+				assert.Equal(t, "blueprints/java", r.Get.Upstream.(location.Git).Directory)
 				assert.Equal(t, filepath.Join(pathPrefix, w.WorkspaceDirectory, "java"), r.Get.Destination)
 			},
 		},
@@ -268,9 +269,9 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 			runE: NoOpRunE,
 			validations: func(repo, _ string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
-				assert.Equal(t, "master", r.Get.Git.Ref)
-				assert.Equal(t, "/blueprints/java", r.Get.Git.Directory)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Upstream.(location.Git).Repo)
+				assert.Equal(t, "master", r.Get.Upstream.(location.Git).Ref)
+				assert.Equal(t, "blueprints/java", r.Get.Upstream.(location.Git).Directory)
 				assert.Equal(t, filepath.Join(pathPrefix, w.WorkspaceDirectory, "baz"), r.Get.Destination)
 			},
 		},
@@ -281,9 +282,9 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 			runE: NoOpRunE,
 			validations: func(repo, _ string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
-				assert.Equal(t, "master", r.Get.Git.Ref)
-				assert.Equal(t, "/blueprints/java", r.Get.Git.Directory)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Upstream.(location.Git).Repo)
+				assert.Equal(t, "master", r.Get.Upstream.(location.Git).Ref)
+				assert.Equal(t, "blueprints/java", r.Get.Upstream.(location.Git).Directory)
 				assert.Equal(t, "/baz", r.Get.Destination)
 			},
 		},
@@ -294,8 +295,8 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 			runE: NoOpRunE,
 			validations: func(repo, dir string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
-				assert.Equal(t, "master", r.Get.Git.Ref)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Upstream.(location.Git).Repo)
+				assert.Equal(t, "master", r.Get.Upstream.(location.Git).Ref)
 				assert.Equal(t, filepath.Join(dir, "my-app"), r.Get.Destination)
 			},
 		},
@@ -306,9 +307,9 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 			runE: NoOpRunE,
 			validations: func(repo, dir string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
-				assert.Equal(t, "/baz", r.Get.Git.Directory)
-				assert.Equal(t, "master", r.Get.Git.Ref)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Upstream.(location.Git).Repo)
+				assert.Equal(t, "baz", r.Get.Upstream.(location.Git).Directory)
+				assert.Equal(t, "master", r.Get.Upstream.(location.Git).Ref)
 				assert.Equal(t, filepath.Join(dir, "my-app"), r.Get.Destination)
 			},
 		},
@@ -319,9 +320,9 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 			runE: NoOpRunE,
 			validations: func(repo, dir string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
-				assert.Equal(t, "/baz", r.Get.Git.Directory)
-				assert.Equal(t, "v1", r.Get.Git.Ref)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Upstream.(location.Git).Repo)
+				assert.Equal(t, "baz", r.Get.Upstream.(location.Git).Directory)
+				assert.Equal(t, "v1", r.Get.Upstream.(location.Git).Ref)
 				assert.Equal(t, filepath.Join(dir, "my-app"), r.Get.Destination)
 			},
 		},
@@ -332,8 +333,8 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 			runE: NoOpRunE,
 			validations: func(repo, dir string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
-				assert.Equal(t, "master", r.Get.Git.Ref)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Upstream.(location.Git).Repo)
+				assert.Equal(t, "master", r.Get.Upstream.(location.Git).Ref)
 				assert.Equal(t, filepath.Join(dir, "package"), r.Get.Destination)
 			},
 		},
@@ -355,8 +356,8 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 			runE: NoOpRunE,
 			validations: func(repo, dir string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
-				assert.Equal(t, "master", r.Get.Git.Ref)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Upstream.(location.Git).Repo)
+				assert.Equal(t, "master", r.Get.Upstream.(location.Git).Ref)
 				assert.Equal(t, filepath.Join(dir, "package"), r.Get.Destination)
 				assert.Equal(t, kptfilev1.FastForward, r.Get.UpdateStrategy)
 			},

--- a/internal/testutil/setup_manager.go
+++ b/internal/testutil/setup_manager.go
@@ -25,8 +25,8 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
 	"github.com/GoogleContainerTools/kpt/internal/testutil/pkgbuilder"
 	"github.com/GoogleContainerTools/kpt/internal/util/get"
-	"github.com/GoogleContainerTools/kpt/internal/util/remote"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
+	"github.com/GoogleContainerTools/kpt/pkg/location"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
@@ -107,11 +107,11 @@ func (g *TestSetupManager) Init() bool {
 	// Get the content from the upstream repo into the local workspace.
 	if !assert.NoError(g.T, get.Command{
 		Destination: filepath.Join(g.LocalWorkspace.WorkspaceDirectory, g.targetDir),
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      g.Repos[Upstream].RepoDirectory,
 			Ref:       g.GetRef,
 			Directory: g.GetSubDirectory,
-		})}.Run(fake.CtxWithDefaultPrinter())) {
+		}}.Run(fake.CtxWithDefaultPrinter())) {
 		return false
 	}
 	localGit, err := gitutil.NewLocalGitRunner(g.LocalWorkspace.WorkspaceDirectory)
@@ -203,11 +203,11 @@ func UpdateGitDir(t *testing.T, name string, gitDir GitDirectory, changes []Cont
 func (g *TestSetupManager) GetSubPkg(dest, repo, upstreamDir string) {
 	assert.NoError(g.T, get.Command{
 		Destination: path.Join(g.LocalWorkspace.FullPackagePath(), dest),
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      g.Repos[repo].RepoDirectory,
 			Ref:       g.GetRef,
 			Directory: path.Join(g.GetSubDirectory, upstreamDir),
-		})}.Run(fake.CtxWithDefaultPrinter()))
+		}}.Run(fake.CtxWithDefaultPrinter()))
 
 	localGit, err := gitutil.NewLocalGitRunner(g.LocalWorkspace.WorkspaceDirectory)
 	assert.NoError(g.T, err)

--- a/internal/util/fetch/fetch.go
+++ b/internal/util/fetch/fetch.go
@@ -20,8 +20,13 @@ import (
 
 	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
-	"github.com/GoogleContainerTools/kpt/internal/util/remote"
+	"github.com/GoogleContainerTools/kpt/internal/printer"
+	"github.com/GoogleContainerTools/kpt/internal/util/pkgutil"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
+	"github.com/GoogleContainerTools/kpt/pkg/content"
+	"github.com/GoogleContainerTools/kpt/pkg/content/open"
+	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
+	"github.com/GoogleContainerTools/kpt/pkg/location"
 )
 
 // Command takes the upstream information in the Kptfile at the path for the
@@ -34,6 +39,8 @@ type Command struct {
 // Run runs the Command.
 func (c Command) Run(ctx context.Context) error {
 	const op errors.Op = "fetch.Run"
+	pr := printer.FromContextOrDie(ctx)
+
 	kf, err := c.Pkg.Kptfile()
 	if err != nil {
 		return errors.E(op, c.Pkg.UniquePath, fmt.Errorf("no Kptfile found"))
@@ -43,14 +50,52 @@ func (c Command) Run(ctx context.Context) error {
 		return errors.E(op, c.Pkg.UniquePath, err)
 	}
 
-	ups, err := remote.NewUpstream(kf)
+	// upstream source location
+	srcRef, err := kptfileutil.NewReferenceFromUpstream(kf)
 	if err != nil {
 		return errors.E(op, c.Pkg.UniquePath, err)
 	}
 
-	if err := ups.CloneUpstream(ctx, c.Pkg.UniquePath.String()); err != nil {
+	// open upstream as filesystem
+	src, err := open.FileSystem(srcRef, open.WithContext(ctx))
+	if err != nil {
 		return errors.E(op, c.Pkg.UniquePath, err)
 	}
+	defer src.Close()
+
+	// destination package location
+	dstRef := location.Dir{
+		Directory: c.Pkg.UniquePath.String(),
+	}
+
+	// open destination as filesystem
+	dst, err := open.FileSystem(dstRef)
+	if err != nil {
+		return errors.E(op, c.Pkg.UniquePath, err)
+	}
+	defer dst.Close()
+
+	pr.Printf("Adding package %q.\n", src.Location)
+
+	// copy package from source to destination
+	if err := pkgutil.CopyPackageFS(src.FileSystemPath, dst.FileSystemPath, true, pkg.All); err != nil {
+		return errors.E(op, c.Pkg.UniquePath, err)
+	}
+
+	if err := kptfileutil.UpdateKptfileWithoutOriginFS(src.FileSystemPath, dst.FileSystemPath, false); err != nil {
+		return errors.E(op, c.Pkg.UniquePath, err)
+	}
+
+	if err := kptfileutil.UpdateUpstreamLocationsFS(dst.FileSystemPath, src.Location); err != nil {
+		return errors.E(op, c.Pkg.UniquePath, err)
+	}
+
+	result, err := content.Commit(dst)
+	if err != nil {
+		return errors.E(op, c.Pkg.UniquePath, err)
+	}
+
+	pr.Printf("Updated %q.\n", result)
 
 	return nil
 }

--- a/internal/util/get/example_test.go
+++ b/internal/util/get/example_test.go
@@ -19,45 +19,44 @@ import (
 
 	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
 	"github.com/GoogleContainerTools/kpt/internal/util/get"
-	"github.com/GoogleContainerTools/kpt/internal/util/remote"
-	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
+	"github.com/GoogleContainerTools/kpt/pkg/location"
 )
 
 func ExampleCommand() {
-	err := get.Command{Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+	err := get.Command{Upstream: location.Git{
 		Repo: "https://github.com/example-org/example-repo",
 		Ref:  "v1.0",
-	})}.Run(fake.CtxWithDefaultPrinter())
+	}}.Run(fake.CtxWithDefaultPrinter())
 	if err != nil {
 		// handle error
 	}
 }
 
 func ExampleCommand_branch() {
-	err := get.Command{Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+	err := get.Command{Upstream: location.Git{
 		Repo: "https://github.com/example-org/example-repo",
 		Ref:  "refs/heads/v1.0",
-	})}.Run(fake.CtxWithDefaultPrinter())
+	}}.Run(fake.CtxWithDefaultPrinter())
 	if err != nil {
 		// handle error
 	}
 }
 
 func ExampleCommand_tag() {
-	err := get.Command{Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+	err := get.Command{Upstream: location.Git{
 		Repo: "https://github.com/example-org/example-repo",
 		Ref:  "refs/tags/v1.0",
-	})}.Run(fake.CtxWithDefaultPrinter())
+	}}.Run(fake.CtxWithDefaultPrinter())
 	if err != nil {
 		// handle error
 	}
 }
 
 func ExampleCommand_commit() {
-	err := get.Command{Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+	err := get.Command{Upstream: location.Git{
 		Repo: "https://github.com/example-org/example-repo",
 		Ref:  "8186bef8e5c0621bf80fa8106bd595aae8b62884",
-	})}.Run(fake.CtxWithDefaultPrinter())
+	}}.Run(fake.CtxWithDefaultPrinter())
 	if err != nil {
 		// handle error
 	}
@@ -65,11 +64,11 @@ func ExampleCommand_commit() {
 
 func ExampleCommand_subdir() {
 	err := get.Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      "https://github.com/example-org/example-repo",
 			Ref:       "v1.0",
 			Directory: filepath.Join("path", "to", "package"),
-		}),
+		},
 	}.Run(fake.CtxWithDefaultPrinter())
 	if err != nil {
 		// handle error
@@ -78,10 +77,10 @@ func ExampleCommand_subdir() {
 
 func ExampleCommand_destination() {
 	err := get.Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo: "https://github.com/example-org/example-repo",
 			Ref:  "v1.0",
-		}),
+		},
 		Destination: "destination-dir"}.Run(fake.CtxWithDefaultPrinter())
 	if err != nil {
 		// handle error

--- a/internal/util/get/get.go
+++ b/internal/util/get/get.go
@@ -34,6 +34,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/util/stack"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
+	"github.com/GoogleContainerTools/kpt/pkg/location"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 )
@@ -41,11 +42,8 @@ import (
 // Command fetches a package from a git repository, copies it to a local
 // directory, and expands any remote subpackages.
 type Command struct {
-	// Git contains information about the git repo to fetch
-	Git *kptfilev1.Git
-
-	// Contains information about the upstraem package to fetch
-	Upstream remote.Upstream
+	// Contains information about the upstream package to fetch
+	Upstream location.Reference
 
 	// Destination is the output directory to clone the package to.  Defaults to the name of the package --
 	// either the base repo name, or the base subdirectory name.
@@ -78,7 +76,9 @@ func (c Command) Run(ctx context.Context) error {
 
 	kf := kptfileutil.DefaultKptfile(c.Name)
 
-	kf.Upstream = c.Upstream.BuildUpstream()
+	if kf.Upstream, err = kptfileutil.NewUpstreamFromReference(c.Upstream); err != nil {
+		return errors.E(op, err)
+	}
 	kf.Upstream.UpdateStrategy = c.UpdateStrategy
 
 	err = kptfileutil.WriteFile(c.Destination, kf)

--- a/internal/util/get/get_test.go
+++ b/internal/util/get/get_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
 	"github.com/GoogleContainerTools/kpt/internal/testutil/pkgbuilder"
 	. "github.com/GoogleContainerTools/kpt/internal/util/get"
-	"github.com/GoogleContainerTools/kpt/internal/util/remote"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
+	"github.com/GoogleContainerTools/kpt/pkg/location"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/filters"
@@ -58,9 +58,9 @@ func TestCommand_Run_failNoRevision(t *testing.T) {
 	defer clean()
 
 	err := Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo: "foo",
-		}),
+		},
 		Destination: w.WorkspaceDirectory,
 	}.Run(fake.CtxWithDefaultPrinter())
 	if !assert.Error(t, err) {
@@ -83,12 +83,14 @@ func TestCommand_Run(t *testing.T) {
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
 
 	absPath := filepath.Join(w.WorkspaceDirectory, g.RepoName)
-	err := Command{Upstream: remote.NewGitUpstream(&kptfilev1.Git{
-		Repo:      "file://" + g.RepoDirectory,
-		Ref:       "master",
-		Directory: "/",
-	}),
-		Destination: absPath}.Run(fake.CtxWithDefaultPrinter())
+	err := Command{
+		Upstream: location.Git{
+			Repo:      "file://" + g.RepoDirectory,
+			Ref:       "master",
+			Directory: "/",
+		},
+		Destination: absPath,
+	}.Run(fake.CtxWithDefaultPrinter())
 	assert.NoError(t, err)
 
 	// verify the cloned contents matches the repository
@@ -144,8 +146,8 @@ func TestCommand_Run_subdir(t *testing.T) {
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
 
 	absPath := filepath.Join(w.WorkspaceDirectory, subdir)
-	err := Command{Upstream: remote.NewGitUpstream(&kptfilev1.Git{
-		Repo: g.RepoDirectory, Ref: "refs/heads/master", Directory: subdir}),
+	err := Command{Upstream: location.Git{
+		Repo: g.RepoDirectory, Ref: "refs/heads/master", Directory: subdir},
 		Destination: absPath,
 	}.Run(fake.CtxWithDefaultPrinter())
 	assert.NoError(t, err)
@@ -208,8 +210,8 @@ func TestCommand_Run_subdir_symlinks(t *testing.T) {
 	cliOutput := &bytes.Buffer{}
 
 	absPath := filepath.Join(w.WorkspaceDirectory, subdir)
-	err := Command{Upstream: remote.NewGitUpstream(&kptfilev1.Git{
-		Repo: g.RepoDirectory, Ref: "refs/heads/master", Directory: subdir}),
+	err := Command{Upstream: location.Git{
+		Repo: g.RepoDirectory, Ref: "refs/heads/master", Directory: subdir},
 		Destination: absPath,
 	}.Run(fake.CtxWithPrinter(cliOutput, cliOutput))
 	assert.NoError(t, err)
@@ -273,11 +275,11 @@ func TestCommand_Run_destination(t *testing.T) {
 
 	absPath := filepath.Join(w.WorkspaceDirectory, dest)
 	err := Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      g.RepoDirectory,
 			Ref:       "master",
 			Directory: "/",
-		}),
+		},
 		Destination: absPath,
 	}.Run(fake.CtxWithDefaultPrinter())
 	assert.NoError(t, err)
@@ -337,11 +339,11 @@ func TestCommand_Run_subdirAndDestination(t *testing.T) {
 
 	absPath := filepath.Join(w.WorkspaceDirectory, dest)
 	err := Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      g.RepoDirectory,
 			Ref:       "master",
 			Directory: subdir,
-		}),
+		},
 		Destination: absPath,
 	}.Run(fake.CtxWithDefaultPrinter())
 	assert.NoError(t, err)
@@ -417,11 +419,11 @@ func TestCommand_Run_branch(t *testing.T) {
 
 	absPath := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	err = Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      g.RepoDirectory,
 			Ref:       "refs/heads/exp",
 			Directory: "/",
-		}),
+		},
 		Destination: absPath,
 	}.Run(fake.CtxWithDefaultPrinter())
 	assert.NoError(t, err)
@@ -500,11 +502,11 @@ func TestCommand_Run_tag(t *testing.T) {
 
 	absPath := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	err = Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      g.RepoDirectory,
 			Ref:       "refs/tags/v2",
 			Directory: "/",
-		}),
+		},
 		Destination: absPath,
 	}.Run(fake.CtxWithDefaultPrinter())
 	assert.NoError(t, err)
@@ -641,11 +643,11 @@ func TestCommand_Run_ref(t *testing.T) {
 
 			absPath := filepath.Join(w.WorkspaceDirectory, repos[testutil.Upstream].RepoName)
 			err = Command{
-				Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+				Upstream: location.Git{
 					Repo:      repos[testutil.Upstream].RepoDirectory,
 					Ref:       ref,
 					Directory: tc.directory,
-				}),
+				},
 				Destination: absPath,
 			}.Run(fake.CtxWithDefaultPrinter())
 			assert.NoError(t, err)
@@ -670,11 +672,11 @@ func TestCommand_Run_failExistingDir(t *testing.T) {
 
 	absPath := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	err := Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      g.RepoDirectory,
 			Ref:       "master",
 			Directory: "/",
-		}),
+		},
 		Destination: absPath,
 	}.Run(fake.CtxWithDefaultPrinter())
 	assert.NoError(t, err)
@@ -724,11 +726,11 @@ func TestCommand_Run_failExistingDir(t *testing.T) {
 
 	// try to clone and expect a failure
 	err = Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      g.RepoDirectory,
 			Ref:       "master",
 			Directory: "/",
-		}),
+		},
 		Destination: absPath,
 	}.Run(fake.CtxWithDefaultPrinter())
 	if !assert.Error(t, err) {
@@ -781,11 +783,11 @@ func TestCommand_Run_nonexistingParentDir(t *testing.T) {
 
 	absPath := filepath.Join(w.WorkspaceDirectory, "more", "dirs", g.RepoName)
 	err := Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      g.RepoDirectory,
 			Ref:       "master",
 			Directory: "/",
-		}),
+		},
 		Destination: absPath,
 	}.Run(fake.CtxWithDefaultPrinter())
 	assert.NoError(t, err)
@@ -801,11 +803,11 @@ func TestCommand_Run_failInvalidRepo(t *testing.T) {
 
 	absPath := filepath.Join(w.WorkspaceDirectory, "foo")
 	err := Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      "foo",
 			Directory: "/",
 			Ref:       "refs/heads/master",
-		}),
+		},
 		Destination: absPath,
 	}.Run(fake.CtxWithDefaultPrinter())
 	if !assert.Error(t, err) {
@@ -831,11 +833,11 @@ func TestCommand_Run_failInvalidBranch(t *testing.T) {
 
 	absPath := filepath.Join(w.WorkspaceDirectory, g.RepoDirectory)
 	err := Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      g.RepoDirectory,
 			Directory: "/",
 			Ref:       "refs/heads/foo",
-		}),
+		},
 		Destination: absPath,
 	}.Run(fake.CtxWithDefaultPrinter())
 	if !assert.Error(t, err) {
@@ -864,11 +866,11 @@ func TestCommand_Run_failInvalidTag(t *testing.T) {
 
 	absPath := filepath.Join(w.WorkspaceDirectory, g.RepoDirectory)
 	err := Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      g.RepoDirectory,
 			Directory: "/",
 			Ref:       "refs/tags/foo",
-		}),
+		},
 		Destination: absPath,
 	}.Run(fake.CtxWithDefaultPrinter())
 	if !assert.Error(t, err) {
@@ -1389,11 +1391,11 @@ func TestCommand_Run_subpackages(t *testing.T) {
 			destinationDir := filepath.Join(w.WorkspaceDirectory, targetDir)
 
 			err = Command{
-				Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+				Upstream: location.Git{
 					Repo:      upstreamRepo.RepoDirectory,
 					Directory: tc.directory,
 					Ref:       tc.ref,
-				}),
+				},
 				Destination:    destinationDir,
 				UpdateStrategy: tc.updateStrategy,
 			}.Run(fake.CtxWithDefaultPrinter())
@@ -1460,11 +1462,11 @@ func TestCommand_Run_symlinks(t *testing.T) {
 
 	destinationDir := filepath.Join(w.WorkspaceDirectory, upstreamRepo.RepoName)
 	err := Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      upstreamRepo.RepoDirectory,
 			Directory: "/",
 			Ref:       "master",
-		}),
+		},
 		Destination: destinationDir,
 	}.Run(fake.CtxWithDefaultPrinter())
 	if !assert.NoError(t, err) {

--- a/internal/util/pathutil/pathutil.go
+++ b/internal/util/pathutil/pathutil.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package pathutil
 
 import (

--- a/pkg/api/kptfile/v1/types.go
+++ b/pkg/api/kptfile/v1/types.go
@@ -155,7 +155,7 @@ type Oci struct {
 	Image string `yaml:"image,omitempty" json:"image,omitempty"`
 
 	// Directory is the sub-package of the image.
-	Directory string `yaml:"path,omitempty" json:"path,omitempty"`
+	Directory string `yaml:"directory,omitempty" json:"directory,omitempty"`
 }
 
 // UpstreamLock is a resolved locator for the last fetch of the package.
@@ -208,7 +208,7 @@ type OciLock struct {
 	Image string `yaml:"image,omitempty" json:"image,omitempty"`
 
 	// Directory is the sub-package of the image.
-	Directory string `yaml:"path,omitempty" json:"path,omitempty"`
+	Directory string `yaml:"directory,omitempty" json:"directory,omitempty"`
 
 	// Digest is the unique sha of the image when it was last pulled.
 	Digest string `yaml:"digest,omitempty" json:"digest,omitempty"`

--- a/pkg/content/commit.go
+++ b/pkg/content/commit.go
@@ -12,33 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package location
+package content
 
-import "fmt"
+import (
+	"github.com/GoogleContainerTools/kpt/pkg/content/extensions"
+	"github.com/GoogleContainerTools/kpt/pkg/location"
+)
 
-type Reference interface {
-	fmt.Stringer
-	Type() string
-	Validate() error
-}
-
-type ReferenceLock interface {
-	Reference
-}
-
-type Location struct {
-	Reference     Reference
-	ReferenceLock ReferenceLock
-}
-
-var _ fmt.Stringer = Location{}
-
-func (p Location) String() string {
-	if p.ReferenceLock != nil {
-		return p.ReferenceLock.String()
+func Commit(content Content) (location.Location, error) {
+	switch content := content.(type) {
+	case extensions.ChangeCommitter:
+		return content.CommitChanges()
+	default:
+		return location.Location{}, nil
 	}
-	if p.Reference != nil {
-		return p.Reference.String()
-	}
-	return fmt.Sprintf("%v", nil)
 }

--- a/pkg/content/content.go
+++ b/pkg/content/content.go
@@ -15,9 +15,7 @@
 package content
 
 import (
-	"io"
+	"github.com/GoogleContainerTools/kpt/pkg/content/extensions"
 )
 
-type Content interface {
-	io.Closer
-}
+type Content = extensions.Content

--- a/pkg/content/content.go
+++ b/pkg/content/content.go
@@ -12,33 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package location
+package content
 
-import "fmt"
+import (
+	"io"
+)
 
-type Reference interface {
-	fmt.Stringer
-	Type() string
-	Validate() error
-}
-
-type ReferenceLock interface {
-	Reference
-}
-
-type Location struct {
-	Reference     Reference
-	ReferenceLock ReferenceLock
-}
-
-var _ fmt.Stringer = Location{}
-
-func (p Location) String() string {
-	if p.ReferenceLock != nil {
-		return p.ReferenceLock.String()
-	}
-	if p.Reference != nil {
-		return p.Reference.String()
-	}
-	return fmt.Sprintf("%v", nil)
+type Content interface {
+	io.Closer
 }

--- a/pkg/content/extensions/extensions.go
+++ b/pkg/content/extensions/extensions.go
@@ -15,6 +15,7 @@
 package extensions
 
 import (
+	"io"
 	"io/fs"
 
 	"github.com/GoogleContainerTools/kpt/pkg/location"
@@ -22,18 +23,26 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/kio"
 )
 
+type Content interface {
+	io.Closer
+}
+
 type ChangeCommitter interface {
+	Content
 	CommitChanges() (location.Location, error)
 }
 
 type FileSystemProvider interface {
+	Content
 	ProvideFileSystem() (filesys.FileSystem, string, error)
 }
 
 type FSProvider interface {
+	Content
 	ProvideFS() (fs.FS, error)
 }
 
 type ReaderProvider interface {
+	Content
 	ProvideReader() (kio.Reader, error)
 }

--- a/pkg/content/extensions/extensions.go
+++ b/pkg/content/extensions/extensions.go
@@ -12,33 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package location
+package extensions
 
-import "fmt"
+import (
+	"io/fs"
 
-type Reference interface {
-	fmt.Stringer
-	Type() string
-	Validate() error
+	"github.com/GoogleContainerTools/kpt/pkg/location"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+)
+
+type ChangeCommitter interface {
+	CommitChanges() (location.Location, error)
 }
 
-type ReferenceLock interface {
-	Reference
+type FileSystemProvider interface {
+	ProvideFileSystem() (filesys.FileSystem, string, error)
 }
 
-type Location struct {
-	Reference     Reference
-	ReferenceLock ReferenceLock
+type FSProvider interface {
+	ProvideFS() (fs.FS, error)
 }
 
-var _ fmt.Stringer = Location{}
-
-func (p Location) String() string {
-	if p.ReferenceLock != nil {
-		return p.ReferenceLock.String()
-	}
-	if p.Reference != nil {
-		return p.Reference.String()
-	}
-	return fmt.Sprintf("%v", nil)
+type ReaderProvider interface {
+	ProvideReader() (kio.Reader, error)
 }

--- a/pkg/content/filesystem.go
+++ b/pkg/content/filesystem.go
@@ -12,33 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package location
+package content
 
-import "fmt"
+import (
+	"fmt"
 
-type Reference interface {
-	fmt.Stringer
-	Type() string
-	Validate() error
-}
+	"github.com/GoogleContainerTools/kpt/pkg/content/extensions"
+	"github.com/GoogleContainerTools/kpt/pkg/content/paths"
+)
 
-type ReferenceLock interface {
-	Reference
-}
-
-type Location struct {
-	Reference     Reference
-	ReferenceLock ReferenceLock
-}
-
-var _ fmt.Stringer = Location{}
-
-func (p Location) String() string {
-	if p.ReferenceLock != nil {
-		return p.ReferenceLock.String()
+func FileSystem(content Content) (paths.FileSystemPath, error) {
+	switch content := content.(type) {
+	case extensions.FileSystemProvider:
+		fsys, path, err := content.ProvideFileSystem()
+		return paths.FileSystemPath{
+			FileSystem: fsys,
+			Path:       path,
+		}, err
+	default:
+		return paths.FileSystemPath{}, fmt.Errorf("not implemented")
 	}
-	if p.Reference != nil {
-		return p.Reference.String()
-	}
-	return fmt.Sprintf("%v", nil)
 }

--- a/pkg/content/fs.go
+++ b/pkg/content/fs.go
@@ -12,33 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package location
+package content
 
-import "fmt"
+import (
+	"fmt"
+	"io/fs"
 
-type Reference interface {
-	fmt.Stringer
-	Type() string
-	Validate() error
-}
+	"github.com/GoogleContainerTools/kpt/pkg/content/extensions"
+)
 
-type ReferenceLock interface {
-	Reference
-}
-
-type Location struct {
-	Reference     Reference
-	ReferenceLock ReferenceLock
-}
-
-var _ fmt.Stringer = Location{}
-
-func (p Location) String() string {
-	if p.ReferenceLock != nil {
-		return p.ReferenceLock.String()
+func FS(content Content) (fs.FS, error) {
+	switch content := content.(type) {
+	case extensions.FSProvider:
+		return content.ProvideFS()
+	default:
+		return nil, fmt.Errorf("not implemented")
 	}
-	if p.Reference != nil {
-		return p.Reference.String()
-	}
-	return fmt.Sprintf("%v", nil)
 }

--- a/pkg/content/open/open.go
+++ b/pkg/content/open/open.go
@@ -1,0 +1,137 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package open
+
+import (
+	"fmt"
+	"io/fs"
+
+	"github.com/GoogleContainerTools/kpt/pkg/content"
+	"github.com/GoogleContainerTools/kpt/pkg/content/paths"
+	"github.com/GoogleContainerTools/kpt/pkg/content/provider/dir"
+	"github.com/GoogleContainerTools/kpt/pkg/content/provider/git"
+	"github.com/GoogleContainerTools/kpt/pkg/content/provider/oci"
+	"github.com/GoogleContainerTools/kpt/pkg/location"
+	"github.com/google/go-containerregistry/pkg/gcrane"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+)
+
+type open struct {
+	content.Content
+	location.Location
+}
+
+func Content(ref location.Reference, opts ...Option) (open, error) {
+	opt := makeOptions(opts...)
+
+	switch ref := ref.(type) {
+	case location.Dir:
+		provider, err := dir.Open(ref)
+		if err != nil {
+			return open{}, err
+		}
+		return open{
+			Content: provider,
+			Location: location.Location{
+				Reference: ref,
+			},
+		}, nil
+	case location.GitLock:
+	case location.Git:
+		provider, lock, err := git.Open(opt.ctx, ref)
+		if err != nil {
+			return open{}, err
+		}
+		return open{
+			Content: provider,
+			Location: location.Location{
+				Reference:     ref,
+				ReferenceLock: lock,
+			},
+		}, nil
+	case location.OciLock:
+	case location.Oci:
+		provider, lock, err := oci.Open(ref, remote.WithAuthFromKeychain(gcrane.Keychain))
+		if err != nil {
+			return open{}, err
+		}
+		return open{
+			Content: provider,
+			Location: location.Location{
+				Reference:     ref,
+				ReferenceLock: lock,
+			},
+		}, nil
+	}
+	return open{}, fmt.Errorf("not supported")
+}
+
+type openFS struct {
+	content.Content
+	location.Location
+	FS fs.FS
+}
+
+func FS(ref location.Reference, opts ...Option) (openFS, error) {
+	open, err := Content(ref, opts...)
+	if err != nil {
+		return openFS{}, err
+	}
+	fsys, err := content.FS(open.Content)
+	if err != nil {
+		open.Close()
+		return openFS{}, err
+	}
+	return openFS{open.Content, open.Location, fsys}, nil
+}
+
+type openFileSystem struct {
+	content.Content
+	location.Location
+	paths.FileSystemPath
+}
+
+func FileSystem(ref location.Reference, opts ...Option) (openFileSystem, error) {
+	open, err := Content(ref, opts...)
+	if err != nil {
+		return openFileSystem{}, err
+	}
+	path, err := content.FileSystem(open.Content)
+	if err != nil {
+		open.Close()
+		return openFileSystem{}, err
+	}
+	return openFileSystem{open.Content, open.Location, path}, nil
+}
+
+type openReader struct {
+	content.Content
+	location.Location
+	Reader kio.Reader
+}
+
+func Reader(ref location.Reference, opts ...Option) (openReader, error) {
+	open, err := Content(ref, opts...)
+	if err != nil {
+		return openReader{}, err
+	}
+	reader, err := content.Reader(open.Content)
+	if err != nil {
+		open.Close()
+		return openReader{}, err
+	}
+	return openReader{open.Content, open.Location, reader}, nil
+}

--- a/pkg/content/open/options.go
+++ b/pkg/content/open/options.go
@@ -12,33 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package location
+package open
 
-import "fmt"
+import "context"
 
-type Reference interface {
-	fmt.Stringer
-	Type() string
-	Validate() error
+type options struct {
+	ctx context.Context
 }
 
-type ReferenceLock interface {
-	Reference
+func makeOptions(opts ...Option) options {
+	opt := options{}
+	Options(opts...)(&opt)
+	return opt
 }
 
-type Location struct {
-	Reference     Reference
-	ReferenceLock ReferenceLock
-}
+// Option is a functional option for content operations.
+type Option func(opt *options)
 
-var _ fmt.Stringer = Location{}
-
-func (p Location) String() string {
-	if p.ReferenceLock != nil {
-		return p.ReferenceLock.String()
+// Options is a convenience to combine several options into one.
+func Options(opts ...Option) Option {
+	return func(opt *options) {
+		for _, option := range opts {
+			if option != nil {
+				option(opt)
+			}
+		}
 	}
-	if p.Reference != nil {
-		return p.Reference.String()
+}
+
+func WithContext(ctx context.Context) Option {
+	return func(opt *options) {
+		opt.ctx = ctx
 	}
-	return fmt.Sprintf("%v", nil)
 }

--- a/pkg/content/paths/paths.go
+++ b/pkg/content/paths/paths.go
@@ -12,33 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package location
+package paths
 
-import "fmt"
+import (
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
 
-type Reference interface {
-	fmt.Stringer
-	Type() string
-	Validate() error
+type FileSystemPath struct {
+	FileSystem filesys.FileSystem
+	Path       string
 }
 
-type ReferenceLock interface {
-	Reference
+func (fsp FileSystemPath) String() string {
+	return fsp.Path
 }
 
-type Location struct {
-	Reference     Reference
-	ReferenceLock ReferenceLock
+type FSPath struct {
+	FileSystem filesys.FileSystem
+	Path       string
 }
 
-var _ fmt.Stringer = Location{}
-
-func (p Location) String() string {
-	if p.ReferenceLock != nil {
-		return p.ReferenceLock.String()
-	}
-	if p.Reference != nil {
-		return p.Reference.String()
-	}
-	return fmt.Sprintf("%v", nil)
+func (fsp FSPath) String() string {
+	return fsp.Path
 }

--- a/pkg/content/provider/dir/dir.go
+++ b/pkg/content/provider/dir/dir.go
@@ -32,7 +32,7 @@ var _ content.Content = &dirProvider{}
 var _ extensions.FileSystemProvider = &dirProvider{}
 var _ extensions.FSProvider = &dirProvider{}
 
-func Open(ref location.Dir) (content.Content, error) {
+func Open(ref location.Dir) (*dirProvider, error) {
 	return &dirProvider{
 		path: ref.Directory,
 	}, nil

--- a/pkg/content/provider/dir/dir.go
+++ b/pkg/content/provider/dir/dir.go
@@ -1,0 +1,51 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dir
+
+import (
+	"io/fs"
+	"os"
+
+	"github.com/GoogleContainerTools/kpt/pkg/content"
+	"github.com/GoogleContainerTools/kpt/pkg/content/extensions"
+	"github.com/GoogleContainerTools/kpt/pkg/location"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
+
+type dirProvider struct {
+	path string
+}
+
+var _ content.Content = &dirProvider{}
+var _ extensions.FileSystemProvider = &dirProvider{}
+var _ extensions.FSProvider = &dirProvider{}
+
+func Open(ref location.Dir) (content.Content, error) {
+	return &dirProvider{
+		path: ref.Directory,
+	}, nil
+}
+
+func (p *dirProvider) Close() error {
+	return nil
+}
+
+func (p *dirProvider) ProvideFileSystem() (filesys.FileSystem, string, error) {
+	return filesys.MakeFsOnDisk(), p.path, nil
+}
+
+func (p *dirProvider) ProvideFS() (fs.FS, error) {
+	return os.DirFS(p.path), nil
+}

--- a/pkg/content/provider/git/git.go
+++ b/pkg/content/provider/git/git.go
@@ -27,14 +27,20 @@ import (
 	"github.com/GoogleContainerTools/kpt/pkg/location"
 )
 
-type gitProvider struct {
+type base interface {
 	extensions.FileSystemProvider
+	extensions.FSProvider
+}
+
+type gitProvider struct {
+	base
 
 	repoSpec *git.RepoSpec
 }
 
 var _ content.Content = &gitProvider{}
 var _ extensions.FileSystemProvider = &gitProvider{}
+var _ extensions.FSProvider = &gitProvider{}
 
 func Open(ctx context.Context, ref location.Git) (_ *gitProvider, _ location.ReferenceLock, _err error) {
 
@@ -70,15 +76,15 @@ func Open(ctx context.Context, ref location.Git) (_ *gitProvider, _ location.Ref
 
 	}
 	return &gitProvider{
-		FileSystemProvider: dir,
+		base: dir,
 		repoSpec:           repoSpec,
 	}, lock, nil
 }
 
 func (p *gitProvider) Close() error {
 	// close the underlying "dir" content provider
-	p.FileSystemProvider.Close()
+	p.base.Close()
 	
-	// remote the temp folder
+	// remove the temp folder
 	return os.RemoveAll(p.repoSpec.Dir)
 }

--- a/pkg/content/provider/git/git.go
+++ b/pkg/content/provider/git/git.go
@@ -1,0 +1,71 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/GoogleContainerTools/kpt/internal/util/git"
+	"github.com/GoogleContainerTools/kpt/internal/util/remote"
+	"github.com/GoogleContainerTools/kpt/pkg/content"
+	"github.com/GoogleContainerTools/kpt/pkg/content/extensions"
+	"github.com/GoogleContainerTools/kpt/pkg/location"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
+
+type gitProvider struct {
+	repoSpec *git.RepoSpec
+}
+
+var _ content.Content = &gitProvider{}
+var _ extensions.FileSystemProvider = &gitProvider{}
+
+func Open(ctx context.Context, ref location.Git) (_ content.Content, _ location.ReferenceLock, _err error) {
+
+	repoSpec := &git.RepoSpec{
+		OrgRepo: ref.Repo,
+		Path:    ref.Directory,
+		Ref:     ref.Ref,
+	}
+
+	if err := remote.ClonerUsingGitExec(ctx, repoSpec); err != nil {
+		return nil, nil, err
+	}
+	defer func() {
+		if _err != nil {
+			os.RemoveAll(repoSpec.Dir)
+		}
+	}()
+
+	// Make lock reference for commit
+	lock, err := ref.SetLock(repoSpec.Commit)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &gitProvider{
+		repoSpec: repoSpec,
+	}, lock, nil
+}
+
+func (p *gitProvider) Close() error {
+	return os.RemoveAll(p.repoSpec.Dir)
+}
+
+func (p *gitProvider) ProvideFileSystem() (filesys.FileSystem, string, error) {
+	return filesys.MakeFsOnDisk(), filepath.Join(p.repoSpec.Dir, p.repoSpec.Path), nil
+}

--- a/pkg/content/provider/oci/oci.go
+++ b/pkg/content/provider/oci/oci.go
@@ -1,0 +1,122 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oci
+
+import (
+	"archive/tar"
+	"io"
+	"path/filepath"
+
+	"github.com/GoogleContainerTools/kpt/pkg/content"
+	"github.com/GoogleContainerTools/kpt/pkg/content/extensions"
+	"github.com/GoogleContainerTools/kpt/pkg/location"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+)
+
+type ociProvider struct {
+	image v1.Image
+	fsys  filesys.FileSystem
+}
+
+var _ extensions.FileSystemProvider = &ociProvider{}
+
+func Open(ref location.Oci, options ...remote.Option) (content.Content, location.ReferenceLock, error) {
+	image, err := remote.Image(ref.Image, options...)
+	if err != nil {
+		return nil, location.OciLock{}, err
+	}
+
+	// Determine the digest of the image that was extracted
+	imageDigestHash, err := image.Digest()
+	if err != nil {
+		return nil, location.OciLock{}, err
+		// return nil, errors.E(op, fmt.Errorf("error calculating image digest: %w", err))
+	}
+
+	lock, err := ref.SetLock("sha256:" + imageDigestHash.Hex)
+	if err != nil {
+		return nil, location.OciLock{}, err
+	}
+
+	return &ociProvider{
+		image: image,
+	}, lock, nil
+}
+
+func (p *ociProvider) Close() error {
+	return nil
+}
+
+func (p *ociProvider) ProvideFileSystem() (filesys.FileSystem, string, error) {
+	if p.fsys != nil {
+		return p.fsys, "/", nil
+	}
+
+	fsys := filesys.MakeFsInMemory()
+
+	if err := pullAndExtract(p.image, fsys, "/"); err != nil {
+		return nil, "", err
+	}
+
+	p.fsys = fsys
+	return fsys, "/", nil
+}
+
+// pullAndExtract uses current credentials (gcloud auth) to pull and
+// extract (untar) image files to target directory. The desired version or digest must
+// be in the imageName, and the resolved image sha256 digest is returned.
+func pullAndExtract(image v1.Image, fsys filesys.FileSystem, dir string) error {
+	// const op errors.Op = "oci.pullAndExtract"
+
+	// Stream image files as if single tar (merged layers)
+	ioReader := mutate.Extract(image)
+	defer ioReader.Close()
+
+	// Write contents to target dir
+	// TODO look for a more robust example of an untar loop
+	tarReader := tar.NewReader(ioReader)
+	for {
+		hdr, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		path := filepath.Join(dir, hdr.Name)
+		switch {
+		case hdr.FileInfo().IsDir():
+			if err := fsys.MkdirAll(path); err != nil {
+				return err
+			}
+		default:
+			file, err := fsys.Create(path)
+			if err != nil {
+				return err
+			}
+			defer file.Close()
+
+			_, err = io.Copy(file, tarReader)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/content/provider/oci/oci.go
+++ b/pkg/content/provider/oci/oci.go
@@ -19,7 +19,6 @@ import (
 	"io"
 	"path/filepath"
 
-	"github.com/GoogleContainerTools/kpt/pkg/content"
 	"github.com/GoogleContainerTools/kpt/pkg/content/extensions"
 	"github.com/GoogleContainerTools/kpt/pkg/location"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -35,22 +34,22 @@ type ociProvider struct {
 
 var _ extensions.FileSystemProvider = &ociProvider{}
 
-func Open(ref location.Oci, options ...remote.Option) (content.Content, location.ReferenceLock, error) {
+func Open(ref location.Oci, options ...remote.Option) (*ociProvider, location.ReferenceLock, error) {
 	image, err := remote.Image(ref.Image, options...)
 	if err != nil {
-		return nil, location.OciLock{}, err
+		return nil, nil, err
 	}
 
 	// Determine the digest of the image that was extracted
 	imageDigestHash, err := image.Digest()
 	if err != nil {
-		return nil, location.OciLock{}, err
+		return nil, nil, err
 		// return nil, errors.E(op, fmt.Errorf("error calculating image digest: %w", err))
 	}
 
 	lock, err := ref.SetLock("sha256:" + imageDigestHash.Hex)
 	if err != nil {
-		return nil, location.OciLock{}, err
+		return nil, nil, err
 	}
 
 	return &ociProvider{

--- a/pkg/content/reader.go
+++ b/pkg/content/reader.go
@@ -1,0 +1,43 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package content
+
+import (
+	"fmt"
+
+	"github.com/GoogleContainerTools/kpt/pkg/content/extensions"
+	"sigs.k8s.io/kustomize/kyaml/filesys"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+)
+
+func Reader(content Content) (kio.Reader, error) {
+	switch content := content.(type) {
+	case extensions.ReaderProvider:
+		return content.ProvideReader()
+	case extensions.FileSystemProvider:
+		fsys, path, err := content.ProvideFileSystem()
+		if err != nil {
+			return nil, err
+		}
+		return &kio.LocalPackageReader{
+			PackagePath:        path,
+			IncludeSubpackages: true,
+
+			FileSystem: filesys.FileSystemOrOnDisk{FileSystem: fsys},
+		}, err
+	default:
+		return nil, fmt.Errorf("not implemented")
+	}
+}

--- a/pkg/kptfile/kptfileutil/util.go
+++ b/pkg/kptfile/kptfileutil/util.go
@@ -249,14 +249,14 @@ func UpdateUpstreamLockFromGit(path string, spec *git.RepoSpec) error {
 // NewUpstreamFromReference creates kptfilev1.Upstream structures from supported
 // location types. The kptfile upstream supports specific, well-known types.
 func NewUpstreamFromReference(ref location.Reference) (*kptfilev1.Upstream, error) {
-	const op errors.Op = "kptfileutil.UpdateUpstreamLock"
+	const op errors.Op = "kptfileutil.NewUpstreamFromReference"
 	switch ref := ref.(type) {
 	case location.Git:
 		return &kptfilev1.Upstream{
 			Type: kptfilev1.GitOrigin,
 			Git: &kptfilev1.Git{
 				Repo:      ref.Repo,
-				Directory: toDirectory(ref.Directory),
+				Directory: toDirectory(ref.Directory, false),
 				Ref:       ref.Ref,
 			},
 		}, nil
@@ -265,7 +265,7 @@ func NewUpstreamFromReference(ref location.Reference) (*kptfilev1.Upstream, erro
 			Type: kptfilev1.OciOrigin,
 			Oci: &kptfilev1.Oci{
 				Image:     ref.Image.Name(),
-				Directory: toDirectory(ref.Directory),
+				Directory: toDirectory(ref.Directory, true),
 			},
 		}, nil
 	}
@@ -276,14 +276,14 @@ func NewUpstreamFromReference(ref location.Reference) (*kptfilev1.Upstream, erro
 // NewUpstreamLockFromReferenceLock creates kptfilev1.UpstreamLock structures from supported
 // location types. The kptfile upstream supports specific, well-known types.
 func NewUpstreamLockFromReferenceLock(ref location.ReferenceLock) (*kptfilev1.UpstreamLock, error) {
-	const op errors.Op = "kptfileutil.UpdateUpstreamLock"
+	const op errors.Op = "kptfileutil.NewUpstreamLockFromReferenceLock"
 	switch ref := ref.(type) {
 	case location.GitLock:
 		return &kptfilev1.UpstreamLock{
 			Type: kptfilev1.GitOrigin,
 			Git: &kptfilev1.GitLock{
 				Repo:      ref.Repo,
-				Directory: toDirectory(ref.Directory),
+				Directory: toDirectory(ref.Directory, false),
 				Ref:       ref.Ref,
 				Commit:    ref.Commit,
 			},
@@ -293,7 +293,7 @@ func NewUpstreamLockFromReferenceLock(ref location.ReferenceLock) (*kptfilev1.Up
 			Type: kptfilev1.OciOrigin,
 			Oci: &kptfilev1.OciLock{
 				Image:     ref.Image.Name(),
-				Directory: toDirectory(ref.Directory),
+				Directory: toDirectory(ref.Directory, true),
 				Digest:    ref.Digest.Name(),
 			},
 		}, nil
@@ -304,8 +304,8 @@ func NewUpstreamLockFromReferenceLock(ref location.ReferenceLock) (*kptfilev1.Up
 
 // toDirectory convert relative Reference sub-package locations to
 // the kptfilev1 absolute-within-repo conventions.
-func toDirectory(relPath string) string {
-	if absPath := filepath.Join("/", relPath); absPath != "/" {
+func toDirectory(relPath string, omitDefault bool) string {
+	if absPath := filepath.Join("/", relPath); absPath != "/" || !omitDefault {
 		return absPath
 	}
 	// root location is default in kptfilev1

--- a/pkg/location/defaultdir.go
+++ b/pkg/location/defaultdir.go
@@ -1,14 +1,19 @@
 package location
 
-import "fmt"
-
+// DirectoryNameDefaulter is present on Reference types that
+// suggest a default local folder name
 type DirectoryNameDefaulter interface {
-	GetDefaultDirectoryName() (string, error)
+	// GetDefaultDirectoryName implements the location.DefaultDirectoryName() method
+	GetDefaultDirectoryName() (string, bool)
 }
 
-func DefaultDirectoryName(ref Reference) (string, error) {
+// DefaultDirectoryName returns the suggested local directory name to
+// create when a package from a remove reference is cloned or pulled.
+// Returns an empty string and false if the Reference type does not have
+// anything path-like to suggest from.
+func DefaultDirectoryName(ref Reference) (string, bool) {
 	if ref, ok := ref.(DirectoryNameDefaulter); ok {
 		return ref.GetDefaultDirectoryName()
 	}
-	return "", fmt.Errorf("default directory not supported for reference: %v", ref)
+	return "", false
 }

--- a/pkg/location/defaultdir.go
+++ b/pkg/location/defaultdir.go
@@ -1,0 +1,14 @@
+package location
+
+import "fmt"
+
+type DirectoryNameDefaulter interface {
+	GetDefaultDirectoryName() (string, error)
+}
+
+func DefaultDirectoryName(ref Reference) (string, error) {
+	if ref, ok := ref.(DirectoryNameDefaulter); ok {
+		return ref.GetDefaultDirectoryName()
+	}
+	return "", fmt.Errorf("default directory not supported for reference: %v", ref)
+}

--- a/pkg/location/defaultdir.go
+++ b/pkg/location/defaultdir.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package location
 
 // DirectoryNameDefaulter is present on Reference types that

--- a/pkg/location/mutate/mutations.go
+++ b/pkg/location/mutate/mutations.go
@@ -42,7 +42,7 @@ func Identifier(ref location.Reference, identifier string) (location.Reference, 
 // LockSetter is implemented by location.Reference types that
 // support mutate.Log
 type LockSetter interface {
-	SetLock(hash string) (location.ReferenceLock, error)
+	SetLock(lock string) (location.ReferenceLock, error)
 }
 
 // Lock returns a new ReferenceLock where the property that identifies the
@@ -50,9 +50,9 @@ type LockSetter interface {
 // The exact meaning of the value depends on the type of reference, and
 // is typically returned from the remote storage system as part of sending or
 // receiving content.
-func Lock(ref location.Reference, hash string) (location.ReferenceLock, error) {
+func Lock(ref location.Reference, lock string) (location.ReferenceLock, error) {
 	if ref, ok := ref.(LockSetter); ok {
-		return ref.SetLock(hash)
+		return ref.SetLock(lock)
 	}
 	return nil, fmt.Errorf("locked reference not support for reference: %v", ref)
 }

--- a/pkg/location/mutate/mutations.go
+++ b/pkg/location/mutate/mutations.go
@@ -11,8 +11,7 @@ type IdentifierSetter interface {
 }
 
 func Identifier(ref location.Reference, identifier string) (location.Reference, error) {
-	switch ref := ref.(type) {
-	case IdentifierSetter:
+	if ref, ok := ref.(IdentifierSetter); ok {
 		return ref.SetIdentifier(identifier)
 	}
 	return nil, fmt.Errorf("changing identifier not supported for reference: %v", ref)
@@ -23,8 +22,7 @@ type LockSetter interface {
 }
 
 func Lock(ref location.Reference, hash string) (location.ReferenceLock, error) {
-	switch ref := ref.(type) {
-	case LockSetter:
+	if ref, ok := ref.(LockSetter); ok {
 		return ref.SetLock(hash)
 	}
 	return nil, fmt.Errorf("locked reference not support for reference: %v", ref)

--- a/pkg/location/mutate/mutations.go
+++ b/pkg/location/mutate/mutations.go
@@ -1,0 +1,31 @@
+package mutate
+
+import (
+	"fmt"
+
+	"github.com/GoogleContainerTools/kpt/pkg/location"
+)
+
+type IdentifierSetter interface {
+	SetIdentifier(identifier string) (location.Reference, error)
+}
+
+func Identifier(ref location.Reference, identifier string) (location.Reference, error) {
+	switch ref := ref.(type) {
+	case IdentifierSetter:
+		return ref.SetIdentifier(identifier)
+	}
+	return nil, fmt.Errorf("identifier not supported for reference: %v", ref)
+}
+
+type LockSetter interface {
+	SetLock(hash string) (location.ReferenceLock, error)
+}
+
+func Lock(ref location.Reference, hash string) (location.ReferenceLock, error) {
+	switch ref := ref.(type) {
+	case LockSetter:
+		return ref.SetLock(hash)
+	}
+	return nil, fmt.Errorf("locked reference not support for reference: %v", ref)
+}

--- a/pkg/location/mutate/mutations.go
+++ b/pkg/location/mutate/mutations.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mutate
 
 import (

--- a/pkg/location/mutate/mutations.go
+++ b/pkg/location/mutate/mutations.go
@@ -6,10 +6,18 @@ import (
 	"github.com/GoogleContainerTools/kpt/pkg/location"
 )
 
+// IdentifierSetter is implemented by location.Reference types that
+// support mutate.Identifier
 type IdentifierSetter interface {
+	// SetIdentifier is called by mutate.Identifier
 	SetIdentifier(identifier string) (location.Reference, error)
 }
 
+// Identifier returns a new Reference where the property that
+// identifies the branch, tag, or label has been replaced with value given.
+// Typical identifier values are often a semantic name like 'draft', 'main', 'prod', or a
+// string representation of a version. The specifics of how the identifier is
+// mapped to storage depends on the type of reference.
 func Identifier(ref location.Reference, identifier string) (location.Reference, error) {
 	if ref, ok := ref.(IdentifierSetter); ok {
 		return ref.SetIdentifier(identifier)
@@ -17,10 +25,17 @@ func Identifier(ref location.Reference, identifier string) (location.Reference, 
 	return nil, fmt.Errorf("changing identifier not supported for reference: %v", ref)
 }
 
+// LockSetter is implemented by location.Reference types that
+// support mutate.Log
 type LockSetter interface {
 	SetLock(hash string) (location.ReferenceLock, error)
 }
 
+// Lock returns a new ReferenceLock where the property that identifies the
+// unique commit or digest has been replaced with the value given.
+// The exact meaning of the value depends on the type of reference, and
+// is typically returned from the remote storage system as part of sending or
+// receiving content.
 func Lock(ref location.Reference, hash string) (location.ReferenceLock, error) {
 	if ref, ok := ref.(LockSetter); ok {
 		return ref.SetLock(hash)

--- a/pkg/location/mutate/mutations.go
+++ b/pkg/location/mutate/mutations.go
@@ -15,7 +15,7 @@ func Identifier(ref location.Reference, identifier string) (location.Reference, 
 	case IdentifierSetter:
 		return ref.SetIdentifier(identifier)
 	}
-	return nil, fmt.Errorf("identifier not supported for reference: %v", ref)
+	return nil, fmt.Errorf("changing identifier not supported for reference: %v", ref)
 }
 
 type LockSetter interface {

--- a/pkg/location/mutate/mutations_test.go
+++ b/pkg/location/mutate/mutations_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mutate
 
 import (

--- a/pkg/location/mutate/mutations_test.go
+++ b/pkg/location/mutate/mutations_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 )
 
+//nolint:scopelint
 func TestSetIdentifier(t *testing.T) {
 	type args struct {
 		ref        location.Reference
@@ -82,6 +83,7 @@ func TestSetIdentifier(t *testing.T) {
 	}
 }
 
+//nolint:scopelint
 func TestSetLock(t *testing.T) {
 	type args struct {
 		ref  location.Reference

--- a/pkg/location/mutate/mutations_test.go
+++ b/pkg/location/mutate/mutations_test.go
@@ -180,6 +180,14 @@ func (ref custom) String() string {
 	return fmt.Sprintf("place:%s label:%s", ref.Place, ref.Label)
 }
 
+func (ref custom) Type() string {
+	return "custom"
+}
+
+func (ref custom) Validate() error {
+	return nil
+}
+
 func (ref custom) SetIdentifier(identifier string) (location.Reference, error) {
 	return custom{
 		Place: ref.Place,

--- a/pkg/location/mutate/mutations_test.go
+++ b/pkg/location/mutate/mutations_test.go
@@ -209,9 +209,9 @@ func (ref custom) SetIdentifier(identifier string) (location.Reference, error) {
 	}, nil
 }
 
-func (ref custom) SetLock(hash string) (location.ReferenceLock, error) {
+func (ref custom) SetLock(lock string) (location.ReferenceLock, error) {
 	return customLock{
 		custom: ref,
-		Lock:   hash,
+		Lock:   lock,
 	}, nil
 }

--- a/pkg/location/mutate/mutations_test.go
+++ b/pkg/location/mutate/mutations_test.go
@@ -1,0 +1,193 @@
+package mutate
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/GoogleContainerTools/kpt/pkg/location"
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+func TestSetIdentifier(t *testing.T) {
+	type args struct {
+		ref        location.Reference
+		identifier string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    location.Reference
+		wantErr bool
+	}{
+		{
+			name: "OciWithIdentifier",
+			args: args{
+				ref: location.Oci{
+					Image:     name.MustParseReference("my-registry.io/name:original"),
+					Directory: "sub/directory",
+				},
+				identifier: "updated",
+			},
+			want: location.Oci{
+				Image:     name.MustParseReference("my-registry.io/name:updated"),
+				Directory: "sub/directory",
+			},
+			wantErr: false,
+		},
+		{
+			name: "GitWithIdentifier",
+			args: args{
+				ref: location.Git{
+					Repo:      "repo",
+					Directory: "sub/directory",
+					Ref:       "original",
+				},
+				identifier: "updated",
+			},
+			want: location.Git{
+				Repo:      "repo",
+				Directory: "sub/directory",
+				Ref:       "updated",
+			},
+			wantErr: false,
+		},
+		{
+			name: "CustomWithIdentifier",
+			args: args{
+				ref: custom{
+					Place: "place",
+					Label: "label",
+				},
+				identifier: "new-label",
+			},
+			want: custom{
+				Place: "place",
+				Label: "new-label",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Identifier(tt.args.ref, tt.args.identifier)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("WithIdentifier() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("WithIdentifier() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetLock(t *testing.T) {
+	type args struct {
+		ref  location.Reference
+		lock string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    location.ReferenceLock
+		wantErr bool
+	}{
+		{
+			name: "OciWithLock",
+			args: args{
+				ref: location.Oci{
+					Image:     name.MustParseReference("my-registry.io/name:original"),
+					Directory: "sub/directory",
+				},
+				lock: "sha256:9f6ca9562c5e7bd8bb53d736a2869adc27529eb202996dfefb804ec2c95237ba",
+			},
+			want: location.OciLock{
+				Oci: location.Oci{
+					Image:     name.MustParseReference("my-registry.io/name:original"),
+					Directory: "sub/directory",
+				},
+				Digest: name.MustParseReference("my-registry.io/name@sha256:9f6ca9562c5e7bd8bb53d736a2869adc27529eb202996dfefb804ec2c95237ba"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "GitWithLock",
+			args: args{
+				ref: location.Git{
+					Repo:      "repo",
+					Directory: "sub/directory",
+					Ref:       "original",
+				},
+				lock: "9f6ca9562c5e7bd8bb53d736a2869adc27529eb202996dfefb804ec2c95237ba",
+			},
+			want: location.GitLock{
+				Git: location.Git{
+					Repo:      "repo",
+					Directory: "sub/directory",
+					Ref:       "original",
+				},
+				Commit: "9f6ca9562c5e7bd8bb53d736a2869adc27529eb202996dfefb804ec2c95237ba",
+			},
+			wantErr: false,
+		},
+		{
+			name: "CustomWithLock",
+			args: args{
+				ref: custom{
+					Place: "place",
+					Label: "label",
+				},
+				lock: "lock",
+			},
+			want: customLock{
+				custom: custom{
+					Place: "place",
+					Label: "label",
+				},
+				Lock: "lock",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Lock(tt.args.ref, tt.args.lock)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("WithLock() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("WithLock() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+type custom struct {
+	Place string
+	Label string
+}
+
+type customLock struct {
+	custom
+	Lock string
+}
+
+func (ref custom) String() string {
+	return fmt.Sprintf("place:%s label:%s", ref.Place, ref.Label)
+}
+
+func (ref custom) SetIdentifier(identifier string) (location.Reference, error) {
+	return custom{
+		Place: ref.Place,
+		Label: identifier,
+	}, nil
+}
+
+func (ref custom) SetLock(hash string) (location.ReferenceLock, error) {
+	return customLock{
+		custom: ref,
+		Lock:   hash,
+	}, nil
+}

--- a/pkg/location/options.go
+++ b/pkg/location/options.go
@@ -1,0 +1,44 @@
+package location
+
+import (
+	"context"
+	"io"
+)
+
+type options struct {
+	ctx    context.Context
+	stdin  io.Reader
+	stdout io.Writer
+}
+
+func makeOptions(opts ...Option) options {
+	opt := options{}
+	for _, o := range opts {
+		o(&opt)
+	}
+	return opt
+}
+
+// Option is a functional option for location parsing.
+type Option func(*options)
+
+// WithDefaultTag sets the default tag that will be used if one is not provided.
+func WithContext(ctx context.Context) Option {
+	return func(opts *options) {
+		opts.ctx = ctx
+	}
+}
+
+// WithStdin enables parser to assign "-" location onto an input io.Reader
+func WithStdin(r io.Reader) Option {
+	return func(opts *options) {
+		opts.stdin = r
+	}
+}
+
+// WithStdout enables parser to assign "-" location onto an output io.Writer
+func WithStdout(w io.Writer) Option {
+	return func(opts *options) {
+		opts.stdout = w
+	}
+}

--- a/pkg/location/options.go
+++ b/pkg/location/options.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package location
 
 import (

--- a/pkg/location/parse.go
+++ b/pkg/location/parse.go
@@ -1,0 +1,58 @@
+package location
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+)
+
+func ParseReference(location string, opts ...Option) (Reference, error) {
+	opt := makeOptions(opts...)
+
+	if location == "-" {
+		switch {
+		case opt.stdin != nil && opt.stdout != nil:
+			return InputOutputStream{
+				Reader: opt.stdin,
+				Writer: opt.stdout,
+			}, nil
+		case opt.stdin != nil:
+			return InputStream{
+				Reader: opt.stdin,
+			}, nil
+		case opt.stdout != nil:
+			return OutputStream{
+				Writer: opt.stdout,
+			}, nil
+		}
+	}
+
+	if _, ok := startsWith(location, "oci://"); ok {
+		oci, ociErr := NewOci(location, opts...)
+		return oci, ociErr
+	}
+
+	git, gitErr := NewGit(location, opts...)
+	if gitErr == nil {
+		return git, nil
+	}
+
+	if s, ok := isDir(location); ok {
+		return Dir{
+			Directory: s,
+		}, nil
+	}
+
+	return nil, errors.New("not implemented")
+}
+
+func startsWith(value string, prefix string) (string, bool) {
+	if parts := strings.SplitN(value, prefix, 2); len(parts) == 2 && len(parts[0]) == 0 {
+		return parts[1], true
+	}
+	return prefix, false
+}
+
+func isDir(value string) (string, bool) {
+	return filepath.Clean(value), true
+}

--- a/pkg/location/parse.go
+++ b/pkg/location/parse.go
@@ -15,24 +15,26 @@
 package location
 
 import (
-	"errors"
+	"fmt"
 	"strings"
 )
 
 func ParseReference(location string, opts ...Option) (Reference, error) {
 	opt := makeOptions(opts...)
 
+	var helpText []string
 	for _, parser := range opt.parsers {
-		ref, err := parser(location, opt)
-		if err != nil {
-			return nil, err
+		result := parser(location, opt)
+		if result.err != nil {
+			return nil, result.err
 		}
-		if ref != nil {
-			return ref, nil
+		if result.ref != nil {
+			return result.ref, nil
 		}
+		helpText = append(helpText, result.helpText...)
 	}
 
-	return nil, errors.New("not implemented")
+	return nil, fmt.Errorf("unable to parse location: %v", helpText)
 }
 
 func startsWith(value string, prefix string) (string, bool) {
@@ -40,4 +42,96 @@ func startsWith(value string, prefix string) (string, bool) {
 		return parts[1], true
 	}
 	return prefix, false
+}
+
+// StdioParser enables "-" to resolve as io streams.
+// Use location.WithStdin to provide the io.Reader.
+// Use location.WithStdout to provide the io.Writer.
+var StdioParser parser = func(value string, opt options) result {
+	if value == "-" {
+		switch {
+		case opt.stdin != nil && opt.stdout != nil:
+			return result{
+				ref: DuplexStream{
+					InputStream:  InputStream{Reader: opt.stdin},
+					OutputStream: OutputStream{Writer: opt.stdout},
+				},
+			}
+		case opt.stdin != nil:
+			return result{
+				ref: InputStream{Reader: opt.stdin},
+			}
+		case opt.stdout != nil:
+			return result{
+				ref: OutputStream{Writer: opt.stdout},
+			}
+		}
+	}
+	res := result{}
+	if opt.stdin != nil {
+		res.helpText = append(res.helpText, "Use '-' to read from input stream")
+	}
+	if opt.stdout != nil {
+		res.helpText = append(res.helpText, "Use '-' to write to output stream")
+	}
+	return res
+}
+
+// GitParser enables standard parsing for the location.Git Reference type
+var GitParser parser = func(value string, opt options) result {
+	return result{
+		ref:      parseGit(value, opt),
+		helpText: []string{},
+	}
+}
+
+// OciParser enables standard parsing for the location.Oci Reference type
+var OciParser parser = func(value string, opt options) result {
+	ref, err := parseOci(value)
+	return result{
+		ref: ref,
+		err: err,
+		helpText: []string{
+			"OCI packages use 'oci://' prefix before standard image name",
+		},
+	}
+}
+
+// DirParser enables standard parsing for the location.Dir Reference type
+var DirParser parser = func(value string, opt options) result {
+	return result{
+		ref: parseDir(value),
+	}
+}
+
+// NewParser returns a parser for a custom Reference type.
+// The returned parser is used in the location.WithParser Option
+func NewParser(helpText []string, parser func(parse *Parse)) parser {
+	return func(value string, opt options) result {
+		req := Parse{
+			Value: value,
+			result: result{
+				helpText: helpText,
+			},
+		}
+		parser(&req)
+		return req.result
+	}
+}
+
+type Parse struct {
+	result
+	Value string
+}
+
+func (r *Parse) Result(ref Reference) {
+	r.ref = ref
+}
+
+func (r *Parse) Fail(err error) {
+	r.err = err
+}
+
+func (r *Parse) AddHelpText(helpText string) {
+	r.helpText = append(r.helpText, helpText)
 }

--- a/pkg/location/parse.go
+++ b/pkg/location/parse.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package location
 
 import (

--- a/pkg/location/parse.go
+++ b/pkg/location/parse.go
@@ -25,6 +25,7 @@ func ParseReference(location string, opts ...Option) (Reference, error) {
 				Writer: opt.stdout,
 			}, nil
 		}
+		return nil, errors.New("stdin/stdout not supported here")
 	}
 
 	if _, ok := startsWith(location, "oci://"); ok {

--- a/pkg/location/parse.go
+++ b/pkg/location/parse.go
@@ -2,46 +2,20 @@ package location
 
 import (
 	"errors"
-	"path/filepath"
 	"strings"
 )
 
 func ParseReference(location string, opts ...Option) (Reference, error) {
 	opt := makeOptions(opts...)
 
-	if location == "-" {
-		switch {
-		case opt.stdin != nil && opt.stdout != nil:
-			return InputOutputStream{
-				Reader: opt.stdin,
-				Writer: opt.stdout,
-			}, nil
-		case opt.stdin != nil:
-			return InputStream{
-				Reader: opt.stdin,
-			}, nil
-		case opt.stdout != nil:
-			return OutputStream{
-				Writer: opt.stdout,
-			}, nil
+	for _, parser := range opt.parsers {
+		ref, err := parser(location, opt)
+		if err != nil {
+			return nil, err
 		}
-		return nil, errors.New("stdin/stdout not supported here")
-	}
-
-	if _, ok := startsWith(location, "oci://"); ok {
-		oci, ociErr := NewOci(location, opts...)
-		return oci, ociErr
-	}
-
-	git, gitErr := NewGit(location, opts...)
-	if gitErr == nil {
-		return git, nil
-	}
-
-	if s, ok := isDir(location); ok {
-		return Dir{
-			Directory: s,
-		}, nil
+		if ref != nil {
+			return ref, nil
+		}
 	}
 
 	return nil, errors.New("not implemented")
@@ -52,8 +26,4 @@ func startsWith(value string, prefix string) (string, bool) {
 		return parts[1], true
 	}
 	return prefix, false
-}
-
-func isDir(value string) (string, bool) {
-	return filepath.Clean(value), true
 }

--- a/pkg/location/parse_test.go
+++ b/pkg/location/parse_test.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	test_reader = &bytes.Buffer{}
-	test_writer = &bytes.Buffer{}
+	testReader = &bytes.Buffer{}
+	testWriter = &bytes.Buffer{}
 )
 
 //nolint:scopelint
@@ -140,10 +140,10 @@ func TestParseReference(t *testing.T) {
 			name: "InputStream",
 			args: args{
 				location: "-",
-				opts:     []Option{WithStdin(test_reader)},
+				opts:     []Option{WithStdin(testReader)},
 			},
 			want: InputStream{
-				Reader: test_reader,
+				Reader: testReader,
 			},
 			wantErr: false,
 		},
@@ -151,10 +151,10 @@ func TestParseReference(t *testing.T) {
 			name: "OutputStream",
 			args: args{
 				location: "-",
-				opts:     []Option{WithStdout(test_writer)},
+				opts:     []Option{WithStdout(testWriter)},
 			},
 			want: OutputStream{
-				Writer: test_writer,
+				Writer: testWriter,
 			},
 			wantErr: false,
 		},
@@ -162,11 +162,11 @@ func TestParseReference(t *testing.T) {
 			name: "DuplexStream",
 			args: args{
 				location: "-",
-				opts:     []Option{WithStdin(test_reader), WithStdout(test_writer)},
+				opts:     []Option{WithStdin(testReader), WithStdout(testWriter)},
 			},
 			want: InputOutputStream{
-				Reader: test_reader,
-				Writer: test_writer,
+				Reader: testReader,
+				Writer: testWriter,
 			},
 			wantErr: false,
 		},

--- a/pkg/location/parse_test.go
+++ b/pkg/location/parse_test.go
@@ -1,0 +1,145 @@
+package location
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+func TestParseReference(t *testing.T) {
+	type args struct {
+		location string
+		opts     []Option
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    Reference
+		wantErr bool
+	}{
+		{
+			name: "OciSimpleName",
+			args: args{
+				location: "oci://ubuntu",
+			},
+			want: Oci{
+				Image:     name.MustParseReference("ubuntu"),
+				Directory: ".",
+			},
+			wantErr: false,
+		},
+		{
+			name: "OciNameWithTag",
+			args: args{
+				location: "oci://my-registry.local/name:tag",
+			},
+			want: Oci{
+				Image:     name.MustParseReference("my-registry.local/name:tag"),
+				Directory: ".",
+			},
+			wantErr: false,
+		},
+		{
+			name: "OciNameWithDigest",
+			args: args{
+				location: "oci://my-registry.local/name@sha256:9f6ca9562c5e7bd8bb53d736a2869adc27529eb202996dfefb804ec2c95237ba",
+			},
+			want: Oci{
+				Image:     name.MustParseReference("my-registry.local/name@sha256:9f6ca9562c5e7bd8bb53d736a2869adc27529eb202996dfefb804ec2c95237ba"),
+				Directory: ".",
+			},
+			wantErr: false,
+		},
+		{
+			name: "OciNameWithDirectory",
+			args: args{
+				location: "oci://my-registry.local/name//sub/directory",
+			},
+			want: Oci{
+				Image:     name.MustParseReference("my-registry.local/name:latest"),
+				Directory: "sub/directory",
+			},
+			wantErr: false,
+		},
+		{
+			name: "OciNameWithDirectoryAndTag",
+			args: args{
+				location: "oci://my-registry.local/name//sub/directory:tag",
+			},
+			want: Oci{
+				Image:     name.MustParseReference("my-registry.local/name:tag"),
+				Directory: "sub/directory",
+			},
+			wantErr: false,
+		},
+		{
+			name: "OciDirectoryExtraSlashes",
+			args: args{
+				location: "oci://my-registry.local/name///sub/directory",
+			},
+			want: Oci{
+				Image:     name.MustParseReference("my-registry.local/name:latest"),
+				Directory: "sub/directory",
+			},
+			wantErr: false,
+		},
+		{
+			name: "OciDirectoryEmptyPath",
+			args: args{
+				location: "oci://my-registry.local/name//",
+			},
+			want: Oci{
+				Image:     name.MustParseReference("my-registry.local/name:latest"),
+				Directory: ".",
+			},
+			wantErr: false,
+		},
+		{
+			name: "GitSimpleRepo",
+			args: args{
+				location: "https://hostname/repo.git@main",
+			},
+			want: Git{
+				Repo:      "https://hostname/repo",
+				Directory: ".",
+				Ref:       "main",
+			},
+			wantErr: false,
+		},
+		{
+			name: "GitWithDirectory",
+			args: args{
+				location: "https://hostname/repo.git/sub/directory@main",
+			},
+			want: Git{
+				Repo:      "https://hostname/repo",
+				Directory: "sub/directory",
+				Ref:       "main",
+			},
+			wantErr: false,
+		},
+		{
+			name: "SimpleDir",
+			args: args{
+				location: "path/to/directory",
+			},
+			want: Dir{
+				Directory: "path/to/directory",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseReference(tt.args.location, tt.args.opts...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Parse() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/location/parse_test.go
+++ b/pkg/location/parse_test.go
@@ -1,10 +1,16 @@
 package location
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
 	"github.com/google/go-containerregistry/pkg/name"
+)
+
+var (
+	test_reader = &bytes.Buffer{}
+	test_writer = &bytes.Buffer{}
 )
 
 func TestParseReference(t *testing.T) {
@@ -128,6 +134,48 @@ func TestParseReference(t *testing.T) {
 				Directory: "path/to/directory",
 			},
 			wantErr: false,
+		},
+		{
+			name: "InputStream",
+			args: args{
+				location: "-",
+				opts:     []Option{WithStdin(test_reader)},
+			},
+			want: InputStream{
+				Reader: test_reader,
+			},
+			wantErr: false,
+		},
+		{
+			name: "OutputStream",
+			args: args{
+				location: "-",
+				opts:     []Option{WithStdout(test_writer)},
+			},
+			want: OutputStream{
+				Writer: test_writer,
+			},
+			wantErr: false,
+		},
+		{
+			name: "DuplexStream",
+			args: args{
+				location: "-",
+				opts:     []Option{WithStdin(test_reader), WithStdout(test_writer)},
+			},
+			want: InputOutputStream{
+				Reader: test_reader,
+				Writer: test_writer,
+			},
+			wantErr: false,
+		},
+		{
+			name: "StreamLocationNotExpected",
+			args: args{
+				location: "-",
+			},
+			want:    nil,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/location/parse_test.go
+++ b/pkg/location/parse_test.go
@@ -13,6 +13,7 @@ var (
 	test_writer = &bytes.Buffer{}
 )
 
+//nolint:scopelint
 func TestParseReference(t *testing.T) {
 	type args struct {
 		location string

--- a/pkg/location/parse_test.go
+++ b/pkg/location/parse_test.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
-	testReader = &bytes.Buffer{}
-	testWriter = &bytes.Buffer{}
+	testReader  = &bytes.Buffer{}
+	testWriter  = &bytes.Buffer{}
+	testOptions = []Option{WithOci(), WithGit(), WithDir()}
 )
 
 //nolint:scopelint
@@ -159,29 +160,19 @@ func TestParseReference(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "DuplexStream",
-			args: args{
-				location: "-",
-				opts:     []Option{WithStdin(testReader), WithStdout(testWriter)},
-			},
-			want: InputOutputStream{
-				Reader: testReader,
-				Writer: testWriter,
-			},
-			wantErr: false,
-		},
-		{
 			name: "StreamLocationNotExpected",
 			args: args{
 				location: "-",
 			},
-			want:    nil,
-			wantErr: true,
+			want: Dir{
+				Directory: "-",
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseReference(tt.args.location, tt.args.opts...)
+			got, err := ParseReference(tt.args.location, append(tt.args.opts, testOptions...)...)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Parse() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/location/parse_test.go
+++ b/pkg/location/parse_test.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package location
 
 import (

--- a/pkg/location/reference.go
+++ b/pkg/location/reference.go
@@ -4,6 +4,8 @@ import "fmt"
 
 type Reference interface {
 	fmt.Stringer
+	Type() string
+	Validate() error
 }
 
 type ReferenceLock interface {

--- a/pkg/location/reference.go
+++ b/pkg/location/reference.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package location
 
 import "fmt"

--- a/pkg/location/reference.go
+++ b/pkg/location/reference.go
@@ -1,0 +1,11 @@
+package location
+
+import "fmt"
+
+type Reference interface {
+	fmt.Stringer
+}
+
+type ReferenceLock interface {
+	Reference
+}

--- a/pkg/location/type_dir.go
+++ b/pkg/location/type_dir.go
@@ -2,6 +2,7 @@ package location
 
 import (
 	"fmt"
+	"io/fs"
 )
 
 type Dir struct {
@@ -9,6 +10,15 @@ type Dir struct {
 }
 
 var _ Reference = Dir{}
+
+func parseDir(location string, opt options) (Reference, error) {
+	if fs.ValidPath(location) {
+		return Dir{
+			Directory: location,
+		}, nil
+	}
+	return nil, nil
+}
 
 func (ref Dir) String() string {
 	return fmt.Sprintf("type:dir directory:%q", ref.Directory)

--- a/pkg/location/type_dir.go
+++ b/pkg/location/type_dir.go
@@ -26,16 +26,16 @@ type Dir struct {
 
 var _ Reference = Dir{}
 
-func parseDir(location string, opt options) (Reference, error) {
+func parseDir(location string) Reference {
 	dir := filepath.Clean(location)
 
 	if fs.ValidPath(dir) {
 		return Dir{
 			Directory: dir,
-		}, nil
+		}
 	}
 
-	return nil, nil
+	return nil
 }
 
 // String implements location.Reference

--- a/pkg/location/type_dir.go
+++ b/pkg/location/type_dir.go
@@ -20,14 +20,17 @@ func parseDir(location string, opt options) (Reference, error) {
 	return nil, nil
 }
 
+// String implements location.Reference
 func (ref Dir) String() string {
 	return fmt.Sprintf("type:dir directory:%q", ref.Directory)
 }
 
+// Type implements location.Reference
 func (ref Dir) Type() string {
 	return "dir"
 }
 
+// Validate implements location.Reference
 func (ref Dir) Validate() error {
 	return nil
 }

--- a/pkg/location/type_dir.go
+++ b/pkg/location/type_dir.go
@@ -17,6 +17,7 @@ package location
 import (
 	"fmt"
 	"io/fs"
+	"path/filepath"
 )
 
 type Dir struct {
@@ -26,11 +27,14 @@ type Dir struct {
 var _ Reference = Dir{}
 
 func parseDir(location string, opt options) (Reference, error) {
-	if fs.ValidPath(location) {
+	dir := filepath.Clean(location)
+
+	if fs.ValidPath(dir) {
 		return Dir{
-			Directory: location,
+			Directory: dir,
 		}, nil
 	}
+
 	return nil, nil
 }
 

--- a/pkg/location/type_dir.go
+++ b/pkg/location/type_dir.go
@@ -1,0 +1,13 @@
+package location
+
+import "fmt"
+
+type Dir struct {
+	Directory string
+}
+
+var _ Reference = Dir{}
+
+func (ref Dir) String() string {
+	return fmt.Sprintf("type:dir directory:%q", ref.Directory)
+}

--- a/pkg/location/type_dir.go
+++ b/pkg/location/type_dir.go
@@ -1,6 +1,8 @@
 package location
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type Dir struct {
 	Directory string
@@ -10,4 +12,12 @@ var _ Reference = Dir{}
 
 func (ref Dir) String() string {
 	return fmt.Sprintf("type:dir directory:%q", ref.Directory)
+}
+
+func (ref Dir) Type() string {
+	return "dir"
+}
+
+func (ref Dir) Validate() error {
+	return nil
 }

--- a/pkg/location/type_dir.go
+++ b/pkg/location/type_dir.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package location
 
 import (

--- a/pkg/location/type_git.go
+++ b/pkg/location/type_git.go
@@ -77,16 +77,16 @@ func newGit(location string, opt options) (Git, error) {
 	}, nil
 }
 
-func parseGit(location string, opt options) (Reference, error) {
+func parseGit(location string, opt options) Reference {
 	git, gitErr := newGit(location, opt)
 	var zero Git
 	if gitErr == nil && git != zero {
-		return git, nil
+		return git
 	}
 
 	// TODO - figure out which gitErr must be returned, and which simply mean "it's not a git path"
 
-	return nil, nil
+	return nil
 }
 
 // String implements location.Reference

--- a/pkg/location/type_git.go
+++ b/pkg/location/type_git.go
@@ -2,9 +2,11 @@ package location
 
 import (
 	"fmt"
+	"path"
 	"path/filepath"
 	"strings"
 
+	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/util/parse"
 )
 
@@ -63,6 +65,31 @@ func (ref Git) String() string {
 
 func (ref GitLock) String() string {
 	return fmt.Sprintf("%v commit:%q", ref.Git, ref.Commit)
+}
+
+func (ref Git) Type() string {
+	return "git"
+}
+
+func (ref Git) Validate() error {
+	const op errors.Op = "git.Validate"
+	if len(ref.Repo) == 0 {
+		return errors.E(op, errors.MissingParam, fmt.Errorf("must specify repo"))
+	}
+	if len(ref.Ref) == 0 {
+		return errors.E(op, errors.MissingParam, fmt.Errorf("must specify ref"))
+	}
+	if len(ref.Directory) == 0 {
+		return errors.E(op, errors.MissingParam, fmt.Errorf("must specify directory"))
+	}
+	return nil
+}
+
+func (ref Git) GetDefaultDirectoryName() (string, error) {
+	repo := ref.Repo
+	repo = strings.TrimSuffix(repo, "/")
+	repo = strings.TrimSuffix(repo, ".git")
+	return path.Base(path.Join(path.Clean(repo), path.Clean(ref.Directory))), nil
 }
 
 func (ref Git) SetIdentifier(name string) (Reference, error) {

--- a/pkg/location/type_git.go
+++ b/pkg/location/type_git.go
@@ -36,11 +36,14 @@ type GitLock struct {
 var _ ReferenceLock = GitLock{}
 
 func NewGit(location string, opts ...Option) (Git, error) {
-	opt := makeOptions(opts...)
+	return newGit(location, makeOptions(opts...))
+}
 
+func newGit(location string, opt options) (Git, error) {
 	// args[1] is "" for commands that do not require an output path
 	gitTarget, err := parse.GitParseArgs(opt.ctx, []string{location, ""})
-	if err != nil {
+	var zero parse.GitTarget
+	if err != nil || gitTarget == zero {
 		return Git{}, err
 	}
 
@@ -57,6 +60,18 @@ func NewGit(location string, opts ...Option) (Git, error) {
 		Directory: dir,
 		Ref:       gitTarget.Ref,
 	}, nil
+}
+
+func parseGit(location string, opt options) (Reference, error) {
+	git, gitErr := newGit(location, opt)
+	var zero Git
+	if gitErr == nil && git != zero {
+		return git, nil
+	}
+
+	// TODO - figure out which gitErr must be returned, and which simply mean "it's not a git path"
+
+	return nil, nil
 }
 
 func (ref Git) String() string {

--- a/pkg/location/type_git.go
+++ b/pkg/location/type_git.go
@@ -1,0 +1,81 @@
+package location
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/GoogleContainerTools/kpt/internal/util/parse"
+)
+
+type Git struct {
+	// Repo is the git repository the package.
+	// e.g. 'https://github.com/kubernetes/examples.git'
+	Repo string
+
+	// Directory is the sub directory of the git repository.
+	// e.g. 'staging/cockroachdb'
+	Directory string
+
+	// Ref can be a Git branch, tag, or a commit SHA-1.
+	Ref string
+}
+
+var _ Reference = Git{}
+
+type GitLock struct {
+	Git
+
+	// Commit is the SHA-1 for the last fetch of the package.
+	// This is set by kpt for bookkeeping purposes.
+	Commit string
+}
+
+var _ ReferenceLock = GitLock{}
+
+func NewGit(location string, opts ...Option) (Git, error) {
+	opt := makeOptions(opts...)
+
+	// args[1] is "" for commands that do not require an output path
+	gitTarget, err := parse.GitParseArgs(opt.ctx, []string{location, ""})
+	if err != nil {
+		return Git{}, err
+	}
+
+	dir := gitTarget.Directory
+	if strings.HasPrefix(dir, "/") {
+		dir, err = filepath.Rel("/", gitTarget.Directory)
+		if err != nil {
+			return Git{}, err
+		}
+	}
+
+	return Git{
+		Repo:      gitTarget.Repo,
+		Directory: dir,
+		Ref:       gitTarget.Ref,
+	}, nil
+}
+
+func (ref Git) String() string {
+	return fmt.Sprintf("type:git repo:%q ref:%q directory:%q", ref.Repo, ref.Ref, ref.Directory)
+}
+
+func (ref GitLock) String() string {
+	return fmt.Sprintf("%v commit:%q", ref.Git, ref.Commit)
+}
+
+func (ref Git) SetIdentifier(name string) (Reference, error) {
+	return Git{
+		Repo:      ref.Repo,
+		Directory: ref.Directory,
+		Ref:       name,
+	}, nil
+}
+
+func (ref Git) SetLock(lock string) (ReferenceLock, error) {
+	return GitLock{
+		Git:    ref,
+		Commit: lock,
+	}, nil
+}

--- a/pkg/location/type_git.go
+++ b/pkg/location/type_git.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package location
 
 import (

--- a/pkg/location/type_io.go
+++ b/pkg/location/type_io.go
@@ -1,0 +1,37 @@
+package location
+
+import (
+	"fmt"
+	"io"
+)
+
+type InputStream struct {
+	Reader io.Reader
+}
+
+var _ Reference = InputStream{}
+
+func (ref InputStream) String() string {
+	return fmt.Sprintf("type:io reader:%v", ref.Reader)
+}
+
+type OutputStream struct {
+	Writer io.Writer
+}
+
+var _ Reference = OutputStream{}
+
+func (ref OutputStream) String() string {
+	return fmt.Sprintf("type:io writer:%v", ref.Writer)
+}
+
+type InputOutputStream struct {
+	Reader io.Reader
+	Writer io.Writer
+}
+
+var _ Reference = InputOutputStream{}
+
+func (ref InputOutputStream) String() string {
+	return fmt.Sprintf("type:io reader:%v writer:%v", ref.Reader, ref.Writer)
+}

--- a/pkg/location/type_io.go
+++ b/pkg/location/type_io.go
@@ -15,6 +15,14 @@ func (ref InputStream) String() string {
 	return fmt.Sprintf("type:io reader:%v", ref.Reader)
 }
 
+func (ref InputStream) Type() string {
+	return "io"
+}
+
+func (ref InputStream) Validate() error {
+	return nil
+}
+
 type OutputStream struct {
 	Writer io.Writer
 }
@@ -23,6 +31,14 @@ var _ Reference = OutputStream{}
 
 func (ref OutputStream) String() string {
 	return fmt.Sprintf("type:io writer:%v", ref.Writer)
+}
+
+func (ref OutputStream) Type() string {
+	return "io"
+}
+
+func (ref OutputStream) Validate() error {
+	return nil
 }
 
 type InputOutputStream struct {
@@ -34,4 +50,12 @@ var _ Reference = InputOutputStream{}
 
 func (ref InputOutputStream) String() string {
 	return fmt.Sprintf("type:io reader:%v writer:%v", ref.Reader, ref.Writer)
+}
+
+func (ref InputOutputStream) Type() string {
+	return "io"
+}
+
+func (ref InputOutputStream) Validate() error {
+	return nil
 }

--- a/pkg/location/type_io.go
+++ b/pkg/location/type_io.go
@@ -20,14 +20,17 @@ func stdinParser(value string, opt options) (Reference, error) {
 	return nil, nil
 }
 
+// String implements location.Reference
 func (ref InputStream) String() string {
 	return fmt.Sprintf("type:io reader:%v", ref.Reader)
 }
 
+// Type implements location.Reference
 func (ref InputStream) Type() string {
 	return "io"
 }
 
+// Validate implements location.Reference
 func (ref InputStream) Validate() error {
 	return nil
 }
@@ -47,14 +50,17 @@ func stdoutParser(value string, opt options) (Reference, error) {
 	return nil, nil
 }
 
+// String implements location.Reference
 func (ref OutputStream) String() string {
 	return fmt.Sprintf("type:io writer:%v", ref.Writer)
 }
 
+// Type implements location.Reference
 func (ref OutputStream) Type() string {
 	return "io"
 }
 
+// Validate implements location.Reference
 func (ref OutputStream) Validate() error {
 	return nil
 }

--- a/pkg/location/type_io.go
+++ b/pkg/location/type_io.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package location
 
 import (

--- a/pkg/location/type_io.go
+++ b/pkg/location/type_io.go
@@ -25,15 +25,6 @@ type InputStream struct {
 
 var _ Reference = InputStream{}
 
-func stdinParser(value string, opt options) (Reference, error) {
-	if value == "-" {
-		return InputStream{
-			Reader: opt.stdin,
-		}, nil
-	}
-	return nil, nil
-}
-
 // String implements location.Reference
 func (ref InputStream) String() string {
 	return fmt.Sprintf("type:io reader:%v", ref.Reader)
@@ -55,15 +46,6 @@ type OutputStream struct {
 
 var _ Reference = OutputStream{}
 
-func stdoutParser(value string, opt options) (Reference, error) {
-	if value == "-" {
-		return OutputStream{
-			Writer: opt.stdout,
-		}, nil
-	}
-	return nil, nil
-}
-
 // String implements location.Reference
 func (ref OutputStream) String() string {
 	return fmt.Sprintf("type:io writer:%v", ref.Writer)
@@ -77,4 +59,14 @@ func (ref OutputStream) Type() string {
 // Validate implements location.Reference
 func (ref OutputStream) Validate() error {
 	return nil
+}
+
+type DuplexStream struct {
+	InputStream
+	OutputStream OutputStream
+}
+
+// String implements location.Reference
+func (ref DuplexStream) String() string {
+	return fmt.Sprintf("type:io reader:%v writer:%v", ref.InputStream.Reader, ref.OutputStream.Writer)
 }

--- a/pkg/location/type_io.go
+++ b/pkg/location/type_io.go
@@ -11,6 +11,15 @@ type InputStream struct {
 
 var _ Reference = InputStream{}
 
+func stdinParser(value string, opt options) (Reference, error) {
+	if value == "-" {
+		return InputStream{
+			Reader: opt.stdin,
+		}, nil
+	}
+	return nil, nil
+}
+
 func (ref InputStream) String() string {
 	return fmt.Sprintf("type:io reader:%v", ref.Reader)
 }
@@ -29,6 +38,15 @@ type OutputStream struct {
 
 var _ Reference = OutputStream{}
 
+func stdoutParser(value string, opt options) (Reference, error) {
+	if value == "-" {
+		return OutputStream{
+			Writer: opt.stdout,
+		}, nil
+	}
+	return nil, nil
+}
+
 func (ref OutputStream) String() string {
 	return fmt.Sprintf("type:io writer:%v", ref.Writer)
 }
@@ -38,24 +56,5 @@ func (ref OutputStream) Type() string {
 }
 
 func (ref OutputStream) Validate() error {
-	return nil
-}
-
-type InputOutputStream struct {
-	Reader io.Reader
-	Writer io.Writer
-}
-
-var _ Reference = InputOutputStream{}
-
-func (ref InputOutputStream) String() string {
-	return fmt.Sprintf("type:io reader:%v writer:%v", ref.Reader, ref.Writer)
-}
-
-func (ref InputOutputStream) Type() string {
-	return "io"
-}
-
-func (ref InputOutputStream) Validate() error {
 	return nil
 }

--- a/pkg/location/type_oci.go
+++ b/pkg/location/type_oci.go
@@ -83,7 +83,7 @@ func NewOci(location string, opts ...Option) (Oci, error) {
 	return Oci{}, fmt.Errorf("invalid format")
 }
 
-func parseOci(value string, opt options) (Reference, error) {
+func parseOci(value string) (Reference, error) {
 	if _, ok := startsWith(value, "oci://"); ok {
 		return NewOci(value)
 	}

--- a/pkg/location/type_oci.go
+++ b/pkg/location/type_oci.go
@@ -1,11 +1,12 @@
 package location
 
 import (
-	"errors"
 	"fmt"
+	"path"
 	"path/filepath"
 	"strings"
 
+	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/google/go-containerregistry/pkg/name"
 )
 
@@ -64,7 +65,7 @@ func NewOci(location string, opts ...Option) (Oci, error) {
 		}, nil
 	}
 
-	return Oci{}, errors.New("invalid format")
+	return Oci{}, fmt.Errorf("invalid format")
 }
 
 func (ref Oci) String() string {
@@ -73,6 +74,22 @@ func (ref Oci) String() string {
 
 func (ref OciLock) String() string {
 	return fmt.Sprintf("%v digest:%q", ref.Oci, ref.Digest)
+}
+
+func (ref Oci) Validate() error {
+	const op errors.Op = "oci.Validate"
+	if ref.Image == nil {
+		return errors.E(op, errors.MissingParam, fmt.Errorf("must specify image"))
+	}
+	return nil
+}
+
+func (ref Oci) Type() string {
+	return "oci"
+}
+
+func (ref Oci) GetDefaultDirectoryName() (string, error) {
+	return path.Base(path.Join(path.Clean(ref.Image.Context().Name()), path.Clean(ref.Directory))), nil
 }
 
 func (ref Oci) SetIdentifier(identifier string) (Reference, error) {

--- a/pkg/location/type_oci.go
+++ b/pkg/location/type_oci.go
@@ -1,0 +1,90 @@
+package location
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/google/go-containerregistry/pkg/name"
+)
+
+type Oci struct {
+	Image     name.Reference
+	Directory string
+}
+
+var _ Reference = Oci{}
+
+type OciLock struct {
+	Oci
+	Digest name.Reference
+}
+
+var _ Reference = OciLock{}
+var _ ReferenceLock = OciLock{}
+
+func NewOci(location string, opts ...Option) (Oci, error) {
+
+	if s, ok := startsWith(location, "oci://"); ok {
+		ref, err := name.ParseReference(s)
+		if err != nil {
+			return Oci{}, err
+		}
+		if parts := strings.SplitN(ref.Context().Name(), "//", 2); len(parts) == 2 {
+			repo, err := name.NewRepository(parts[0])
+			if err != nil {
+				return Oci{}, err
+			}
+
+			dir := filepath.Clean(parts[1])
+			if filepath.IsAbs(dir) {
+				dir, err = filepath.Rel("/", dir)
+				if err != nil {
+					return Oci{}, err
+				}
+			}
+
+			switch ref := ref.(type) {
+			case name.Tag:
+				return Oci{
+					Image:     repo.Tag(ref.TagStr()),
+					Directory: dir,
+				}, nil
+			case name.Digest:
+				return Oci{
+					Image:     repo.Digest(ref.DigestStr()),
+					Directory: dir,
+				}, nil
+			}
+		}
+		return Oci{
+			Image:     ref,
+			Directory: ".",
+		}, nil
+	}
+
+	return Oci{}, errors.New("invalid format")
+}
+
+func (ref Oci) String() string {
+	return fmt.Sprintf("type:oci image:%q directory:%q", ref.Image, ref.Directory)
+}
+
+func (ref OciLock) String() string {
+	return fmt.Sprintf("%v digest:%q", ref.Oci, ref.Digest)
+}
+
+func (ref Oci) SetIdentifier(identifier string) (Reference, error) {
+	return Oci{
+		Image:     ref.Image.Context().Tag(identifier),
+		Directory: ref.Directory,
+	}, nil
+}
+
+func (ref Oci) SetLock(lock string) (ReferenceLock, error) {
+	return OciLock{
+		Oci:    ref,
+		Digest: ref.Image.Context().Digest(lock),
+	}, nil
+}

--- a/pkg/location/type_oci.go
+++ b/pkg/location/type_oci.go
@@ -116,7 +116,7 @@ func (ref Oci) Type() string {
 
 // GetDefaultDirectoryName is called from location.DefaultDirectoryName
 func (ref Oci) GetDefaultDirectoryName() (string, bool) {
-	return path.Base(path.Join(path.Clean(ref.Image.Context().Name()), path.Clean(ref.Directory))), false
+	return path.Base(path.Join(path.Clean(ref.Image.Context().Name()), path.Clean(ref.Directory))), true
 }
 
 // SetIdentifier is called from mutate.Identifier

--- a/pkg/location/type_oci.go
+++ b/pkg/location/type_oci.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package location
 
 import (

--- a/pkg/location/type_oci.go
+++ b/pkg/location/type_oci.go
@@ -68,6 +68,13 @@ func NewOci(location string, opts ...Option) (Oci, error) {
 	return Oci{}, fmt.Errorf("invalid format")
 }
 
+func parseOci(value string, opt options) (Reference, error) {
+	if _, ok := startsWith(value, "oci://"); ok {
+		return NewOci(value)
+	}
+	return nil, nil
+}
+
 func (ref Oci) String() string {
 	return fmt.Sprintf("type:oci image:%q directory:%q", ref.Image, ref.Directory)
 }


### PR DESCRIPTION
Draft PR to preview shifting the `kpt pkg get` from for oci-support onto new virtual fs types

Adds "content" layer above "location" layer to make it simple to work with location as FileSystem and Reader abstractly.

The change from remote.Upstream interface to location.Reference in get command object also updates some tests - the difference is small but looks like an improvement.
