### PR TITLE
Use simple evaluator in tests

### DIFF
--- a/porch/engine/go.mod
+++ b/porch/engine/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/GoogleContainerTools/kpt/porch/api v0.0.0-00010101000000-000000000000
 	github.com/GoogleContainerTools/kpt/porch/controllers v0.0.0-00010101000000-000000000000
 	github.com/GoogleContainerTools/kpt/porch/repository v0.0.0-00010101000000-000000000000
+	github.com/google/go-cmp v0.5.6
 	k8s.io/klog/v2 v2.40.1
 	sigs.k8s.io/kustomize/api v0.8.11
 	sigs.k8s.io/kustomize/kyaml v0.13.1
@@ -44,7 +45,6 @@ require (
 	github.com/go-openapi/swag v0.19.14 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/go-containerregistry v0.8.0 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect

--- a/porch/engine/pkg/kpt/eval.go
+++ b/porch/engine/pkg/kpt/eval.go
@@ -28,31 +28,31 @@ import (
 )
 
 func NewPlaceholderFunctionRunner() fn.FunctionRunner {
-	return &evaluator{}
+	return &runner{}
 }
 
-type evaluator struct {
+type runner struct {
 }
 
-var _ fn.FunctionRunner = &evaluator{}
+var _ fn.FunctionRunner = &runner{}
 
-func (e *evaluator) NewRunner(ctx context.Context, fn *kptfilev1.Function, opts fn.RunnerOptions) (kio.Filter, error) {
-	return &runner{
+func (e *runner) NewRunner(ctx context.Context, fn *kptfilev1.Function, opts fn.RunnerOptions) (kio.Filter, error) {
+	return &filter{
 		ctx: ctx,
 		fn:  *fn,
 		rl:  opts.ResultList,
 	}, nil
 }
 
-type runner struct {
+type filter struct {
 	ctx context.Context
 	fn  kptfilev1.Function
 	rl  *fnresultv1.ResultList
 }
 
-var _ kio.Filter = &runner{}
+var _ kio.Filter = &filter{}
 
-func (r *runner) Filter(items []*yaml.RNode) ([]*yaml.RNode, error) {
+func (r *filter) Filter(items []*yaml.RNode) ([]*yaml.RNode, error) {
 	rl := &framework.ResourceList{
 		Items:   items,
 		Results: []*framework.Result{},

--- a/porch/engine/pkg/kpt/eval_test.go
+++ b/porch/engine/pkg/kpt/eval_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestSetLabels(t *testing.T) {
-	k := &evaluator{}
+	k := &runner{}
 
 	const pkgYaml = `# Comment
 apiVersion: storage.cnrm.cloud.google.com/v1beta1


### PR DESCRIPTION
This avoids dependency on docker in unit tests.
The price is that the simple functions don't support full semantics,
but they also run much faster.

