### PR TITLE
RemoteRootSyncSet: use specified OCI image

### DIFF
--- a/porch/controllers/remoterootsync/api/v1alpha1/remoterootsyncset_types.go
+++ b/porch/controllers/remoterootsync/api/v1alpha1/remoterootsyncset_types.go
@@ -42,10 +42,24 @@ type RemoteRootSyncSet struct {
 	Status RemoteRootSyncSetStatus `json:"status,omitempty"`
 }
 
+func (o *RemoteRootSyncSet) GetSpec() *RemoteRootSyncSetSpec {
+	if o == nil {
+		return nil
+	}
+	return &o.Spec
+}
+
 // RemoteRootSyncSetSpec defines the desired state of RemoteRootSync
 type RemoteRootSyncSetSpec struct {
 	ClusterRefs []*ClusterRef     `json:"clusterRefs,omitempty"`
 	Template    *RootSyncTemplate `json:"template,omitempty"`
+}
+
+func (o *RemoteRootSyncSetSpec) GetTemplate() *RootSyncTemplate {
+	if o == nil {
+		return nil
+	}
+	return o.Template
 }
 
 type ClusterRef struct {
@@ -61,8 +75,22 @@ type RootSyncTemplate struct {
 	OCI *OCISpec `json:"oci,omitempty"`
 }
 
+func (o *RootSyncTemplate) GetOCI() *OCISpec {
+	if o == nil {
+		return nil
+	}
+	return o.OCI
+}
+
 type OCISpec struct {
 	Repository string `json:"repository,omitempty"`
+}
+
+func (o *OCISpec) GetRepository() string {
+	if o == nil {
+		return ""
+	}
+	return o.Repository
 }
 
 // RootSyncSetStatus defines the observed state of RootSyncSet

--- a/porch/repository/pkg/oci/storage.go
+++ b/porch/repository/pkg/oci/storage.go
@@ -71,6 +71,17 @@ func (i ImageTagName) ociReference() (name.Reference, error) {
 	return imageRef, nil
 }
 
+func ParseImageTagName(s string) (*ImageTagName, error) {
+	t, err := name.NewTag(s)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse %q as tag: %w", s, err)
+	}
+	return &ImageTagName{
+		Image: t.Repository.Name(),
+		Tag:   t.TagStr(),
+	}, nil
+}
+
 // ImageDigestName holds an image we know by digest (which is immutable and more cacheable)
 type ImageDigestName struct {
 	Image  string


### PR DESCRIPTION
Stop hard-coding and use the image the user specifies!
