### PR TITLE
Add capability to override function runner in fnrender

### DIFF
--- a/internal/util/render/executor.go
+++ b/internal/util/render/executor.go
@@ -51,6 +51,9 @@ type Renderer struct {
 	// kpt function evaluator
 	Runner fn.FunctionRunner
 
+	// Picker knows how to pick a functionexecutor for a given function
+	Picker fn.FunctionPicker
+
 	// ResultsDirPath is absolute path to the directory to write results
 	ResultsDirPath string
 
@@ -91,6 +94,7 @@ func (e *Renderer) Execute(ctx context.Context) error {
 		allowExec:       e.AllowExec,
 		fileSystem:      e.FileSystem,
 		runner:          e.Runner,
+		picker:          e.Picker,
 	}
 
 	if _, err = hydrate(ctx, root, hctx); err != nil {
@@ -207,6 +211,9 @@ type hydrationContext struct {
 
 	// custom function runner
 	runner fn.FunctionRunner
+
+	// function picker
+	picker fn.FunctionPicker
 }
 
 //
@@ -492,7 +499,7 @@ func (pn *pkgNode) runValidators(ctx context.Context, hctx *hydrationContext, in
 		if hctx.runner != nil {
 			validator, err = hctx.runner.NewRunner(ctx, &function, fn.RunnerOptions{ResultList: hctx.fnResults})
 		} else {
-			validator, err = fnruntime.NewRunner(ctx, &function, pn.pkg.UniquePath, hctx.fnResults, hctx.imagePullPolicy, displayResourceCount)
+			validator, err = fnruntime.NewRunner(ctx, &function, pn.pkg.UniquePath, hctx.fnResults, hctx.imagePullPolicy, displayResourceCount, hctx.picker)
 		}
 		if err != nil {
 			return err
@@ -613,7 +620,7 @@ func fnChain(ctx context.Context, hctx *hydrationContext, pkgPath types.UniquePa
 		if hctx.runner != nil {
 			runner, err = hctx.runner.NewRunner(ctx, &function, fn.RunnerOptions{ResultList: hctx.fnResults})
 		} else {
-			runner, err = fnruntime.NewRunner(ctx, &function, pkgPath, hctx.fnResults, hctx.imagePullPolicy, displayResourceCount)
+			runner, err = fnruntime.NewRunner(ctx, &function, pkgPath, hctx.fnResults, hctx.imagePullPolicy, displayResourceCount, hctx.picker)
 		}
 		if err != nil {
 			return nil, err

--- a/pkg/fn/eval.go
+++ b/pkg/fn/eval.go
@@ -16,6 +16,7 @@ package fn
 
 import (
 	"context"
+	"io"
 
 	fnresult "github.com/GoogleContainerTools/kpt/pkg/api/fnresult/v1"
 	v1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
@@ -30,3 +31,12 @@ type RunnerOptions struct {
 type FunctionRunner interface {
 	NewRunner(ctx context.Context, fn *v1.Function, opts RunnerOptions) (kio.Filter, error)
 }
+
+// FunctionExecutor knows how to run a function.
+type FunctionExecutor interface {
+	// Run method accepts resourceList in wireformat and returns resourceList in wire format.
+	Run(r io.Reader, w io.Writer) error
+}
+
+// FunctionPicker returns a function executor to be used for a given function configuration.
+type FunctionPicker func(fn *v1.Function) FunctionExecutor

--- a/pkg/fn/render.go
+++ b/pkg/fn/render.go
@@ -23,6 +23,8 @@ import (
 type RenderOptions struct {
 	Runner  FunctionRunner
 	PkgPath string
+
+	Picker FunctionPicker
 }
 
 type Renderer interface {


### PR DESCRIPTION
This PR just shows how to provide a hook for override function executor when using `fn render` as library. Don't worry about the naming... they are just for the placeholder.

This approach wraps the provided function executor so that all the goodness of fn orchestration such as comment/indentation preservation is preserved.

Raising this PR for a discussion with @phanimarupaka @martinmaly 