### PR TITLE
tests: Fix test flake from timestamp sanitization (#2713)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/cpuguy83/go-md2man/v2 v2.0.1
 	github.com/go-errors/errors v1.4.0
+	github.com/google/go-cmp v0.5.6
 	github.com/google/go-containerregistry v0.8.0
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/igorsobreira/titlecase v0.0.0-20140109233139-4156b5b858ac

--- a/pkg/test/runner/sanitize_test.go
+++ b/pkg/test/runner/sanitize_test.go
@@ -1,0 +1,73 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestSanitizeTimestamps(t *testing.T) {
+	grid := []struct {
+		Name   string
+		Input  string
+		Output string
+	}{
+		{
+			Name: "Prefix match: 12s and 12.1s",
+			Input: `
+[RUNNING] \"gcr.io/kpt-fn/starlark:v0.2.1\"
+[PASS] \"gcr.io/kpt-fn/starlark:v0.2.1\" in 12s
+[RUNNING] \"gcr.io/kpt-fn/set-namespace:v0.1.3\" on 1 resource(s)
+[PASS] \"gcr.io/kpt-fn/set-namespace:v0.1.3\" in 12.1s
+`,
+			Output: `
+[RUNNING] \"gcr.io/kpt-fn/starlark:v0.2.1\"
+[PASS] \"gcr.io/kpt-fn/starlark:v0.2.1\" in 0s
+[RUNNING] \"gcr.io/kpt-fn/set-namespace:v0.1.3\" on 1 resource(s)
+[PASS] \"gcr.io/kpt-fn/set-namespace:v0.1.3\" in 0s
+`,
+		},
+		{
+			Name: "Suffix match: 1s and 0.1s",
+			Input: `
+[RUNNING] \"gcr.io/kpt-fn/starlark:v0.2.1\"
+[PASS] \"gcr.io/kpt-fn/starlark:v0.2.1\" in 1s
+[RUNNING] \"gcr.io/kpt-fn/set-namespace:v0.1.3\" on 1 resource(s)
+[PASS] \"gcr.io/kpt-fn/set-namespace:v0.1.3\" in 0.1s
+`,
+			Output: `
+[RUNNING] \"gcr.io/kpt-fn/starlark:v0.2.1\"
+[PASS] \"gcr.io/kpt-fn/starlark:v0.2.1\" in 0s
+[RUNNING] \"gcr.io/kpt-fn/set-namespace:v0.1.3\" on 1 resource(s)
+[PASS] \"gcr.io/kpt-fn/set-namespace:v0.1.3\" in 0s
+`,
+		},
+		{
+			Name: "Only substitute matching lines",
+			Input: `
+[RUNNING] \"gcr.io/kpt-fn/starlark:v0.2.1\"
+[PASS] \"gcr.io/kpt-fn/starlark:v0.2.1\" in 1s
+[RUNNING] \"gcr.io/kpt-fn/set-namespace:1s\" on 1 resource(s)
+[PASS] \"gcr.io/kpt-fn/set-namespace:v0.1.3\" notin 1s
+`,
+			Output: `
+[RUNNING] \"gcr.io/kpt-fn/starlark:v0.2.1\"
+[PASS] \"gcr.io/kpt-fn/starlark:v0.2.1\" in 0s
+[RUNNING] \"gcr.io/kpt-fn/set-namespace:1s\" on 1 resource(s)
+[PASS] \"gcr.io/kpt-fn/set-namespace:v0.1.3\" notin 1s
+`,
+		},
+	}
+
+	for _, g := range grid {
+		g := g // Avoid range go-tcha
+		t.Run(g.Name, func(t *testing.T) {
+			got := sanitizeTimestamps(g.Input)
+			want := g.Output
+
+			if diff := cmp.Diff(got, want); diff != "" {
+				t.Errorf("unexpected results (-want, +got): %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Fix test flake from timestamp sanitization

When timestamps "overlap", sanitization did not work correctly.

For example:

in 1s ... in 2.1s

The first substitution would replace 1s => 0s

in 0s ... in 2.0s

The second substitution is predetermined, and replaces 2.1s => 0s, but
2.1s is no longer in the string.

* Use new sanitization function in tests, remove old function
