### PR TITLE
Pass Function Config to Eval

### DIFF
--- a/porch/engine/pkg/engine/engine.go
+++ b/porch/engine/pkg/engine/engine.go
@@ -15,7 +15,6 @@
 package engine
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io/fs"
@@ -25,7 +24,6 @@ import (
 	"reflect"
 	"strings"
 
-	v1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/GoogleContainerTools/kpt/pkg/fn"
 	api "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
 	configapi "github.com/GoogleContainerTools/kpt/porch/controllers/pkg/apis/porch/v1alpha1"
@@ -36,8 +34,6 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"k8s.io/klog/v2"
-	"sigs.k8s.io/kustomize/kyaml/kio"
-	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 type CaDEngine interface {
@@ -376,93 +372,6 @@ func loadResourcesFromDirectory(dir string) (repository.PackageResources, error)
 	}
 
 	return result, nil
-}
-
-type evalFunctionMutation struct {
-	runtime fn.FunctionRuntime
-	task    *api.Task
-}
-
-func (m *evalFunctionMutation) Apply(ctx context.Context, resources repository.PackageResources) (repository.PackageResources, *api.Task, error) {
-	e := m.task.Eval
-
-	// TODO: Apply should accept filesystem instead of PackageResources
-
-	runner, err := m.runtime.GetRunner(ctx, &v1.Function{
-		Image: e.Image,
-	})
-	if err != nil {
-		return repository.PackageResources{}, nil, fmt.Errorf("failed to create function runner: %w", err)
-	}
-
-	var functionConfig *yaml.RNode
-	if m.task.Eval.ConfigMap != nil {
-		if cm, err := kpt.NewConfigMap(m.task.Eval.ConfigMap); err != nil {
-			return repository.PackageResources{}, nil, fmt.Errorf("failed to create function config: %w", err)
-		} else {
-			functionConfig = cm
-		}
-	}
-
-	pr := &packageReader{
-		input: resources,
-		extra: map[string]string{},
-	}
-
-	// r := &kio.LocalPackageReader{
-	// 	PackagePath:        "/",
-	// 	IncludeSubpackages: true,
-	// 	FileSystem:         filesys.FileSystemOrOnDisk{FileSystem: fs},
-	// 	WrapBareSeqNode:    true,
-	// }
-
-	var rl bytes.Buffer
-	w := &kio.ByteWriter{
-		Writer:                &rl,
-		KeepReaderAnnotations: true,
-		FunctionConfig:        functionConfig,
-		WrappingKind:          kio.ResourceListKind,
-		WrappingAPIVersion:    kio.ResourceListAPIVersion,
-	}
-
-	pipeline := kio.Pipeline{
-		Inputs:  []kio.Reader{pr},
-		Outputs: []kio.Writer{w},
-	}
-
-	if err := pipeline.Execute(); err != nil {
-		return repository.PackageResources{}, nil, fmt.Errorf("failed to serialize package: %w", err)
-	}
-
-	// Evaluate the function
-	var output bytes.Buffer
-	if err := runner.Run(&rl, &output); err != nil {
-		return repository.PackageResources{}, nil, fmt.Errorf("failed to evaluate function: %w", err)
-	}
-
-	result := repository.PackageResources{
-		Contents: map[string]string{},
-	}
-
-	if err := (kio.Pipeline{
-		Inputs: []kio.Reader{&kio.ByteReader{
-			Reader:            &output,
-			PreserveSeqIndent: true,
-			WrapBareSeqNode:   true,
-		}},
-		Outputs: []kio.Writer{&packageWriter{
-			output: result,
-		}},
-	}.Execute()); err != nil {
-		return repository.PackageResources{}, nil, fmt.Errorf("failed to de-serialize function result: %w", err)
-	}
-
-	// Return extras. TODO: Apply should accept FS.
-	for k, v := range pr.extra {
-		result.Contents[k] = v
-	}
-
-	return result, m.task, nil
 }
 
 type mutationReplaceResources struct {

--- a/porch/engine/pkg/engine/eval.go
+++ b/porch/engine/pkg/engine/eval.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package engine
 
 import (

--- a/porch/engine/pkg/engine/eval.go
+++ b/porch/engine/pkg/engine/eval.go
@@ -1,0 +1,102 @@
+package engine
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	v1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
+	"github.com/GoogleContainerTools/kpt/pkg/fn"
+	api "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
+	"github.com/GoogleContainerTools/kpt/porch/engine/pkg/kpt"
+	"github.com/GoogleContainerTools/kpt/porch/repository/pkg/repository"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+type evalFunctionMutation struct {
+	runtime fn.FunctionRuntime
+	task    *api.Task
+}
+
+func (m *evalFunctionMutation) Apply(ctx context.Context, resources repository.PackageResources) (repository.PackageResources, *api.Task, error) {
+	e := m.task.Eval
+
+	// TODO: Apply should accept filesystem instead of PackageResources
+
+	runner, err := m.runtime.GetRunner(ctx, &v1.Function{
+		Image: e.Image,
+	})
+	if err != nil {
+		return repository.PackageResources{}, nil, fmt.Errorf("failed to create function runner: %w", err)
+	}
+
+	var functionConfig *yaml.RNode
+	if m.task.Eval.ConfigMap != nil {
+		if cm, err := kpt.NewConfigMap(m.task.Eval.ConfigMap); err != nil {
+			return repository.PackageResources{}, nil, fmt.Errorf("failed to create function config: %w", err)
+		} else {
+			functionConfig = cm
+		}
+	}
+
+	pr := &packageReader{
+		input: resources,
+		extra: map[string]string{},
+	}
+
+	// r := &kio.LocalPackageReader{
+	// 	PackagePath:        "/",
+	// 	IncludeSubpackages: true,
+	// 	FileSystem:         filesys.FileSystemOrOnDisk{FileSystem: fs},
+	// 	WrapBareSeqNode:    true,
+	// }
+
+	var rl bytes.Buffer
+	w := &kio.ByteWriter{
+		Writer:                &rl,
+		KeepReaderAnnotations: true,
+		FunctionConfig:        functionConfig,
+		WrappingKind:          kio.ResourceListKind,
+		WrappingAPIVersion:    kio.ResourceListAPIVersion,
+	}
+
+	pipeline := kio.Pipeline{
+		Inputs:  []kio.Reader{pr},
+		Outputs: []kio.Writer{w},
+	}
+
+	if err := pipeline.Execute(); err != nil {
+		return repository.PackageResources{}, nil, fmt.Errorf("failed to serialize package: %w", err)
+	}
+
+	// Evaluate the function
+	var output bytes.Buffer
+	if err := runner.Run(&rl, &output); err != nil {
+		return repository.PackageResources{}, nil, fmt.Errorf("failed to evaluate function: %w", err)
+	}
+
+	result := repository.PackageResources{
+		Contents: map[string]string{},
+	}
+
+	if err := (kio.Pipeline{
+		Inputs: []kio.Reader{&kio.ByteReader{
+			Reader:            &output,
+			PreserveSeqIndent: true,
+			WrapBareSeqNode:   true,
+		}},
+		Outputs: []kio.Writer{&packageWriter{
+			output: result,
+		}},
+	}.Execute()); err != nil {
+		return repository.PackageResources{}, nil, fmt.Errorf("failed to de-serialize function result: %w", err)
+	}
+
+	// Return extras. TODO: Apply should accept FS.
+	for k, v := range pr.extra {
+		result.Contents[k] = v
+	}
+
+	return result, m.task, nil
+}

--- a/porch/engine/pkg/kpt/eval.go
+++ b/porch/engine/pkg/kpt/eval.go
@@ -24,6 +24,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/porch/engine/pkg/internal"
 	"sigs.k8s.io/kustomize/kyaml/fn/framework"
 	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 func NewSimpleFunctionRuntime() FunctionRuntime {
@@ -43,7 +44,6 @@ func (e *runtime) GetRunner(ctx context.Context, fn *kptfilev1.Function) (fn.Fun
 
 	return &runner{
 		ctx:       ctx,
-		fn:        *fn,
 		processor: processor,
 	}, nil
 }
@@ -54,7 +54,6 @@ func (e *runtime) Close() error {
 
 type runner struct {
 	ctx       context.Context
-	fn        kptfilev1.Function
 	processor framework.ResourceListProcessorFunc
 }
 
@@ -68,4 +67,23 @@ func (fr *runner) Run(r io.Reader, w io.Writer) error {
 	}
 
 	return framework.Execute(fr.processor, rw)
+}
+
+func NewConfigMap(data map[string]string) (*yaml.RNode, error) {
+	node := yaml.NewMapRNode(&data)
+	if node == nil {
+		return nil, nil
+	}
+	// create a ConfigMap only for configMap config
+	configMap := yaml.MustParse(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: function-input
+data: {}
+`)
+	if err := configMap.PipeE(yaml.SetField("data", node)); err != nil {
+		return nil, err
+	}
+	return configMap, nil
 }

--- a/porch/engine/pkg/kpt/eval_test.go
+++ b/porch/engine/pkg/kpt/eval_test.go
@@ -89,22 +89,3 @@ func TestSetLabels(t *testing.T) {
 		}
 	}
 }
-
-func NewConfigMap(data map[string]string) (*yaml.RNode, error) {
-	node := yaml.NewMapRNode(&data)
-	if node == nil {
-		return nil, nil
-	}
-	// create a ConfigMap only for configMap config
-	configMap := yaml.MustParse(`
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: function-input
-data: {}
-`)
-	if err := configMap.PipeE(yaml.SetField("data", node)); err != nil {
-		return nil, err
-	}
-	return configMap, nil
-}


### PR DESCRIPTION
* remove unused field (runner.fn)
* move ConfigMap construction back to engine
* construct function config for eval

Note: eval has issues where it drops config comments; further kpt
refactoring is needed.
