### PR TITLE
Run Porch With Consistent Working Dir

### DIFF
--- a/porch/.dockerignore
+++ b/porch/.dockerignore
@@ -1,3 +1,4 @@
 .build/
 .cache/
 default.etcd/
+apiserver.local.config/

--- a/porch/Makefile
+++ b/porch/Makefile
@@ -103,11 +103,13 @@ vet: $(MODULES)
 fmt: $(MODULES)
 	@for f in $(^D); do (cd $$f; echo "Formatting $$f"; gofmt -s -w .); done
 
+PORCH = $(BUILDDIR)/porch
+
 .PHONY: run-local
-run-local:
+run-local: porch
 	KUBECONFIG=$(KUBECONFIG) kubectl apply -f hack/local/localconfig.yaml
 	KUBECONFIG=$(KUBECONFIG) kubectl apply -f controllers/pkg/apis/porch/v1alpha1/
-	cd apiserver; go run ./cmd/porch \
+	$(PORCH) \
 	--secure-port 9443 \
 	--standalone-debug-mode \
 	--kubeconfig="$(KUBECONFIG)" \
@@ -120,7 +122,7 @@ run-jaeger:
 
 .PHONY: porch
 porch:
-	cd apiserver; go build ./cmd/porch
+	cd apiserver; go build -o $(PORCH) ./cmd/porch
 
 .PHONY: fix-headers
 fix-headers:


### PR DESCRIPTION
`go run` doesn't support setting working directory; use `go build`
instead.
