### PR TITLE
make kpt binary optional in test harness

### DIFF
--- a/pkg/test/runner/runner.go
+++ b/pkg/test/runner/runner.go
@@ -73,9 +73,11 @@ func NewRunner(t *testing.T, testCase TestCase, c string) (*Runner, error) {
 	}
 	kptBin, err := getKptBin()
 	if err != nil {
-		return nil, fmt.Errorf("failed to find kpt binary: %w", err)
+		t.Logf("failed to find kpt binary: %v", err)
 	}
-	t.Logf("Using kpt binary: %s", kptBin)
+	if kptBin != "" {
+		t.Logf("Using kpt binary: %s", kptBin)
+	}
 	return &Runner{
 		pkgName:  filepath.Base(testCase.Path),
 		testCase: testCase,


### PR DESCRIPTION
I would like to leverage this test harness in the KRM functions registry testing CI because I've found it very useful to run e2e tests for functions invoked by kustomize as well as kpt. 

However, the test harness currently requires that there be a kpt binary available, which is not necessary nor desirable for the tests I want to use it for in https://github.com/kubernetes-sigs/krm-functions-registry/pull/5. Can we make the existence of the kpt binary optional for the runner, so that we can use it in the KRM functions registry repo? 

The other option is to rewrite another test harness from scratch, which I can do if that is a more desirable option though it will take a bit longer. 