### PR TITLE
Add Missing file.Close() calls

### DIFF
--- a/internal/fnruntime/runner.go
+++ b/internal/fnruntime/runner.go
@@ -470,6 +470,7 @@ func newFnConfig(f *kptfilev1.Function, pkgPath types.UniquePath) (*yaml.RNode, 
 			return nil, errors.E(op, fn,
 				fmt.Errorf("missing function config %q", f.ConfigPath))
 		}
+		defer file.Close()
 		b, err := ioutil.ReadAll(file)
 		if err != nil {
 			return nil, errors.E(op, fn, err)

--- a/pkg/api/kptfile/v1/validation.go
+++ b/pkg/api/kptfile/v1/validation.go
@@ -177,6 +177,7 @@ func GetValidatedFnConfigFromPath(pkgPath types.UniquePath, configPath string) (
 	if err != nil {
 		return nil, fmt.Errorf("functionConfig must exist in the current package")
 	}
+	defer file.Close()
 	reader := kio.ByteReader{Reader: file, PreserveSeqIndent: true, WrapBareSeqNode: true, DisableUnwrapping: true}
 	nodes, err := reader.Read()
 	if err != nil {


### PR DESCRIPTION
Calls to close files were missing in a couple of places
