### PR TITLE
Updating command code

### DIFF
--- a/internal/cmdget/cmdget_test.go
+++ b/internal/cmdget/cmdget_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
+	"github.com/GoogleContainerTools/kpt/pkg/location"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
@@ -230,8 +231,8 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 			runE: NoOpRunE,
 			validations: func(_, _ string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, "master", r.Get.Git.Ref)
-				assert.Equal(t, "something://foo", r.Get.Git.Repo)
+				assert.Equal(t, "master", r.Get.Upstream.(location.Git).Ref)
+				assert.Equal(t, "something://foo", r.Get.Upstream.(location.Git).Repo)
 				assert.Equal(t, filepath.Join(pathPrefix, w.WorkspaceDirectory, "foo"), r.Get.Destination)
 			},
 		},
@@ -242,9 +243,9 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 			runE: NoOpRunE,
 			validations: func(repo, _ string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
-				assert.Equal(t, "master", r.Get.Git.Ref)
-				assert.Equal(t, "/blueprints/java", r.Get.Git.Directory)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Upstream.(location.Git).Repo)
+				assert.Equal(t, "master", r.Get.Upstream.(location.Git).Ref)
+				assert.Equal(t, "blueprints/java", r.Get.Upstream.(location.Git).Directory)
 				assert.Equal(t, filepath.Join(pathPrefix, w.WorkspaceDirectory, "java"), r.Get.Destination)
 			},
 		},
@@ -255,9 +256,9 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 			runE: NoOpRunE,
 			validations: func(repo, _ string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
-				assert.Equal(t, "master", r.Get.Git.Ref)
-				assert.Equal(t, "/blueprints/java", r.Get.Git.Directory)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Upstream.(location.Git).Repo)
+				assert.Equal(t, "master", r.Get.Upstream.(location.Git).Ref)
+				assert.Equal(t, "blueprints/java", r.Get.Upstream.(location.Git).Directory)
 				assert.Equal(t, filepath.Join(pathPrefix, w.WorkspaceDirectory, "java"), r.Get.Destination)
 			},
 		},
@@ -268,9 +269,9 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 			runE: NoOpRunE,
 			validations: func(repo, _ string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
-				assert.Equal(t, "master", r.Get.Git.Ref)
-				assert.Equal(t, "/blueprints/java", r.Get.Git.Directory)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Upstream.(location.Git).Repo)
+				assert.Equal(t, "master", r.Get.Upstream.(location.Git).Ref)
+				assert.Equal(t, "blueprints/java", r.Get.Upstream.(location.Git).Directory)
 				assert.Equal(t, filepath.Join(pathPrefix, w.WorkspaceDirectory, "baz"), r.Get.Destination)
 			},
 		},
@@ -281,9 +282,9 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 			runE: NoOpRunE,
 			validations: func(repo, _ string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
-				assert.Equal(t, "master", r.Get.Git.Ref)
-				assert.Equal(t, "/blueprints/java", r.Get.Git.Directory)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Upstream.(location.Git).Repo)
+				assert.Equal(t, "master", r.Get.Upstream.(location.Git).Ref)
+				assert.Equal(t, "blueprints/java", r.Get.Upstream.(location.Git).Directory)
 				assert.Equal(t, "/baz", r.Get.Destination)
 			},
 		},
@@ -294,8 +295,8 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 			runE: NoOpRunE,
 			validations: func(repo, dir string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
-				assert.Equal(t, "master", r.Get.Git.Ref)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Upstream.(location.Git).Repo)
+				assert.Equal(t, "master", r.Get.Upstream.(location.Git).Ref)
 				assert.Equal(t, filepath.Join(dir, "my-app"), r.Get.Destination)
 			},
 		},
@@ -306,9 +307,9 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 			runE: NoOpRunE,
 			validations: func(repo, dir string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
-				assert.Equal(t, "/baz", r.Get.Git.Directory)
-				assert.Equal(t, "master", r.Get.Git.Ref)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Upstream.(location.Git).Repo)
+				assert.Equal(t, "baz", r.Get.Upstream.(location.Git).Directory)
+				assert.Equal(t, "master", r.Get.Upstream.(location.Git).Ref)
 				assert.Equal(t, filepath.Join(dir, "my-app"), r.Get.Destination)
 			},
 		},
@@ -319,9 +320,9 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 			runE: NoOpRunE,
 			validations: func(repo, dir string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
-				assert.Equal(t, "/baz", r.Get.Git.Directory)
-				assert.Equal(t, "v1", r.Get.Git.Ref)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Upstream.(location.Git).Repo)
+				assert.Equal(t, "baz", r.Get.Upstream.(location.Git).Directory)
+				assert.Equal(t, "v1", r.Get.Upstream.(location.Git).Ref)
 				assert.Equal(t, filepath.Join(dir, "my-app"), r.Get.Destination)
 			},
 		},
@@ -332,8 +333,8 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 			runE: NoOpRunE,
 			validations: func(repo, dir string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
-				assert.Equal(t, "master", r.Get.Git.Ref)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Upstream.(location.Git).Repo)
+				assert.Equal(t, "master", r.Get.Upstream.(location.Git).Ref)
 				assert.Equal(t, filepath.Join(dir, "package"), r.Get.Destination)
 			},
 		},
@@ -355,8 +356,8 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 			runE: NoOpRunE,
 			validations: func(repo, dir string, r *cmdget.Runner, err error) {
 				assert.NoError(t, err)
-				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Git.Repo)
-				assert.Equal(t, "master", r.Get.Git.Ref)
+				assert.Equal(t, fmt.Sprintf("file://%s", repo), r.Get.Upstream.(location.Git).Repo)
+				assert.Equal(t, "master", r.Get.Upstream.(location.Git).Ref)
 				assert.Equal(t, filepath.Join(dir, "package"), r.Get.Destination)
 				assert.Equal(t, kptfilev1.FastForward, r.Get.UpdateStrategy)
 			},

--- a/internal/cmdliveinit/cmdliveinit_test.go
+++ b/internal/cmdliveinit/cmdliveinit_test.go
@@ -13,12 +13,12 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
+	"github.com/GoogleContainerTools/kpt/internal/types"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	rgfilev1alpha1 "github.com/GoogleContainerTools/kpt/pkg/api/resourcegroup/v1alpha1"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
-	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 var (
@@ -294,7 +294,7 @@ func TestCmd_Run(t *testing.T) {
 			// Otherwise, validate the kptfile values and/or resourcegroup values.
 			var actualInv kptfilev1.Inventory
 			assert.NoError(t, err)
-			kf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, w.WorkspaceDirectory)
+			kf, err := pkg.ReadKptfile(types.DiskPath(w.WorkspaceDirectory))
 			assert.NoError(t, err)
 
 			switch tc.rgfilename {

--- a/internal/cmdmigrate/migratecmd_test.go
+++ b/internal/cmdmigrate/migratecmd_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
+	"github.com/GoogleContainerTools/kpt/internal/types"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -20,7 +21,6 @@ import (
 	"sigs.k8s.io/cli-utils/pkg/inventory"
 	"sigs.k8s.io/cli-utils/pkg/manifestreader"
 	"sigs.k8s.io/cli-utils/pkg/object"
-	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
 
 var testNamespace = "test-inventory-namespace"
@@ -158,7 +158,7 @@ func TestKptMigrate_updateKptfile(t *testing.T) {
 				return
 			}
 			assert.NoError(t, err)
-			kf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, dir)
+			kf, err := pkg.ReadKptfile(types.DiskPath(dir))
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/internal/cmdpull/cmdpull.go
+++ b/internal/cmdpull/cmdpull.go
@@ -24,11 +24,10 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/types"
 	"github.com/GoogleContainerTools/kpt/internal/util/argutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
-	"github.com/GoogleContainerTools/kpt/internal/util/parse"
+	"github.com/GoogleContainerTools/kpt/internal/util/parse/parseref"
 	"github.com/GoogleContainerTools/kpt/internal/util/pathutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/pull"
-	"github.com/GoogleContainerTools/kpt/internal/util/remote"
-	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
+	"github.com/GoogleContainerTools/kpt/pkg/location"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
@@ -77,19 +76,16 @@ func (r *Runner) preRunE(_ *cobra.Command, args []string) error {
 			args[1] = resolvedPath
 		}
 	}
-	destination, err := parse.ParseArgs(r.ctx, args, parse.Options{
-		SetGit: func(git *kptfilev1.Git) error {
-			r.Pull.Origin = remote.NewGitOrigin(git)
-			return nil
-		},
-		SetOci: func(oci *kptfilev1.Oci) error {
-			r.Pull.Origin = remote.NewOciOrigin(oci)
-			return nil
-		},
-	})
+
+	origin, destination, err := parseref.ParseArgs(
+		args,
+		location.WithContext(r.ctx),
+		location.WithParsers(location.GitParser, location.OciParser))
 	if err != nil {
-		return err
+		return errors.E(op, err)
 	}
+
+	r.Pull.Origin = origin
 
 	absDestPath, _, err := pathutil.ResolveAbsAndRelPaths(destination)
 	if err != nil {

--- a/internal/cmdpush/cmdpush.go
+++ b/internal/cmdpush/cmdpush.go
@@ -27,11 +27,9 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/types"
 	"github.com/GoogleContainerTools/kpt/internal/util/argutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/cmdutil"
-	"github.com/GoogleContainerTools/kpt/internal/util/parse"
 	"github.com/GoogleContainerTools/kpt/internal/util/pathutil"
 	"github.com/GoogleContainerTools/kpt/internal/util/push"
-	"github.com/GoogleContainerTools/kpt/internal/util/remote"
-	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
+	"github.com/GoogleContainerTools/kpt/pkg/location"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 )
@@ -126,15 +124,15 @@ func (r *Runner) preRunE(_ *cobra.Command, args []string) error {
 	}
 
 	if r.Origin != "" {
-		_, err := parse.ParseArgs(r.ctx, []string{r.Origin, path}, parse.Options{
-			SetOci: func(oci *kptfilev1.Oci) error {
-				r.Push.Origin = remote.NewOciOrigin(oci)
-				return nil
-			},
-		})
+		ref, err := location.ParseReference(
+			r.Origin,
+			location.WithContext(r.ctx),
+			location.WithParsers(location.GitParser, location.OciParser),
+		)
 		if err != nil {
 			return err
 		}
+		r.Push.Origin = ref
 	}
 
 	return nil

--- a/internal/util/get/get.go
+++ b/internal/util/get/get.go
@@ -30,10 +30,10 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/util/attribution"
 	"github.com/GoogleContainerTools/kpt/internal/util/fetch"
 	"github.com/GoogleContainerTools/kpt/internal/util/pathutil"
-	"github.com/GoogleContainerTools/kpt/internal/util/remote"
 	"github.com/GoogleContainerTools/kpt/internal/util/stack"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
+	"github.com/GoogleContainerTools/kpt/pkg/location"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 )
@@ -41,11 +41,8 @@ import (
 // Command fetches a package from a git repository, copies it to a local
 // directory, and expands any remote subpackages.
 type Command struct {
-	// Git contains information about the git repo to fetch
-	Git *kptfilev1.Git
-
-	// Contains information about the upstraem package to fetch
-	Upstream remote.Upstream
+	// Contains information about the upstream package to fetch
+	Upstream location.Reference
 
 	// Destination is the output directory to clone the package to.  Defaults to the name of the package --
 	// either the base repo name, or the base subdirectory name.
@@ -78,8 +75,9 @@ func (c Command) Run(ctx context.Context) error {
 
 	kf := kptfileutil.DefaultKptfile(c.Name)
 
-	kf.Upstream = c.Upstream.BuildUpstream()
-	kf.Upstream.UpdateStrategy = c.UpdateStrategy
+	if kf.Upstream, err = kptfileutil.NewUpstreamFromReference(c.Upstream, c.UpdateStrategy); err != nil {
+		return errors.E(op, err)
+	}
 
 	err = kptfileutil.WriteFile(c.Destination, kf)
 	if err != nil {
@@ -90,6 +88,7 @@ func (c Command) Run(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
 	p, err := pkg.New(filesys.FileSystemOrOnDisk{}, absDestPath)
 	if err != nil {
 		return cleanUpDirAndError(c.Destination, err)
@@ -135,11 +134,11 @@ func (c Command) fetchPackages(ctx context.Context, rootPkg *pkg.Pkg) error {
 			packageCount += 1
 			pr.PrintPackage(p, !(p == rootPkg))
 
-			upstream, err := remote.NewUpstream(kf)
+			ref, err := kptfileutil.NewReferenceFromUpstream(kf)
 			if err != nil {
 				return errors.E(op, p.UniquePath, err)
 			}
-			pr.Printf("Fetching %s\n", upstream.String())
+			pr.Printf("Fetching %s\n", ref.String())
 
 			err = (&fetch.Command{
 				Pkg: p,

--- a/internal/util/get/get_test.go
+++ b/internal/util/get/get_test.go
@@ -24,8 +24,8 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
 	"github.com/GoogleContainerTools/kpt/internal/testutil/pkgbuilder"
 	. "github.com/GoogleContainerTools/kpt/internal/util/get"
-	"github.com/GoogleContainerTools/kpt/internal/util/remote"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
+	"github.com/GoogleContainerTools/kpt/pkg/location"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/filters"
@@ -58,9 +58,9 @@ func TestCommand_Run_failNoRevision(t *testing.T) {
 	defer clean()
 
 	err := Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo: "foo",
-		}),
+		},
 		Destination: w.WorkspaceDirectory,
 	}.Run(fake.CtxWithDefaultPrinter())
 	if !assert.Error(t, err) {
@@ -83,12 +83,14 @@ func TestCommand_Run(t *testing.T) {
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
 
 	absPath := filepath.Join(w.WorkspaceDirectory, g.RepoName)
-	err := Command{Upstream: remote.NewGitUpstream(&kptfilev1.Git{
-		Repo:      "file://" + g.RepoDirectory,
-		Ref:       "master",
-		Directory: "/",
-	}),
-		Destination: absPath}.Run(fake.CtxWithDefaultPrinter())
+	err := Command{
+		Upstream: location.Git{
+			Repo:      "file://" + g.RepoDirectory,
+			Ref:       "master",
+			Directory: "/",
+		},
+		Destination: absPath,
+	}.Run(fake.CtxWithDefaultPrinter())
 	assert.NoError(t, err)
 
 	// verify the cloned contents matches the repository
@@ -144,8 +146,8 @@ func TestCommand_Run_subdir(t *testing.T) {
 	defer testutil.Chdir(t, w.WorkspaceDirectory)()
 
 	absPath := filepath.Join(w.WorkspaceDirectory, subdir)
-	err := Command{Upstream: remote.NewGitUpstream(&kptfilev1.Git{
-		Repo: g.RepoDirectory, Ref: "refs/heads/master", Directory: subdir}),
+	err := Command{Upstream: location.Git{
+		Repo: g.RepoDirectory, Ref: "refs/heads/master", Directory: subdir},
 		Destination: absPath,
 	}.Run(fake.CtxWithDefaultPrinter())
 	assert.NoError(t, err)
@@ -208,8 +210,8 @@ func TestCommand_Run_subdir_symlinks(t *testing.T) {
 	cliOutput := &bytes.Buffer{}
 
 	absPath := filepath.Join(w.WorkspaceDirectory, subdir)
-	err := Command{Upstream: remote.NewGitUpstream(&kptfilev1.Git{
-		Repo: g.RepoDirectory, Ref: "refs/heads/master", Directory: subdir}),
+	err := Command{Upstream: location.Git{
+		Repo: g.RepoDirectory, Ref: "refs/heads/master", Directory: subdir},
 		Destination: absPath,
 	}.Run(fake.CtxWithPrinter(cliOutput, cliOutput))
 	assert.NoError(t, err)
@@ -273,11 +275,11 @@ func TestCommand_Run_destination(t *testing.T) {
 
 	absPath := filepath.Join(w.WorkspaceDirectory, dest)
 	err := Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      g.RepoDirectory,
 			Ref:       "master",
 			Directory: "/",
-		}),
+		},
 		Destination: absPath,
 	}.Run(fake.CtxWithDefaultPrinter())
 	assert.NoError(t, err)
@@ -337,11 +339,11 @@ func TestCommand_Run_subdirAndDestination(t *testing.T) {
 
 	absPath := filepath.Join(w.WorkspaceDirectory, dest)
 	err := Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      g.RepoDirectory,
 			Ref:       "master",
 			Directory: subdir,
-		}),
+		},
 		Destination: absPath,
 	}.Run(fake.CtxWithDefaultPrinter())
 	assert.NoError(t, err)
@@ -417,11 +419,11 @@ func TestCommand_Run_branch(t *testing.T) {
 
 	absPath := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	err = Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      g.RepoDirectory,
 			Ref:       "refs/heads/exp",
 			Directory: "/",
-		}),
+		},
 		Destination: absPath,
 	}.Run(fake.CtxWithDefaultPrinter())
 	assert.NoError(t, err)
@@ -500,11 +502,11 @@ func TestCommand_Run_tag(t *testing.T) {
 
 	absPath := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	err = Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      g.RepoDirectory,
 			Ref:       "refs/tags/v2",
 			Directory: "/",
-		}),
+		},
 		Destination: absPath,
 	}.Run(fake.CtxWithDefaultPrinter())
 	assert.NoError(t, err)
@@ -641,11 +643,11 @@ func TestCommand_Run_ref(t *testing.T) {
 
 			absPath := filepath.Join(w.WorkspaceDirectory, repos[testutil.Upstream].RepoName)
 			err = Command{
-				Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+				Upstream: location.Git{
 					Repo:      repos[testutil.Upstream].RepoDirectory,
 					Ref:       ref,
 					Directory: tc.directory,
-				}),
+				},
 				Destination: absPath,
 			}.Run(fake.CtxWithDefaultPrinter())
 			assert.NoError(t, err)
@@ -670,11 +672,11 @@ func TestCommand_Run_failExistingDir(t *testing.T) {
 
 	absPath := filepath.Join(w.WorkspaceDirectory, g.RepoName)
 	err := Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      g.RepoDirectory,
 			Ref:       "master",
 			Directory: "/",
-		}),
+		},
 		Destination: absPath,
 	}.Run(fake.CtxWithDefaultPrinter())
 	assert.NoError(t, err)
@@ -724,11 +726,11 @@ func TestCommand_Run_failExistingDir(t *testing.T) {
 
 	// try to clone and expect a failure
 	err = Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      g.RepoDirectory,
 			Ref:       "master",
 			Directory: "/",
-		}),
+		},
 		Destination: absPath,
 	}.Run(fake.CtxWithDefaultPrinter())
 	if !assert.Error(t, err) {
@@ -781,11 +783,11 @@ func TestCommand_Run_nonexistingParentDir(t *testing.T) {
 
 	absPath := filepath.Join(w.WorkspaceDirectory, "more", "dirs", g.RepoName)
 	err := Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      g.RepoDirectory,
 			Ref:       "master",
 			Directory: "/",
-		}),
+		},
 		Destination: absPath,
 	}.Run(fake.CtxWithDefaultPrinter())
 	assert.NoError(t, err)
@@ -801,11 +803,11 @@ func TestCommand_Run_failInvalidRepo(t *testing.T) {
 
 	absPath := filepath.Join(w.WorkspaceDirectory, "foo")
 	err := Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      "foo",
 			Directory: "/",
 			Ref:       "refs/heads/master",
-		}),
+		},
 		Destination: absPath,
 	}.Run(fake.CtxWithDefaultPrinter())
 	if !assert.Error(t, err) {
@@ -831,11 +833,11 @@ func TestCommand_Run_failInvalidBranch(t *testing.T) {
 
 	absPath := filepath.Join(w.WorkspaceDirectory, g.RepoDirectory)
 	err := Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      g.RepoDirectory,
 			Directory: "/",
 			Ref:       "refs/heads/foo",
-		}),
+		},
 		Destination: absPath,
 	}.Run(fake.CtxWithDefaultPrinter())
 	if !assert.Error(t, err) {
@@ -864,11 +866,11 @@ func TestCommand_Run_failInvalidTag(t *testing.T) {
 
 	absPath := filepath.Join(w.WorkspaceDirectory, g.RepoDirectory)
 	err := Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      g.RepoDirectory,
 			Directory: "/",
 			Ref:       "refs/tags/foo",
-		}),
+		},
 		Destination: absPath,
 	}.Run(fake.CtxWithDefaultPrinter())
 	if !assert.Error(t, err) {
@@ -1389,11 +1391,11 @@ func TestCommand_Run_subpackages(t *testing.T) {
 			destinationDir := filepath.Join(w.WorkspaceDirectory, targetDir)
 
 			err = Command{
-				Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+				Upstream: location.Git{
 					Repo:      upstreamRepo.RepoDirectory,
 					Directory: tc.directory,
 					Ref:       tc.ref,
-				}),
+				},
 				Destination:    destinationDir,
 				UpdateStrategy: tc.updateStrategy,
 			}.Run(fake.CtxWithDefaultPrinter())
@@ -1460,11 +1462,11 @@ func TestCommand_Run_symlinks(t *testing.T) {
 
 	destinationDir := filepath.Join(w.WorkspaceDirectory, upstreamRepo.RepoName)
 	err := Command{
-		Upstream: remote.NewGitUpstream(&kptfilev1.Git{
+		Upstream: location.Git{
 			Repo:      upstreamRepo.RepoDirectory,
 			Directory: "/",
 			Ref:       "master",
-		}),
+		},
 		Destination: destinationDir,
 	}.Run(fake.CtxWithDefaultPrinter())
 	if !assert.NoError(t, err) {

--- a/internal/util/update/update_test.go
+++ b/internal/util/update/update_test.go
@@ -28,12 +28,12 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
 	"github.com/GoogleContainerTools/kpt/internal/testutil/pkgbuilder"
+	"github.com/GoogleContainerTools/kpt/internal/types"
 	. "github.com/GoogleContainerTools/kpt/internal/util/update"
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
 	"github.com/stretchr/testify/assert"
 	"sigs.k8s.io/kustomize/kyaml/copyutil"
-	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/kio"
 	"sigs.k8s.io/kustomize/kyaml/kio/filters"
 )
@@ -260,7 +260,7 @@ func TestCommand_Run_localPackageChanges(t *testing.T) {
 			expectedErr: "local package files have been modified",
 			expectedCommit: func(writer *testutil.TestSetupManager) (string, error) {
 				upstreamRepo := writer.Repos[testutil.Upstream]
-				f, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, filepath.Join(writer.LocalWorkspace.WorkspaceDirectory, upstreamRepo.RepoName))
+				f, err := pkg.ReadKptfile(types.DiskPath(filepath.Join(writer.LocalWorkspace.WorkspaceDirectory, upstreamRepo.RepoName)))
 				if err != nil {
 					return "", err
 				}
@@ -2038,7 +2038,7 @@ func TestCommand_Run_local_subpackages(t *testing.T) {
 
 				expectedPath := result.expectedLocal.ExpandPkgWithName(t,
 					g.LocalWorkspace.PackageDir, testutil.ToReposInfo(g.Repos))
-				kf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, expectedPath)
+				kf, err := pkg.ReadKptfile(types.DiskPath(expectedPath))
 				if !assert.NoError(t, err) {
 					t.FailNow()
 				}
@@ -3774,7 +3774,7 @@ func TestReplaceNonKRMFiles(t *testing.T) {
 			// expectedLocal.
 			err = ioutil.WriteFile(filepath.Join(updated, "new.yaml"), []byte("a: b"), 0600)
 			assert.NoError(t, err)
-			err = ReplaceNonKRMFiles(updated, original, local)
+			err = ReplaceNonKRMFiles(types.DiskPath(updated), types.DiskPath(original), types.DiskPath(local))
 			assert.NoError(t, err)
 			tg := testutil.TestGitRepo{}
 			tg.AssertEqual(t, local, filepath.Join(expectedLocal), false)


### PR DESCRIPTION
Last of 3 PR. This is the update to the CLI command code that rests on the changes to the util code.

The good news --- altogether the changes did not change fundamentally _what_ the commands and util did, in what order, and all of the tests at this point are passing without change down to the CLI output text (except of course for places where test code needed to pass a disk filesystem instead of a simple string path, for example)