### PR TITLE
Use Context to Drive Server Shutdown

### DIFF
--- a/porch/apiserver/cmd/porch/main.go
+++ b/porch/apiserver/cmd/porch/main.go
@@ -48,10 +48,10 @@ func run() int {
 	http.DefaultTransport = otelhttp.NewTransport(http.DefaultClient.Transport)
 	http.DefaultClient.Transport = http.DefaultTransport
 
-	stopCh := genericapiserver.SetupSignalHandler()
+	ctx := genericapiserver.SetupSignalContext()
 
 	options := server.NewPorchServerOptions(os.Stdout, os.Stderr)
-	cmd := server.NewCommandStartPorchServer(options, stopCh)
+	cmd := server.NewCommandStartPorchServer(ctx, options)
 	code := cli.Run(cmd)
 	return code
 }

--- a/porch/apiserver/pkg/apiserver/apiserver.go
+++ b/porch/apiserver/pkg/apiserver/apiserver.go
@@ -15,6 +15,7 @@
 package apiserver
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/GoogleContainerTools/kpt/porch/api/porch/install"
@@ -188,7 +189,7 @@ func (c completedConfig) New() (*PorchServer, error) {
 	return s, nil
 }
 
-func (s *PorchServer) Run(stopCh <-chan struct{}) error {
-	porch.RunBackground(s.coreClient, s.cache, stopCh)
-	return s.GenericAPIServer.PrepareRun().Run(stopCh)
+func (s *PorchServer) Run(ctx context.Context) error {
+	porch.RunBackground(ctx, s.coreClient, s.cache)
+	return s.GenericAPIServer.PrepareRun().Run(ctx.Done())
 }

--- a/porch/apiserver/pkg/cmd/server/start.go
+++ b/porch/apiserver/pkg/cmd/server/start.go
@@ -15,6 +15,7 @@
 package server
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -80,7 +81,7 @@ func NewPorchServerOptions(out, errOut io.Writer) *PorchServerOptions {
 
 // NewCommandStartPorchServer provides a CLI handler for 'start master' command
 // with a default PorchServerOptions.
-func NewCommandStartPorchServer(defaults *PorchServerOptions, stopCh <-chan struct{}) *cobra.Command {
+func NewCommandStartPorchServer(ctx context.Context, defaults *PorchServerOptions) *cobra.Command {
 	o := *defaults
 	cmd := &cobra.Command{
 		Short: "Launch a porch API server",
@@ -92,7 +93,7 @@ func NewCommandStartPorchServer(defaults *PorchServerOptions, stopCh <-chan stru
 			if err := o.Validate(args); err != nil {
 				return err
 			}
-			if err := o.RunPorchServer(stopCh); err != nil {
+			if err := o.RunPorchServer(ctx); err != nil {
 				return err
 			}
 			return nil
@@ -187,7 +188,7 @@ func (o *PorchServerOptions) Config() (*apiserver.Config, error) {
 }
 
 // RunPorchServer starts a new PorchServer given PorchServerOptions
-func (o PorchServerOptions) RunPorchServer(stopCh <-chan struct{}) error {
+func (o PorchServerOptions) RunPorchServer(ctx context.Context) error {
 	config, err := o.Config()
 	if err != nil {
 		return err
@@ -206,7 +207,7 @@ func (o PorchServerOptions) RunPorchServer(stopCh <-chan struct{}) error {
 		})
 	}
 
-	return server.Run(stopCh)
+	return server.Run(ctx)
 }
 
 func (o *PorchServerOptions) AddFlags(fs *pflag.FlagSet) {

--- a/porch/apiserver/pkg/registry/porch/background.go
+++ b/porch/apiserver/pkg/registry/porch/background.go
@@ -28,13 +28,12 @@ import (
 	"github.com/GoogleContainerTools/kpt/porch/repository/pkg/cache"
 )
 
-func RunBackground(coreClient client.WithWatch, cache *cache.Cache, stopCh <-chan struct{}) {
+func RunBackground(ctx context.Context, coreClient client.WithWatch, cache *cache.Cache) {
 	b := background{
 		coreClient: coreClient,
 		cache:      cache,
 	}
-	ctx := context.Background()
-	go b.run(ctx, stopCh)
+	go b.run(ctx)
 }
 
 // background manages background tasks
@@ -43,8 +42,8 @@ type background struct {
 	cache      *cache.Cache
 }
 
-// run will run until ctx is done or stopCh is closed
-func (b *background) run(ctx context.Context, stopCh <-chan struct{}) {
+// run will run until ctx is done
+func (b *background) run(ctx context.Context) {
 	klog.Infof("Background routine starting ...")
 
 	// Repository watch.
@@ -110,10 +109,6 @@ loop:
 			} else {
 				klog.Infof("Background routine exiting; context done")
 			}
-			break loop
-
-		case <-stopCh:
-			klog.Info("Background routine exiting; stop channel closed")
 			break loop
 		}
 	}


### PR DESCRIPTION
Turns out k8s apiserver supports both and we can get the core context to
listen on instead of just getting the close channel.
