### PR TITLE
Clean up Required/Optional API Fields

### DIFF
--- a/porch/controllers/pkg/apis/porch/v1alpha1/config.porch.kpt.dev_repositories.yaml
+++ b/porch/controllers/pkg/apis/porch/v1alpha1/config.porch.kpt.dev_repositories.yaml
@@ -67,7 +67,7 @@ spec:
                   branch:
                     description: Name of the branch containig the packages. Finalized
                       packages will be committed to this branch (if the repository
-                      allows write access).
+                      allows write access). If unspecified, defaults to "main".
                     type: string
                   directory:
                     description: Directory within the Git repository where the packages
@@ -85,10 +85,10 @@ spec:
                           be located in the same namespace as the resource containing
                           the reference.
                         type: string
+                    required:
+                    - name
                     type: object
                 required:
-                - branch
-                - directory
                 - repo
                 type: object
               mutators:
@@ -139,6 +139,8 @@ spec:
                           be located in the same namespace as the resource containing
                           the reference.
                         type: string
+                    required:
+                    - name
                     type: object
                 required:
                 - registry
@@ -161,7 +163,7 @@ spec:
                       branch:
                         description: Name of the branch containig the packages. Finalized
                           packages will be committed to this branch (if the repository
-                          allows write access).
+                          allows write access). If unspecified, defaults to "main".
                         type: string
                       directory:
                         description: Directory within the Git repository where the
@@ -181,10 +183,10 @@ spec:
                               to be located in the same namespace as the resource
                               containing the reference.
                             type: string
+                        required:
+                        - name
                         type: object
                     required:
-                    - branch
-                    - directory
                     - repo
                     type: object
                   oci:
@@ -203,6 +205,8 @@ spec:
                               to be located in the same namespace as the resource
                               containing the reference.
                             type: string
+                        required:
+                        - name
                         type: object
                     required:
                     - registry

--- a/porch/controllers/pkg/apis/porch/v1alpha1/types.go
+++ b/porch/controllers/pkg/apis/porch/v1alpha1/types.go
@@ -86,10 +86,10 @@ type GitRepository struct {
 	// Address of the Git repository, for example:
 	//   `https://github.com/GoogleCloudPlatform/blueprints.git`
 	Repo string `json:"repo"`
-	// Name of the branch containig the packages. Finalized packages will be committed to this branch (if the repository allows write access).
-	Branch string `json:"branch"`
+	// Name of the branch containig the packages. Finalized packages will be committed to this branch (if the repository allows write access). If unspecified, defaults to "main".
+	Branch string `json:"branch,omitempty"`
 	// Directory within the Git repository where the packages are stored. A subdirectory of this directory containing a Kptfile is considered a package. If unspecified, defaults to root directory.
-	Directory string `json:"directory"`
+	Directory string `json:"directory,omitempty"`
 	// Reference to secret containing authentication credentials.
 	SecretRef SecretRef `json:"secretRef,omitempty"`
 }
@@ -124,7 +124,7 @@ type RepositoryRef struct {
 
 type SecretRef struct {
 	// Name of the secret. The secret is expected to be located in the same namespace as the resource containing the reference.
-	Name string `json:"name,omitempty"`
+	Name string `json:"name"`
 }
 
 type FunctionEval struct {


### PR DESCRIPTION
Git branch and directory can be optional (defaulting to `main` and `/` respectively,
while `SecretRef.Name` is required since nameless secret reference is unhelpful.
