### PR TITLE
Use controller-gen v0.8.0

### DIFF
--- a/porch/controllers/pkg/apis/porch/v1alpha1/config.porch.kpt.dev_repositories.yaml
+++ b/porch/controllers/pkg/apis/porch/v1alpha1/config.porch.kpt.dev_repositories.yaml
@@ -18,7 +18,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.7.0
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: repositories.config.porch.kpt.dev
 spec:
@@ -49,7 +49,7 @@ spec:
             type: object
           spec:
             description: "RepositorySpec defines the desired state of Repository \n
-              Notes:  * deployment repository - in KRM API ConfigSync would be configured
+              Notes: * deployment repository - in KRM API ConfigSync would be configured
               directly? (or via this API)"
             properties:
               content:
@@ -75,7 +75,7 @@ spec:
                       is considered a package. If unspecified, defaults to root directory.
                     type: string
                   repo:
-                    description: 'Address of the Git repository, for example:   `https://github.com/GoogleCloudPlatform/blueprints.git`'
+                    description: 'Address of the Git repository, for example: `https://github.com/GoogleCloudPlatform/blueprints.git`'
                     type: string
                   secretRef:
                     description: Reference to secret containing authentication credentials.
@@ -172,7 +172,8 @@ spec:
                           to root directory.
                         type: string
                       repo:
-                        description: 'Address of the Git repository, for example:   `https://github.com/GoogleCloudPlatform/blueprints.git`'
+                        description: 'Address of the Git repository, for example:
+                          `https://github.com/GoogleCloudPlatform/blueprints.git`'
                         type: string
                       secretRef:
                         description: Reference to secret containing authentication

--- a/porch/controllers/pkg/apis/porch/v1alpha1/groupversion_info.go
+++ b/porch/controllers/pkg/apis/porch/v1alpha1/groupversion_info.go
@@ -23,7 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-//go:generate go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0 object object:headerFile="../../../../../hack/boilerplate.go.txt" crd:crdVersions=v1 output:crd:artifacts:config=. paths=./...
+//go:generate go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.8.0 object object:headerFile="../../../../../hack/boilerplate.go.txt" crd:crdVersions=v1 output:crd:artifacts:config=. paths=./...
 
 var (
 	// GroupVersion is group version used to register these objects

--- a/porch/controllers/remoterootsync/api/v1alpha1/groupversion_info.go
+++ b/porch/controllers/remoterootsync/api/v1alpha1/groupversion_info.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 )
 
-//go:generate go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1 object object:headerFile="../../../../hack/boilerplate.go.txt" paths="./..."
+//go:generate go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.8.0 object object:headerFile="../../../../hack/boilerplate.go.txt" paths="./..."
 
 var (
 	// GroupVersion is group version used to register these objects

--- a/porch/controllers/remoterootsync/config/crd/bases/config.cloud.google.com_remoterootsyncsets.yaml
+++ b/porch/controllers/remoterootsync/config/crd/bases/config.cloud.google.com_remoterootsyncsets.yaml
@@ -18,7 +18,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.4.1
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: remoterootsyncsets.config.cloud.google.com
 spec:
@@ -98,13 +98,13 @@ spec:
                           the current state of this API Resource. --- This struct
                           is intended for direct use as an array at the field path
                           .status.conditions.  For example, type FooStatus struct{
-                          \    // Represents the observations of a foo's current state.
-                          \    // Known .status.conditions.type are: \"Available\",
-                          \"Progressing\", and \"Degraded\"     // +patchMergeKey=type
-                          \    // +patchStrategy=merge     // +listType=map     //
-                          +listMapKey=type     Conditions []metav1.Condition `json:\"conditions,omitempty\"
-                          patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
-                          \n     // other fields }"
+                          // Represents the observations of a foo's current state.
+                          // Known .status.conditions.type are: \"Available\", \"Progressing\",
+                          and \"Degraded\" // +patchMergeKey=type // +patchStrategy=merge
+                          // +listType=map // +listMapKey=type Conditions []metav1.Condition
+                          `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
+                          protobuf:\"bytes,1,rep,name=conditions\"` \n // other fields
+                          }"
                         properties:
                           lastTransitionTime:
                             description: lastTransitionTime is the last time the condition

--- a/porch/controllers/remoterootsync/main.go
+++ b/porch/controllers/remoterootsync/main.go
@@ -14,7 +14,7 @@
 
 package main
 
-//go:generate go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.4.1 crd:preserveUnknownFields=false rbac:roleName=configmanagement-operator webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+//go:generate go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.8.0 crd rbac:roleName=configmanagement-operator webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 import (
 	"context"


### PR DESCRIPTION
Use consistent version of controller-gen (v0.8.0)
crd:preserveUnknownFields marker has been removed (`false` was the
required value for v1 CRDs).
