### PR TITLE
Insert a sleep in the watch loop

### DIFF
--- a/porch/apiserver/pkg/registry/porch/background.go
+++ b/porch/apiserver/pkg/registry/porch/background.go
@@ -84,6 +84,8 @@ loop:
 			if !eventOk {
 				klog.Errorf("Watch event stream closed. Will restart watch from bookmark %q", bookmark)
 				watcher.Stop()
+				// Avoid busy-spinning
+				time.Sleep(1 * time.Second)
 				events = nil
 				watcher = nil
 			} else if repository, ok := event.Object.(*configapi.Repository); ok {


### PR DESCRIPTION
We don't currently support watch on repositories, so this is behaving
very oddly - there's no error, but the watch stream is just
immediately closed.
