### PR TITLE
Fix missing error handling

### DIFF
--- a/porch/apiserver/pkg/apiserver/apiserver.go
+++ b/porch/apiserver/pkg/apiserver/apiserver.go
@@ -169,6 +169,9 @@ func (c completedConfig) New() (*PorchServer, error) {
 		engine.WithGRPCFunctionRuntime(c.ExtraConfig.FunctionRunnerAddress),
 		engine.WithCredentialResolver(credentialResolver),
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	porchGroup, err := porch.NewRESTStorage(Scheme, Codecs, cad, coreClient)
 	if err != nil {

--- a/porch/engine/pkg/engine/engine.go
+++ b/porch/engine/pkg/engine/engine.go
@@ -44,7 +44,9 @@ type CaDEngine interface {
 func NewCaDEngine(opts ...EngineOption) (CaDEngine, error) {
 	engine := &cadEngine{}
 	for _, opt := range opts {
-		opt.apply(engine)
+		if err := opt.apply(engine); err != nil {
+			return nil, err
+		}
 	}
 	return engine, nil
 }


### PR DESCRIPTION
We weren't checking errors when building a CaDEngine.
