### PR TITLE
remoterootsync: Add containerclusters read permission

### DIFF
--- a/porch/config/deploy/9-controllers.yaml
+++ b/porch/config/deploy/9-controllers.yaml
@@ -64,6 +64,9 @@ rules:
 - apiGroups: ["config.cloud.google.com"]
   resources: ["remoterootsyncsets/status"]
   verbs: ["get", "list", "watch", "create", "update", "patch"]
+- apiGroups: ["container.cnrm.cloud.google.com"]
+  resources: ["containerclusters"]
+  verbs: ["get", "list", "watch"]
 
 ---
 

--- a/porch/controllers/remoterootsync/config/rbac/role.yaml
+++ b/porch/controllers/remoterootsync/config/rbac/role.yaml
@@ -54,6 +54,14 @@ rules:
   - patch
   - update
 - apiGroups:
+  - container.cnrm.cloud.google.com
+  resources:
+  - containerclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - coordination.k8s.io
   resources:
   - leases

--- a/porch/controllers/remoterootsync/pkg/remoteclient/getremoteclient.go
+++ b/porch/controllers/remoterootsync/pkg/remoteclient/getremoteclient.go
@@ -34,6 +34,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+//+kubebuilder:rbac:groups=container.cnrm.cloud.google.com,resources=containerclusters,verbs=get;list;watch
+
 // GetCCRESTConfig builds a rest.Config for accessing the config controller cluster,
 // this is a tmp workaround.
 func GetCCRESTConfig(ctx context.Context, cluster *unstructured.Unstructured) (*rest.Config, error) {


### PR DESCRIPTION
This allows us to get endpoint information for clusters.
