### PR TITLE
update resourcegroup CRD

### DIFF
--- a/internal/cmdapply/cmdapply.go
+++ b/internal/cmdapply/cmdapply.go
@@ -200,11 +200,19 @@ func runApply(r *Runner, invInfo inventory.InventoryInfo, objs []*unstructured.U
 	dryRunStrategy common.DryRunStrategy) error {
 	if r.installCRD {
 		f := r.factory
-		// Only install the ResourceGroup CRD if it is not already installed.
-		if err := cmdutil.VerifyResourceGroupCRD(f); err != nil {
-			err = cmdutil.InstallResourceGroupCRD(r.ctx, f)
-			if err != nil {
+		// Install the ResourceGroup CRD if it is not already installed
+		// or if the ResourceGroup CRD doesn't match the CRD in the
+		// kpt binary.
+		err := cmdutil.VerifyResourceGroupCRD(f)
+		if err != nil {
+			if err = cmdutil.InstallResourceGroupCRD(r.ctx, f); err != nil {
 				return err
+			}
+		} else if !live.ResourceGroupCRDMatched(f) {
+			if err = cmdutil.InstallResourceGroupCRD(r.ctx, f); err != nil {
+				return &cmdutil.ResourceGroupCRDNotLatestError{
+					Err: err,
+				}
 			}
 		}
 	}

--- a/internal/cmdutil/util.go
+++ b/internal/cmdutil/util.go
@@ -16,6 +16,7 @@ package cmdutil
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/GoogleContainerTools/kpt/internal/printer"
 	"github.com/GoogleContainerTools/kpt/pkg/live"
@@ -72,4 +73,17 @@ type NoResourceGroupCRDError struct{}
 
 func (*NoResourceGroupCRDError) Error() string {
 	return "type ResourceGroup not found"
+}
+
+// ResourceGroupCRDNotLatestError is an error type that will be used when a
+// cluster has a ResourceGroup CRD that doesn't match the
+// latest declaration.
+type ResourceGroupCRDNotLatestError struct{
+	Err error
+}
+
+func (e *ResourceGroupCRDNotLatestError) Error() string {
+	return fmt.Sprintf(
+		"Type ResourceGroup CRD needs update. Please make sure you have the permission " +
+			"to update CRD then run `kpt live install-resource-group`.\n %v",  e.Err)
 }

--- a/pkg/live/example-resource-group-crd-for-v1.yaml
+++ b/pkg/live/example-resource-group-crd-for-v1.yaml
@@ -149,6 +149,10 @@ spec:
                   description: ResourceStatus contains the status of a given resource
                     uniquely identified by its group, kind, name and namespace.
                   properties:
+                    actuation:
+                      description: actuation indicates whether actuation has been
+                        performed yet and how it went.
+                      type: string
                     conditions:
                       items:
                         properties:
@@ -184,8 +188,18 @@ spec:
                       type: string
                     namespace:
                       type: string
+                    reconcile:
+                      description: reconcile indicates whether reconciliation has
+                        been performed yet and how it went.
+                      type: string
+                    sourceHash:
+                      type: string
                     status:
                       description: Status describes the status of a resource
+                      type: string
+                    strategy:
+                      description: strategy indicates the method of actuation (apply
+                        or delete) used or planned to be used.
                       type: string
                   required:
                   - group

--- a/pkg/live/example-resource-group-crd.yaml
+++ b/pkg/live/example-resource-group-crd.yaml
@@ -150,6 +150,10 @@ spec:
                 description: ResourceStatus contains the status of a given resource
                   uniquely identified by its group, kind, name and namespace.
                 properties:
+                  actuation:
+                    description: actuation indicates whether actuation has been
+                      performed yet and how it went.
+                    type: string
                   conditions:
                     items:
                       properties:
@@ -185,8 +189,18 @@ spec:
                     type: string
                   namespace:
                     type: string
+                  reconcile:
+                    description: reconcile indicates whether reconciliation has
+                      been performed yet and how it went.
+                    type: string
+                  sourceHash:
+                    type: string
                   status:
                     description: Status describes the status of a resource
+                    type: string
+                  strategy:
+                    description: strategy indicates the method of actuation (apply
+                      or delete) used or planned to be used.
                     type: string
                 required:
                 - group


### PR DESCRIPTION
- Add the new fields for capturing the apply and reconcile status
- Update the pre-steps of apply. If the ResourceGroup CRD is
  installed but doesn't match the latest declaration, the ResourceGroup
  CRD should be re-applied.

<!--  Thanks for sending a pull request!  Here are some tips for you:

In your PR, please ensure that you include the following information:
* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

If you are updating the documentation, please do it in separate PRs from
code changes and the commit message should start with `Docs:`.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
