### PR TITLE
Return Git PackageRevisionResources Correctly

### DIFF
--- a/porch/apiserver/go.mod
+++ b/porch/apiserver/go.mod
@@ -28,6 +28,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65
 	k8s.io/utils v0.0.0-20211208161948-7d6a63dca704
 	sigs.k8s.io/controller-runtime v0.11.0
+	sigs.k8s.io/kustomize/kyaml v0.13.3
 )
 
 replace (
@@ -160,7 +161,6 @@ require (
 	sigs.k8s.io/cli-utils v0.27.0 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/kustomize/api v0.11.1 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.13.3 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/porch/repository/pkg/git/git.go
+++ b/porch/repository/pkg/git/git.go
@@ -205,14 +205,12 @@ func (r *gitRepository) CreatePackageRevision(ctx context.Context, obj *v1alpha1
 	}
 
 	return &gitPackageDraft{
-		gitPackageRevision: gitPackageRevision{
-			parent:   r,
-			path:     obj.Spec.PackageName,
-			revision: obj.Spec.Revision,
-			updated:  time.Now(),
-			draft:    head,
-			sha:      main.Hash(),
-		},
+		parent:   r,
+		path:     obj.Spec.PackageName,
+		revision: obj.Spec.Revision,
+		updated:  time.Now(),
+		draft:    head,
+		sha:      main.Hash(),
 	}, nil
 }
 
@@ -234,15 +232,13 @@ func (r *gitRepository) UpdatePackage(ctx context.Context, old repository.Packag
 	}
 
 	return &gitPackageDraft{
-		gitPackageRevision: gitPackageRevision{
-			parent:   r,
-			path:     oldGitPackage.path,
-			revision: oldGitPackage.revision,
-			updated:  rev.updated,
-			draft:    rev.draft,
-			tree:     rev.tree,
-			sha:      rev.sha,
-		},
+		parent:   r,
+		path:     oldGitPackage.path,
+		revision: oldGitPackage.revision,
+		updated:  rev.updated,
+		draft:    rev.draft,
+		tree:     rev.tree,
+		sha:      rev.sha,
 	}, nil
 }
 


### PR DESCRIPTION
Newly created Git package returned package resources at its old commit
SHA where no package contents existed, thus returning empty resources.
As package changes, advance the reference to return up-to-date package
revision contents.
