### PR TITLE
Force Push

### DIFF
--- a/porch/repository/pkg/git/draft.go
+++ b/porch/repository/pkg/git/draft.go
@@ -115,10 +115,10 @@ func (d *gitPackageDraft) Close(ctx context.Context) (repository.PackageRevision
 	}
 
 	if err := d.parent.repo.Push(&git.PushOptions{
-		RemoteName:        "origin",
-		RefSpecs:          []config.RefSpec{refSpec},
-		Auth:              auth,
-		RequireRemoteRefs: []config.RefSpec{},
+		RemoteName: "origin",
+		RefSpecs:   []config.RefSpec{refSpec},
+		Auth:       auth,
+		Force:      true, // TODO: implement conflict recovery.
 	}); err != nil {
 		return nil, fmt.Errorf("failed to push to git: %w", err)
 	}


### PR DESCRIPTION
For the time being, use force when pushing to remote(s). Eventually
we'll implement conflict resolution but until deletion and conflict
resolution are supported, Force is a good way to avoid hard to recover
scenarios
