### PR TITLE
feat: Write function to Kptfile

### DIFF
--- a/e2e/testdata/fn-eval/save-fn/exec/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/exec/.expected/config.yaml
@@ -1,0 +1,18 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+stdErr: |
+  [RUNNING] "./function.sh"
+  [PASS] "./function.sh" in 0s
+  function is added to Kptfile

--- a/e2e/testdata/fn-eval/save-fn/exec/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/save-fn/exec/.expected/diff.patch
@@ -1,0 +1,46 @@
+diff --git a/Kptfile b/Kptfile
+index d9e2f05..3d2827b 100644
+--- a/Kptfile
++++ b/Kptfile
+@@ -2,3 +2,8 @@ apiVersion: kpt.dev/v1
+ kind: Kptfile
+ metadata:
+   name: app
++pipeline:
++  mutators:
++    - exec: ./function.sh
++      configPath: fn-config.yaml
++      name: ./function.sh
+diff --git a/fn-config.yaml b/fn-config.yaml
+index b160cd1..4f69f62 100644
+--- a/fn-config.yaml
++++ b/fn-config.yaml
+@@ -11,7 +11,6 @@
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+-
+ apiVersion: v1
+ kind: ConfigMap
+ metadata:
+diff --git a/resources.yaml b/resources.yaml
+index 9e9c98f..9adc2f7 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -15,7 +15,7 @@ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+   name: nginx-deployment
+-  namespace: foo
++  namespace: bar
+ spec:
+   replicas: 3
+ ---
+@@ -23,6 +23,6 @@ apiVersion: custom.io/v1
+ kind: Custom
+ metadata:
+   name: custom
+-  namespace: foo
++  namespace: bar
+ spec:
+   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/save-fn/exec/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/exec/.expected/exec.sh
@@ -1,0 +1,17 @@
+#! /bin/bash
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -eo pipefail
+
+kpt fn eval -s --exec ./function.sh --fn-config=fn-config.yaml

--- a/e2e/testdata/fn-eval/save-fn/exec/.krmignore
+++ b/e2e/testdata/fn-eval/save-fn/exec/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-eval/save-fn/exec/Kptfile
+++ b/e2e/testdata/fn-eval/save-fn/exec/Kptfile
@@ -1,0 +1,4 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: app

--- a/e2e/testdata/fn-eval/save-fn/exec/fn-config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/exec/fn-config.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: save-fn
+data:
+  name: test

--- a/e2e/testdata/fn-eval/save-fn/exec/function.sh
+++ b/e2e/testdata/fn-eval/save-fn/exec/function.sh
@@ -1,0 +1,16 @@
+#! /usr/bin/env bash
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+sed -e 's/foo/bar/'

--- a/e2e/testdata/fn-eval/save-fn/exec/resources.yaml
+++ b/e2e/testdata/fn-eval/save-fn/exec/resources.yaml
@@ -1,0 +1,28 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  namespace: foo
+spec:
+  replicas: 3
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+  namespace: foo
+spec:
+  image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/save-fn/image/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/image/.expected/config.yaml
@@ -1,0 +1,22 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+testType: eval
+image: set-namespace:v0.1.3
+args:
+  namespace: staging
+stdErr: |
+  [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3"
+  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s
+  function is added to Kptfile

--- a/e2e/testdata/fn-eval/save-fn/image/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/save-fn/image/.expected/diff.patch
@@ -1,0 +1,33 @@
+diff --git a/Kptfile b/Kptfile
+index d9e2f05..7765932 100644
+--- a/Kptfile
++++ b/Kptfile
+@@ -2,3 +2,9 @@ apiVersion: kpt.dev/v1
+ kind: Kptfile
+ metadata:
+   name: app
++pipeline:
++  mutators:
++    - image: gcr.io/kpt-fn/set-namespace:v0.1.3
++      configMap:
++        namespace: staging
++      name: gcr.io/kpt-fn/set-namespace:v0.1.3
+diff --git a/resources.yaml b/resources.yaml
+index ac634f3..0e09da8 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -15,6 +15,7 @@ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+   name: nginx-deployment
++  namespace: staging
+ spec:
+   replicas: 3
+ ---
+@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
+ kind: Custom
+ metadata:
+   name: custom
++  namespace: staging
+ spec:
+   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/save-fn/image/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/image/.expected/exec.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+kpt fn eval -s -i set-namespace:v0.1.3 -- namespace=staging

--- a/e2e/testdata/fn-eval/save-fn/image/.krmignore
+++ b/e2e/testdata/fn-eval/save-fn/image/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-eval/save-fn/image/Kptfile
+++ b/e2e/testdata/fn-eval/save-fn/image/Kptfile
@@ -1,0 +1,4 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: app

--- a/e2e/testdata/fn-eval/save-fn/image/resources.yaml
+++ b/e2e/testdata/fn-eval/save-fn/image/resources.yaml
@@ -1,0 +1,26 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+spec:
+  image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/save-fn/match-selector/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/match-selector/.expected/config.yaml
@@ -1,0 +1,18 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+stdErr: |
+  [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3" on 1 resource(s)
+  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s
+  function is added to Kptfile

--- a/e2e/testdata/fn-eval/save-fn/match-selector/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/save-fn/match-selector/.expected/diff.patch
@@ -1,0 +1,28 @@
+diff --git a/Kptfile b/Kptfile
+index d9e2f05..33c8c8b 100644
+--- a/Kptfile
++++ b/Kptfile
+@@ -2,3 +2,11 @@ apiVersion: kpt.dev/v1
+ kind: Kptfile
+ metadata:
+   name: app
++pipeline:
++  mutators:
++    - image: gcr.io/kpt-fn/set-namespace:v0.1.3
++      configMap:
++        namespace: staging
++      name: gcr.io/kpt-fn/set-namespace:v0.1.3
++      selectors:
++        - kind: Deployment
+diff --git a/resources.yaml b/resources.yaml
+index 7a494c9..9d82bd6 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -15,6 +15,7 @@ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+   name: nginx-deployment
++  namespace: staging
+ spec:
+   replicas: 3
+ ---

--- a/e2e/testdata/fn-eval/save-fn/match-selector/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/match-selector/.expected/exec.sh
@@ -1,0 +1,19 @@
+#! /bin/bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+set -eo pipefail
+
+kpt fn eval -s -i set-namespace:v0.1.3 --match-kind Deployment -- namespace=staging

--- a/e2e/testdata/fn-eval/save-fn/match-selector/.krmignore
+++ b/e2e/testdata/fn-eval/save-fn/match-selector/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-eval/save-fn/match-selector/Kptfile
+++ b/e2e/testdata/fn-eval/save-fn/match-selector/Kptfile
@@ -1,0 +1,4 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: app

--- a/e2e/testdata/fn-eval/save-fn/match-selector/resources.yaml
+++ b/e2e/testdata/fn-eval/save-fn/match-selector/resources.yaml
@@ -1,0 +1,26 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+spec:
+  image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/save-fn/no-save-when-fail/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/no-save-when-fail/.expected/config.yaml
@@ -1,0 +1,22 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+testType: eval
+image: set-namespace:v0.1.3
+args:
+  namespace: staging
+stdErr: |
+  [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3"
+  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s
+  function not added: Kptfile not exists

--- a/e2e/testdata/fn-eval/save-fn/no-save-when-fail/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/save-fn/no-save-when-fail/.expected/diff.patch
@@ -1,0 +1,19 @@
+diff --git a/resources.yaml b/resources.yaml
+index ac634f3..0e09da8 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -15,6 +15,7 @@ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+   name: nginx-deployment
++  namespace: staging
+ spec:
+   replicas: 3
+ ---
+@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
+ kind: Custom
+ metadata:
+   name: custom
++  namespace: staging
+ spec:
+   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/save-fn/no-save-when-fail/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/no-save-when-fail/.expected/exec.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+kpt fn eval -s -i set-namespace:v0.1.3 -- namespace=staging

--- a/e2e/testdata/fn-eval/save-fn/no-save-when-fail/.krmignore
+++ b/e2e/testdata/fn-eval/save-fn/no-save-when-fail/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-eval/save-fn/no-save-when-fail/resources.yaml
+++ b/e2e/testdata/fn-eval/save-fn/no-save-when-fail/resources.yaml
@@ -1,0 +1,26 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+spec:
+  image: nginx:1.2.3

--- a/thirdparty/cmdconfig/commands/cmdeval/cmdeval_test.go
+++ b/thirdparty/cmdconfig/commands/cmdeval/cmdeval_test.go
@@ -14,15 +14,11 @@ import (
 	"testing"
 
 	"github.com/GoogleContainerTools/kpt/internal/fnruntime"
-	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
-	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
-	"github.com/GoogleContainerTools/kpt/pkg/kptfile/kptfileutil"
 	"github.com/GoogleContainerTools/kpt/thirdparty/kyaml/runfn"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
-	"sigs.k8s.io/kustomize/kyaml/filesys"
 	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
 )
 
@@ -464,98 +460,6 @@ func TestCmd_flagAndArgParsing_Symlink(t *testing.T) {
 	err = r.Command.Execute()
 	assert.NoError(t, err)
 	assert.Equal(t, filepath.Join("path", "to", "pkg", "dir"), r.RunFns.Path)
-}
-
-func TestAddImageToKptfile(t *testing.T) {
-	testCases := map[string]struct {
-		Pipeline         *kptfilev1.Pipeline
-		Image            string
-		FnConfigPath     string
-		FnDataItems      []string
-		ExpectedStdout   string
-		ExpectedPipeline *kptfilev1.Pipeline
-	}{
-		"Add Image with ConfigMap": {
-			Pipeline: &kptfilev1.Pipeline{
-				Mutators: []kptfilev1.Function{
-					{Name: "fake-fn1", Image: "fake-fn1", ConfigMap: map[string]string{"cfg": "fake-cfg1"}},
-					{Name: "fake-fn2", Image: "fake-fn2", ConfigPath: "fake-path2"},
-				},
-			},
-			Image:          "fake-fn3",
-			FnDataItems:    []string{"cfg=fake-cfg3"},
-			ExpectedStdout: "image is added to Kptfile\n",
-			ExpectedPipeline: &kptfilev1.Pipeline{
-				Mutators: []kptfilev1.Function{
-					{Name: "fake-fn1", Image: "fake-fn1", ConfigMap: map[string]string{"cfg": "fake-cfg1"}},
-					{Name: "fake-fn2", Image: "fake-fn2", ConfigPath: "fake-path2"},
-					{Name: "fake-fn3", Image: "fake-fn3", ConfigMap: map[string]string{"cfg": "fake-cfg3"}},
-				},
-			},
-		},
-		"Add Image with ConfigPath": {
-			Pipeline: &kptfilev1.Pipeline{
-				Mutators: []kptfilev1.Function{
-					{Name: "fake-fn1", Image: "fake-fn1", ConfigMap: map[string]string{"cfg": "fake-cfg1"}},
-					{Name: "fake-fn2", Image: "fake-fn2", ConfigPath: "fake-path2"},
-				},
-			},
-			Image:          "fake-fn3",
-			FnConfigPath:   "fake-path3",
-			ExpectedStdout: "image is added to Kptfile\n",
-			ExpectedPipeline: &kptfilev1.Pipeline{
-				Mutators: []kptfilev1.Function{
-					{Name: "fake-fn1", Image: "fake-fn1", ConfigMap: map[string]string{"cfg": "fake-cfg1"}},
-					{Name: "fake-fn2", Image: "fake-fn2", ConfigPath: "fake-path2"},
-					{Name: "fake-fn3", Image: "fake-fn3", ConfigPath: "fake-path3"},
-				},
-			},
-		},
-
-		"Kptfile not exist": {
-			Pipeline:         nil,
-			ExpectedStdout:   "image not added: Kptfile not exists\n",
-			ExpectedPipeline: nil,
-		},
-		"Image already exist": {
-			Pipeline: &kptfilev1.Pipeline{Mutators: []kptfilev1.Function{
-				{Name: "fake-fn1", Image: "fake-fn1", ConfigMap: map[string]string{"cfg": "fake-cfg1"}}},
-			},
-			Image:          "fake-fn1",
-			FnDataItems:    []string{"cfg=fake-cfg1"},
-			ExpectedStdout: "skip adding image: already exists in Kptfile\n",
-			ExpectedPipeline: &kptfilev1.Pipeline{Mutators: []kptfilev1.Function{
-				{Name: "fake-fn1", Image: "fake-fn1", ConfigMap: map[string]string{"cfg": "fake-cfg1"}}},
-			},
-		},
-	}
-	for tn, tc := range testCases {
-		t.Run(tn, func(t *testing.T) {
-			// Setup
-			w, clean := testutil.SetupWorkspace(t)
-			defer clean()
-			if tc.Pipeline != nil {
-				kf := kptfileutil.DefaultKptfile(filepath.Base(w.WorkspaceDirectory))
-				kf.Pipeline = tc.Pipeline
-				testutil.AddKptfileToWorkspace(t, w, kf)
-			}
-			revert := testutil.Chdir(t, w.WorkspaceDirectory)
-			defer revert()
-			var outBuf bytes.Buffer
-			r := GetEvalFnRunner(fake.CtxWithPrinter(&outBuf, &outBuf), "kpt")
-			r.Image = tc.Image
-			r.dataItems = tc.FnDataItems
-			r.FnConfigPath = tc.FnConfigPath
-			// test
-			r.SaveFnToKptfile()
-			assert.Equal(t, strings.TrimSpace(tc.ExpectedStdout), strings.TrimSpace(outBuf.String()))
-			actualKf, err := pkg.ReadKptfile(filesys.FileSystemOrOnDisk{}, r.Dest)
-			if tc.ExpectedPipeline != nil {
-				assert.NoError(t, err)
-				assert.Equal(t, actualKf.Pipeline.String(), tc.ExpectedPipeline.String())
-			}
-		})
-	}
 }
 
 // NoOpRunE is a noop function to replace the run function of a command.  Useful for testing argument parsing.


### PR DESCRIPTION
### description
- Add a boolean flag `--save` to `kpt fn eval`. If set to true, the kpt function will be added to the Kptfile after `kpt fn eval` successfully executes.
- The functionConfig to be written to Kptfile can be FunctionConfigMap, functionConfigPath, no functionConfig, deferring to the arguments. 
- If writing to the Kptfile fails, it won't fail the `kpt fn eval`.
- e2e test coverage:
   
     - `./save-fn/image` runs `kpt fn eval -s -i .. -- [args]`. It writes the fn image and configMap as fnConfig to Kptfile
     - `./save-fn/exec` runs `kpt fn eval -s --exec .. --fn-config=..`. It writes the executable and configPath as fnConfig to Kptfile
     - `./save-fn/match-selector` runs `kpt fn eval -s  --match-kind -i ..`. It writes the function with selectors to Kptfile.
     -  `./save-fn/no-save-when-fail` does not have `Kptfile`, so it only updates the resources, but not write the fn to the Kptfile.

Context: This flag is an easy approach for package authoring.  Another option could be to add a new set of sub commands like `kpt editor` to do CLI-side authoring. But we do not have many feature requirements on these new subcommands.
 