### PR TITLE
Remove auth `token` field from basic auth

### DIFF
--- a/porch/repository/pkg/git/git.go
+++ b/porch/repository/pkg/git/git.go
@@ -129,11 +129,7 @@ func resolveCredential(ctx context.Context, namespace, name string, resolver rep
 	}
 
 	username := cred.Data["username"]
-	password, ok := cred.Data["password"]
-	if !ok {
-		// Try "token" for back-compat; TODO: remove
-		password = cred.Data["token"]
-	}
+	password := cred.Data["password"]
 
 	return &http.BasicAuth{
 		Username: string(username),


### PR DESCRIPTION
Use standard kubernetes.io/basic-autha secrets.
