### PR TITLE
Enable Porch to Resolve References

### DIFF
--- a/porch/apiserver/pkg/apiserver/apiserver.go
+++ b/porch/apiserver/pkg/apiserver/apiserver.go
@@ -163,6 +163,7 @@ func (c completedConfig) New() (*PorchServer, error) {
 	}
 
 	credentialResolver := porch.NewCredentialResolver(coreClient)
+	referenceResolver := porch.NewReferenceResolver(coreClient)
 
 	renderer := kpt.NewRenderer()
 
@@ -172,6 +173,7 @@ func (c completedConfig) New() (*PorchServer, error) {
 		engine.WithGRPCFunctionRuntime(c.ExtraConfig.FunctionRunnerAddress),
 		engine.WithCredentialResolver(credentialResolver),
 		engine.WithRenderer(renderer),
+		engine.WithReferenceResolver(referenceResolver),
 	)
 	if err != nil {
 		return nil, err

--- a/porch/apiserver/pkg/registry/porch/reference.go
+++ b/porch/apiserver/pkg/registry/porch/reference.go
@@ -1,0 +1,41 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package porch
+
+import (
+	"context"
+
+	"github.com/GoogleContainerTools/kpt/porch/engine/pkg/engine"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func NewReferenceResolver(coreClient client.Reader) engine.ReferenceResolver {
+	return &referenceResolver{
+		coreClient: coreClient,
+	}
+}
+
+type referenceResolver struct {
+	coreClient client.Reader
+}
+
+var _ engine.ReferenceResolver = &referenceResolver{}
+
+func (r *referenceResolver) ResolveReference(ctx context.Context, namespace, name string, result engine.Object) error {
+	return r.coreClient.Get(ctx, client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}, result)
+}

--- a/porch/engine/go.mod
+++ b/porch/engine/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/go-git/go-git/v5 v5.4.3-0.20220119145113-935af59cf64f
 	github.com/google/go-cmp v0.5.7
 	google.golang.org/grpc v1.44.0
+	k8s.io/apimachinery v0.23.2
 	k8s.io/klog/v2 v2.40.1
 	sigs.k8s.io/kustomize/kyaml v0.13.3
 )
@@ -103,7 +104,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/api v0.23.2 // indirect
-	k8s.io/apimachinery v0.23.2 // indirect
 	k8s.io/cli-runtime v0.23.2 // indirect
 	k8s.io/client-go v0.23.2 // indirect
 	k8s.io/component-base v0.23.2 // indirect

--- a/porch/engine/pkg/engine/engine.go
+++ b/porch/engine/pkg/engine/engine.go
@@ -56,6 +56,7 @@ type cadEngine struct {
 	renderer           fn.Renderer
 	runtime            fn.FunctionRuntime
 	credentialResolver repository.CredentialResolver
+	referenceResolver  ReferenceResolver
 }
 
 var _ CaDEngine = &cadEngine{}

--- a/porch/engine/pkg/engine/environment.go
+++ b/porch/engine/pkg/engine/environment.go
@@ -1,0 +1,31 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type Object interface {
+	metav1.Object
+	runtime.Object
+}
+
+type ReferenceResolver interface {
+	ResolveReference(ctx context.Context, namespace, name string, result Object) error
+}

--- a/porch/engine/pkg/engine/options.go
+++ b/porch/engine/pkg/engine/options.go
@@ -85,6 +85,13 @@ func WithCredentialResolver(resolver repository.CredentialResolver) EngineOption
 	})
 }
 
+func WithReferenceResolver(resolver ReferenceResolver) EngineOption {
+	return EngineOptionFunc(func(engine *cadEngine) error {
+		engine.referenceResolver = resolver
+		return nil
+	})
+}
+
 func createFunctionRuntime(address string) (kpt.FunctionRuntime, error) {
 	if address == "" {
 		return nil, fmt.Errorf("address is required to instantiate gRPC function runtime")


### PR DESCRIPTION
Define a ReferenceResolver API which allows Porch Engine to resolve references
such as reference to another repository resource.
Apiserver implements the API using k8s client.
