### PR TITLE
Skip Self When Generating LICENSES (#2835)

### DIFF
--- a/scripts/create-licenses.sh
+++ b/scripts/create-licenses.sh
@@ -188,6 +188,13 @@ for PACKAGE in $(go list -mod=mod -m -json all | jq -r .Path | sort -f); do
     continue
   fi
 
+  # Skip self.
+  # The LICENSE file is at the root but vendor directory contents are selective.
+  if [[ "${PACKAGE}" =~ ^github.com/GoogleContainerTools/kpt(/.*)?$ ]]; then
+    # echo "Skipping ${PACKAGE}" > /dev/stderr
+    continue
+  fi
+
   process_content "${PACKAGE}" LICENSE
   process_content "${PACKAGE}" COPYRIGHT
   process_content "${PACKAGE}" COPYING


### PR DESCRIPTION
The script generates licenses of dependencies, but contets of kpt
repository are 'self'. No need to include them. Furthemore, the
`go mod vendor` is selective in populating vendor directory and
may only include specific sub-modules from the kpt repository, omitting
LICENSE and related file(s).

