### PR TITLE
Add Deployment Repository Field

### DIFF
--- a/porch/controllers/pkg/apis/porch/v1alpha1/config.porch.kpt.dev_repositories.yaml
+++ b/porch/controllers/pkg/apis/porch/v1alpha1/config.porch.kpt.dev_repositories.yaml
@@ -57,6 +57,10 @@ spec:
                   - the literal values correspond to the API resource names). TODO:
                   support repository with mixed content?'
                 type: string
+              deployment:
+                description: The repository is a deployment repository; final packages
+                  in this repository are deployment ready.
+                type: boolean
               description:
                 description: User-friendly description of the repository
                 type: string
@@ -260,6 +264,8 @@ spec:
                       type: string
                   type: object
                 type: array
+            required:
+            - deployment
             type: object
           status:
             description: RepositoryStatus defines the observed state of Repository

--- a/porch/controllers/pkg/apis/porch/v1alpha1/types.go
+++ b/porch/controllers/pkg/apis/porch/v1alpha1/types.go
@@ -53,6 +53,8 @@ type RepositorySpec struct {
 	Title string `json:"title,omitempty"`
 	// User-friendly description of the repository
 	Description string `json:"description,omitempty"`
+	// The repository is a deployment repository; final packages in this repository are deployment ready.
+	Deployment bool `json:"deployment"`
 	// Type of the repository (i.e. git, OCI)
 	Type RepositoryType `json:"type,omitempty"`
 	// Content stored in the repository (i.e. Function, PackageRevision - the literal values correspond to the API resource names).

--- a/porch/controllers/remoterootsync/config/crd/bases/config.cloud.google.com_remoterootsyncsets.yaml
+++ b/porch/controllers/remoterootsync/config/crd/bases/config.cloud.google.com_remoterootsyncsets.yaml
@@ -115,14 +115,13 @@ spec:
                       description: "Condition contains details for one aspect of the
                         current state of this API Resource. --- This struct is intended
                         for direct use as an array at the field path .status.conditions.
-                        \ For example, type FooStatus struct{     // Represents the
-                        observations of a foo's current state.     // Known .status.conditions.type
-                        are: \"Available\", \"Progressing\", and \"Degraded\"     //
-                        +patchMergeKey=type     // +patchStrategy=merge     // +listType=map
-                        \    // +listMapKey=type     Conditions []metav1.Condition
-                        `json:\"conditions,omitempty\" patchStrategy:\"merge\" patchMergeKey:\"type\"
-                        protobuf:\"bytes,1,rep,name=conditions\"` \n     // other
-                        fields }"
+                        \ For example, type FooStatus struct{ // Represents the observations
+                        of a foo's current state. // Known .status.conditions.type
+                        are: \"Available\", \"Progressing\", and \"Degraded\" // +patchMergeKey=type
+                        // +patchStrategy=merge // +listType=map // +listMapKey=type
+                        Conditions []metav1.Condition `json:\"conditions,omitempty\"
+                        patchStrategy:\"merge\" patchMergeKey:\"type\" protobuf:\"bytes,1,rep,name=conditions\"`
+                        \n // other fields }"
                       properties:
                         lastTransitionTime:
                           description: lastTransitionTime is the last time the condition


### PR DESCRIPTION
Use first-class field to mark repository as 'deployment repository'.

Packages in a deployment repository are considered ready to be deployed
by the deployment mechanism.
