### PR TITLE
Rename CLI Packages

### DIFF
--- a/commands/repocmd.go
+++ b/commands/repocmd.go
@@ -19,7 +19,7 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/GoogleContainerTools/kpt/internal/cmdreg"
+	"github.com/GoogleContainerTools/kpt/internal/cmdreporeg"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
@@ -57,7 +57,7 @@ func NewRepoCommand(ctx context.Context, version string) *cobra.Command {
 	pf.AddGoFlagSet(flag.CommandLine)
 
 	repo.AddCommand(
-		cmdreg.NewCommand(ctx, kubeflags),
+		cmdreporeg.NewCommand(ctx, kubeflags),
 	)
 
 	return repo

--- a/commands/rpkgcmd.go
+++ b/commands/rpkgcmd.go
@@ -19,9 +19,9 @@ import (
 	"flag"
 	"fmt"
 
-	"github.com/GoogleContainerTools/kpt/internal/cmdlist"
-	"github.com/GoogleContainerTools/kpt/internal/cmdres"
-	"github.com/GoogleContainerTools/kpt/internal/cmdstore"
+	"github.com/GoogleContainerTools/kpt/internal/cmdrpkgget"
+	"github.com/GoogleContainerTools/kpt/internal/cmdrpkgpull"
+	"github.com/GoogleContainerTools/kpt/internal/cmdrpkgpush"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
@@ -59,9 +59,9 @@ func NewRpkgCommand(ctx context.Context, version string) *cobra.Command {
 	pf.AddGoFlagSet(flag.CommandLine)
 
 	repo.AddCommand(
-		cmdlist.NewCommand(ctx, kubeflags),
-		cmdres.NewCommand(ctx, kubeflags),
-		cmdstore.NewCommand(ctx, kubeflags),
+		cmdrpkgget.NewCommand(ctx, kubeflags),
+		cmdrpkgpull.NewCommand(ctx, kubeflags),
+		cmdrpkgpush.NewCommand(ctx, kubeflags),
 	)
 
 	return repo

--- a/internal/cmdreporeg/command.go
+++ b/internal/cmdreporeg/command.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmdreg
+package cmdreporeg
 
 import (
 	"context"
@@ -30,7 +30,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const regLong = `
+const (
+	command = "cmdreporeg"
+	longMsg = `
 kpt alpha repo reg[ister] REPOSITORY [flags]
 
 Args:
@@ -57,8 +59,8 @@ Flags:
 
 --repo-password
 	Password for repository authentication.
-
 `
+)
 
 func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner {
 	r := &runner{
@@ -66,15 +68,14 @@ func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner 
 		cfg: rcg,
 	}
 	c := &cobra.Command{
-		Use:        "reg REPOSITORY",
-		Aliases:    []string{"register"},
-		SuggestFor: []string{},
-		Short:      "Registers a package repository with Package Orchestrator.",
-		Long:       regLong,
-		Example:    "TODO",
-		PreRunE:    r.preRunE,
-		RunE:       r.runE,
-		Hidden:     true,
+		Hidden:  true,
+		Use:     "reg REPOSITORY",
+		Aliases: []string{"register"},
+		Short:   "Registers a package repository with Package Orchestrator.",
+		Long:    longMsg,
+		Example: "TODO",
+		PreRunE: r.preRunE,
+		RunE:    r.runE,
 	}
 	r.Command = c
 
@@ -108,7 +109,8 @@ type runner struct {
 }
 
 func (r *runner) preRunE(cmd *cobra.Command, args []string) error {
-	const op errors.Op = "cmdreg.preRunE"
+	const op errors.Op = command + ".preRunE"
+
 	config, err := r.cfg.ToRESTConfig()
 	if err != nil {
 		return errors.E(op, err)
@@ -129,7 +131,7 @@ func (r *runner) preRunE(cmd *cobra.Command, args []string) error {
 }
 
 func (r *runner) runE(cmd *cobra.Command, args []string) error {
-	const op errors.Op = "cmdreg.runE"
+	const op errors.Op = command + ".runE"
 
 	if len(args) == 0 {
 		return errors.E(op, "repository is required positional argument")

--- a/internal/cmdreporeg/command_test.go
+++ b/internal/cmdreporeg/command_test.go
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmdres
+package cmdreporeg

--- a/internal/cmdrpkgget/command.go
+++ b/internal/cmdrpkgget/command.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmdlist
+package cmdrpkgget
 
 import (
 	"context"
@@ -29,12 +29,17 @@ import (
 )
 
 const listLong string = `
-kpt alpha rpkg list [flags]
+kpt alpha rpkg get [flags]
+
+Args:
+
+PACKAGE:
+  Name of the package revision to get.
 
 Flags:
 
 --name
-	Name of the packages to list. Any package whose name contains this value will be included in the results.
+	Name of the packages to get. Any package whose name contains this value will be included in the results.
 
 `
 
@@ -44,10 +49,10 @@ func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner 
 		cfg: rcg,
 	}
 	c := &cobra.Command{
-		Use:        "list",
-		Aliases:    []string{},
+		Use:        "get",
+		Aliases:    []string{"list"},
 		SuggestFor: []string{},
-		Short:      "Lists packages in registered repositories.",
+		Short:      "Gets or lists packages in registered repositories.",
 		Long:       listLong,
 		Example:    "TODO",
 		PreRunE:    r.preRunE,
@@ -56,7 +61,7 @@ func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner 
 	}
 	r.Command = c
 
-	c.Flags().StringVar(&r.name, "name", "", "Name of the packages to list. Any package whose name contains this value will be included in the results.")
+	c.Flags().StringVar(&r.name, "name", "", "Name of the packages to get. Any package whose name contains this value will be included in the results.")
 
 	return r
 }
@@ -78,7 +83,8 @@ type runner struct {
 }
 
 func (r *runner) preRunE(cmd *cobra.Command, args []string) error {
-	const op errors.Op = "cmdlist.preRunE"
+	const op errors.Op = "cmdrpkgget.preRunE"
+
 	config, err := r.cfg.ToRESTConfig()
 	if err != nil {
 		return errors.E(op, err)
@@ -100,7 +106,7 @@ func (r *runner) preRunE(cmd *cobra.Command, args []string) error {
 }
 
 func (r *runner) runE(cmd *cobra.Command, args []string) error {
-	const op errors.Op = "cmdlist.runE"
+	const op errors.Op = "cmdrpkgget.runE"
 
 	var list porchapi.PackageRevisionList
 	if err := r.client.List(r.ctx, &list); err != nil {

--- a/internal/cmdrpkgget/command_test.go
+++ b/internal/cmdrpkgget/command_test.go
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmdlist
+package cmdrpkgget

--- a/internal/cmdrpkgpull/command.go
+++ b/internal/cmdrpkgpull/command.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmdres
+package cmdrpkgpull
 
 import (
 	"context"
@@ -35,7 +35,7 @@ import (
 )
 
 const resLong = `
-kpt alpha rpkg res[ources] PACKAGE [DIR]
+kpt alpha rpkg pull PACKAGE [DIR]
 
 Args:
 
@@ -59,8 +59,8 @@ func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner 
 		cfg: rcg,
 	}
 	c := &cobra.Command{
-		Use:        "res PACKAGE [DIR]",
-		Aliases:    []string{"resources", "read"},
+		Use:        "pull PACKAGE [DIR]",
+		Aliases:    []string{"source", "read"},
 		SuggestFor: []string{},
 		Short:      "Reads package resources.",
 		Long:       resLong,

--- a/internal/cmdrpkgpull/command_test.go
+++ b/internal/cmdrpkgpull/command_test.go
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmdreg
+package cmdrpkgpull

--- a/internal/cmdrpkgpush/command.go
+++ b/internal/cmdrpkgpush/command.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmdstore
+package cmdrpkgpush
 
 import (
 	"bytes"
@@ -37,13 +37,13 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
-const storeLong = `
-kpt alpha rpkg store PACKAGE [DIR]
+const pushLong = `
+kpt alpha rpkg push PACKAGE [DIR]
 
 Args:
 
 PACKAGE:
-	Name of the package where to store the resources.
+	Name of the package where to push the resources.
 
 DIR:
 	Optional path to a local directory to read resources from.
@@ -62,11 +62,11 @@ func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner 
 		cfg: rcg,
 	}
 	c := &cobra.Command{
-		Use:        "store PACKAGE [DIR]",
-		Aliases:    []string{},
+		Use:        "push PACKAGE [DIR]",
+		Aliases:    []string{"sink", "write"},
 		SuggestFor: []string{},
-		Short:      "Stores package resources into a remote package.",
-		Long:       storeLong,
+		Short:      "Pushes package resources into a remote package.",
+		Long:       pushLong,
 		Example:    "TODO",
 		PreRunE:    r.preRunE,
 		RunE:       r.runE,
@@ -89,7 +89,7 @@ type runner struct {
 }
 
 func (r *runner) preRunE(cmd *cobra.Command, args []string) error {
-	const op errors.Op = "cmdstore.preRunE"
+	const op errors.Op = "cmdrpkgpush.preRunE"
 	config, err := r.cfg.ToRESTConfig()
 	if err != nil {
 		return errors.E(op, err)
@@ -111,7 +111,7 @@ func (r *runner) preRunE(cmd *cobra.Command, args []string) error {
 }
 
 func (r *runner) runE(cmd *cobra.Command, args []string) error {
-	const op errors.Op = "cmdstore.runE"
+	const op errors.Op = "cmdrpkgpush.runE"
 
 	if len(args) == 0 {
 		return errors.E(op, "PACKAGE is a required positional argument")

--- a/internal/cmdrpkgpush/command_test.go
+++ b/internal/cmdrpkgpush/command_test.go
@@ -12,4 +12,4 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cmdstore
+package cmdrpkgpush


### PR DESCRIPTION
In anticipation of adding more commands, create more consistent package naming:

Repository (`repo` command group):
* cmdreg->cmdreporeg

Remote Packages (`rpkg` command group):
* Get package resources: cmdres->cmdrpkgpull
* Store package resources: cmdstore->cmdrpkgpush
* Get/List package revisions: cmdlist->cmdrpkgget
