### PR TITLE
Porch CLI Fixes

### DIFF
--- a/internal/cmdrepoget/command.go
+++ b/internal/cmdrepoget/command.go
@@ -99,7 +99,6 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 				return errors.E(op, err)
 			}
 
-			// TODO: is the server not returning this?
 			repository.Kind = "Repository"
 			repository.APIVersion = configapi.GroupVersion.Identifier()
 
@@ -110,6 +109,8 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 		if err := r.client.List(r.ctx, &repositories); err != nil {
 			return errors.E(op, err)
 		}
+		repositories.Kind = "RepositoryList"
+		repositories.APIVersion = configapi.GroupVersion.Identifier()
 		objs = append(objs, &repositories)
 	}
 

--- a/internal/cmdreporeg/command.go
+++ b/internal/cmdreporeg/command.go
@@ -38,27 +38,27 @@ kpt alpha repo reg[ister] REPOSITORY [flags]
 Args:
 
 REPOSITORY:
-	Address of the repository to register. Required argument.
+  Address of the repository to register. Required argument.
 
 Flags:
 
 --description
-	Brief description of the package repository.
+  Brief description of the package repository.
 
 --name
-	Name of the package repository. If unspecified, will use the name portion (last segment) of the repository URL.
+  Name of the package repository. If unspecified, will use the name portion (last segment) of the repository URL.
 
 --title
-	Title of the package repository.
+  Title of the package repository.
 
 --deployment
   Repository is a deployment repository; packages in a deployment repository are considered deployment-ready.
 
 --repo-username
-	Username for repository authentication.
+  Username for repository authentication.
 
 --repo-password
-	Password for repository authentication.
+  Password for repository authentication.
 `
 )
 

--- a/internal/cmdrepounreg/command.go
+++ b/internal/cmdrepounreg/command.go
@@ -31,19 +31,19 @@ import (
 const (
 	command = "cmdrepounreg"
 	longMsg = `
-kpt alpha repo unreg[ister] REPOSITORY [flags]
+kpt alpha repo unreg REPOSITORY [flags]
 
 Unregisters a package repository from Package Orchestrator.
 
 Args:
 
 REPOSITORY:
-	Name of the registered repoisitory resource to unregister.
+  Name of the registered repoisitory resource to unregister.
 
 Flags:
 
 --keep-auth-secret
-	Do not delete the repository authentication secret, if it exists.
+  Do not delete the repository authentication secret, if it exists.
 `
 )
 
@@ -57,7 +57,7 @@ func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner 
 		cfg: rcg,
 	}
 	c := &cobra.Command{
-		Use:     "unreg[ister] REPOSITORY [flags]",
+		Use:     "unreg REPOSITORY [flags]",
 		Aliases: []string{"unregister"},
 		Short:   "Unregisters a package repository from Package Orchestrator.",
 		Long:    longMsg,

--- a/internal/cmdrpkgclone/command.go
+++ b/internal/cmdrpkgclone/command.go
@@ -176,6 +176,7 @@ func (r *runner) preRunE(cmd *cobra.Command, args []string) error {
 	if targetPackageName.Revision == "" {
 		targetPackageName.Revision = "v1"
 	}
+	r.target = targetPackageName
 
 	return nil
 }

--- a/internal/cmdrpkgclone/command.go
+++ b/internal/cmdrpkgclone/command.go
@@ -40,13 +40,13 @@ Args:
 
 SOURCE_PACKAGE:
   Source package. Can be a reference to an OCI package, Git package, or an package resource name:
-	* oci://oci-repository/package-name
-	* http://git-repository.git/package-name
-	* repository:package:revision
+    * oci://oci-repository/package-name
+    * http://git-repository.git/package-name
+    * repository:package:revision
 
 TARGET:
   Target package name in the format: REPOSITORY[:PACKAGE[:REVISION]]
-	Example: package-repository:package-name:v1
+  Example: package-repository:package-name:v1
 
 Flags:
 

--- a/internal/cmdrpkgget/command.go
+++ b/internal/cmdrpkgget/command.go
@@ -42,7 +42,7 @@ PACKAGE:
 Flags:
 
 --name
-	Name of the packages to get. Any package whose name contains this value will be included in the results.
+  Name of the packages to get. Any package whose name contains this value will be included in the results.
 
 `
 )

--- a/internal/cmdrpkgget/command.go
+++ b/internal/cmdrpkgget/command.go
@@ -113,7 +113,6 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 				return errors.E(op, err)
 			}
 
-			// TODO: is the server not returning GVK?
 			pr.Kind = "PackageRevision"
 			pr.APIVersion = porchapi.SchemeGroupVersion.Identifier()
 
@@ -124,10 +123,24 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 		if err := r.client.List(r.ctx, &list); err != nil {
 			return errors.E(op, err)
 		}
+
+		list.Kind = "PackageRevisionList"
+		list.APIVersion = porchapi.SchemeGroupVersion.Identifier()
+
 		for i := range list.Items {
 			pr := &list.Items[i]
-			if r.match(pr) {
-				objs = append(objs, pr)
+			pr.Kind = "PackageRevision"
+			pr.APIVersion = porchapi.SchemeGroupVersion.Identifier()
+		}
+
+		if r.name == "" {
+			objs = append(objs, &list)
+		} else {
+			for i := range list.Items {
+				pr := &list.Items[i]
+				if r.match(pr) {
+					objs = append(objs, pr)
+				}
 			}
 		}
 	}

--- a/internal/cmdrpkginit/command.go
+++ b/internal/cmdrpkginit/command.go
@@ -38,7 +38,7 @@ Args:
 
 PACKAGE:
   Target package name in the format: REPOSITORY:PACKAGE:REVISION
-	Example: package-repository:package-name:v1
+  Example: package-repository:package-name:v1
 
 
 Flags:

--- a/internal/cmdrpkgpull/command.go
+++ b/internal/cmdrpkgpull/command.go
@@ -43,16 +43,16 @@ kpt alpha rpkg pull PACKAGE [DIR]
 Args:
 
 PACKAGE:
-	Name of the package containing the resources.
+  Name of the package containing the resources.
 
 DIR:
-	Optional path to a local directory to write resources to. The directory must not already exist.
+  Optional path to a local directory to write resources to. The directory must not already exist.
 
 
 Flags:
 
 --namespace
-	Namespace containing the package.
+  Namespace containing the package.
 
 `
 )

--- a/internal/cmdrpkgpush/command.go
+++ b/internal/cmdrpkgpush/command.go
@@ -46,16 +46,15 @@ kpt alpha rpkg push PACKAGE [DIR]
 Args:
 
 PACKAGE:
-	Name of the package where to push the resources.
+  Name of the package where to push the resources.
 
 DIR:
-	Optional path to a local directory to read resources from.
-
+  Optional path to a local directory to read resources from.
 
 Flags:
 
 --namespace
-	Namespace containing the package.
+  Namespace containing the package.
 
 `
 )

--- a/internal/util/porch/const.go
+++ b/internal/util/porch/const.go
@@ -15,4 +15,4 @@
 package porch
 
 // Controls whether the Package Orchestration CLI commands are hidden.
-const HidePorchCommands = true
+const HidePorchCommands = false


### PR DESCRIPTION
- Fix kpt alpha help text formatting
- Set GVK In The Client
- Set Target Package Name
- Show Porch Commants By Default
