### PR TITLE
fixed a flaky test

### DIFF
--- a/e2e/testdata/fn-eval/exec-function-stderr/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/exec-function-stderr/.expected/config.yaml
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This test tests `fn eval` UX with a function that succeeds with stderr output
+#
 testType: eval
 stdErr: |
   [RUNNING] "./function.sh"

--- a/e2e/testdata/fn-eval/exec-function-stderr/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/exec-function-stderr/.expected/exec.sh
@@ -15,5 +15,4 @@
 
 set -eo pipefail
 
-kpt fn source \
-  | kpt fn eval --exec ./function.sh
+kpt fn eval --exec ./function.sh


### PR DESCRIPTION
This PR fixes a flaky test.

The test is not using the `PIPE` correctly that results in `141` (SIGPIPE) errors in some environments. SIGPIPE is received if the reader (writer) involved in the pipe has closed the connection. I realized that the PIPE is not necessary for the test, so removed it.

Some background about `SIGPIPE` failures in bash. [1](https://stackoverflow.com/questions/19120263/why-exit-code-141-with-grep-q#:~:text=This%20is%20because%20grep%20%2Dq,with%20a%20status%20of%20141%20.) [2](http://www.pixelbeat.org/programming/sigpipe_handling.html)