### PR TITLE
kpt pkg init generates dummy package context

### DIFF
--- a/internal/builtins/pkg_context.go
+++ b/internal/builtins/pkg_context.go
@@ -29,7 +29,7 @@ import (
 )
 
 const (
-	pkgContextFile = "package-context.yaml"
+	PkgContextFile = "package-context.yaml"
 	pkgContextName = "kptfile.kpt.dev"
 )
 
@@ -118,7 +118,7 @@ data: {}
 		return nil, err
 	}
 	annotations := map[string]string{
-		kioutil.PathAnnotation: path.Join(path.Dir(kptfilePath), pkgContextFile),
+		kioutil.PathAnnotation: path.Join(path.Dir(kptfilePath), PkgContextFile),
 	}
 
 	for k, v := range annotations {
@@ -130,4 +130,19 @@ data: {}
 		"name": kf.GetName(),
 	})
 	return cm, nil
+}
+
+// DummyPkgContext returns content for package context that contains
+// placeholder value for package name. This will be used to create
+// abstract blueprints.
+func DummyPkgContext() string {
+	return fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  name: example
+`, pkgContextName)
 }

--- a/internal/builtins/pkg_context.go
+++ b/internal/builtins/pkg_context.go
@@ -103,15 +103,7 @@ func (pc *PackageContextGenerator) Process(resourceList *framework.ResourceList)
 // pkgContextResource generates package context resource from a given
 // Kptfile. The resource is generated adjacent to the Kptfile of the package.
 func pkgContextResource(kf *yaml.RNode) (*yaml.RNode, error) {
-	cm := yaml.MustParse(fmt.Sprintf(`
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: %s
-  annotations:
-    config.kubernetes.io/local-config: "true"
-data: {}
-`, pkgContextName))
+	cm := yaml.MustParse(AbstractPkgContext())
 
 	kptfilePath, _, err := kioutil.GetFileAnnotations(kf)
 	if err != nil {
@@ -132,10 +124,10 @@ data: {}
 	return cm, nil
 }
 
-// DummyPkgContext returns content for package context that contains
+// AbstractPkgContext returns content for package context that contains
 // placeholder value for package name. This will be used to create
 // abstract blueprints.
-func DummyPkgContext() string {
+func AbstractPkgContext() string {
 	return fmt.Sprintf(`apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/internal/cmdinit/cmdinit.go
+++ b/internal/cmdinit/cmdinit.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/GoogleContainerTools/kpt/internal/builtins"
 	docs "github.com/GoogleContainerTools/kpt/internal/docs/generated/pkgdocs"
 	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	"github.com/GoogleContainerTools/kpt/internal/printer"
@@ -154,6 +155,13 @@ func (r *Runner) runE(c *cobra.Command, args []string) error {
 		}
 	}
 
+	pkgContextPath := filepath.Join(up, builtins.PkgContextFile)
+	if _, err = os.Stat(pkgContextPath); os.IsNotExist(err) {
+		pr.Printf("writing %s\n", filepath.Join(args[0], builtins.PkgContextFile))
+		if err := ioutil.WriteFile(pkgContextPath, []byte(builtins.DummyPkgContext()), 0644); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/internal/cmdinit/cmdinit.go
+++ b/internal/cmdinit/cmdinit.go
@@ -158,7 +158,7 @@ func (r *Runner) runE(c *cobra.Command, args []string) error {
 	pkgContextPath := filepath.Join(up, builtins.PkgContextFile)
 	if _, err = os.Stat(pkgContextPath); os.IsNotExist(err) {
 		pr.Printf("writing %s\n", filepath.Join(args[0], builtins.PkgContextFile))
-		if err := ioutil.WriteFile(pkgContextPath, []byte(builtins.DummyPkgContext()), 0644); err != nil {
+		if err := ioutil.WriteFile(pkgContextPath, []byte(builtins.AbstractPkgContext()), 0644); err != nil {
 			return err
 		}
 	}

--- a/internal/cmdinit/cmdinit_test.go
+++ b/internal/cmdinit/cmdinit_test.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/GoogleContainerTools/kpt/internal/builtins"
 	"github.com/GoogleContainerTools/kpt/internal/cmdinit"
 	"github.com/GoogleContainerTools/kpt/internal/printer/fake"
 	"github.com/GoogleContainerTools/kpt/internal/testutil"
@@ -78,6 +79,10 @@ kpt live apply my-pkg --reconcile-timeout=2m --output=table
 '''
 Details: https://kpt.dev/reference/cli/live/
 `, "'", "`"), string(b))
+
+	b, err = ioutil.ReadFile(filepath.Join(d, "my-pkg", builtins.PkgContextFile))
+	assert.NoError(t, err)
+	assert.Equal(t, b, []byte(builtins.DummyPkgContext()))
 }
 
 func TestCmd_currentDir(t *testing.T) {

--- a/internal/cmdinit/cmdinit_test.go
+++ b/internal/cmdinit/cmdinit_test.go
@@ -82,7 +82,7 @@ Details: https://kpt.dev/reference/cli/live/
 
 	b, err = ioutil.ReadFile(filepath.Join(d, "my-pkg", builtins.PkgContextFile))
 	assert.NoError(t, err)
-	assert.Equal(t, b, []byte(builtins.DummyPkgContext()))
+	assert.Equal(t, b, []byte(builtins.AbstractPkgContext()))
 }
 
 func TestCmd_currentDir(t *testing.T) {


### PR DESCRIPTION
With this change:
`kpt pkg init` will generate `package-context.yaml` file with following content:

```
# package-context.yaml

apiVersion: v1
kind: ConfigMap
metadata:
  name: kptfile.kpt.dev
  annotations:
    config.kubernetes.io/local-config: "true"
data:
  name: example
```