### PR TITLE
Generate Context When Creating Deployment Package

### DIFF
--- a/porch/.vscode/launch.json
+++ b/porch/.vscode/launch.json
@@ -5,6 +5,17 @@
     "version": "0.2.0",
     "configurations": [
         {
+            "name": "Launch test function",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${workspaceFolder}/apiserver/pkg/e2e",
+            "args": [
+                "-test.run",
+                "TestE2E/PorchSuite/TestCloneIntoDeploymentRepository"
+            ]
+        },
+        {
             "name": "Launch Server",
             "type": "go",
             "request": "launch",

--- a/porch/Makefile
+++ b/porch/Makefile
@@ -130,7 +130,7 @@ porch:
 .PHONY: fix-headers
 fix-headers:
 	# TODO: switch to google/addlicense once we have https://github.com/google/addlicense/pull/104
-	go run github.com/justinsb/addlicense@v1.0.1 -c "Google LLC" -l apache --ignore ".build/**" . 2>/dev/null
+	go run github.com/justinsb/addlicense@v1.0.1 -c "Google LLC" -l apache --ignore ".build/**" --ignore "**/testdata/**" . 2>/dev/null
 
 .PHONY: fix-all
 fix-all: fix-headers fmt tidy

--- a/porch/apiserver/go.mod
+++ b/porch/apiserver/go.mod
@@ -19,7 +19,6 @@ require (
 	go.opentelemetry.io/otel/sdk v0.20.0
 	go.opentelemetry.io/otel/sdk/metric v0.20.0
 	google.golang.org/grpc v1.44.0
-	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.23.2
 	k8s.io/apimachinery v0.23.2
 	k8s.io/apiserver v0.23.2
@@ -145,6 +144,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 	k8s.io/cli-runtime v0.23.2 // indirect
 	k8s.io/kubectl v0.23.2 // indirect

--- a/porch/engine/pkg/engine/builtin.go
+++ b/porch/engine/pkg/engine/builtin.go
@@ -1,0 +1,91 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoogleContainerTools/kpt/internal/builtins"
+	"github.com/GoogleContainerTools/kpt/internal/fnruntime"
+	"github.com/GoogleContainerTools/kpt/pkg/fn"
+	api "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
+	"github.com/GoogleContainerTools/kpt/porch/repository/pkg/repository"
+	"sigs.k8s.io/kustomize/kyaml/fn/runtime/runtimeutil"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
+)
+
+type builtinEvalMutation struct {
+	function string
+	runner   fn.FunctionRunner
+}
+
+func newBuiltinFunctionMutation(function string) (mutation, error) {
+	var runner fn.FunctionRunner
+	switch function {
+	case fnruntime.FuncGenPkgContext:
+		runner = &builtins.PackageContextGenerator{}
+	default:
+		return nil, fmt.Errorf("unrecognized built-in function %q", function)
+	}
+
+	return &builtinEvalMutation{
+		function: function,
+		runner:   runner,
+	}, nil
+}
+
+var _ mutation = &builtinEvalMutation{}
+
+func (m *builtinEvalMutation) Apply(ctx context.Context, resources repository.PackageResources) (repository.PackageResources, *api.Task, error) {
+	ff := &runtimeutil.FunctionFilter{
+		Run:     m.runner.Run,
+		Results: &yaml.RNode{},
+	}
+
+	pr := &packageReader{
+		input: resources,
+		extra: map[string]string{},
+	}
+
+	result := repository.PackageResources{
+		Contents: map[string]string{},
+	}
+
+	pipeline := kio.Pipeline{
+		Inputs:  []kio.Reader{pr},
+		Filters: []kio.Filter{ff},
+		Outputs: []kio.Writer{&packageWriter{
+			output: result,
+		}},
+	}
+
+	if err := pipeline.Execute(); err != nil {
+		return repository.PackageResources{}, nil, fmt.Errorf("failed to evaluate function %q: %w", m.function, err)
+	}
+
+	for k, v := range pr.extra {
+		result.Contents[k] = v
+	}
+
+	return result, &api.Task{
+		Type: api.TaskTypeEval,
+		Eval: &api.FunctionEvalTaskSpec{
+			Image:                m.function,
+			IncludeMetaResources: true,
+		},
+	}, nil
+}

--- a/porch/engine/pkg/engine/builtin_test.go
+++ b/porch/engine/pkg/engine/builtin_test.go
@@ -1,0 +1,78 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"flag"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleContainerTools/kpt/internal/fnruntime"
+	"github.com/google/go-cmp/cmp"
+)
+
+var (
+	update = flag.Bool("update", false, "update golden files")
+)
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	os.Exit(m.Run())
+}
+
+func TestUnknownBuiltinFunctionMutation(t *testing.T) {
+	const doesNotExist = "function-does-not-exist"
+	m, err := newBuiltinFunctionMutation(doesNotExist)
+	if err == nil || m != nil {
+		t.Errorf("creating builtin function runner for an unknown function %q unexpectedly succeeded", doesNotExist)
+	}
+}
+
+func TestPackageContext(t *testing.T) {
+	testdata, err := filepath.Abs(filepath.Join(".", "testdata", "context"))
+	if err != nil {
+		t.Fatalf("Failed to find testdata: %v", err)
+	}
+
+	input := readPackage(t, filepath.Join(testdata, "input"))
+
+	m, err := newBuiltinFunctionMutation(fnruntime.FuncGenPkgContext)
+	if err != nil {
+		t.Fatalf("Failed to get builtin function mutation: %v", err)
+	}
+
+	got, _, err := m.Apply(context.Background(), input)
+	if err != nil {
+		t.Fatalf("Failed to apply builtin function mutation: %v", err)
+	}
+
+	expectedPackage := filepath.Join(testdata, "expected")
+
+	if *update {
+		if err := os.RemoveAll(expectedPackage); err != nil {
+			t.Fatalf("Failed to update golden files: %v", err)
+		}
+
+		writePackage(t, expectedPackage, got)
+	}
+
+	want := readPackage(t, expectedPackage)
+
+	if !cmp.Equal(want, got) {
+		t.Errorf("Unexpected result of builtin function mutation (-want, +got): %s", cmp.Diff(want, got))
+	}
+}

--- a/porch/engine/pkg/engine/clone_test.go
+++ b/porch/engine/pkg/engine/clone_test.go
@@ -54,7 +54,7 @@ func createRepoWithContents(t *testing.T, contentDir string) *gogit.Repository {
 		if info.IsDir() {
 			return nil
 		} else if !info.Mode().IsRegular() {
-			return fmt.Errorf("irredular file object detected: %q (%s)", path, info.Mode())
+			return fmt.Errorf("irregular file object detected: %q (%s)", path, info.Mode())
 		}
 		rel, err := filepath.Rel(contentDir, path)
 		if err != nil {

--- a/porch/engine/pkg/engine/engine.go
+++ b/porch/engine/pkg/engine/engine.go
@@ -24,6 +24,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/GoogleContainerTools/kpt/internal/fnruntime"
 	"github.com/GoogleContainerTools/kpt/pkg/fn"
 	api "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
 	configapi "github.com/GoogleContainerTools/kpt/porch/controllers/pkg/apis/porch/v1alpha1"
@@ -96,6 +97,15 @@ func (cad *cadEngine) CreatePackageRevision(ctx context.Context, repositoryObj *
 	for i := range tasks {
 		task := &tasks[i]
 		mutation, err := cad.mapTaskToMutation(ctx, obj, task)
+		if err != nil {
+			return nil, err
+		}
+		mutations = append(mutations, mutation)
+	}
+
+	// If creating a package in a deployment repository, generate context
+	if repositoryObj.Spec.Deployment {
+		mutation, err := newBuiltinFunctionMutation(fnruntime.FuncGenPkgContext)
 		if err != nil {
 			return nil, err
 		}

--- a/porch/engine/pkg/engine/testdata/context/expected/Kptfile
+++ b/porch/engine/pkg/engine/testdata/context/expected/Kptfile
@@ -1,0 +1,8 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: input
+  annotations:
+    config.kubernetes.io/path: 'Kptfile'
+info:
+  description: Builtin Function Test Package

--- a/porch/engine/pkg/engine/testdata/context/expected/bucket.yaml
+++ b/porch/engine/pkg/engine/testdata/context/expected/bucket.yaml
@@ -1,0 +1,13 @@
+apiVersion: storage.cnrm.cloud.google.com/v1beta1
+kind: StorageBucket
+metadata:
+  name: bucket-name
+  namespace: bucket-namespace
+  annotations:
+    cnrm.cloud.google.com/project-id: bucket-project
+    config.kubernetes.io/path: 'bucket.yaml'
+spec:
+  storageClass: standard
+  uniformBucketLevelAccess: true
+  versioning:
+    enabled: false

--- a/porch/engine/pkg/engine/testdata/context/expected/package-context.yaml
+++ b/porch/engine/pkg/engine/testdata/context/expected/package-context.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kptfile.kpt.dev
+  annotations:
+    config.kubernetes.io/local-config: "true"
+    config.kubernetes.io/path: 'package-context.yaml'
+data:
+  name: input

--- a/porch/engine/pkg/engine/testdata/context/input/Kptfile
+++ b/porch/engine/pkg/engine/testdata/context/input/Kptfile
@@ -1,0 +1,6 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: input
+info:
+  description: Builtin Function Test Package

--- a/porch/engine/pkg/engine/testdata/context/input/bucket.yaml
+++ b/porch/engine/pkg/engine/testdata/context/input/bucket.yaml
@@ -1,0 +1,12 @@
+apiVersion: storage.cnrm.cloud.google.com/v1beta1
+kind: StorageBucket
+metadata:
+  name: bucket-name
+  namespace: bucket-namespace
+  annotations:
+    cnrm.cloud.google.com/project-id: bucket-project
+spec:
+  storageClass: standard
+  uniformBucketLevelAccess: true
+  versioning:
+    enabled: false

--- a/porch/engine/pkg/engine/testing.go
+++ b/porch/engine/pkg/engine/testing.go
@@ -1,0 +1,69 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"fmt"
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/GoogleContainerTools/kpt/porch/repository/pkg/repository"
+)
+
+func readPackage(t *testing.T, packageDir string) repository.PackageResources {
+	results := map[string]string{}
+
+	if err := filepath.Walk(packageDir, func(p string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		} else if !info.Mode().IsRegular() {
+			return fmt.Errorf("irregular file object detected: %q (%s)", p, info.Mode())
+		}
+		rel, err := filepath.Rel(packageDir, p)
+		if err != nil {
+			return fmt.Errorf("failed to get relative path from %q to %q: %w", packageDir, p, err)
+		}
+		contents, err := ioutil.ReadFile(p)
+		if err != nil {
+			return fmt.Errorf("failed to open the source file %q: %w", p, err)
+		}
+		results[rel] = string(contents)
+		return nil
+	}); err != nil {
+		t.Errorf("Failed to read package from disk %q: %v", packageDir, err)
+	}
+	return repository.PackageResources{
+		Contents: results,
+	}
+}
+
+func writePackage(t *testing.T, packageDir string, contents repository.PackageResources) {
+	for k, v := range contents.Contents {
+		abs := filepath.Join(packageDir, k)
+		dir := filepath.Dir(abs)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("Failed to crete directory %q: %v", dir, err)
+		}
+		if err := ioutil.WriteFile(abs, []byte(v), 0644); err != nil {
+			t.Errorf("Failed to write package file %q: %v", abs, err)
+		}
+	}
+}


### PR DESCRIPTION
When creating (cloning or creating new) package revision in a deployment
repository, call `builtins/gen-pkg-context` function to generate package
context.
