### PR TITLE
List In Correct Namespace

### DIFF
--- a/porch/apiserver/pkg/e2e/e2e_test.go
+++ b/porch/apiserver/pkg/e2e/e2e_test.go
@@ -199,7 +199,7 @@ func (t *PorchSuite) TestGitRepository(ctx context.Context) {
 	t.registerGitRepositoryF(ctx, testBlueprintsRepo, "test-blueprints")
 
 	var pr porchapi.PackageRevisionResourcesList
-	t.ListE(ctx, &pr)
+	t.ListE(ctx, &pr, client.InNamespace(t.namespace))
 
 	// Ensure basens package exists
 	const name = "test-blueprints:basens:v1"
@@ -416,7 +416,7 @@ func (t *PorchSuite) TestFunctionRepository(ctx context.Context) {
 	})
 
 	list := &porchapi.FunctionList{}
-	t.ListE(ctx, list)
+	t.ListE(ctx, list, client.InNamespace(t.namespace))
 
 	if got := len(list.Items); got == 0 {
 		t.Errorf("Found no functions in gcr.io/kpt-fn repository; expected at least one")
@@ -427,7 +427,7 @@ func (t *PorchSuite) TestPublicGitRepository(ctx context.Context) {
 	t.registerGitRepositoryF(ctx, testBlueprintsRepo, "demo-blueprints")
 
 	var list porchapi.PackageRevisionList
-	t.ListE(ctx, &list)
+	t.ListE(ctx, &list, client.InNamespace(t.namespace))
 
 	if got := len(list.Items); got == 0 {
 		t.Errorf("Found no package revisions in %s; expected at least one", testBlueprintsRepo)


### PR DESCRIPTION
By default the list operation will return resources cross-namespace. Tests
should only list within the current test namespace.

