### PR TITLE
Use More Unique Label on Porch Server

### DIFF
--- a/porch/config/deploy/3-porch-server.yaml
+++ b/porch/config/deploy/3-porch-server.yaml
@@ -24,17 +24,15 @@ kind: Deployment
 metadata:
   name: porch-server
   namespace: porch-system
-  labels:
-    apiserver: "true"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      apiserver: "true"
+      app: porch-server
   template:
     metadata:
       labels:
-        apiserver: "true"
+        app: porch-server
     spec:
       serviceAccountName: porch-server
       volumes:
@@ -70,4 +68,4 @@ spec:
       protocol: TCP
       targetPort: 443
   selector:
-    apiserver: "true"
+    app: porch-server


### PR DESCRIPTION
apiserver:true is too generic and may lead to accidental conflicts all
too easily.
