### PR TITLE
Increase Watch Retry Durations

### DIFF
--- a/porch/apiserver/pkg/registry/porch/background.go
+++ b/porch/apiserver/pkg/registry/porch/background.go
@@ -43,8 +43,8 @@ type background struct {
 }
 
 const (
-	minReconnectDelay = 100 * time.Millisecond
-	maxReconnectDelay = 10 * time.Second
+	minReconnectDelay = 1 * time.Second
+	maxReconnectDelay = 30 * time.Second
 )
 
 // run will run until ctx is done


### PR DESCRIPTION
If we successfully establish watch and it is immediately closed,
retry is too short. Set 1s minimum.
