### PR TITLE
Git Test Repository Scripts

### DIFF
--- a/porch/hack/create-test-repo.sh
+++ b/porch/hack/create-test-repo.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function error() {
+    echo "$@"
+    exit 1 
+}
+
+if [[ $# -ne 1 ]]; then
+  error "${0} requires exactly one argument - path to a directory in which to initialize git repository"
+fi
+
+git init "${1}"
+
+WORKTREE="${1}"
+(
+    cd ${WORKTREE}
+    rm ./.git/hooks/*.sample
+    git config user.name "Porch Test"
+    git config user.email "porch@kpt.dev"
+    echo "Porch Test Repository" > .git/description
+)
+

--- a/porch/hack/tar-test-repo.sh
+++ b/porch/hack/tar-test-repo.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+function error() {
+    echo "$@"
+    exit 1 
+}
+
+if [[ $# -ne 2 ]]; then
+  error "Invalid # of arguments; ${#}. 2 expected: GIT_DIRECTORY OUTPUT_TAR_FILE"
+fi
+
+tar -c -f "${2}" -C "${1}" --owner=porch:0 --group=porch:0 \
+  --exclude '.git/logs' \
+  --exclude '.git/COMMIT_EDITMSG' \
+  --exclude '.git/ORIG_HEAD' \
+  .git

--- a/porch/repository/pkg/git/testdata/README.md
+++ b/porch/repository/pkg/git/testdata/README.md
@@ -1,0 +1,26 @@
+# Git Repository Test Data
+
+The `tar` files in this directory contain archived Git repositories
+which the tests unarchive into a temporary directory as a starting point
+of the tests. This is to avoid constructing the repositories in code by
+synthesizing commits, and (over time) to set up scenarios for handling
+edge cases, etc.
+
+The repositories are archived as bare, i.e. only their `.git` directory
+is included in the archive.
+
+To inspect the git repository contents
+
+```sh
+mkdir repo
+cd repo
+
+# This will unarchive the .git directory.
+tar xfv <archived-repository>.tar
+# Checkout the main branch and populate the worktree.
+git reset --hard main
+```
+
+The scripts used to create and archive these repositories are:
+* [hack/create-test-repo.sh](../../../../hack/create-test-repo.sh)
+* [hack/tar-test-repo.sh](../../../../hack/tar-test-repo.sh)


### PR DESCRIPTION
The scripts can be used to create an initial git repository to
subsequently populate with commits and archive it for use with
tests.
