### PR TITLE
Trim '/' When Composing Git Ref From Package Dir

### DIFF
--- a/porch/repository/pkg/git/git.go
+++ b/porch/repository/pkg/git/git.go
@@ -320,6 +320,9 @@ func (r *gitRepository) GetPackage(version, path string) (repository.PackageRevi
 
 	var hash plumbing.Hash
 
+	// Trim leading and trailing slashes
+	path = strings.Trim(path, "/")
+
 	// Versions map to git tags in one of two ways:
 	//
 	// * directly (tag=version)- but then this means that all packages in the repo must be versioned together.


### PR DESCRIPTION
Client may provide package directory with leading slash.
For defense-in-depth, trim the leading and trailing slash
when constructing the git ref to look for the package.
