### PR TITLE
Fix Test Git Server Handling Of Empty Repositories

### DIFF
--- a/porch/Makefile
+++ b/porch/Makefile
@@ -106,7 +106,7 @@ tidy:
 
 .PHONY: test
 test:
-	@for f in $(MODULES); do (cd $$f; echo "Testing $$f"; go test ./...) || exit 1; done
+	@for f in $(MODULES); do (cd $$f; echo "Testing $$f"; go test --count=1 ./...) || exit 1; done
 
 .PHONY: vet
 vet:

--- a/porch/repository/pkg/git/git_test.go
+++ b/porch/repository/pkg/git/git_test.go
@@ -329,51 +329,61 @@ func TestListPackagesEmpty(t *testing.T) {
 
 	// TODO: Enable the rest of the test when gogit can push into an empty repository.
 
-	// packageRevision := &v1alpha1.PackageRevision{
-	// 	ObjectMeta: metav1.ObjectMeta{
-	// 		Name:      "empty:test-packgae:v1",
-	// 		Namespace: namespace,
-	// 	},
-	// 	Spec: v1alpha1.PackageRevisionSpec{
-	// 		PackageName:    "test-package",
-	// 		Revision:       "v1",
-	// 		RepositoryName: repositoryName,
-	// 		Lifecycle:      v1alpha1.PackageRevisionLifecycleDraft,
-	// 	},
-	// }
+	packageRevision := &v1alpha1.PackageRevision{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "empty:test-packgae:v1",
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.PackageRevisionSpec{
+			PackageName:    "test-package",
+			Revision:       "v1",
+			RepositoryName: repositoryName,
+			Lifecycle:      v1alpha1.PackageRevisionLifecycleDraft,
+		},
+	}
 
-	// // Create a package draft
-	// draft, err := git.CreatePackageRevision(ctx, packageRevision)
-	// if err != nil {
-	// 	t.Fatalf("CreatePackageRevision() failed: %v", err)
-	// }
-	// resources := &v1alpha1.PackageRevisionResources{
-	// 	Spec: v1alpha1.PackageRevisionResourcesSpec{
-	// 		Resources: map[string]string{
-	// 			"Kptfile": Kptfile,
-	// 		},
-	// 	},
-	// }
-	// if err := draft.UpdateResources(ctx, resources, &v1alpha1.Task{
-	// 	Type: v1alpha1.TaskTypeInit,
-	// 	Init: &v1alpha1.PackageInitTaskSpec{
-	// 		Description: "Empty Package",
-	// 	},
-	// }); err != nil {
-	// 	t.Fatalf("UpdateResources() failed: %v", err)
-	// }
-	// newRevision, err := draft.Close(ctx)
-	// if err != nil {
-	// 	t.Fatalf("draft.Close() failed: %v", err)
-	// }
+	// Create a package draft
+	draft, err := git.CreatePackageRevision(ctx, packageRevision)
+	if err != nil {
+		t.Fatalf("CreatePackageRevision() failed: %v", err)
+	}
+	resources := &v1alpha1.PackageRevisionResources{
+		Spec: v1alpha1.PackageRevisionResourcesSpec{
+			Resources: map[string]string{
+				"Kptfile": Kptfile,
+			},
+		},
+	}
+	if err := draft.UpdateResources(ctx, resources, &v1alpha1.Task{
+		Type: v1alpha1.TaskTypeInit,
+		Init: &v1alpha1.PackageInitTaskSpec{
+			Description: "Empty Package",
+		},
+	}); err != nil {
+		t.Fatalf("UpdateResources() failed: %v", err)
+	}
+	newRevision, err := draft.Close(ctx)
+	if err != nil {
+		t.Fatalf("draft.Close() failed: %v", err)
+	}
 
-	// result, err := newRevision.GetPackageRevision()
-	// if err != nil {
-	// 	t.Fatalf("GetPackageRevision() failed: %v", err)
-	// }
-	// if got, want := result.Spec.Lifecycle, v1alpha1.PackageRevisionLifecycleDraft; got != want {
-	// 	t.Errorf("Newly created package type: got %q, want %q", got, want)
-	// }
+	result, err := newRevision.GetPackageRevision()
+	if err != nil {
+		t.Fatalf("GetPackageRevision() failed: %v", err)
+	}
+	if got, want := result.Spec.Lifecycle, v1alpha1.PackageRevisionLifecycleDraft; got != want {
+		t.Errorf("Newly created package type: got %q, want %q", got, want)
+	}
+
+	// Verify
+	verify, err := gogit.PlainOpen(filepath.Join(tempdir, ".git"))
+	if err != nil {
+		t.Fatalf("Failed to open git repository for verification: %v", err)
+	}
+	draftRefName := plumbing.NewBranchReferenceName("drafts/test-package/v1")
+	if _, err = verify.Reference(draftRefName, true); err != nil {
+		t.Errorf("Failed to resolve %q references: %v", draftRefName, err)
+	}
 }
 
 // trivial-repository.tar has a repon with a `main` branch and a single empty commit.

--- a/porch/repository/pkg/git/git_test.go
+++ b/porch/repository/pkg/git/git_test.go
@@ -327,8 +327,6 @@ func TestListPackagesEmpty(t *testing.T) {
 		t.Errorf("Number of packges in empty repository: got %d, want %d", got, want)
 	}
 
-	// TODO: Enable the rest of the test when gogit can push into an empty repository.
-
 	packageRevision := &v1alpha1.PackageRevision{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "empty:test-packgae:v1",


### PR DESCRIPTION
When returning empty repositories without any refs, the correct server
response is:

`empty_list = PKT-LINE(zero-id SP "capabilities^{}" NUL cap-list LF)`

Always Run Tests. Go may cache test resultes even when server has changed,
which increases risks of missing test failures.

<!--  Thanks for sending a pull request!  Here are some tips for you:

In your PR, please ensure that you include the following information:
* a description of the change
* the motivation for the change
* what issue it fixes, if any, in GitHub syntax (e.g. Fixes #XYZ)

Both the description and motivation may reference other issues and PRs,
but should be mostly understandable without following the links (e.g. when
reading the git commit log).

If you are updating the documentation, please do it in separate PRs from
code changes and the commit message should start with `Docs:`.

**PLEASE REMOVE THIS COMMENT BLOCK BEFORE SUBMITTING THE PR** (the bits
between the arrows)

-->
