### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/internal/cmddiff/cmddiff_test.go
+++ b/internal/cmddiff/cmddiff_test.go
@@ -15,7 +15,6 @@
 package cmddiff_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -73,14 +72,10 @@ func TestCmdExecute(t *testing.T) {
 }
 
 func TestCmd_flagAndArgParsing_Symlink(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	defer testutil.Chdir(t, dir)()
 
-	err = os.MkdirAll(filepath.Join(dir, "path", "to", "pkg", "dir"), 0700)
+	err := os.MkdirAll(filepath.Join(dir, "path", "to", "pkg", "dir"), 0700)
 	assert.NoError(t, err)
 	err = os.Symlink(filepath.Join("path", "to", "pkg", "dir"), "foo")
 	assert.NoError(t, err)

--- a/internal/cmdget/cmdget_test.go
+++ b/internal/cmdget/cmdget_test.go
@@ -16,7 +16,6 @@ package cmdget_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -392,14 +391,10 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 }
 
 func TestCmd_flagAndArgParsing_Symlink(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	defer testutil.Chdir(t, dir)()
 
-	err = os.MkdirAll(filepath.Join(dir, "path", "to", "pkg", "dir"), 0700)
+	err := os.MkdirAll(filepath.Join(dir, "path", "to", "pkg", "dir"), 0700)
 	assert.NoError(t, err)
 	err = os.Symlink(filepath.Join("path", "to", "pkg", "dir"), "link")
 	assert.NoError(t, err)

--- a/internal/cmdinit/cmdinit_test.go
+++ b/internal/cmdinit/cmdinit_test.go
@@ -35,13 +35,12 @@ func TestMain(m *testing.M) {
 
 // TestCmd verifies the directory is initialized
 func TestCmd(t *testing.T) {
-	d, err := ioutil.TempDir("", "kpt")
-	assert.NoError(t, err)
+	d := t.TempDir()
 	assert.NoError(t, os.Mkdir(filepath.Join(d, "my-pkg"), 0700))
 
 	r := cmdinit.NewRunner(fake.CtxWithDefaultPrinter(), "kpt")
 	r.Command.SetArgs([]string{filepath.Join(d, "my-pkg"), "--description", "my description"})
-	err = r.Command.Execute()
+	err := r.Command.Execute()
 	assert.NoError(t, err)
 
 	// verify the contents
@@ -86,8 +85,7 @@ Details: https://kpt.dev/reference/cli/live/
 }
 
 func TestCmd_currentDir(t *testing.T) {
-	d, err := ioutil.TempDir("", "kpt")
-	assert.NoError(t, err)
+	d := t.TempDir()
 	assert.NoError(t, os.Mkdir(filepath.Join(d, "my-pkg"), 0700))
 	packageDir := filepath.Join(d, "my-pkg")
 	currentDir, err := os.Getwd()
@@ -123,8 +121,7 @@ info:
 }
 
 func TestCmd_DefaultToCurrentDir(t *testing.T) {
-	d, err := ioutil.TempDir("", "kpt")
-	assert.NoError(t, err)
+	d := t.TempDir()
 	assert.NoError(t, os.Mkdir(filepath.Join(d, "my-pkg"), 0700))
 	packageDir := filepath.Join(d, "my-pkg")
 	currentDir, err := os.Getwd()
@@ -161,11 +158,10 @@ info:
 
 // TestCmd_failExists verifies the command throws and error if the directory exists
 func TestCmd_failNotExists(t *testing.T) {
-	d, err := ioutil.TempDir("", "kpt")
-	assert.NoError(t, err)
+	d := t.TempDir()
 	r := cmdinit.NewRunner(fake.CtxWithDefaultPrinter(), "kpt")
 	r.Command.SetArgs([]string{filepath.Join(d, "my-pkg"), "--description", "my description"})
-	err = r.Command.Execute()
+	err := r.Command.Execute()
 	if assert.Error(t, err) {
 		assert.Contains(t, err.Error(), "does not exist")
 	}

--- a/internal/cmdmigrate/migratecmd_test.go
+++ b/internal/cmdmigrate/migratecmd_test.go
@@ -136,10 +136,9 @@ func TestKptMigrate_updateKptfile(t *testing.T) {
 			ioStreams, _, _, _ := genericclioptions.NewTestIOStreams() //nolint:dogsled
 
 			// Set up temp directory with Ktpfile
-			dir, err := ioutil.TempDir("", "kpt-migrate-test")
-			assert.NoError(t, err)
+			dir := t.TempDir()
 			p := filepath.Join(dir, "Kptfile")
-			err = ioutil.WriteFile(p, []byte(tc.kptfile), 0600)
+			err := ioutil.WriteFile(p, []byte(tc.kptfile), 0600)
 			assert.NoError(t, err)
 
 			ctx := fake.CtxWithDefaultPrinter()
@@ -228,10 +227,9 @@ func TestKptMigrate_migrateKptfileToRG(t *testing.T) {
 			ioStreams, _, _, _ := genericclioptions.NewTestIOStreams() //nolint:dogsled
 
 			// Set up temp directory with Ktpfile
-			dir, err := ioutil.TempDir("", "kpt-migrate-test")
-			assert.NoError(t, err)
+			dir := t.TempDir()
 			p := filepath.Join(dir, "Kptfile")
-			err = ioutil.WriteFile(p, []byte(tc.kptfile), 0600)
+			err := ioutil.WriteFile(p, []byte(tc.kptfile), 0600)
 			assert.NoError(t, err)
 
 			if tc.resourcegroup != "" {

--- a/internal/cmdrender/cmdrender_test.go
+++ b/internal/cmdrender/cmdrender_test.go
@@ -15,7 +15,6 @@
 package cmdrender
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,14 +26,10 @@ import (
 )
 
 func TestCmd_flagAndArgParsing_Symlink(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	defer testutil.Chdir(t, dir)()
 
-	err = os.MkdirAll(filepath.Join(dir, "path", "to", "pkg", "dir"), 0700)
+	err := os.MkdirAll(filepath.Join(dir, "path", "to", "pkg", "dir"), 0700)
 	assert.NoError(t, err)
 	err = os.Symlink(filepath.Join("path", "to", "pkg", "dir"), "foo")
 	assert.NoError(t, err)

--- a/internal/cmdupdate/cmdupdate_test.go
+++ b/internal/cmdupdate/cmdupdate_test.go
@@ -16,7 +16,6 @@ package cmdupdate_test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -296,18 +295,14 @@ func (t NoOpFailRunE) runE(cmd *cobra.Command, args []string) error {
 func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 	failRun := NoOpFailRunE{t: t}.runE
 
-	dir, err := ioutil.TempDir("", "")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	defer testutil.Chdir(t, filepath.Dir(dir))()
 
 	// verify the current working directory is used if no path is specified
 	r := cmdupdate.NewRunner(fake.CtxWithDefaultPrinter(), "kpt")
 	r.Command.RunE = NoOpRunE
 	r.Command.SetArgs([]string{})
-	err = r.Command.Execute()
+	err := r.Command.Execute()
 	assert.NoError(t, err)
 	assert.Equal(t, "", r.Update.Ref)
 	assert.Equal(t, kptfilev1.ResourceMerge, r.Update.Strategy)
@@ -350,14 +345,10 @@ func TestCmd_Execute_flagAndArgParsing(t *testing.T) {
 }
 
 func TestCmd_flagAndArgParsing_Symlink(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	defer testutil.Chdir(t, dir)()
 
-	err = os.MkdirAll(filepath.Join(dir, "path", "to", "pkg", "dir"), 0700)
+	err := os.MkdirAll(filepath.Join(dir, "path", "to", "pkg", "dir"), 0700)
 	assert.NoError(t, err)
 	err = os.Symlink(filepath.Join("path", "to", "pkg", "dir"), "foo")
 	assert.NoError(t, err)
@@ -393,11 +384,7 @@ func TestCmd_path(t *testing.T) {
 		pathPrefix = "/private"
 	}
 
-	dir, err := ioutil.TempDir("", "")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	testCases := []struct {
 		name                    string
@@ -450,7 +437,7 @@ func TestCmd_path(t *testing.T) {
 			}
 
 			r.Command.SetArgs([]string{test.path})
-			err = r.Command.Execute()
+			err := r.Command.Execute()
 
 			if test.expectedErrMsg != "" {
 				if !assert.Error(t, err) {

--- a/internal/gitutil/gitutil_test.go
+++ b/internal/gitutil/gitutil_test.go
@@ -15,7 +15,6 @@
 package gitutil_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -58,10 +57,7 @@ func TestLocalGitRunner(t *testing.T) {
 
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "kpt-test")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
+			dir := t.TempDir()
 
 			runner, err := NewLocalGitRunner(dir)
 			if !assert.NoError(t, err) {
@@ -94,12 +90,9 @@ func TestLocalGitRunner(t *testing.T) {
 }
 
 func TestNewGitUpstreamRepo_noRepo(t *testing.T) {
-	dir, err := ioutil.TempDir("", "kpt-test")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
+	dir := t.TempDir()
 
-	_, err = NewGitUpstreamRepo(fake.CtxWithDefaultPrinter(), dir)
+	_, err := NewGitUpstreamRepo(fake.CtxWithDefaultPrinter(), dir)
 	if !assert.Error(t, err) {
 		t.FailNow()
 	}
@@ -107,10 +100,7 @@ func TestNewGitUpstreamRepo_noRepo(t *testing.T) {
 }
 
 func TestNewGitUpstreamRepo_noRefs(t *testing.T) {
-	dir, err := ioutil.TempDir("", "kpt-test")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
+	dir := t.TempDir()
 
 	runner, err := NewLocalGitRunner(dir)
 	if !assert.NoError(t, err) {
@@ -189,10 +179,7 @@ func TestNewGitUpstreamRepo(t *testing.T) {
 }
 
 func TestGitUpstreamRepo_GetDefaultBranch_noRefs(t *testing.T) {
-	dir, err := ioutil.TempDir("", "kpt-test")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
+	dir := t.TempDir()
 
 	runner, err := NewLocalGitRunner(dir)
 	if !assert.NoError(t, err) {

--- a/internal/pkg/pkg_test.go
+++ b/internal/pkg/pkg_test.go
@@ -16,7 +16,6 @@ package pkg
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -77,10 +76,8 @@ func TestNewPkg(t *testing.T) {
 	for i := range tests {
 		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "")
-			defer os.RemoveAll(dir)
-			assert.NoError(t, err)
-			err = os.MkdirAll(filepath.Join(dir, "foo", "bar", "baz"), 0700)
+			dir := t.TempDir()
+			err := os.MkdirAll(filepath.Join(dir, "foo", "bar", "baz"), 0700)
 			assert.NoError(t, err)
 			revert := Chdir(t, filepath.Join(dir, test.workingDir))
 			defer revert()
@@ -163,10 +160,8 @@ func TestAdjustDisplayPathForSubpkg(t *testing.T) {
 	for i := range tests {
 		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "")
-			defer os.RemoveAll(dir)
-			assert.NoError(t, err)
-			err = os.MkdirAll(filepath.Join(dir, "rootPkgParentDir", "rootPkg", "subPkg", "nestedPkg"), 0700)
+			dir := t.TempDir()
+			err := os.MkdirAll(filepath.Join(dir, "rootPkgParentDir", "rootPkg", "subPkg", "nestedPkg"), 0700)
 			assert.NoError(t, err)
 			revert := Chdir(t, filepath.Join(dir, "rootPkgParentDir", test.workingDir))
 			defer revert()

--- a/internal/util/addmergecomment/addmergecomment_test.go
+++ b/internal/util/addmergecomment/addmergecomment_test.go
@@ -16,7 +16,6 @@ package addmergecomment
 
 import (
 	"io/ioutil"
-	"os"
 	"strings"
 	"testing"
 
@@ -142,11 +141,7 @@ spec:
 	for i := range tests {
 		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
-			baseDir, err := ioutil.TempDir("", "")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
-			defer os.RemoveAll(baseDir)
+			baseDir := t.TempDir()
 
 			r, err := ioutil.TempFile(baseDir, "k8s-cli-*.yaml")
 			if !assert.NoError(t, err) {

--- a/internal/util/argutil/argutil_test.go
+++ b/internal/util/argutil/argutil_test.go
@@ -15,7 +15,6 @@
 package argutil_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -123,13 +122,9 @@ func TestParseDirVersionWithDefaults(t *testing.T) {
 }
 
 func TestResolveSymlink(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
-	if !assert.NoError(t, err) {
-		t.FailNow()
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	defer testutil.Chdir(t, dir)()
-	err = os.MkdirAll(filepath.Join(dir, "foo"), 0700)
+	err := os.MkdirAll(filepath.Join(dir, "foo"), 0700)
 	assert.NoError(t, err)
 	err = os.Symlink("foo", "foo-link")
 	assert.NoError(t, err)

--- a/internal/util/attribution/attribution_test.go
+++ b/internal/util/attribution/attribution_test.go
@@ -204,11 +204,7 @@ metadata:
 	for i := range tests {
 		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
-			baseDir, err := ioutil.TempDir("", "")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
-			defer os.RemoveAll(baseDir)
+			baseDir := t.TempDir()
 
 			r, err := ioutil.TempFile(baseDir, "k8s-cli-*.yaml")
 			if !assert.NoError(t, err) {

--- a/internal/util/cmdutil/cmdutil_test.go
+++ b/internal/util/cmdutil/cmdutil_test.go
@@ -16,8 +16,6 @@ package cmdutil
 
 import (
 	"bytes"
-	"io/ioutil"
-	"os"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -267,18 +265,14 @@ metadata:
 	for i := range tests {
 		test := tests[i]
 		t.Run(test.name, func(t *testing.T) {
-			baseDir, err := ioutil.TempDir("", "")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
-			defer os.RemoveAll(baseDir)
+			baseDir := t.TempDir()
 
 			if test.dest != "" && test.dest != Stdout && test.dest != Unwrap {
 				test.dest = filepath.Join(baseDir, test.dest)
 			}
 
 			// this method should create a directory and write the output if the dest is a directory path
-			err = WriteFnOutput(test.dest, test.content, test.fromStdin, &test.writer)
+			err := WriteFnOutput(test.dest, test.content, test.fromStdin, &test.writer)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/internal/util/diff/diff_test.go
+++ b/internal/util/diff/diff_test.go
@@ -23,7 +23,6 @@ import (
 	"bufio"
 	"bytes"
 	"io"
-	"io/ioutil"
 	"regexp"
 	"strings"
 	"testing"
@@ -442,10 +441,7 @@ func TestCommand_Diff3Parameters(t *testing.T) {
 // Tests against directories in different states
 func TestCommand_NotAKptDirectory(t *testing.T) {
 	// Initial test setup
-	dir, err := ioutil.TempDir("", "example")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 
 	testCases := map[string]struct {
 		directory string

--- a/internal/util/man/man_test.go
+++ b/internal/util/man/man_test.go
@@ -30,11 +30,10 @@ import (
 // TestMan_Execute verifies that Execute will find the man page file,
 // format it as a man page, and execute a command to display it.
 func TestMan_Execute(t *testing.T) {
-	d, err := ioutil.TempDir("", "kptman")
-	assert.NoError(t, err)
+	d := t.TempDir()
 
 	// write the KptFile
-	err = ioutil.WriteFile(filepath.Join(d, kptfilev1.KptFileName), []byte(`
+	err := ioutil.WriteFile(filepath.Join(d, kptfilev1.KptFileName), []byte(`
 apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
@@ -190,13 +189,10 @@ func TestMan_GetStdOut(t *testing.T) {
 // TestMan_Execute_failNoManPage verifies that if the man page is not
 // specified for the package, an error is returned.
 func TestMan_Execute_failNoManPage(t *testing.T) {
-	d, err := ioutil.TempDir("", "kpt-man-test")
-	if !assert.NoError(t, err) {
-		return
-	}
+	d := t.TempDir()
 
 	// write the KptFile
-	err = ioutil.WriteFile(filepath.Join(d, kptfilev1.KptFileName), []byte(`
+	err := ioutil.WriteFile(filepath.Join(d, kptfilev1.KptFileName), []byte(`
 apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
@@ -225,11 +221,10 @@ info:
 // TestMan_Execute_failBadPath verifies that Execute will fail if the man
 // path does not exist.
 func TestMan_Execute_failBadPath(t *testing.T) {
-	d, err := ioutil.TempDir("", "kpt-man-test")
-	assert.NoError(t, err)
+	d := t.TempDir()
 
 	// write the KptFile
-	err = ioutil.WriteFile(filepath.Join(d, kptfilev1.KptFileName), []byte(`
+	err := ioutil.WriteFile(filepath.Join(d, kptfilev1.KptFileName), []byte(`
 apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:
@@ -254,11 +249,10 @@ info:
 // TestMan_Execute_failLocation verifies that Execute will fail if the man
 // path is not under the package directory.
 func TestMan_Execute_failLocation(t *testing.T) {
-	d, err := ioutil.TempDir("", "kpt-man-test")
-	assert.NoError(t, err)
+	d := t.TempDir()
 
 	// write the KptFile
-	err = ioutil.WriteFile(filepath.Join(d, kptfilev1.KptFileName), []byte(`
+	err := ioutil.WriteFile(filepath.Join(d, kptfilev1.KptFileName), []byte(`
 apiVersion: kpt.dev/v1
 kind: Kptfile
 metadata:

--- a/internal/util/merge/merge3_test.go
+++ b/internal/util/merge/merge3_test.go
@@ -573,13 +573,9 @@ spec:
 		t.Run(tn, func(t *testing.T) {
 
 			// setup the local directory
-			dir, err := ioutil.TempDir("", "merge3-test")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
-			err = os.MkdirAll(filepath.Join(dir, "localDir"), 0700)
+			err := os.MkdirAll(filepath.Join(dir, "localDir"), 0700)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/internal/util/pkgutil/pkgutil_test.go
+++ b/internal/util/pkgutil/pkgutil_test.go
@@ -15,7 +15,6 @@
 package pkgutil_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -364,12 +363,9 @@ func TestCopyPackage(t *testing.T) {
 	for tn, tc := range testCases {
 		t.Run(tn, func(t *testing.T) {
 			pkgPath := tc.pkg.ExpandPkg(t, testutil.EmptyReposInfo)
-			dest, err := ioutil.TempDir("", "kpt-")
-			if !assert.NoError(t, err) {
-				t.FailNow()
-			}
+			dest := t.TempDir()
 
-			err = pkgutil.CopyPackage(pkgPath, dest, tc.copyRootKptfile, tc.subpackageMatcher)
+			err := pkgutil.CopyPackage(pkgPath, dest, tc.copyRootKptfile, tc.subpackageMatcher)
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/internal/util/update/update_test.go
+++ b/internal/util/update/update_test.go
@@ -3747,14 +3747,10 @@ func TestReplaceNonKRMFiles(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			ds, err := testutil.GetTestDataPath()
 			assert.NoError(t, err)
-			updated, err := ioutil.TempDir("", "")
-			assert.NoError(t, err)
-			original, err := ioutil.TempDir("", "")
-			assert.NoError(t, err)
-			local, err := ioutil.TempDir("", "")
-			assert.NoError(t, err)
-			expectedLocal, err := ioutil.TempDir("", "")
-			assert.NoError(t, err)
+			updated := t.TempDir()
+			original := t.TempDir()
+			local := t.TempDir()
+			expectedLocal := t.TempDir()
 
 			err = copyutil.CopyDir(filepath.Join(ds, test.updated), updated)
 			assert.NoError(t, err)

--- a/pkg/api/kptfile/v1/validation_test.go
+++ b/pkg/api/kptfile/v1/validation_test.go
@@ -505,9 +505,8 @@ metadata:
 	for _, tc := range testcases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			d, err := ioutil.TempDir("", "")
-			assert.NoError(t, err)
-			err = ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(tc.input), 0700)
+			d := t.TempDir()
+			err := ioutil.WriteFile(filepath.Join(d, "f1.yaml"), []byte(tc.input), 0700)
 			assert.NoError(t, err)
 			got, err := GetValidatedFnConfigFromPath(filesys.FileSystemOrOnDisk{}, types.UniquePath(d), "f1.yaml")
 			if tc.errMsg != "" {

--- a/pkg/kptfile/kptfileutil/util_test.go
+++ b/pkg/kptfile/kptfileutil/util_test.go
@@ -16,7 +16,6 @@ package kptfileutil
 
 import (
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -63,12 +62,9 @@ func TestValidateInventory(t *testing.T) {
 }
 
 func TestUpdateKptfile(t *testing.T) {
-	writeKptfileToTemp := func(name string, content string) string {
-		dir, err := ioutil.TempDir("", name)
-		if !assert.NoError(t, err) {
-			t.FailNow()
-		}
-		err = ioutil.WriteFile(filepath.Join(dir, kptfilev1.KptFileName), []byte(content), 0600)
+	writeKptfileToTemp := func(tt *testing.T, content string) string {
+		dir := tt.TempDir()
+		err := ioutil.WriteFile(filepath.Join(dir, kptfilev1.KptFileName), []byte(content), 0600)
 		if !assert.NoError(t, err) {
 			t.FailNow()
 		}
@@ -338,14 +334,9 @@ pipeline: {}
 			}
 			dirs := make(map[string]string)
 			for n, content := range files {
-				dir := writeKptfileToTemp(n, content)
+				dir := writeKptfileToTemp(t, content)
 				dirs[n] = dir
 			}
-			defer func() {
-				for _, p := range dirs {
-					_ = os.RemoveAll(p)
-				}
-			}()
 
 			err := UpdateKptfile(dirs["local"], dirs["updated"], dirs["origin"], tc.updateUpstream)
 			if !assert.NoError(t, err) {

--- a/pkg/live/rgpath_test.go
+++ b/pkg/live/rgpath_test.go
@@ -183,8 +183,7 @@ func TestPathManifestReader_Read(t *testing.T) {
 			}
 
 			// Set up the yaml manifests (including Kptfile) in temp dir.
-			dir, err := ioutil.TempDir("", "path-reader-test")
-			assert.NoError(t, err)
+			dir := t.TempDir()
 			for filename, content := range tc.manifests {
 				p := filepath.Join(dir, filename)
 				err := ioutil.WriteFile(p, []byte(content), 0600)

--- a/porch/repository/pkg/git/git_test.go
+++ b/porch/repository/pkg/git/git_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -49,15 +48,7 @@ func TestGitPackageRoundTrip(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	tempdir, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("TempDir failed: %v", err)
-	}
-	defer func() {
-		if err := os.RemoveAll(tempdir); err != nil {
-			t.Errorf("RemoveAll(%q) failed: %v", tempdir, err)
-		}
-	}()
+	tempdir := t.TempDir()
 
 	// Start a mock git server
 	gitServerAddressChannel := make(chan net.Addr)


### PR DESCRIPTION
A testing cleanup. This PR replaces `ioutil.TempDir` with `t.TempDir` in tests.

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir