### PR TITLE
Kpt depends on specific version of Porch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/GoogleContainerTools/kpt
 go 1.17
 
 require (
-	github.com/GoogleContainerTools/kpt/porch/api v0.0.0-00010101000000-000000000000
-	github.com/GoogleContainerTools/kpt/porch/controllers v0.0.0-00010101000000-000000000000
+	github.com/GoogleContainerTools/kpt/porch/api v0.0.0-20220321233950-4752a2528bee
+	github.com/GoogleContainerTools/kpt/porch/controllers v0.0.0-20220321233950-4752a2528bee
 	github.com/cpuguy83/go-md2man/v2 v2.0.1
 	github.com/go-errors/errors v1.4.0
 	github.com/google/go-cmp v0.5.7
@@ -104,9 +104,4 @@ require (
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
-)
-
-replace (
-	github.com/GoogleContainerTools/kpt/porch/api => ./porch/api
-	github.com/GoogleContainerTools/kpt/porch/controllers => ./porch/controllers
 )

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,10 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/GoogleContainerTools/kpt/porch/api v0.0.0-20220321233950-4752a2528bee h1:Y4cNN/nJx2egsGadJbozqTslveMem9EC29uUtGi6ggk=
+github.com/GoogleContainerTools/kpt/porch/api v0.0.0-20220321233950-4752a2528bee/go.mod h1:yo0K0CqcOMyN8nPjuW+2kVz7uDLjCvL9hur6VMdeVdk=
+github.com/GoogleContainerTools/kpt/porch/controllers v0.0.0-20220321233950-4752a2528bee h1:t61LBgyb6OOdY35vNdSjB2YESa3QjLR03FbiooUJ/n0=
+github.com/GoogleContainerTools/kpt/porch/controllers v0.0.0-20220321233950-4752a2528bee/go.mod h1:ZLrogcsqAlrJDFtg8hvZ4aYVzZfY+YIXExDmtbI+lyA=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd h1:sjQovDkwrZp8u+gxLtPgKGjk5hCxuy2hrRejBTA9xFU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=

--- a/porch/apiserver/go.mod
+++ b/porch/apiserver/go.mod
@@ -4,8 +4,8 @@ go 1.17
 
 require (
 	github.com/GoogleContainerTools/kpt v0.0.0-00010101000000-000000000000
-	github.com/GoogleContainerTools/kpt/porch/api v0.0.0-00010101000000-000000000000
-	github.com/GoogleContainerTools/kpt/porch/controllers v0.0.0-00010101000000-000000000000
+	github.com/GoogleContainerTools/kpt/porch/api v0.0.0-20220321233950-4752a2528bee
+	github.com/GoogleContainerTools/kpt/porch/controllers v0.0.0-20220321233950-4752a2528bee
 	github.com/GoogleContainerTools/kpt/porch/engine v0.0.0-00010101000000-000000000000
 	github.com/GoogleContainerTools/kpt/porch/repository v0.0.0-00010101000000-000000000000
 	github.com/go-git/go-git/v5 v5.4.3-0.20220119145113-935af59cf64f

--- a/porch/controllers/remoterootsync/go.mod
+++ b/porch/controllers/remoterootsync/go.mod
@@ -32,8 +32,8 @@ require (
 	github.com/Azure/go-autorest/logger v0.2.1 // indirect
 	github.com/Azure/go-autorest/tracing v0.6.0 // indirect
 	github.com/GoogleContainerTools/kpt v0.0.0-00010101000000-000000000000 // indirect
-	github.com/GoogleContainerTools/kpt/porch/api v0.0.0-00010101000000-000000000000 // indirect
-	github.com/GoogleContainerTools/kpt/porch/controllers v0.0.0-00010101000000-000000000000 // indirect
+	github.com/GoogleContainerTools/kpt/porch/api v0.0.0-20220321233950-4752a2528bee // indirect
+	github.com/GoogleContainerTools/kpt/porch/controllers v0.0.0-20220321233950-4752a2528bee // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/porch/engine/go.mod
+++ b/porch/engine/go.mod
@@ -5,8 +5,8 @@ go 1.17
 require (
 	github.com/GoogleContainerTools/kpt v0.0.0-00010101000000-000000000000
 	github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/apply-setters v0.2.0
-	github.com/GoogleContainerTools/kpt/porch/api v0.0.0-00010101000000-000000000000
-	github.com/GoogleContainerTools/kpt/porch/controllers v0.0.0-00010101000000-000000000000
+	github.com/GoogleContainerTools/kpt/porch/api v0.0.0-20220321233950-4752a2528bee
+	github.com/GoogleContainerTools/kpt/porch/controllers v0.0.0-20220321233950-4752a2528bee
 	github.com/GoogleContainerTools/kpt/porch/func v0.0.0-00010101000000-000000000000
 	github.com/GoogleContainerTools/kpt/porch/repository v0.0.0-00010101000000-000000000000
 	github.com/go-git/go-billy/v5 v5.3.1

--- a/porch/repository/go.mod
+++ b/porch/repository/go.mod
@@ -4,8 +4,8 @@ go 1.17
 
 require (
 	github.com/GoogleContainerTools/kpt v0.0.0-00010101000000-000000000000
-	github.com/GoogleContainerTools/kpt/porch/api v0.0.0-00010101000000-000000000000
-	github.com/GoogleContainerTools/kpt/porch/controllers v0.0.0-00010101000000-000000000000
+	github.com/GoogleContainerTools/kpt/porch/api v0.0.0-20220321233950-4752a2528bee
+	github.com/GoogleContainerTools/kpt/porch/controllers v0.0.0-20220321233950-4752a2528bee
 	github.com/go-git/go-git/v5 v5.4.3-0.20220119145113-935af59cf64f
 	github.com/google/go-cmp v0.5.7
 	github.com/google/go-containerregistry v0.8.0

--- a/porch/test/go.mod
+++ b/porch/test/go.mod
@@ -17,8 +17,8 @@ require (
 
 require (
 	github.com/GoogleContainerTools/kpt v0.0.0-00010101000000-000000000000 // indirect
-	github.com/GoogleContainerTools/kpt/porch/api v0.0.0-00010101000000-000000000000 // indirect
-	github.com/GoogleContainerTools/kpt/porch/controllers v0.0.0-00010101000000-000000000000 // indirect
+	github.com/GoogleContainerTools/kpt/porch/api v0.0.0-20220321233950-4752a2528bee // indirect
+	github.com/GoogleContainerTools/kpt/porch/controllers v0.0.0-20220321233950-4752a2528bee // indirect
 	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20220113124808-70ae35bab23f // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect


### PR DESCRIPTION
By having kpt module depend on specific version of `api` and `controllers` there
is no need to use pseudo-modules. The redirects in sub-modules continue to work
but it will require update to kpt to take dependency on newer versions of `api`
and `controllers`.

This is an alternative to #2928

