### PR TITLE
Create Deterministic Yaml Output

### DIFF
--- a/e2e/porch_test.go
+++ b/e2e/porch_test.go
@@ -30,7 +30,7 @@ import (
 
 	"github.com/GoogleContainerTools/kpt/pkg/test/porch"
 	"github.com/google/go-cmp/cmp"
-	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
 const (

--- a/e2e/porch_test.go
+++ b/e2e/porch_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/GoogleContainerTools/kpt/pkg/test/porch"
 	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -88,6 +89,10 @@ func runTestCase(t *testing.T, git string, tc porch.TestCaseConfig) {
 
 		err := cmd.Run()
 
+		if command.Yaml {
+			reorderYamlStdout(t, &stdout)
+		}
+
 		if *update {
 			updateCommand(command, err, stdout.String(), stderr.String())
 		}
@@ -105,6 +110,25 @@ func runTestCase(t *testing.T, git string, tc porch.TestCaseConfig) {
 
 	if *update {
 		porch.WriteTestCaseConfig(t, &tc)
+	}
+}
+
+func reorderYamlStdout(t *testing.T, buf *bytes.Buffer) {
+	var data interface{}
+	if err := yaml.Unmarshal(buf.Bytes(), &data); err != nil {
+		// not yaml.
+		return
+	}
+
+	var stable bytes.Buffer
+	encoder := yaml.NewEncoder(&stable)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(data); err != nil {
+		t.Fatalf("Failed to re-encode yaml output: %v", err)
+	}
+	buf.Reset()
+	if _, err := buf.Write(stable.Bytes()); err != nil {
+		t.Fatalf("Failed to update reordered yaml output: %v", err)
 	}
 }
 

--- a/e2e/testdata/porch/rpkg-clone/config.yaml
+++ b/e2e/testdata/porch/rpkg-clone/config.yaml
@@ -34,41 +34,42 @@ commands:
       - git:basens-clone:v0
     stdout: |
       apiVersion: config.kubernetes.io/v1
-      kind: ResourceList
       items:
-      - apiVersion: kpt.dev/v1
-        kind: Kptfile
-        metadata:
-          name: basens-clone
-          annotations:
-            config.kubernetes.io/index: '0'
-            internal.config.kubernetes.io/index: '0'
-            internal.config.kubernetes.io/path: 'Kptfile'
-            config.kubernetes.io/path: 'Kptfile'
-        upstream:
-          type: git
-          git:
-            repo: https://github.com/platkrm/test-blueprints
-            directory: basens
-            ref: basens/v1
-        upstreamLock:
-          type: git
-          git:
-            repo: https://github.com/platkrm/test-blueprints
-            directory: basens
-            ref: basens/v1
-            commit: 67f29546028f0a48c6bbb08614934d0e070cdd3a
-        info:
-          description: sample description
-      - apiVersion: v1
-        kind: Namespace
-        metadata:
-          name: example
-          annotations:
-            config.kubernetes.io/index: '0'
-            internal.config.kubernetes.io/index: '0'
-            internal.config.kubernetes.io/path: 'namespace.yaml'
-            config.kubernetes.io/path: 'namespace.yaml'
+        - apiVersion: kpt.dev/v1
+          info:
+            description: sample description
+          kind: Kptfile
+          metadata:
+            annotations:
+              config.kubernetes.io/index: "0"
+              config.kubernetes.io/path: Kptfile
+              internal.config.kubernetes.io/index: "0"
+              internal.config.kubernetes.io/path: Kptfile
+            name: basens-clone
+          upstream:
+            git:
+              directory: basens
+              ref: basens/v1
+              repo: https://github.com/platkrm/test-blueprints
+            type: git
+          upstreamLock:
+            git:
+              commit: 67f29546028f0a48c6bbb08614934d0e070cdd3a
+              directory: basens
+              ref: basens/v1
+              repo: https://github.com/platkrm/test-blueprints
+            type: git
+        - apiVersion: v1
+          kind: Namespace
+          metadata:
+            annotations:
+              config.kubernetes.io/index: "0"
+              config.kubernetes.io/path: namespace.yaml
+              internal.config.kubernetes.io/index: "0"
+              internal.config.kubernetes.io/path: namespace.yaml
+            name: example
+      kind: ResourceList
+    yaml: true
   - args:
       - alpha
       - rpkg
@@ -77,28 +78,29 @@ commands:
       - git:empty-clone:v0
     stdout: |
       apiVersion: config.kubernetes.io/v1
-      kind: ResourceList
       items:
-      - apiVersion: kpt.dev/v1
-        kind: Kptfile
-        metadata:
-          name: empty-clone
-          annotations:
-            config.kubernetes.io/index: '0'
-            internal.config.kubernetes.io/index: '0'
-            internal.config.kubernetes.io/path: 'Kptfile'
-        upstream:
-          type: git
-          git:
-            repo: https://github.com/platkrm/test-blueprints
-            directory: empty
-            ref: v1
-        upstreamLock:
-          type: git
-          git:
-            repo: https://github.com/platkrm/test-blueprints
-            directory: empty
-            ref: v1
-            commit: 3de8635354eda8e7de756494a4e0eb5c12af01ab
-        info:
-          description: Empty Blueprint
+        - apiVersion: kpt.dev/v1
+          info:
+            description: Empty Blueprint
+          kind: Kptfile
+          metadata:
+            annotations:
+              config.kubernetes.io/index: "0"
+              internal.config.kubernetes.io/index: "0"
+              internal.config.kubernetes.io/path: Kptfile
+            name: empty-clone
+          upstream:
+            git:
+              directory: empty
+              ref: v1
+              repo: https://github.com/platkrm/test-blueprints
+            type: git
+          upstreamLock:
+            git:
+              commit: 3de8635354eda8e7de756494a4e0eb5c12af01ab
+              directory: empty
+              ref: v1
+              repo: https://github.com/platkrm/test-blueprints
+            type: git
+      kind: ResourceList
+    yaml: true

--- a/e2e/testdata/porch/rpkg-clone/config.yaml
+++ b/e2e/testdata/porch/rpkg-clone/config.yaml
@@ -35,39 +35,39 @@ commands:
     stdout: |
       apiVersion: config.kubernetes.io/v1
       items:
-        - apiVersion: kpt.dev/v1
-          info:
-            description: sample description
-          kind: Kptfile
-          metadata:
-            annotations:
-              config.kubernetes.io/index: "0"
-              config.kubernetes.io/path: Kptfile
-              internal.config.kubernetes.io/index: "0"
-              internal.config.kubernetes.io/path: Kptfile
-            name: basens-clone
-          upstream:
-            git:
-              directory: basens
-              ref: basens/v1
-              repo: https://github.com/platkrm/test-blueprints
-            type: git
-          upstreamLock:
-            git:
-              commit: 67f29546028f0a48c6bbb08614934d0e070cdd3a
-              directory: basens
-              ref: basens/v1
-              repo: https://github.com/platkrm/test-blueprints
-            type: git
-        - apiVersion: v1
-          kind: Namespace
-          metadata:
-            annotations:
-              config.kubernetes.io/index: "0"
-              config.kubernetes.io/path: namespace.yaml
-              internal.config.kubernetes.io/index: "0"
-              internal.config.kubernetes.io/path: namespace.yaml
-            name: example
+      - apiVersion: kpt.dev/v1
+        info:
+          description: sample description
+        kind: Kptfile
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/path: Kptfile
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: Kptfile
+          name: basens-clone
+        upstream:
+          git:
+            directory: basens
+            ref: basens/v1
+            repo: https://github.com/platkrm/test-blueprints
+          type: git
+        upstreamLock:
+          git:
+            commit: 67f29546028f0a48c6bbb08614934d0e070cdd3a
+            directory: basens
+            ref: basens/v1
+            repo: https://github.com/platkrm/test-blueprints
+          type: git
+      - apiVersion: v1
+        kind: Namespace
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/path: namespace.yaml
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: namespace.yaml
+          name: example
       kind: ResourceList
     yaml: true
   - args:
@@ -79,28 +79,28 @@ commands:
     stdout: |
       apiVersion: config.kubernetes.io/v1
       items:
-        - apiVersion: kpt.dev/v1
-          info:
-            description: Empty Blueprint
-          kind: Kptfile
-          metadata:
-            annotations:
-              config.kubernetes.io/index: "0"
-              internal.config.kubernetes.io/index: "0"
-              internal.config.kubernetes.io/path: Kptfile
-            name: empty-clone
-          upstream:
-            git:
-              directory: empty
-              ref: v1
-              repo: https://github.com/platkrm/test-blueprints
-            type: git
-          upstreamLock:
-            git:
-              commit: 3de8635354eda8e7de756494a4e0eb5c12af01ab
-              directory: empty
-              ref: v1
-              repo: https://github.com/platkrm/test-blueprints
-            type: git
+      - apiVersion: kpt.dev/v1
+        info:
+          description: Empty Blueprint
+        kind: Kptfile
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: Kptfile
+          name: empty-clone
+        upstream:
+          git:
+            directory: empty
+            ref: v1
+            repo: https://github.com/platkrm/test-blueprints
+          type: git
+        upstreamLock:
+          git:
+            commit: 3de8635354eda8e7de756494a4e0eb5c12af01ab
+            directory: empty
+            ref: v1
+            repo: https://github.com/platkrm/test-blueprints
+          type: git
       kind: ResourceList
     yaml: true

--- a/e2e/testdata/porch/rpkg-init-deploy/config.yaml
+++ b/e2e/testdata/porch/rpkg-init-deploy/config.yaml
@@ -35,32 +35,33 @@ commands:
       - git:test-package:v0
     stdout: |
       apiVersion: config.kubernetes.io/v1
-      kind: ResourceList
       items:
-      - apiVersion: kpt.dev/v1
-        kind: Kptfile
-        metadata:
-          name: test-package
-          annotations:
-            config.kubernetes.io/path: 'Kptfile'
-            internal.config.kubernetes.io/path: 'Kptfile'
-            config.kubernetes.io/index: '0'
-            internal.config.kubernetes.io/index: '0'
-        info:
-          site: http://kpt.dev/test-package
-          description: Test Package Description
-          keywords:
-          - test
-          - package
-      - apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: kptfile.kpt.dev
-          annotations:
-            config.kubernetes.io/local-config: "true"
-            config.kubernetes.io/index: '0'
-            internal.config.kubernetes.io/index: '0'
-            internal.config.kubernetes.io/path: 'package-context.yaml'
-            config.kubernetes.io/path: 'package-context.yaml'
-        data:
-          name: test-package
+        - apiVersion: kpt.dev/v1
+          info:
+            description: Test Package Description
+            keywords:
+              - test
+              - package
+            site: http://kpt.dev/test-package
+          kind: Kptfile
+          metadata:
+            annotations:
+              config.kubernetes.io/index: "0"
+              config.kubernetes.io/path: Kptfile
+              internal.config.kubernetes.io/index: "0"
+              internal.config.kubernetes.io/path: Kptfile
+            name: test-package
+        - apiVersion: v1
+          data:
+            name: test-package
+          kind: ConfigMap
+          metadata:
+            annotations:
+              config.kubernetes.io/index: "0"
+              config.kubernetes.io/local-config: "true"
+              config.kubernetes.io/path: package-context.yaml
+              internal.config.kubernetes.io/index: "0"
+              internal.config.kubernetes.io/path: package-context.yaml
+            name: kptfile.kpt.dev
+      kind: ResourceList
+    yaml: true

--- a/e2e/testdata/porch/rpkg-init-deploy/config.yaml
+++ b/e2e/testdata/porch/rpkg-init-deploy/config.yaml
@@ -36,32 +36,32 @@ commands:
     stdout: |
       apiVersion: config.kubernetes.io/v1
       items:
-        - apiVersion: kpt.dev/v1
-          info:
-            description: Test Package Description
-            keywords:
-              - test
-              - package
-            site: http://kpt.dev/test-package
-          kind: Kptfile
-          metadata:
-            annotations:
-              config.kubernetes.io/index: "0"
-              config.kubernetes.io/path: Kptfile
-              internal.config.kubernetes.io/index: "0"
-              internal.config.kubernetes.io/path: Kptfile
-            name: test-package
-        - apiVersion: v1
-          data:
-            name: test-package
-          kind: ConfigMap
-          metadata:
-            annotations:
-              config.kubernetes.io/index: "0"
-              config.kubernetes.io/local-config: "true"
-              config.kubernetes.io/path: package-context.yaml
-              internal.config.kubernetes.io/index: "0"
-              internal.config.kubernetes.io/path: package-context.yaml
-            name: kptfile.kpt.dev
+      - apiVersion: kpt.dev/v1
+        info:
+          description: Test Package Description
+          keywords:
+          - test
+          - package
+          site: http://kpt.dev/test-package
+        kind: Kptfile
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/path: Kptfile
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: Kptfile
+          name: test-package
+      - apiVersion: v1
+        data:
+          name: test-package
+        kind: ConfigMap
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/local-config: "true"
+            config.kubernetes.io/path: package-context.yaml
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: package-context.yaml
+          name: kptfile.kpt.dev
       kind: ResourceList
     yaml: true

--- a/e2e/testdata/porch/rpkg-init/config.yaml
+++ b/e2e/testdata/porch/rpkg-init/config.yaml
@@ -34,19 +34,20 @@ commands:
       - git:test-package:v0
     stdout: |
       apiVersion: config.kubernetes.io/v1
-      kind: ResourceList
       items:
-      - apiVersion: kpt.dev/v1
-        kind: Kptfile
-        metadata:
-          name: test-package
-          annotations:
-            config.kubernetes.io/index: '0'
-            internal.config.kubernetes.io/index: '0'
-            internal.config.kubernetes.io/path: 'Kptfile'
-        info:
-          site: http://kpt.dev/test-package
-          description: Test Package Description
-          keywords:
-          - test
-          - package
+        - apiVersion: kpt.dev/v1
+          info:
+            description: Test Package Description
+            keywords:
+              - test
+              - package
+            site: http://kpt.dev/test-package
+          kind: Kptfile
+          metadata:
+            annotations:
+              config.kubernetes.io/index: "0"
+              internal.config.kubernetes.io/index: "0"
+              internal.config.kubernetes.io/path: Kptfile
+            name: test-package
+      kind: ResourceList
+    yaml: true

--- a/e2e/testdata/porch/rpkg-init/config.yaml
+++ b/e2e/testdata/porch/rpkg-init/config.yaml
@@ -35,19 +35,19 @@ commands:
     stdout: |
       apiVersion: config.kubernetes.io/v1
       items:
-        - apiVersion: kpt.dev/v1
-          info:
-            description: Test Package Description
-            keywords:
-              - test
-              - package
-            site: http://kpt.dev/test-package
-          kind: Kptfile
-          metadata:
-            annotations:
-              config.kubernetes.io/index: "0"
-              internal.config.kubernetes.io/index: "0"
-              internal.config.kubernetes.io/path: Kptfile
-            name: test-package
+      - apiVersion: kpt.dev/v1
+        info:
+          description: Test Package Description
+          keywords:
+          - test
+          - package
+          site: http://kpt.dev/test-package
+        kind: Kptfile
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: Kptfile
+          name: test-package
       kind: ResourceList
     yaml: true

--- a/e2e/testdata/porch/rpkg-push/config.yaml
+++ b/e2e/testdata/porch/rpkg-push/config.yaml
@@ -21,16 +21,16 @@ commands:
     stdout: |
       apiVersion: config.kubernetes.io/v1
       items:
-        - apiVersion: kpt.dev/v1
-          info:
-            description: sample description
-          kind: Kptfile
-          metadata:
-            annotations:
-              config.kubernetes.io/index: "0"
-              internal.config.kubernetes.io/index: "0"
-              internal.config.kubernetes.io/path: Kptfile
-            name: test-package
+      - apiVersion: kpt.dev/v1
+        info:
+          description: sample description
+        kind: Kptfile
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: Kptfile
+          name: test-package
       kind: ResourceList
     yaml: true
   - args:
@@ -72,28 +72,28 @@ commands:
     stdout: |
       apiVersion: config.kubernetes.io/v1
       items:
-        - apiVersion: kpt.dev/v1
-          info:
-            description: Updated Test Package Description
-            site: http://kpt.dev/test-package
-          kind: Kptfile
-          metadata:
-            annotations:
-              config.kubernetes.io/index: "0"
-              config.kubernetes.io/path: Kptfile
-              internal.config.kubernetes.io/index: "0"
-              internal.config.kubernetes.io/path: Kptfile
-            name: test-package
-        - apiVersion: v1
-          data:
-            key: value
-          kind: ConfigMap
-          metadata:
-            annotations:
-              config.kubernetes.io/index: "0"
-              config.kubernetes.io/path: config-map.yaml
-              internal.config.kubernetes.io/index: "0"
-              internal.config.kubernetes.io/path: config-map.yaml
-            name: new-config-map
+      - apiVersion: kpt.dev/v1
+        info:
+          description: Updated Test Package Description
+          site: http://kpt.dev/test-package
+        kind: Kptfile
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/path: Kptfile
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: Kptfile
+          name: test-package
+      - apiVersion: v1
+        data:
+          key: value
+        kind: ConfigMap
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/path: config-map.yaml
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: config-map.yaml
+          name: new-config-map
       kind: ResourceList
     yaml: true

--- a/e2e/testdata/porch/rpkg-push/config.yaml
+++ b/e2e/testdata/porch/rpkg-push/config.yaml
@@ -20,18 +20,19 @@ commands:
       - git:test-package:v0
     stdout: |
       apiVersion: config.kubernetes.io/v1
-      kind: ResourceList
       items:
-      - apiVersion: kpt.dev/v1
-        kind: Kptfile
-        metadata:
-          name: test-package
-          annotations:
-            config.kubernetes.io/index: '0'
-            internal.config.kubernetes.io/index: '0'
-            internal.config.kubernetes.io/path: 'Kptfile'
-        info:
-          description: sample description
+        - apiVersion: kpt.dev/v1
+          info:
+            description: sample description
+          kind: Kptfile
+          metadata:
+            annotations:
+              config.kubernetes.io/index: "0"
+              internal.config.kubernetes.io/index: "0"
+              internal.config.kubernetes.io/path: Kptfile
+            name: test-package
+      kind: ResourceList
+    yaml: true
   - args:
       - alpha
       - rpkg
@@ -70,28 +71,29 @@ commands:
       - git:test-package:v0
     stdout: |
       apiVersion: config.kubernetes.io/v1
-      kind: ResourceList
       items:
-      - apiVersion: kpt.dev/v1
-        kind: Kptfile
-        metadata:
-          name: test-package
-          annotations:
-            config.kubernetes.io/index: '0'
-            internal.config.kubernetes.io/index: '0'
-            internal.config.kubernetes.io/path: 'Kptfile'
-            config.kubernetes.io/path: 'Kptfile'
-        info:
-          site: http://kpt.dev/test-package
-          description: Updated Test Package Description
-      - apiVersion: v1
-        kind: ConfigMap
-        metadata:
-          name: new-config-map
-          annotations:
-            config.kubernetes.io/path: 'config-map.yaml'
-            internal.config.kubernetes.io/path: 'config-map.yaml'
-            config.kubernetes.io/index: '0'
-            internal.config.kubernetes.io/index: '0'
-        data:
-          key: value
+        - apiVersion: kpt.dev/v1
+          info:
+            description: Updated Test Package Description
+            site: http://kpt.dev/test-package
+          kind: Kptfile
+          metadata:
+            annotations:
+              config.kubernetes.io/index: "0"
+              config.kubernetes.io/path: Kptfile
+              internal.config.kubernetes.io/index: "0"
+              internal.config.kubernetes.io/path: Kptfile
+            name: test-package
+        - apiVersion: v1
+          data:
+            key: value
+          kind: ConfigMap
+          metadata:
+            annotations:
+              config.kubernetes.io/index: "0"
+              config.kubernetes.io/path: config-map.yaml
+              internal.config.kubernetes.io/index: "0"
+              internal.config.kubernetes.io/path: config-map.yaml
+            name: new-config-map
+      kind: ResourceList
+    yaml: true

--- a/pkg/test/porch/config.go
+++ b/pkg/test/porch/config.go
@@ -34,6 +34,8 @@ type Command struct {
 	Stderr string `yaml:"stderr,omitempty"`
 	// ExitCode is the expected exit code frm the command.
 	ExitCode int `yaml:"exitCode,omitempty"`
+	// Yaml indicates that stdout is yaml and the test will reformat it for stable ordering
+	Yaml bool `yaml:"yaml,omitempty"`
 }
 
 type TestCaseConfig struct {

--- a/porch/.vscode/launch.json
+++ b/porch/.vscode/launch.json
@@ -63,6 +63,7 @@
             "mode": "test",
             "program": "${workspaceFolder}/../e2e",
             "args": [
+                "-v",
                 "-test.run",
                 "TestPorch"
             ]


### PR DESCRIPTION
The go-yaml serializer orders nodes deterministically. Use it to create output
that can be compared reliably.
