### PR TITLE
add local-config annotation to kptfile

### DIFF
--- a/internal/cmdinit/cmdinit.go
+++ b/internal/cmdinit/cmdinit.go
@@ -35,6 +35,7 @@ import (
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/kustomize/kyaml/errors"
 	"sigs.k8s.io/kustomize/kyaml/filesys"
+	"sigs.k8s.io/kustomize/kyaml/kio/filters"
 	"sigs.k8s.io/kustomize/kyaml/yaml"
 )
 
@@ -103,6 +104,10 @@ func (r *Runner) runE(c *cobra.Command, args []string) error {
 				ObjectMeta: yaml.ObjectMeta{
 					NameMeta: yaml.NameMeta{
 						Name: r.Name,
+					},
+					// mark Kptfile as local-config
+					Annotations: map[string]string{
+						filters.LocalConfigAnnotation: "true",
 					},
 				},
 			},

--- a/internal/cmdinit/cmdinit_test.go
+++ b/internal/cmdinit/cmdinit_test.go
@@ -50,6 +50,8 @@ func TestCmd(t *testing.T) {
 kind: Kptfile
 metadata:
   name: my-pkg
+  annotations:
+    config.kubernetes.io/local-config: "true"
 info:
   description: my description
 `, string(b))
@@ -115,6 +117,8 @@ func TestCmd_currentDir(t *testing.T) {
 kind: Kptfile
 metadata:
   name: my-pkg
+  annotations:
+    config.kubernetes.io/local-config: "true"
 info:
   description: my description
 `, string(b))
@@ -151,6 +155,8 @@ func TestCmd_DefaultToCurrentDir(t *testing.T) {
 kind: Kptfile
 metadata:
   name: my-pkg
+  annotations:
+    config.kubernetes.io/local-config: "true"
 info:
   description: my description
 `, string(b))


### PR DESCRIPTION
With this change, `Kptfile` created on `kpt pkg init` will have local-config annotation set to "true".