### PR TITLE
WIP: Create multi-runtime capability

### DIFF
--- a/pkg/fn/eval.go
+++ b/pkg/fn/eval.go
@@ -16,6 +16,7 @@ package fn
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	v1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
@@ -28,6 +29,15 @@ type FunctionRunner interface {
 }
 
 // FunctionRuntime provides a way to obtain a function runner to be used for a given function configuration.
+// If the function is not found, this should return an error that includes a NotFoundError in the chain.
 type FunctionRuntime interface {
 	GetRunner(ctx context.Context, fn *v1.Function) (FunctionRunner, error)
+}
+
+type NotFoundError struct {
+	Function v1.Function
+}
+
+func (e *NotFoundError) Error() string {
+	return fmt.Sprintf("function %q not found", e.Function.Image)
 }

--- a/pkg/fn/eval_test.go
+++ b/pkg/fn/eval_test.go
@@ -1,0 +1,43 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fn
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	v1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
+)
+
+func TestNotFound(t *testing.T) {
+	var err error
+
+	fn := &v1.Function{Image: "foo"}
+	err = &NotFoundError{Function: *fn}
+
+	var notFoundErr *NotFoundError
+	if !errors.As(err, &notFoundErr) {
+		t.Fatalf("expected NotFoundError to satisfy errors.As")
+	}
+
+	if got, want := notFoundErr.Function, *fn; !reflect.DeepEqual(got, want) {
+		t.Fatalf("function in NotFoundError did not match expected; got %#v, want %#v", got, want)
+	}
+
+	if got, want := notFoundErr.Error(), "function \"foo\" not found"; !reflect.DeepEqual(got, want) {
+		t.Fatalf("string form NotFoundError did not match expected; got %#v, want %#v", got, want)
+	}
+}

--- a/pkg/fn/multiruntime.go
+++ b/pkg/fn/multiruntime.go
@@ -1,0 +1,55 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fn
+
+import (
+	"context"
+	"errors"
+
+	v1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
+)
+
+// MultiRuntime is a compound FunctionRuntime that will use the first available runner.
+type MultiRuntime struct {
+	runtimes []FunctionRuntime
+}
+
+// NewMultiRuntime builds a MultiRuntime.
+func NewMultiRuntime(runtimes []FunctionRuntime) *MultiRuntime {
+	return &MultiRuntime{
+		runtimes: runtimes,
+	}
+}
+
+var _ FunctionRuntime = &MultiRuntime{}
+
+// GetRunner implements FunctionRuntime
+func (r *MultiRuntime) GetRunner(ctx context.Context, fn *v1.Function) (FunctionRunner, error) {
+	for _, runtime := range r.runtimes {
+		runner, err := runtime.GetRunner(ctx, fn)
+		if err != nil {
+			var notFoundError *NotFoundError
+			if errors.As(err, &notFoundError) {
+				// maybe another runtime
+			} else {
+				return nil, err
+			}
+		} else {
+			return runner, nil
+		}
+	}
+
+	return nil, &NotFoundError{Function: *fn}
+}

--- a/porch/engine/pkg/engine/grpcruntime.go
+++ b/porch/engine/pkg/engine/grpcruntime.go
@@ -36,6 +36,7 @@ type grpcRuntime struct {
 var _ kpt.FunctionRuntime = &grpcRuntime{}
 
 func (gr *grpcRuntime) GetRunner(ctx context.Context, fn *v1.Function) (fn.FunctionRunner, error) {
+	// TODO: Check if the function is actually available?
 	return &grpcRunner{
 		ctx:    ctx,
 		client: gr.client,

--- a/porch/engine/pkg/kpt/eval.go
+++ b/porch/engine/pkg/kpt/eval.go
@@ -16,7 +16,6 @@ package kpt
 
 import (
 	"context"
-	"fmt"
 	"io"
 
 	kptfilev1 "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
@@ -39,7 +38,7 @@ var _ FunctionRuntime = &runtime{}
 func (e *runtime) GetRunner(ctx context.Context, fn *kptfilev1.Function) (fn.FunctionRunner, error) {
 	processor := internal.FindProcessor(fn.Image)
 	if processor == nil {
-		return nil, fmt.Errorf("unsupported kpt function %q", fn.Image)
+		return nil, &fn.NotFoundError{Function: *fn}
 	}
 
 	return &runner{


### PR DESCRIPTION
Better define the error when a function is not found, and use this to
support multiple engines.
