### PR TITLE
Create Lifecycle Strategies

### DIFF
--- a/porch/apiserver/pkg/e2e/e2e_test.go
+++ b/porch/apiserver/pkg/e2e/e2e_test.go
@@ -562,6 +562,12 @@ func (t *PorchSuite) TestProposeApprove(ctx context.Context) {
 		t.Fatalf("Proposed package lifecycle value: got %s, want %s", got, want)
 	}
 
+	// Approve using Update should fail.
+	proposed.Spec.Lifecycle = v1alpha1.PackageRevisionLifecycleFinal
+	if err := t.client.Update(ctx, &proposed); err == nil {
+		t.Fatalf("Finalization of a package via Update unexpectedly succeeded")
+	}
+
 	// Approve the package
 	proposed.Spec.Lifecycle = v1alpha1.PackageRevisionLifecycleFinal
 	approved := t.UpdateApprovalF(ctx, &proposed, metav1.UpdateOptions{})

--- a/porch/apiserver/pkg/registry/porch/packagecommon.go
+++ b/porch/apiserver/pkg/registry/porch/packagecommon.go
@@ -18,22 +18,28 @@ import (
 	"context"
 	"fmt"
 
+	api "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
 	configapi "github.com/GoogleContainerTools/kpt/porch/controllers/pkg/apis/porch/v1alpha1"
 	"github.com/GoogleContainerTools/kpt/porch/engine/pkg/engine"
 	"github.com/GoogleContainerTools/kpt/porch/repository/pkg/repository"
+	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type packageCommon struct {
 	cad engine.CaDEngine
 	// coreClient is a client back to the core kubernetes API server, useful for querying CRDs etc
-	coreClient client.Client
-
-	gr schema.GroupResource
+	coreClient     client.Client
+	gr             schema.GroupResource
+	updateStrategy SimpleRESTUpdateStrategy
 }
 
 func (r *packageCommon) listPackages(ctx context.Context, callback func(p repository.PackageRevision) error) error {
@@ -104,4 +110,90 @@ func (r *packageCommon) getPackage(ctx context.Context, name string) (repository
 	}
 
 	return nil, apierrors.NewNotFound(r.gr, name)
+}
+
+func (r *packageCommon) getPackageRevision(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	pkg, err := r.getPackage(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+
+	obj, err := pkg.GetPackageRevision()
+	if err != nil {
+		return nil, err
+	}
+	return obj, nil
+}
+
+// Common implementation of PackageRevision update logic.
+func (r *packageCommon) updatePackageRevision(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	// TODO: Is this all boilerplate??
+
+	ns, namespaced := genericapirequest.NamespaceFrom(ctx)
+	if !namespaced {
+		return nil, false, apierrors.NewBadRequest("namespace must be specified")
+	}
+
+	oldPackage, err := r.getPackage(ctx, name)
+	if err != nil {
+		return nil, false, err
+	}
+
+	oldObj, err := oldPackage.GetPackageRevision()
+	if err != nil {
+		klog.Infof("update failed to retrieve old object: %v", err)
+		return nil, false, err
+	}
+
+	newRuntimeObj, err := objInfo.UpdatedObject(ctx, oldObj)
+	if err != nil {
+		klog.Infof("update failed to construct UpdatedObject: %v", err)
+		return nil, false, err
+	}
+
+	r.updateStrategy.PrepareForUpdate(ctx, newRuntimeObj, oldObj)
+
+	if updateValidation != nil {
+		err := updateValidation(ctx, newRuntimeObj, oldObj)
+		if err != nil {
+			klog.Infof("update failed validation: %v", err)
+			return nil, false, err
+		}
+	}
+
+	fieldErrors := r.updateStrategy.ValidateUpdate(ctx, newRuntimeObj, oldObj)
+	if len(fieldErrors) > 0 {
+		return nil, false, errors.NewInvalid(api.SchemeGroupVersion.WithKind("PackageRevision").GroupKind(), oldObj.Name, fieldErrors)
+	}
+	r.updateStrategy.Canonicalize(newRuntimeObj)
+
+	newObj, ok := newRuntimeObj.(*api.PackageRevision)
+	if !ok {
+		return nil, false, apierrors.NewBadRequest(fmt.Sprintf("expected PackageRevision object, got %T", newRuntimeObj))
+	}
+
+	nameTokens, err := ParseName(name)
+	if err != nil {
+		return nil, false, apierrors.NewBadRequest(fmt.Sprintf("invalid name %q", name))
+	}
+
+	var repositoryObj configapi.Repository
+	repositoryID := types.NamespacedName{Namespace: ns, Name: nameTokens.RepositoryName}
+	if err := r.coreClient.Get(ctx, repositoryID, &repositoryObj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, false, apierrors.NewNotFound(api.PackageRevisionResourcesGVR.GroupResource(), repositoryID.Name)
+		}
+		return nil, false, apierrors.NewInternalError(fmt.Errorf("error getting repository %v: %w", repositoryID, err))
+	}
+
+	rev, err := r.cad.UpdatePackageRevision(ctx, &repositoryObj, oldPackage, oldObj, newObj)
+	if err != nil {
+		return nil, false, apierrors.NewInternalError(err)
+	}
+
+	created, err := rev.GetPackageRevision()
+	if err != nil {
+		return nil, false, apierrors.NewInternalError(err)
+	}
+	return created, false, nil
 }

--- a/porch/apiserver/pkg/registry/porch/packagerevision_approval_test.go
+++ b/porch/apiserver/pkg/registry/porch/packagerevision_approval_test.go
@@ -1,0 +1,66 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package porch
+
+import (
+	"testing"
+
+	api "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
+)
+
+func TestApprovalUpdateStrategy(t *testing.T) {
+	s := packageRevisionApprovalStrategy{}
+
+	type testCase struct {
+		old     api.PackageRevisionLifecycle
+		valid   []api.PackageRevisionLifecycle
+		invalid []api.PackageRevisionLifecycle
+	}
+
+	for _, tc := range []testCase{
+		{
+			old:     "",
+			valid:   []api.PackageRevisionLifecycle{},
+			invalid: []api.PackageRevisionLifecycle{"", "Wrong", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed, api.PackageRevisionLifecycleFinal},
+		},
+		{
+			old:     "Wrong",
+			valid:   []api.PackageRevisionLifecycle{},
+			invalid: []api.PackageRevisionLifecycle{"", "Wrong", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed, api.PackageRevisionLifecycleFinal},
+		},
+		{
+			old:     api.PackageRevisionLifecycleDraft,
+			valid:   []api.PackageRevisionLifecycle{},
+			invalid: []api.PackageRevisionLifecycle{"", "Wrong", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed, api.PackageRevisionLifecycleFinal},
+		},
+		{
+			old:     api.PackageRevisionLifecycleFinal,
+			valid:   []api.PackageRevisionLifecycle{},
+			invalid: []api.PackageRevisionLifecycle{"", "Wrong", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed, api.PackageRevisionLifecycleFinal},
+		},
+		{
+			old:     api.PackageRevisionLifecycleProposed,
+			valid:   []api.PackageRevisionLifecycle{api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleFinal},
+			invalid: []api.PackageRevisionLifecycle{"", "Wrong", api.PackageRevisionLifecycleProposed},
+		},
+	} {
+		for _, new := range tc.valid {
+			testValidateUpdate(t, s, tc.old, new, true)
+		}
+		for _, new := range tc.invalid {
+			testValidateUpdate(t, s, tc.old, new, false)
+		}
+	}
+}

--- a/porch/apiserver/pkg/registry/porch/packagerevision_test.go
+++ b/porch/apiserver/pkg/registry/porch/packagerevision_test.go
@@ -1,0 +1,66 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package porch
+
+import (
+	"testing"
+
+	api "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
+)
+
+func TestUpdateStrategy(t *testing.T) {
+	type testCase struct {
+		old     api.PackageRevisionLifecycle
+		valid   []api.PackageRevisionLifecycle
+		invalid []api.PackageRevisionLifecycle
+	}
+
+	s := packageRevisionStrategy{}
+
+	for _, tc := range []testCase{
+		{
+			old:     "",
+			valid:   []api.PackageRevisionLifecycle{"", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed},
+			invalid: []api.PackageRevisionLifecycle{"Wrong", api.PackageRevisionLifecycleFinal},
+		},
+		{
+			old:     api.PackageRevisionLifecycleDraft,
+			valid:   []api.PackageRevisionLifecycle{"", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed},
+			invalid: []api.PackageRevisionLifecycle{"Wrong", api.PackageRevisionLifecycleFinal},
+		},
+		{
+			old:     api.PackageRevisionLifecycleProposed,
+			valid:   []api.PackageRevisionLifecycle{"", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed},
+			invalid: []api.PackageRevisionLifecycle{"Wrong", api.PackageRevisionLifecycleFinal},
+		},
+		{
+			old:     api.PackageRevisionLifecycleFinal,
+			valid:   []api.PackageRevisionLifecycle{},
+			invalid: []api.PackageRevisionLifecycle{"", "Wrong", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed, api.PackageRevisionLifecycleFinal},
+		},
+		{
+			old:     "Wrong",
+			valid:   []api.PackageRevisionLifecycle{},
+			invalid: []api.PackageRevisionLifecycle{"", "Wrong", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed, api.PackageRevisionLifecycleFinal},
+		},
+	} {
+		for _, new := range tc.valid {
+			testValidateUpdate(t, s, tc.old, new, true)
+		}
+		for _, new := range tc.invalid {
+			testValidateUpdate(t, s, tc.old, new, false)
+		}
+	}
+}

--- a/porch/apiserver/pkg/registry/porch/packagerevisions_approval.go
+++ b/porch/apiserver/pkg/registry/porch/packagerevisions_approval.go
@@ -69,7 +69,8 @@ func (s packageRevisionApprovalStrategy) ValidateUpdate(ctx context.Context, obj
 	newRevision := obj.(*api.PackageRevision)
 
 	if lifecycle := oldRevision.Spec.Lifecycle; lifecycle != api.PackageRevisionLifecycleProposed {
-		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "lifecycle"), lifecycle, fmt.Sprintf("cannot only approve package with Proposed lifecycle value")))
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "lifecycle"), lifecycle,
+			fmt.Sprintf("can only approve package with Proposed lifecycle value")))
 	}
 
 	switch lifecycle := newRevision.Spec.Lifecycle; lifecycle {

--- a/porch/apiserver/pkg/registry/porch/rest.go
+++ b/porch/apiserver/pkg/registry/porch/rest.go
@@ -1,0 +1,38 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package porch
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// SimpleRESTUpdateStrategy is similar to rest.RESTUpdateStrategy, though only contains
+// methods currently required.
+type SimpleRESTUpdateStrategy interface {
+	PrepareForUpdate(ctx context.Context, obj, old runtime.Object)
+	ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList
+	Canonicalize(obj runtime.Object)
+}
+
+type NoopUpdateStrategy struct{}
+
+func (s NoopUpdateStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {}
+func (s NoopUpdateStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
+	return nil
+}
+func (s NoopUpdateStrategy) Canonicalize(obj runtime.Object) {}

--- a/porch/apiserver/pkg/registry/porch/storage.go
+++ b/porch/apiserver/pkg/registry/porch/storage.go
@@ -29,14 +29,20 @@ func NewRESTStorage(scheme *runtime.Scheme, codecs serializer.CodecFactory, cad 
 	packageRevisions := &packageRevisions{
 		TableConvertor: rest.NewDefaultTableConvertor(porch.Resource("packagerevisions")),
 		packageCommon: packageCommon{
-			cad:        cad,
-			gr:         porch.Resource("packagerevisions"),
-			coreClient: coreClient,
+			cad:            cad,
+			gr:             porch.Resource("packagerevisions"),
+			coreClient:     coreClient,
+			updateStrategy: packageRevisionStrategy{},
 		},
 	}
 
 	packageRevisionsApproval := &packageRevisionsApproval{
-		revisions: packageRevisions,
+		common: packageCommon{
+			cad:            cad,
+			coreClient:     coreClient,
+			gr:             porch.Resource("packagerevisions"),
+			updateStrategy: packageRevisionApprovalStrategy{},
+		},
 	}
 
 	packageRevisionResources := &packageRevisionResources{

--- a/porch/apiserver/pkg/registry/porch/testing.go
+++ b/porch/apiserver/pkg/registry/porch/testing.go
@@ -1,0 +1,51 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package porch
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	api "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
+)
+
+func testValidateUpdate(t *testing.T, s SimpleRESTUpdateStrategy, old, new api.PackageRevisionLifecycle, valid bool) {
+	ctx := context.Background()
+	t.Run(fmt.Sprintf("%s-%s", old, new), func(t *testing.T) {
+		oldRev := &api.PackageRevision{
+			Spec: api.PackageRevisionSpec{
+				Lifecycle: old,
+			},
+		}
+		newRev := &api.PackageRevision{
+			Spec: api.PackageRevisionSpec{
+				Lifecycle: new,
+			},
+		}
+
+		allErrs := s.ValidateUpdate(ctx, newRev, oldRev)
+
+		if valid {
+			if len(allErrs) > 0 {
+				t.Errorf("Update %s -> %s failed unexpectedly: %v", old, new, allErrs.ToAggregate().Error())
+			}
+		} else {
+			if len(allErrs) == 0 {
+				t.Errorf("Update %s -> %s should fail but didn't", old, new)
+			}
+		}
+	})
+}


### PR DESCRIPTION
`packageCommon` now carries update strategy similar to what k8s
apiserver uses (though simpler) to validate package revision lifecycle
values and enforce approval flow via the subresource.
