### PR TITLE
feat: change `--save` behavior from skip to Override

### DIFF
--- a/e2e/testdata/fn-eval/save-fn/exec/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/exec/.expected/config.yaml
@@ -15,4 +15,5 @@
 stdErr: |
   [RUNNING] "./function.sh"
   [PASS] "./function.sh" in 0s
-  function is added to Kptfile
+  adding function to Kptfile
+  Kptfile updated

--- a/e2e/testdata/fn-eval/save-fn/match-selector/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/match-selector/.expected/config.yaml
@@ -15,4 +15,5 @@
 stdErr: |
   [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3" on 1 resource(s)
   [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s
-  function is added to Kptfile
+  adding function to Kptfile
+  Kptfile updated

--- a/e2e/testdata/fn-eval/save-fn/override-fn/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/override-fn/.expected/config.yaml
@@ -19,5 +19,5 @@ args:
 stdErr: |
   [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3"
   [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s
-  adding function to Kptfile
+  found image in Kptfile, updating...
   Kptfile updated

--- a/e2e/testdata/fn-eval/save-fn/override-fn/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/save-fn/override-fn/.expected/diff.patch
@@ -1,0 +1,35 @@
+diff --git a/Kptfile b/Kptfile
+index 4a1e2fa..f094437 100644
+--- a/Kptfile
++++ b/Kptfile
+@@ -4,7 +4,7 @@ metadata:
+   name: app
+ pipeline:
+   mutators:
+-  - image: gcr.io/kpt-fn/set-namespace:v0.1.3
+-    configMap:
+-      namespace: oldNs
+-    name: gcr.io/kpt-fn/set-namespace:v0.1.3
++    - image: gcr.io/kpt-fn/set-namespace:v0.1.3
++      configMap:
++        namespace: newNs
++      name: gcr.io/kpt-fn/set-namespace:v0.1.3
+diff --git a/resources.yaml b/resources.yaml
+index ac634f3..80e1b9e 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -15,6 +15,7 @@ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+   name: nginx-deployment
++  namespace: newNs
+ spec:
+   replicas: 3
+ ---
+@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
+ kind: Custom
+ metadata:
+   name: custom
++  namespace: newNs
+ spec:
+   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/save-fn/override-fn/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/override-fn/.expected/exec.sh
@@ -1,4 +1,5 @@
-# Copyright 2022 Google LLC
+#! /bin/bash
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-testType: eval
-image: set-namespace:v0.1.3
-args:
-  namespace: staging
-stdErr: |
-  [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3"
-  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s
-  adding function to Kptfile
-  Kptfile updated
+set -eo pipefail
+
+kpt fn eval -s -i set-namespace:v0.1.3 -- namespace=newNs

--- a/e2e/testdata/fn-eval/save-fn/override-fn/.krmignore
+++ b/e2e/testdata/fn-eval/save-fn/override-fn/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-eval/save-fn/override-fn/Kptfile
+++ b/e2e/testdata/fn-eval/save-fn/override-fn/Kptfile
@@ -1,0 +1,10 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: app
+pipeline:
+  mutators:
+  - image: gcr.io/kpt-fn/set-namespace:v0.1.3
+    configMap:
+      namespace: oldNs
+    name: gcr.io/kpt-fn/set-namespace:v0.1.3

--- a/e2e/testdata/fn-eval/save-fn/override-fn/resources.yaml
+++ b/e2e/testdata/fn-eval/save-fn/override-fn/resources.yaml
@@ -11,13 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-testType: eval
-image: set-namespace:v0.1.3
-args:
-  namespace: staging
-stdErr: |
-  [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3"
-  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s
-  adding function to Kptfile
-  Kptfile updated
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+spec:
+  image: nginx:1.2.3


### PR DESCRIPTION
- `--save` flag skips the Kptfile editing if it finds the fn in the mutators list. This PR changes the behavior to override the Kptfile with the new function arguments.
- bug fix: modify the Kptfile read/write path.

related:
- #2249 
- https://github.com/GoogleContainerTools/kpt/pull/2841#issuecomment-1081295669