### PR TITLE
Delete PackageRevisions in Git

### DIFF
--- a/porch/apiserver/pkg/e2e/e2e_test.go
+++ b/porch/apiserver/pkg/e2e/e2e_test.go
@@ -361,7 +361,8 @@ func (t *PorchSuite) TestInitTaskPackage(ctx context.Context) {
 func (t *PorchSuite) TestCloneIntoDeploymentRepository(ctx context.Context) {
 	const downstreamRepository = "deployment"
 	const downstreamPackage = "istions"
-	const downstreamName = downstreamRepository + ":" + downstreamPackage + ":v1"
+	const downstreamRevision = "v1"
+	const downstreamName = downstreamRepository + ":" + downstreamPackage + ":" + downstreamRevision
 
 	// Register the deployment repository
 	t.registerMainGitRepositoryF(ctx, downstreamRepository, withDeployment())
@@ -385,7 +386,7 @@ func (t *PorchSuite) TestCloneIntoDeploymentRepository(ctx context.Context) {
 		},
 		Spec: porchapi.PackageRevisionSpec{
 			PackageName:    downstreamPackage,
-			Revision:       "v1",
+			Revision:       downstreamRevision,
 			RepositoryName: downstreamRepository,
 			Tasks: []porchapi.Task{
 				{

--- a/porch/apiserver/pkg/e2e/e2e_test.go
+++ b/porch/apiserver/pkg/e2e/e2e_test.go
@@ -838,7 +838,7 @@ func (t *PorchSuite) createPackageDraftF(ctx context.Context, repository, name, 
 }
 
 func (t *PorchSuite) mustExist(ctx context.Context, key client.ObjectKey, obj client.Object) {
-	t.GetE(ctx, key, obj)
+	t.GetF(ctx, key, obj)
 	if got, want := obj.GetName(), key.Name; got != want {
 		t.Errorf("%T.Name: got %q, want %q", obj, got, want)
 	}

--- a/porch/apiserver/pkg/e2e/suite.go
+++ b/porch/apiserver/pkg/e2e/suite.go
@@ -243,6 +243,11 @@ func (t *TestSuite) CreateF(ctx context.Context, obj client.Object, opts ...clie
 func (t *TestSuite) CreateE(ctx context.Context, obj client.Object, opts ...client.CreateOption) {
 	t.create(ctx, obj, opts, t.Errorf)
 }
+
+func (t *TestSuite) DeleteF(ctx context.Context, obj client.Object, opts ...client.DeleteOption) {
+	t.delete(ctx, obj, opts, t.Fatalf)
+}
+
 func (t *TestSuite) DeleteE(ctx context.Context, obj client.Object, opts ...client.DeleteOption) {
 	t.delete(ctx, obj, opts, t.Errorf)
 }

--- a/porch/repository/pkg/git/commit.go
+++ b/porch/repository/pkg/git/commit.go
@@ -127,6 +127,9 @@ func initializeTrees(storer storage.Storer, root *object.Tree, packagePath strin
 		}
 		trees[packagePath] = packageTree
 		setOrAddDirEntry(parent, lastPart)
+	} else {
+		// Remove the entry if one exists
+		removeDirEntry(parent, lastPart)
 	}
 
 	return trees, nil
@@ -162,6 +165,17 @@ func setOrAddDirEntry(tree *object.Tree, name string) {
 	}
 	// Not found. append new
 	tree.Entries = append(tree.Entries, te)
+}
+
+func removeDirEntry(tree *object.Tree, name string) {
+	entries := tree.Entries
+	for i := range entries {
+		e := &entries[i]
+		if e.Name == name {
+			tree.Entries = append(entries[:i], entries[i+1:]...)
+			return
+		}
+	}
 }
 
 func (h *commitHelper) storeFile(path, contents string) error {

--- a/porch/repository/pkg/git/testing_repo.go
+++ b/porch/repository/pkg/git/testing_repo.go
@@ -203,3 +203,13 @@ func refMustNotExist(t *testing.T, repo *gogit.Repository, name plumbing.Referen
 		t.Fatalf("Unexpected error resolving reference %q: %v", name, err)
 	}
 }
+
+func forEachRef(t *testing.T, repo *gogit.Repository, fn func(*plumbing.Reference) error) {
+	refs, err := repo.References()
+	if err != nil {
+		t.Fatalf("Failed to create references iterator: %v", err)
+	}
+	if err := refs.ForEach(fn); err != nil {
+		t.Fatalf("References.ForEach faile: %v", err)
+	}
+}


### PR DESCRIPTION
If package has its own Git ref (own branch or package-specific tag),
the ref is deleted. This is true for drafts, proposals, and final
packages tagged with their own tag (refs/tags/<package patch>/revision).

If the package is tagged with general tag of a different format,
we can't delete it and deletion fails.

If the package is in a branch, we delete it by creating a commit
that removes it from that branch.

This change also includes few bug fixes that ensure that we track
package lifecycle correctly through package updates.
