### PR TITLE
Re-enable staticcheck

### DIFF
--- a/porch/Makefile
+++ b/porch/Makefile
@@ -115,7 +115,7 @@ test:
 
 .PHONY: vet
 vet:
-	@#for f in $(MODULES); do (cd $$f; echo "Checking $$f"; go run honnef.co/go/tools/cmd/staticcheck@latest ./...); done
+	@for f in $(MODULES); do (cd $$f; echo "Checking $$f"; go run honnef.co/go/tools/cmd/staticcheck@latest ./...); done
 	@for f in $(MODULES); do (cd $$f; echo "Vetting $$f"; go vet ./...) || exit 1; done
 
 .PHONY: fmt

--- a/porch/apiserver/pkg/registry/porch/packagecommon.go
+++ b/porch/apiserver/pkg/registry/porch/packagecommon.go
@@ -22,7 +22,6 @@ import (
 	configapi "github.com/GoogleContainerTools/kpt/porch/controllers/pkg/apis/porch/v1alpha1"
 	"github.com/GoogleContainerTools/kpt/porch/engine/pkg/engine"
 	"github.com/GoogleContainerTools/kpt/porch/repository/pkg/repository"
-	"k8s.io/apimachinery/pkg/api/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -163,7 +162,7 @@ func (r *packageCommon) updatePackageRevision(ctx context.Context, name string, 
 
 	fieldErrors := r.updateStrategy.ValidateUpdate(ctx, newRuntimeObj, oldObj)
 	if len(fieldErrors) > 0 {
-		return nil, false, errors.NewInvalid(api.SchemeGroupVersion.WithKind("PackageRevision").GroupKind(), oldObj.Name, fieldErrors)
+		return nil, false, apierrors.NewInvalid(api.SchemeGroupVersion.WithKind("PackageRevision").GroupKind(), oldObj.Name, fieldErrors)
 	}
 	r.updateStrategy.Canonicalize(newRuntimeObj)
 

--- a/porch/apiserver/pkg/registry/porch/packagerevisions_approval.go
+++ b/porch/apiserver/pkg/registry/porch/packagerevisions_approval.go
@@ -70,7 +70,7 @@ func (s packageRevisionApprovalStrategy) ValidateUpdate(ctx context.Context, obj
 
 	if lifecycle := oldRevision.Spec.Lifecycle; lifecycle != api.PackageRevisionLifecycleProposed {
 		allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "lifecycle"), lifecycle,
-			fmt.Sprintf("can only approve package with Proposed lifecycle value")))
+			fmt.Sprintf("cannot approve package with %s lifecycle value; only Proposed packages can be approved", lifecycle)))
 	}
 
 	switch lifecycle := newRevision.Spec.Lifecycle; lifecycle {

--- a/porch/controllers/remoterootsync/pkg/applyset/applyset.go
+++ b/porch/controllers/remoterootsync/pkg/applyset/applyset.go
@@ -120,11 +120,6 @@ func (r *ApplyResults) checkInvariants() {
 	}
 }
 
-// applySkipped records that the apply of an object was skipped because it was already applied.
-func (r *ApplyResults) applySkipped(gvk schema.GroupVersionKind, nn types.NamespacedName) {
-	r.applySuccessCount++
-}
-
 // applyError records that the apply of an object failed with an error.
 func (r *ApplyResults) applyError(gvk schema.GroupVersionKind, nn types.NamespacedName, err error) {
 	r.applyFailCount++

--- a/porch/controllers/remoterootsync/pkg/controllers/remoterootsyncset/remoterootsync_controller.go
+++ b/porch/controllers/remoterootsync/pkg/controllers/remoterootsyncset/remoterootsync_controller.go
@@ -43,10 +43,10 @@ import (
 )
 
 var (
-	rootSyncNamespace  = "config-management-system"
-	rootSyncApiVersion = "configsync.gke.io/v1beta1"
-	rootSyncName       = "root-sync"
-	rootSyncKind       = "RootSync"
+	RootSyncNamespace  = "config-management-system"
+	RootSyncApiVersion = "configsync.gke.io/v1beta1"
+	RootSyncName       = "root-sync"
+	RootSyncKind       = "RootSync"
 )
 
 // RemoteRootSyncSetReconciler reconciles RemoteRootSyncSet objects
@@ -406,6 +406,6 @@ func (r *RemoteRootSyncSetReconciler) deleteExternalResources(ctx context.Contex
 		}
 		return deleteErrs[0]
 	}
-	klog.Infof("external resource %s delete Done!", rootSyncName)
+	klog.Infof("external resource %s delete Done!", RootSyncName)
 	return nil
 }

--- a/porch/repository/pkg/git/commit_test.go
+++ b/porch/repository/pkg/git/commit_test.go
@@ -99,6 +99,9 @@ func TestPackageCommitToMain(t *testing.T) {
 	bucketEntry := findTreeEntry(t, draftTree, packagePath)
 	bucketTree := bucketEntry.Hash
 	ch, err := newCommitHelper(repo.Storer, main.Hash(), packagePath, bucketTree)
+	if err != nil {
+		t.Fatalf("Failed to create commit helper: %v", err)
+	}
 
 	commitHash, treeHash, err := ch.commit("Move bucket to main", packagePath)
 	if err != nil {

--- a/porch/repository/pkg/git/draft.go
+++ b/porch/repository/pkg/git/draft.go
@@ -43,6 +43,9 @@ var _ repository.PackageDraft = &gitPackageDraft{}
 
 func (d *gitPackageDraft) UpdateResources(ctx context.Context, new *v1alpha1.PackageRevisionResources, change *v1alpha1.Task) error {
 	ch, err := newCommitHelper(d.parent.repo.Storer, d.ref.Hash(), d.path, plumbing.ZeroHash)
+	if err != nil {
+		return fmt.Errorf("failed to commit packgae: %w", err)
+	}
 
 	for k, v := range new.Spec.Resources {
 		ch.storeFile(path.Join(d.path, k), v)

--- a/porch/repository/pkg/git/git_test.go
+++ b/porch/repository/pkg/git/git_test.go
@@ -652,11 +652,6 @@ func TestDeletePackages(t *testing.T) {
 		t.Fatalf("OpenRepository(%q) failed: %v", address, err)
 	}
 
-	type PackageReference struct {
-		name string
-		ref  plumbing.ReferenceName
-	}
-
 	// If we delete one of these packages, we expect the reference to be deleted too
 	wantDeletedRefs := map[string]plumbing.ReferenceName{
 		"delete:bucket:v1":  "refs/heads/drafts/bucket/v1",

--- a/porch/repository/pkg/git/package.go
+++ b/porch/repository/pkg/git/package.go
@@ -158,7 +158,3 @@ func (p *gitPackageRevision) getPackageRevisionLifecycle() v1alpha1.PackageRevis
 		return v1alpha1.PackageRevisionLifecycleFinal
 	}
 }
-
-func (p *gitPackageRevision) isDraft() bool {
-	return p.ref != nil && strings.HasPrefix(p.ref.Name().String(), refDraftPrefix)
-}


### PR DESCRIPTION
Staticcheck was temporarily broken by transition to golang 1.18.
The issues now seem fixed so we can re-enable it. Along the way,
fixing all outstanding staticcheck issues.
