### PR TITLE
Set Commit Author to Authenticated User

### DIFF
--- a/porch/apiserver/pkg/apiserver/apiserver.go
+++ b/porch/apiserver/pkg/apiserver/apiserver.go
@@ -178,6 +178,7 @@ func (c completedConfig) New() (*PorchServer, error) {
 		engine.WithCredentialResolver(credentialResolver),
 		engine.WithRenderer(renderer),
 		engine.WithReferenceResolver(referenceResolver),
+		engine.WithUserInfoProvider(&porch.ApiserverUserInfoProvider{}),
 	)
 	if err != nil {
 		return nil, err

--- a/porch/apiserver/pkg/apiserver/apiserver.go
+++ b/porch/apiserver/pkg/apiserver/apiserver.go
@@ -164,10 +164,14 @@ func (c completedConfig) New() (*PorchServer, error) {
 
 	credentialResolver := porch.NewCredentialResolver(coreClient)
 	referenceResolver := porch.NewReferenceResolver(coreClient)
+	userInfoProvider := &porch.ApiserverUserInfoProvider{}
 
 	renderer := kpt.NewRenderer()
 
-	cache := cache.NewCache(c.ExtraConfig.CacheDirectory, credentialResolver)
+	cache := cache.NewCache(c.ExtraConfig.CacheDirectory, cache.CacheOptions{
+		CredentialResolver: credentialResolver,
+		UserInfoProvider:   userInfoProvider,
+	})
 	cad, err := engine.NewCaDEngine(
 		engine.WithCache(cache),
 		// The order of registering the function runtimes matters here. When
@@ -178,7 +182,7 @@ func (c completedConfig) New() (*PorchServer, error) {
 		engine.WithCredentialResolver(credentialResolver),
 		engine.WithRenderer(renderer),
 		engine.WithReferenceResolver(referenceResolver),
-		engine.WithUserInfoProvider(&porch.ApiserverUserInfoProvider{}),
+		engine.WithUserInfoProvider(userInfoProvider),
 	)
 	if err != nil {
 		return nil, err

--- a/porch/apiserver/pkg/registry/porch/userinfo.go
+++ b/porch/apiserver/pkg/registry/porch/userinfo.go
@@ -26,22 +26,25 @@ type ApiserverUserInfoProvider struct{}
 
 var _ repository.UserInfoProvider = &ApiserverUserInfoProvider{}
 
-func (p *ApiserverUserInfoProvider) GetUserName(ctx context.Context) (string, bool) {
+func (p *ApiserverUserInfoProvider) GetUserInfo(ctx context.Context) *repository.UserInfo {
 	userinfo, ok := request.UserFrom(ctx)
 	if !ok {
-		return "", false
+		return nil
 	}
 
 	name := userinfo.GetName()
 	if name == "" {
-		return "", false
+		return nil
 	}
 
 	for _, group := range userinfo.GetGroups() {
 		if group == user.AllAuthenticated {
-			return name, true
+			return &repository.UserInfo{
+				Name:  name, // k8s authentication only provides single name; use it for both values for now.
+				Email: name,
+			}
 		}
 	}
 
-	return "", false
+	return nil
 }

--- a/porch/apiserver/pkg/registry/porch/userinfo.go
+++ b/porch/apiserver/pkg/registry/porch/userinfo.go
@@ -1,0 +1,47 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package porch
+
+import (
+	"context"
+
+	"github.com/GoogleContainerTools/kpt/porch/repository/pkg/repository"
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+type ApiserverUserInfoProvider struct{}
+
+var _ repository.UserInfoProvider = &ApiserverUserInfoProvider{}
+
+func (p *ApiserverUserInfoProvider) GetUserName(ctx context.Context) (string, bool) {
+	userinfo, ok := request.UserFrom(ctx)
+	if !ok {
+		return "", false
+	}
+
+	name := userinfo.GetName()
+	if name == "" {
+		return "", false
+	}
+
+	for _, group := range userinfo.GetGroups() {
+		if group == user.AllAuthenticated {
+			return name, true
+		}
+	}
+
+	return "", false
+}

--- a/porch/apiserver/pkg/registry/porch/userinfo_test.go
+++ b/porch/apiserver/pkg/registry/porch/userinfo_test.go
@@ -1,0 +1,100 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package porch
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"k8s.io/apiserver/pkg/authentication/user"
+	"k8s.io/apiserver/pkg/endpoints/request"
+)
+
+func TestApiserverProvider(t *testing.T) {
+
+	uip := &ApiserverUserInfoProvider{}
+
+	for _, tc := range []struct {
+		name   string
+		groups []string
+
+		want_user string
+		want_ok   bool
+	}{
+		{
+			want_user: "",
+			want_ok:   false,
+		},
+		{
+			name:      "user1@domain.com",
+			groups:    []string{},
+			want_user: "",
+			want_ok:   false,
+		},
+		{
+			name:      "user2@domain.com",
+			groups:    []string{user.AllUnauthenticated, user.Anonymous},
+			want_user: "",
+			want_ok:   false,
+		},
+		{
+			name:      "",
+			groups:    []string{user.AllAuthenticated},
+			want_user: "",
+			want_ok:   false,
+		},
+		{
+			name:      "user3@domain.com",
+			groups:    []string{user.AllAuthenticated},
+			want_user: "user3@domain.com",
+			want_ok:   true,
+		},
+	} {
+		di := &user.DefaultInfo{
+			Name:   tc.name,
+			UID:    "uuid",
+			Groups: tc.groups,
+			Extra:  map[string][]string{},
+		}
+
+		ctx := request.WithUser(context.Background(), di)
+
+		got_user, got_ok := uip.GetUserName(ctx)
+
+		if got_ok != tc.want_ok {
+			t.Errorf("GetUserName with user %q and groups: %s: got ok flag %t, want %t", tc.name, strings.Join(tc.groups, ","), got_ok, tc.want_ok)
+		}
+
+		if got_user != tc.want_user {
+			t.Errorf("GetUserName with user %q and groups: %s: got user %q, want %q", tc.name, strings.Join(tc.groups, ","), got_user, tc.want_user)
+		}
+	}
+}
+
+func TestEmptyUserInfo(t *testing.T) {
+	uip := &ApiserverUserInfoProvider{}
+
+	got_user, got_ok := uip.GetUserName(context.Background())
+	want_user, want_ok := "", false
+
+	if got_ok != want_ok {
+		t.Errorf("GetUserName with empty context: got ok %t, want %t", got_ok, want_ok)
+	}
+
+	if got_user != want_user {
+		t.Errorf("GetUserName with empty context: got user %q, want %q", got_user, want_user)
+	}
+}

--- a/porch/engine/pkg/engine/clone.go
+++ b/porch/engine/pkg/engine/clone.go
@@ -141,8 +141,9 @@ func (m *clonePackageMutation) cloneFromGit(ctx context.Context, gitPackage *api
 	}
 	defer os.RemoveAll(dir)
 
-	credentialResolver := m.credentialResolver
-	r, err := git.OpenRepository(ctx, "", "", &spec, credentialResolver, dir)
+	r, err := git.OpenRepository(ctx, "", "", &spec, dir, git.GitRepositoryOptions{
+		CredentialResolver: m.credentialResolver,
+	})
 	if err != nil {
 		return repository.PackageResources{}, fmt.Errorf("cannot clone Git repository: %w", err)
 	}

--- a/porch/engine/pkg/engine/engine.go
+++ b/porch/engine/pkg/engine/engine.go
@@ -58,6 +58,7 @@ type cadEngine struct {
 	runtime            fn.FunctionRuntime
 	credentialResolver repository.CredentialResolver
 	referenceResolver  ReferenceResolver
+	userInfoProvider   repository.UserInfoProvider
 }
 
 var _ CaDEngine = &cadEngine{}

--- a/porch/engine/pkg/engine/options.go
+++ b/porch/engine/pkg/engine/options.go
@@ -107,3 +107,10 @@ func WithReferenceResolver(resolver ReferenceResolver) EngineOption {
 		return nil
 	})
 }
+
+func WithUserInfoProvider(provider repository.UserInfoProvider) EngineOption {
+	return EngineOptionFunc(func(engine *cadEngine) error {
+		engine.userInfoProvider = provider
+		return nil
+	})
+}

--- a/porch/repository/pkg/git/commit.go
+++ b/porch/repository/pkg/git/commit.go
@@ -353,18 +353,22 @@ func entrySortKey(e *object.TreeEntry) string {
 
 func storeCommit(store storer.EncodedObjectStorer, parent plumbing.Hash, tree plumbing.Hash, author, message string) (plumbing.Hash, error) {
 	now := time.Now()
-	authorSignature := object.Signature{
-		Name:  porchSignatureName,
-		Email: porchSignatureEmail,
-		When:  time.Time{},
-	}
+	var authorName, authorEmail string
 	if author != "" {
 		// Authenticated user info only provides one value...
-		authorSignature.Name = author
-		authorSignature.Email = author
+		authorName = author
+		authorEmail = author
+	} else {
+		// Defaults
+		authorName = porchSignatureName
+		authorEmail = porchSignatureEmail
 	}
 	commit := &object.Commit{
-		Author: authorSignature,
+		Author: object.Signature{
+			Name:  authorName,
+			Email: authorEmail,
+			When:  now,
+		},
 		Committer: object.Signature{
 			Name:  porchSignatureName,
 			Email: porchSignatureEmail,

--- a/porch/repository/pkg/git/commit.go
+++ b/porch/repository/pkg/git/commit.go
@@ -15,12 +15,14 @@
 package git
 
 import (
+	"context"
 	"fmt"
 	"path"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/GoogleContainerTools/kpt/porch/repository/pkg/repository"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/filemode"
 	"github.com/go-git/go-git/v5/plumbing/object"
@@ -28,15 +30,22 @@ import (
 	"github.com/go-git/go-git/v5/storage"
 )
 
+const (
+	porchSignatureName  = "Package Orchestration Service"
+	porchSignatureEmail = "porch@kpt.dev"
+)
+
 type commitHelper struct {
-	storer storage.Storer
-	trees  map[string]*object.Tree
-	parent plumbing.Hash
+	storer           storage.Storer
+	trees            map[string]*object.Tree
+	parent           plumbing.Hash
+	userInfoProvider repository.UserInfoProvider
 }
 
 // if packageTree is zero, new tree for the package will be created (effectively replacing the package with the subsequently provided
 // contents). If the packageTree is provided, the tree will be used as the initial package contents, possibly subsequently modified.
-func newCommitHelper(storer storage.Storer, parent plumbing.Hash, packagePath string, packageTree plumbing.Hash) (*commitHelper, error) {
+func newCommitHelper(storer storage.Storer, userInfoProvider repository.UserInfoProvider,
+	parent plumbing.Hash, packagePath string, packageTree plumbing.Hash) (*commitHelper, error) {
 	var root *object.Tree
 
 	if parent.IsZero() {
@@ -60,9 +69,10 @@ func newCommitHelper(storer storage.Storer, parent plumbing.Hash, packagePath st
 	}
 
 	ch := &commitHelper{
-		storer: storer,
-		trees:  trees,
-		parent: parent,
+		storer:           storer,
+		trees:            trees,
+		parent:           parent,
+		userInfoProvider: userInfoProvider,
 	}
 
 	return ch, nil
@@ -190,13 +200,21 @@ func (h *commitHelper) storeFile(path, contents string) error {
 	return nil
 }
 
-func (h *commitHelper) commit(message string, pkgPath string) (commit, pkgTree plumbing.Hash, err error) {
+func (h *commitHelper) commit(ctx context.Context, message string, pkgPath string) (commit, pkgTree plumbing.Hash, err error) {
 	treeHash, err := storeTrees(h.storer, h.trees, "")
 	if err != nil {
 		return plumbing.ZeroHash, plumbing.ZeroHash, err
 	}
 
-	commit, err = storeCommit(h.storer, h.parent, treeHash, message)
+	var author string
+	if h.userInfoProvider != nil {
+		user, ok := h.userInfoProvider.GetUserName(ctx)
+		if ok {
+			author = user
+		}
+	}
+
+	commit, err = storeCommit(h.storer, h.parent, treeHash, author, message)
 	if err != nil {
 		return plumbing.ZeroHash, plumbing.ZeroHash, err
 	}
@@ -333,17 +351,23 @@ func entrySortKey(e *object.TreeEntry) string {
 	return e.Name
 }
 
-func storeCommit(store storer.EncodedObjectStorer, parent plumbing.Hash, tree plumbing.Hash, message string) (plumbing.Hash, error) {
+func storeCommit(store storer.EncodedObjectStorer, parent plumbing.Hash, tree plumbing.Hash, author, message string) (plumbing.Hash, error) {
 	now := time.Now()
+	authorSignature := object.Signature{
+		Name:  porchSignatureName,
+		Email: porchSignatureEmail,
+		When:  time.Time{},
+	}
+	if author != "" {
+		// Authenticated user info only provides one value...
+		authorSignature.Name = author
+		authorSignature.Email = author
+	}
 	commit := &object.Commit{
-		Author: object.Signature{
-			Name:  "Porch Author",
-			Email: "author@kpt.dev",
-			When:  now,
-		},
+		Author: authorSignature,
 		Committer: object.Signature{
-			Name:  "Porch Committer",
-			Email: "committer@kpt.dev",
+			Name:  porchSignatureName,
+			Email: porchSignatureEmail,
 			When:  now,
 		},
 		Message:  message,

--- a/porch/repository/pkg/git/commit.go
+++ b/porch/repository/pkg/git/commit.go
@@ -206,15 +206,12 @@ func (h *commitHelper) commit(ctx context.Context, message string, pkgPath strin
 		return plumbing.ZeroHash, plumbing.ZeroHash, err
 	}
 
-	var author string
+	var ui *repository.UserInfo
 	if h.userInfoProvider != nil {
-		user, ok := h.userInfoProvider.GetUserName(ctx)
-		if ok {
-			author = user
-		}
+		ui = h.userInfoProvider.GetUserInfo(ctx)
 	}
 
-	commit, err = storeCommit(h.storer, h.parent, treeHash, author, message)
+	commit, err = storeCommit(h.storer, h.parent, treeHash, ui, message)
 	if err != nil {
 		return plumbing.ZeroHash, plumbing.ZeroHash, err
 	}
@@ -351,13 +348,13 @@ func entrySortKey(e *object.TreeEntry) string {
 	return e.Name
 }
 
-func storeCommit(store storer.EncodedObjectStorer, parent plumbing.Hash, tree plumbing.Hash, author, message string) (plumbing.Hash, error) {
+func storeCommit(store storer.EncodedObjectStorer, parent plumbing.Hash, tree plumbing.Hash, userInfo *repository.UserInfo, message string) (plumbing.Hash, error) {
 	now := time.Now()
 	var authorName, authorEmail string
-	if author != "" {
+	if userInfo != nil {
 		// Authenticated user info only provides one value...
-		authorName = author
-		authorEmail = author
+		authorName = userInfo.Name
+		authorEmail = userInfo.Email
 	} else {
 		// Defaults
 		authorName = porchSignatureName

--- a/porch/repository/pkg/git/commit_test.go
+++ b/porch/repository/pkg/git/commit_test.go
@@ -131,12 +131,11 @@ func TestPackageCommitToMain(t *testing.T) {
 }
 
 type testUserInfoProvider struct {
-	user string
-	ok   bool
+	userInfo *repository.UserInfo
 }
 
-func (p *testUserInfoProvider) GetUserName(ctx context.Context) (string, bool) {
-	return p.user, p.ok
+func (p *testUserInfoProvider) GetUserInfo(ctx context.Context) *repository.UserInfo {
+	return p.userInfo
 }
 
 func TestCommitWithUser(t *testing.T) {
@@ -147,11 +146,14 @@ func TestCommitWithUser(t *testing.T) {
 	main := resolveReference(t, repo, refMain)
 
 	{
-		const testUser = "porch-test@porch-domain.com"
+		const testEmail = "porch-test@porch-domain.com"
+		const testName = "Porch Test"
 		// Make one commit with user info provided
 		userInfoProvider := &testUserInfoProvider{
-			user: testUser,
-			ok:   true,
+			userInfo: &repository.UserInfo{
+				Name:  testName,
+				Email: testEmail,
+			},
 		}
 
 		var zeroHash plumbing.Hash
@@ -175,10 +177,10 @@ func TestCommitWithUser(t *testing.T) {
 
 		commit := getCommitObject(t, repo, commitHash)
 
-		if got, want := commit.Author.Email, testUser; got != want {
+		if got, want := commit.Author.Email, testEmail; got != want {
 			t.Errorf("Commit.Author.Email: got %q, want %q", got, want)
 		}
-		if got, want := commit.Author.Name, testUser; got != want {
+		if got, want := commit.Author.Name, testName; got != want {
 			t.Errorf("Commit.Author.Name: got %q, want %q", got, want)
 		}
 
@@ -194,8 +196,7 @@ func TestCommitWithUser(t *testing.T) {
 	{
 		// And another without ...
 		userInfoProvider := &testUserInfoProvider{
-			user: "",
-			ok:   false,
+			userInfo: nil,
 		}
 
 		var zeroHash plumbing.Hash

--- a/porch/repository/pkg/git/git.go
+++ b/porch/repository/pkg/git/git.go
@@ -877,13 +877,13 @@ func (r *gitRepository) createPackageDeleteCommit(ctx context.Context, branch pl
 
 	// Create commit helper. Use zero hash for the initial package tree. Commit helper will initialize trees
 	// without TreeEntry for this package present - the package is deleted.
-	ch, err := newCommitHelper(repo.Storer, commit.Hash, packagePath, zero)
+	ch, err := newCommitHelper(repo.Storer, r.userInfoProvider, commit.Hash, packagePath, zero)
 	if err != nil {
 		return zero, fmt.Errorf("failed to initialize commit of package %q to %q: %w", packagePath, ref, err)
 	}
 
 	message := fmt.Sprintf("Delete %s", packagePath)
-	commitHash, _, err := ch.commit(message, packagePath)
+	commitHash, _, err := ch.commit(ctx, message, packagePath)
 	if err != nil {
 		return zero, fmt.Errorf("failed to commit package %q to %q: %w", packagePath, ref, err)
 	}

--- a/porch/repository/pkg/git/git_test.go
+++ b/porch/repository/pkg/git/git_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
 	configapi "github.com/GoogleContainerTools/kpt/porch/controllers/pkg/apis/porch/v1alpha1"
-	"github.com/GoogleContainerTools/kpt/porch/repository/pkg/repository"
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/filemode"
@@ -91,10 +90,9 @@ func TestGitPackageRoundTrip(t *testing.T) {
 		Repo: gitServerURL,
 	}
 
-	var credentialResolver repository.CredentialResolver
 	root := filepath.Join(tempdir, "work")
 
-	repo, err := OpenRepository(ctx, name, namespace, spec, credentialResolver, root)
+	repo, err := OpenRepository(ctx, name, namespace, spec, root, GitRepositoryOptions{})
 	if err != nil {
 		t.Fatalf("failed to open repository: %v", err)
 	}
@@ -146,7 +144,7 @@ func TestGitPackageRoundTrip(t *testing.T) {
 
 	// We reopen to refetch
 	// TODO: This is pretty hacky...
-	repo, err = OpenRepository(ctx, name, namespace, spec, credentialResolver, root)
+	repo, err = OpenRepository(ctx, name, namespace, spec, root, GitRepositoryOptions{})
 	if err != nil {
 		t.Fatalf("failed to open repository: %v", err)
 	}
@@ -299,14 +297,13 @@ func TestListPackagesEmpty(t *testing.T) {
 		repositoryName = "empty"
 		namespace      = "default"
 	)
-	var resolver repository.CredentialResolver
 
 	git, err := OpenRepository(ctx, repositoryName, namespace, &configapi.GitRepository{
 		Repo:      address,
 		Branch:    "main",
 		Directory: "/",
 		SecretRef: configapi.SecretRef{},
-	}, resolver, tempdir)
+	}, tempdir, GitRepositoryOptions{})
 	if err != nil {
 		t.Fatalf("Failed to open Git repository loaded from %q: %v", tarfile, err)
 	}
@@ -392,14 +389,13 @@ func TestCreatePackageInTrivialRepository(t *testing.T) {
 		repositoryName = "trivial"
 		namespace      = "default"
 	)
-	var resolver repository.CredentialResolver
 
 	git, err := OpenRepository(ctx, repositoryName, namespace, &configapi.GitRepository{
 		Repo:      address,
 		Branch:    "main",
 		Directory: "/",
 		SecretRef: configapi.SecretRef{},
-	}, resolver, tempdir)
+	}, tempdir, GitRepositoryOptions{})
 	if err != nil {
 		t.Fatalf("Failed to open Git repository loaded from %q: %v", tarfile, err)
 	}
@@ -470,14 +466,13 @@ func TestListPackagesSimple(t *testing.T) {
 		repositoryName = "simple"
 		namespace      = "default"
 	)
-	var resolver repository.CredentialResolver
 
 	git, err := OpenRepository(ctx, repositoryName, namespace, &configapi.GitRepository{
 		Repo:      address,
 		Branch:    "main",
 		Directory: "/",
 		SecretRef: configapi.SecretRef{},
-	}, resolver, tempdir)
+	}, tempdir, GitRepositoryOptions{})
 	if err != nil {
 		t.Fatalf("Failed to open Git repository loaded from %q: %v", tarfile, err)
 	}
@@ -527,14 +522,13 @@ func TestListPackagesDrafts(t *testing.T) {
 		repositoryName = "drafts"
 		namespace      = "default"
 	)
-	var resolver repository.CredentialResolver
 
 	git, err := OpenRepository(ctx, repositoryName, namespace, &configapi.GitRepository{
 		Repo:      address,
 		Branch:    "main",
 		Directory: "/",
 		SecretRef: configapi.SecretRef{},
-	}, resolver, tempdir)
+	}, tempdir, GitRepositoryOptions{})
 	if err != nil {
 		t.Fatalf("Failed to open Git repository loaded from %q: %v", tarfile, err)
 	}
@@ -586,12 +580,11 @@ func TestApproveDraft(t *testing.T) {
 		finalReferenceName plumbing.ReferenceName = "refs/tags/bucket/v1"
 	)
 	ctx := context.Background()
-	var resolver repository.CredentialResolver
 	git, err := OpenRepository(ctx, repositoryName, namespace, &configapi.GitRepository{
 		Repo:      address,
 		Branch:    "main",
 		Directory: "/",
-	}, resolver, tempdir)
+	}, tempdir, GitRepositoryOptions{})
 	if err != nil {
 		t.Fatalf("Failed to open Git repository loaded from %q: %v", tarfile, err)
 	}
@@ -644,10 +637,9 @@ func TestDeletePackages(t *testing.T) {
 	)
 
 	ctx := context.Background()
-	var resolver repository.CredentialResolver
 	git, err := OpenRepository(ctx, repositoryName, namespace, &configapi.GitRepository{
 		Repo: address,
-	}, resolver, tempdir)
+	}, tempdir, GitRepositoryOptions{})
 	if err != nil {
 		t.Fatalf("OpenRepository(%q) failed: %v", address, err)
 	}

--- a/porch/repository/pkg/repository/repository.go
+++ b/porch/repository/pkg/repository/repository.go
@@ -72,6 +72,10 @@ type FunctionRepository interface {
 	ListFunctions(ctx context.Context) ([]Function, error)
 }
 
+// The definitions below would be more appropriately located in a package usable by any Porch component.
+// They are located in repository package because repository is one such package though thematically
+// they rather belong to a package of their own.
+
 type Credential struct {
 	// TODO: support different credential types
 	Data map[string][]byte
@@ -79,4 +83,13 @@ type Credential struct {
 
 type CredentialResolver interface {
 	ResolveCredential(ctx context.Context, namespace, name string) (Credential, error)
+}
+
+// UserInfoProvider providers name of the authenticated user on whose behalf the request
+// is being processed.
+type UserInfoProvider interface {
+	// GetUserName returns the user name of the user on whose behalf the request is being
+	// processed, if any. The first return value is the user name, the second is boolean
+	// indicator whether there is an authenticated user (true) or not (false).
+	GetUserName(ctx context.Context) (string, bool)
 }

--- a/porch/repository/pkg/repository/repository.go
+++ b/porch/repository/pkg/repository/repository.go
@@ -85,11 +85,15 @@ type CredentialResolver interface {
 	ResolveCredential(ctx context.Context, namespace, name string) (Credential, error)
 }
 
+type UserInfo struct {
+	Name  string
+	Email string
+}
+
 // UserInfoProvider providers name of the authenticated user on whose behalf the request
 // is being processed.
 type UserInfoProvider interface {
-	// GetUserName returns the user name of the user on whose behalf the request is being
-	// processed, if any. The first return value is the user name, the second is boolean
-	// indicator whether there is an authenticated user (true) or not (false).
-	GetUserName(ctx context.Context) (string, bool)
+	// GetUserInfo returns the information about the user on whose behalf the request is being
+	// processed, if any. If user cannot be determnined, returns nil.
+	GetUserInfo(ctx context.Context) *UserInfo
 }


### PR DESCRIPTION
- Create UserInfoProvider which apiserver provides to engine to determine
  authenticated user information.
- Create GitRepositoryOptions to make passing of options easier
- Pass UserInfoProvider to git repository layer
- Set Commit Author from Authenticated User
