### PR TITLE
e2e test: updated golden file for save-fn/override-fn fn eval test

### DIFF
--- a/e2e/testdata/fn-eval/save-fn/override-fn/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/save-fn/override-fn/.expected/diff.patch
@@ -1,9 +1,12 @@
 diff --git a/Kptfile b/Kptfile
-index 4a1e2fa..f094437 100644
+index 4a1e2fa..00e5aa8 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -4,7 +4,7 @@ metadata:
+@@ -2,9 +2,10 @@ apiVersion: kpt.dev/v1
+ kind: Kptfile
+ metadata:
    name: app
++  namespace: newNs
  pipeline:
    mutators:
 -  - image: gcr.io/kpt-fn/set-namespace:v0.1.3


### PR DESCRIPTION
This PR updates a test which was failing because of recent merge of https://github.com/GoogleContainerTools/kpt/pull/2894

