### PR TITLE
 Discover catalog function in `kpt fn eval`

### DIFF
--- a/internal/cmdfndoc/cmdfndoc.go
+++ b/internal/cmdfndoc/cmdfndoc.go
@@ -44,7 +44,7 @@ func NewRunner(ctx context.Context, parent string) *Runner {
 	r.Command = c
 	c.Flags().StringVarP(&r.Image, "image", "i", "", "kpt function image name")
 	_ = r.Command.RegisterFlagCompletionFunc("image", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return cmdutil.FetchFunctionImages(), cobra.ShellCompDirectiveDefault
+		return cmdutil.SuggestFunctions(cmd), cobra.ShellCompDirectiveDefault
 	})
 	cmdutil.FixDocs("kpt", parent, c)
 	return r
@@ -64,7 +64,7 @@ func (r *Runner) runE(c *cobra.Command, _ []string) error {
 	if r.Image == "" {
 		return errors.New("image must be specified")
 	}
-	r.Image = fnruntime.AddDefaultImagePathPrefix(r.Image)
+	r.Image = fnruntime.AddDefaultImagePathPrefix(c.Context(), r.Image)
 	var out, errout bytes.Buffer
 	dockerRunArgs := []string{
 		"run",

--- a/internal/fnruntime/container.go
+++ b/internal/fnruntime/container.go
@@ -175,13 +175,16 @@ func NewContainerEnvFromStringSlice(envStr []string) *runtimeutil.ContainerEnv {
 	return ce
 }
 
-// AddDefaultImagePathPrefix adds default gcr.io/kpt-fn/ path prefix to image if only image name is specified
+// AddDefaultImagePathPrefix converts the function short path to the full image url.
+// If the function is Catalog function, it adds "gcr.io/kpt-fn/".e.g. set-namespace:v0.1 --> gcr.io/kpt-fn/set-namespace:v0.1
+// If the function is porch function, it queries porch to get the function image by name and namespace.
+// e.g. default:set-namespace:v0.1 --> us-west1-docker.pkg.dev/cpa-kit-dev/packages/set-namespace:v0.1
 func AddDefaultImagePathPrefix(ctx context.Context, image string) string {
 	segments := strings.Split(image, ":")
 	if len(segments) == 4 {
 		// Porch function
 		functionName := strings.Join(segments[1:], ":")
-		function, err := porch.FunctionGetter{Ctx: ctx}.Get(functionName, segments[0])
+		function, err := porch.FunctionGetter{}.Get(ctx, functionName, segments[0])
 		if err != nil {
 			return image
 		}

--- a/internal/fnruntime/runner.go
+++ b/internal/fnruntime/runner.go
@@ -58,7 +58,7 @@ func NewRunner(
 		return nil, err
 	}
 	if f.Image != "" {
-		f.Image = AddDefaultImagePathPrefix(f.Image)
+		f.Image = AddDefaultImagePathPrefix(ctx, f.Image)
 	}
 
 	fnResult := &fnresult.Result{

--- a/internal/util/cmdutil/cmdutil_test.go
+++ b/internal/util/cmdutil/cmdutil_test.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/GoogleContainerTools/kpt/internal/util/function"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/kustomize/kyaml/kio"
@@ -308,7 +309,7 @@ metadata:
 }
 
 func TestListImages(t *testing.T) {
-	result := listImages(`{
+	functions := parseFunctions(`{
   "apply-setters": {
     "v0.1": {
       "LatestPatchVersion": "v0.1.1",
@@ -344,6 +345,7 @@ func TestListImages(t *testing.T) {
     }
   }
 }`)
+	result := function.GetNames(functions)
 	sort.Strings(result)
 	assert.Equal(t, []string{"apply-setters:v0.1.1", "gatekeeper:v0.2.1"}, result)
 }

--- a/internal/util/function/catalogfn.go
+++ b/internal/util/function/catalogfn.go
@@ -1,0 +1,42 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"fmt"
+
+	"github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CatalogV2 is the an invalid namespace used to build catalog function into the porch v1alpha1.function struct.
+// This namespace distinguishes catalog function from porch functions. This will be trimmed before showing to users.
+const CatalogV2 = "__catalog_v2"
+
+// CatalogFunction converts catalog function into the porch v1alpha1.function struct.
+func CatalogFunction(name string, keywords []string, fnTypes []v1alpha1.FunctionType) v1alpha1.Function {
+	return v1alpha1.Function{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: CatalogV2,
+		},
+		Spec: v1alpha1.FunctionSpec{
+			Image:         fmt.Sprintf("gcr.io/kpt-fn/%s", name),
+			FunctionTypes: fnTypes,
+			Keywords:      keywords,
+		},
+	}
+}

--- a/internal/util/function/matcher.go
+++ b/internal/util/function/matcher.go
@@ -20,8 +20,6 @@ import (
 	"github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
 )
 
-const CatalogV2 = "__catalog_v2"
-
 type Matcher interface {
 	Match(v1alpha1.Function) bool
 }

--- a/internal/util/function/matcher.go
+++ b/internal/util/function/matcher.go
@@ -1,0 +1,100 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package function
+
+import (
+	"fmt"
+
+	"github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
+)
+
+const CatalogV2 = "__catalog_v2"
+
+type Matcher interface {
+	Match(v1alpha1.Function) bool
+}
+
+var _ Matcher = TypeMatcher{}
+var _ Matcher = KeywordsMatcher{}
+
+type TypeMatcher struct {
+	FnType string
+}
+
+// Match determines whether the `function` (which can be multi-typed), belongs
+// to the matcher's FnType. type value should only be `validator` or `mutator`.
+func (m TypeMatcher) Match(function v1alpha1.Function) bool {
+	for _, actualType := range function.Spec.FunctionTypes {
+		if string(actualType) == m.FnType {
+			return true
+		}
+	}
+	return false
+}
+
+type KeywordsMatcher struct {
+	Keywords []string
+}
+
+// Match determines whether the `function` has keywords which match the matcher's `Keywords`.
+// Experimental: This logic may change to only if all function keywords are found from  matcher's `Keywords`,
+// can it claims a match (return true).
+func (m KeywordsMatcher) Match(function v1alpha1.Function) bool {
+	if len(m.Keywords) == 0 {
+		// Accept all functions if keywords are not given.
+		return true
+	}
+	for _, actual := range function.Spec.Keywords {
+		for _, expected := range m.Keywords {
+			if actual == expected {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func MatchFunctions(functions []v1alpha1.Function, matchers ...Matcher) []v1alpha1.Function {
+	var suggestedFunctions []v1alpha1.Function
+	for _, function := range functions {
+		match := true
+		for _, matcher := range matchers {
+			if !matcher.Match(function) {
+				match = false
+			}
+		}
+		if match {
+			suggestedFunctions = append(suggestedFunctions, function)
+		}
+	}
+	return suggestedFunctions
+}
+
+// GetNames returns the list of function names.
+// - Porch function name is <PackageRepository>:<ImageName>:<Version>. e.g. kpt-functions:set-annotation:v0.1
+// - Catalog v2 function name is trimed to only contain <ImageName>:<Version>, and exclude gcr.io/kpt-fn. e.g. set-annotation:v0.1
+func GetNames(functions []v1alpha1.Function) []string {
+	var names []string
+	for _, function := range functions {
+		var name string
+		if function.Namespace == CatalogV2 {
+			name = function.Name
+		} else {
+			name = fmt.Sprintf("%v:%v", function.Namespace, function.Name)
+		}
+		names = append(names, name)
+	}
+	return names
+}

--- a/internal/util/porch/function.go
+++ b/internal/util/porch/function.go
@@ -16,7 +16,6 @@ package porch
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
@@ -30,14 +29,14 @@ import (
 
 const expirationNanoSecond = 10
 
-var PorchExpiration = time.Duration(expirationNanoSecond) * time.Second
+var Expiration = time.Duration(expirationNanoSecond) * time.Second
 
-// FunctionGetter gets the list of v1alpha1.Functions from the cluster.
-type FunctionGetter struct {
-	ctx context.Context
+// FunctionListGetter gets the list of v1alpha1.Functions from the cluster.
+type FunctionListGetter struct {
+	Ctx context.Context
 }
 
-func (f FunctionGetter) Get() []v1alpha1.Function {
+func (f FunctionListGetter) Get() []v1alpha1.Function {
 	kubeflags := genericclioptions.NewConfigFlags(true)
 	client, err := CreateRESTClient(kubeflags)
 	if err != nil {
@@ -50,81 +49,48 @@ func (f FunctionGetter) Get() []v1alpha1.Function {
 	codec := runtime.NewParameterCodec(scheme)
 	var functions v1alpha1.FunctionList
 	if err := client.Get().
-		Timeout(PorchExpiration).
+		Timeout(Expiration).
 		Resource("functions").
 		VersionedParams(&metav1.GetOptions{}, codec).
-		Do(f.ctx).
+		Do(f.Ctx).
 		Into(&functions); err != nil {
 		return nil
 	}
 	return functions.Items
 }
 
-type Matcher interface {
-	Match(v1alpha1.Function) bool
+// FunctionGetter gets a specific v1alpha1.Functions by name.
+type FunctionGetter struct {
+	Ctx context.Context
 }
 
-var _ Matcher = TypeMatcher{}
-var _ Matcher = KeywordsMatcher{}
-
-type TypeMatcher struct {
-	FnType string
-}
-
-// Match determines whether the `function` (which can be multi-typed), belongs
-// to the matcher's FnType. type value should only be `validator` or `mutator`.
-func (m TypeMatcher) Match(function v1alpha1.Function) bool {
-	for _, actualType := range function.Spec.FunctionTypes {
-		if string(actualType) == m.FnType {
-			return true
-		}
+func (f FunctionGetter) Get(name, namespace string) (v1alpha1.Function, error) {
+	kubeflags := genericclioptions.NewConfigFlags(true)
+	var function v1alpha1.Function
+	client, err := CreateRESTClient(kubeflags)
+	if err != nil {
+		return function, err
 	}
-	return false
-}
-
-type KeywordsMatcher struct {
-	Keywords []string
-}
-
-// Match determines whether the `function` has keywords which match the matcher's `Keywords`.
-// Experimental: This logic may change to only if all function keywords are found from  matcher's `Keywords`,
-// can it claims a match (return true).
-func (m KeywordsMatcher) Match(function v1alpha1.Function) bool {
-	if len(m.Keywords) == 0 {
-		// Accept all functions if keywords are not given.
-		return true
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.SchemeBuilder.AddToScheme(scheme); err != nil {
+		return function, err
 	}
-	for _, actual := range function.Spec.Keywords {
-		for _, expected := range m.Keywords {
-			if actual != expected {
-				return true
-			}
-		}
-	}
-	return false
+	codec := runtime.NewParameterCodec(scheme)
+	err = client.Get().
+		Timeout(Expiration).
+		Resource("functions").
+		Name(name).
+		Namespace(namespace).
+		VersionedParams(&metav1.GetOptions{}, codec).
+		Do(f.Ctx).
+		Into(&function)
+	return function, err
 }
 
-func MatchFunctions(ctx context.Context, matchers ...Matcher) []v1alpha1.Function {
-	var suggestedFunctions []v1alpha1.Function
-	functions := FunctionGetter{ctx: ctx}.Get()
-	for _, function := range functions {
-		for _, matcher := range matchers {
-			if matcher.Match(function) {
-				suggestedFunctions = append(suggestedFunctions, function)
-			}
-		}
-	}
-	return suggestedFunctions
-}
-
-// ToShortNames trims the function image to remove the OCI repo prefix and
-// only show the actual image and tag (or digest).
-// TODO(yuwenma): or may users prefer the Function `meta.name`?
 func ToShortNames(functions []v1alpha1.Function) []string {
 	var shortNameFunctions []string
 	for _, function := range functions {
-		slash := strings.LastIndex(function.Spec.Image, "/")
-		shortNameFunctions = append(shortNameFunctions, function.Spec.Image[slash+1:])
+		shortNameFunctions = append(shortNameFunctions, function.Name)
 	}
 	return shortNameFunctions
 }

--- a/internal/util/porch/function.go
+++ b/internal/util/porch/function.go
@@ -27,16 +27,12 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
-const expirationNanoSecond = 10
-
-var Expiration = time.Duration(expirationNanoSecond) * time.Second
+const Expiration time.Duration = 10 * time.Second
 
 // FunctionListGetter gets the list of v1alpha1.Functions from the cluster.
-type FunctionListGetter struct {
-	Ctx context.Context
-}
+type FunctionListGetter struct{}
 
-func (f FunctionListGetter) Get() []v1alpha1.Function {
+func (f FunctionListGetter) Get(ctx context.Context) []v1alpha1.Function {
 	kubeflags := genericclioptions.NewConfigFlags(true)
 	client, err := CreateRESTClient(kubeflags)
 	if err != nil {
@@ -52,7 +48,7 @@ func (f FunctionListGetter) Get() []v1alpha1.Function {
 		Timeout(Expiration).
 		Resource("functions").
 		VersionedParams(&metav1.GetOptions{}, codec).
-		Do(f.Ctx).
+		Do(ctx).
 		Into(&functions); err != nil {
 		return nil
 	}
@@ -60,11 +56,9 @@ func (f FunctionListGetter) Get() []v1alpha1.Function {
 }
 
 // FunctionGetter gets a specific v1alpha1.Functions by name.
-type FunctionGetter struct {
-	Ctx context.Context
-}
+type FunctionGetter struct{}
 
-func (f FunctionGetter) Get(name, namespace string) (v1alpha1.Function, error) {
+func (f FunctionGetter) Get(ctx context.Context, name, namespace string) (v1alpha1.Function, error) {
 	kubeflags := genericclioptions.NewConfigFlags(true)
 	var function v1alpha1.Function
 	client, err := CreateRESTClient(kubeflags)
@@ -82,7 +76,7 @@ func (f FunctionGetter) Get(name, namespace string) (v1alpha1.Function, error) {
 		Name(name).
 		Namespace(namespace).
 		VersionedParams(&metav1.GetOptions{}, codec).
-		Do(f.Ctx).
+		Do(ctx).
 		Into(&function)
 	return function, err
 }

--- a/porch/repository/pkg/oci/function.go
+++ b/porch/repository/pkg/oci/function.go
@@ -73,8 +73,10 @@ type ociFunction struct {
 
 var _ repository.Function = &ociFunction{}
 
+// LINT.IfChange(Name)
 func (f *ociFunction) Name() string {
 	return fmt.Sprintf("%s:%s:%s", f.parent.name, f.name, f.version)
+	// LINT.ThenChange(internal/fnruntime/container.go AddDefaultImagePathPrefix)
 }
 
 func (f *ociFunction) GetFunction() (*v1alpha1.Function, error) {

--- a/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
+++ b/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
@@ -378,7 +378,7 @@ func (r *EvalFnRunner) preRunE(c *cobra.Command, args []string) error {
 		return errors.Errorf("must specify --image or --exec")
 	}
 	if r.Image != "" {
-		r.Image = fnruntime.AddDefaultImagePathPrefix(r.Image)
+		r.Image = fnruntime.AddDefaultImagePathPrefix(c.Context(), r.Image)
 		err := cmdutil.DockerCmdAvailable()
 		if err != nil {
 			return err


### PR DESCRIPTION
### Description

This PR allows users to discover and filter Catalog functions via `kpt fn eval --type --keywords --image`.

Functions have two sources.
1. catalog function, which provides general solutions like `set-namespace`, `set-annotation` . its metadata is stored in ttps://catalog.kpt.dev/catalog-v2.json
2. porch functions, which is custom KRM functions whose meta config is stored on the cluster api resource.

In previous work:
- https://github.com/GoogleContainerTools/kpt/pull/2980 adds "--type" "--keyword" flags with autocompletion in `kpt fn eval` to discover and filter porch function.
- https://github.com/GoogleContainerTools/kpt-functions-catalog/pull/824 will add the function types and keywords to catalog function metadata. 
 
This PR is the last change, which contains:
- Read the new Catalog metadata from "https://catalog.kpt.dev/catalog-v2.json"
- Map Catalog function to porch `v1alpha1.Function`, to merge the logic on function matching.
- Change the format of displayed function names
   - Porch function name is `<PackageRepository>:<ImageName>:<Version>`. When displayed in kpt, it has the namespace as prefix e.g. `default:kpt-functions:set-annotation:v0.1`
   - Catalog v2 function name is trimmed to only contain `<ImageName>:<Version>`, and exclude `gcr.io/kpt-fn`. e.g. `set-annotation:v0.1`. 
- Retrieve the Porch function "Image" by function name in function `evaluation`. 
- To record porch function namespace (used to get porch function image later on), we add the namespace as prefix in the displayed function name. We use a fake namespace  "__catalog_v2" to mark catalog functions, which does not live in porch but used the fixed url `gcr.io/kpt-fn/<FUNCTION NAME>:<TAG>` to get the image.


Fix bugs:
- a multiple matcher should choose a function if the function satisfies all matcher conditions, not XNOR.   
