### PR TITLE
Low Level Git Primitives

### DIFF
--- a/porch/repository/go.mod
+++ b/porch/repository/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/GoogleContainerTools/kpt v0.0.0-00010101000000-000000000000
 	github.com/GoogleContainerTools/kpt/porch/api v0.0.0-20220330205144-0b1442857d49
 	github.com/GoogleContainerTools/kpt/porch/controllers v0.0.0-20220330205144-0b1442857d49
+	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.3-0.20220119145113-935af59cf64f
 	github.com/google/go-cmp v0.5.7
 	github.com/google/go-containerregistry v0.8.0
@@ -38,7 +39,6 @@ require (
 	github.com/emirpasic/gods v1.12.0 // indirect
 	github.com/go-errors/errors v1.4.2 // indirect
 	github.com/go-git/gcfg v1.5.0 // indirect
-	github.com/go-git/go-billy/v5 v5.3.1 // indirect
 	github.com/go-logr/logr v1.2.1 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.19.5 // indirect

--- a/porch/repository/pkg/git/git.go
+++ b/porch/repository/pkg/git/git.go
@@ -49,6 +49,7 @@ const (
 	refRemoteBranchPrefix                        = "refs/remotes/origin/"
 	refOriginMain         plumbing.ReferenceName = refRemoteBranchPrefix + "main"
 	originName                                   = "origin"
+	originFetchSpec                              = "+refs/heads/*:refs/remotes/origin/*"
 )
 
 type GitRepository interface {
@@ -72,8 +73,7 @@ func OpenRepository(ctx context.Context, name, namespace string, spec *configapi
 			return nil, err
 		}
 
-		isBare := true
-		r, err := git.PlainInit(dir, isBare)
+		r, err := InitEmptyRepository(dir)
 		if err != nil {
 			return nil, fmt.Errorf("error cloning git repository %q: %w", spec.Repo, err)
 		}

--- a/porch/repository/pkg/git/git.go
+++ b/porch/repository/pkg/git/git.go
@@ -73,7 +73,7 @@ func OpenRepository(ctx context.Context, name, namespace string, spec *configapi
 			return nil, err
 		}
 
-		r, err := InitEmptyRepository(dir)
+		r, err := initEmptyRepository(dir)
 		if err != nil {
 			return nil, fmt.Errorf("error cloning git repository %q: %w", spec.Repo, err)
 		}
@@ -94,7 +94,7 @@ func OpenRepository(ctx context.Context, name, namespace string, spec *configapi
 		// Internal error - corrupted cache.
 		return nil, fmt.Errorf("cannot clone git repository %q: %w", spec.Repo, err)
 	} else {
-		r, err := git.PlainOpen(dir)
+		r, err := openRepository(dir)
 		if err != nil {
 			return nil, err
 		}

--- a/porch/repository/pkg/git/git_test.go
+++ b/porch/repository/pkg/git/git_test.go
@@ -54,7 +54,7 @@ func TestGitPackageRoundTrip(t *testing.T) {
 	gitServerAddressChannel := make(chan net.Addr)
 
 	p := filepath.Join(tempdir, "repo")
-	serverRepo, err := gogit.PlainInit(p, true)
+	serverRepo, err := InitEmptyRepository(p)
 	if err != nil {
 		t.Fatalf("failed to open source repo %q: %v", p, err)
 	}

--- a/porch/repository/pkg/git/git_test.go
+++ b/porch/repository/pkg/git/git_test.go
@@ -54,7 +54,7 @@ func TestGitPackageRoundTrip(t *testing.T) {
 	gitServerAddressChannel := make(chan net.Addr)
 
 	p := filepath.Join(tempdir, "repo")
-	serverRepo, err := InitEmptyRepository(p)
+	serverRepo, err := initEmptyRepository(p)
 	if err != nil {
 		t.Fatalf("failed to open source repo %q: %v", p, err)
 	}

--- a/porch/repository/pkg/git/gogit.go
+++ b/porch/repository/pkg/git/gogit.go
@@ -1,0 +1,46 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+import (
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+// This file contains helpers for interacting with gogit.
+
+func InitEmptyRepository(path string) (*git.Repository, error) {
+	isBare := true // Porch only uses bare repositories
+	repo, err := git.PlainInit(path, isBare)
+	if err != nil {
+		return nil, err
+	}
+	if err := RemoveDefaultBranches(repo); err != nil {
+		return nil, err
+	}
+	return repo, nil
+}
+
+func RemoveDefaultBranches(repo *git.Repository) error {
+	// Adjust default references
+	if err := repo.Storer.RemoveReference(plumbing.Master); err != nil {
+		return err
+	}
+	// gogit points HEAD at a wrong branch; delete it too
+	if err := repo.Storer.RemoveReference(plumbing.HEAD); err != nil {
+		return err
+	}
+	return nil
+}

--- a/porch/repository/pkg/git/primitives_test.go
+++ b/porch/repository/pkg/git/primitives_test.go
@@ -1,0 +1,275 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+func TestUpdateRef(t *testing.T) {
+	gitdir := t.TempDir()
+	repo := OpenGitRepositoryFromArchiveWithWorktree(t, filepath.Join("testdata", "drafts-repository.tar"), gitdir)
+
+	const draftReferenceName plumbing.ReferenceName = "refs/heads/drafts/bucket/v1"
+	draftRef := resolveReference(t, repo, draftReferenceName)
+
+	{
+		// Crete a commit and advance the draft reference.
+		commit := createTestCommit(t, repo, draftRef.Hash(), "Commit One", "one.txt", "File one")
+		newDraft := plumbing.NewHashReference(draftReferenceName, commit)
+
+		if err := repo.Storer.CheckAndSetReference(newDraft, draftRef); err != nil {
+			t.Fatalf("Failed to update reference %s with check %s", newDraft, draftRef)
+		}
+	}
+
+	{
+		// Create another (competing) commit with draft parent;
+		// we shouldn't be able to update the ref to that commit
+		commit := createTestCommit(t, repo, draftRef.Hash(), "Commit Two", "two.txt", "File two")
+		newDraft := plumbing.NewHashReference(draftReferenceName, commit)
+		if err := repo.Storer.CheckAndSetReference(newDraft, draftRef); err == nil {
+			t.Fatalf("Unexpectedly succeeded to update reference %s with check %s", newDraft, draftRef)
+		} else {
+			t.Logf("Expected error: %v", err)
+		}
+	}
+}
+
+func TestSimpleFetch(t *testing.T) {
+	upstreamDir := t.TempDir()
+	downstreamDir := t.TempDir()
+
+	upstream, address := ServeGitRepository(t, filepath.Join("testdata", "drafts-repository.tar"), upstreamDir)
+	downstream := initRepositoryWithRemote(t, downstreamDir, address)
+
+	const remoteDraftReferenceName = "refs/remotes/origin/drafts/bucket/v1"
+
+	originRef := resolveReference(t, upstream, "refs/heads/drafts/bucket/v1")
+	refMustNotExist(t, downstream, remoteDraftReferenceName)
+
+	downstream.Fetch(&git.FetchOptions{
+		RemoteName: originName,
+		Tags:       git.AllTags,
+	})
+
+	clonedRef := resolveReference(t, downstream, remoteDraftReferenceName)
+	if got, want := clonedRef.Hash(), originRef.Hash(); got != want {
+		t.Errorf("%s after fetch; got %s, want %s", remoteDraftReferenceName, clonedRef, originRef)
+	}
+
+	logRefs(t, downstream, "Fetched: ")
+}
+
+func TestSimplePush(t *testing.T) {
+	upstreamDir := t.TempDir()
+	downstreamDir := t.TempDir()
+
+	upstream, address := ServeGitRepository(t, filepath.Join("testdata", "drafts-repository.tar"), upstreamDir)
+	downstream := initRepositoryWithRemote(t, downstreamDir, address)
+	downstream.Fetch(&git.FetchOptions{
+		RemoteName: originName,
+		Tags:       git.AllTags,
+	})
+
+	const draftReferenceName = "refs/heads/drafts/bucket/v1"
+	const remoteDraftReferenceName = "refs/remotes/origin/drafts/bucket/v1"
+
+	draftRef := resolveReference(t, downstream, remoteDraftReferenceName)
+
+	var commit plumbing.Hash
+	{
+		// Create a firstCommit in test branch
+		commit = createTestCommit(t, downstream, draftRef.Hash(), "Draft Commit", "readme.txt", "Hello, World!")
+		if err := downstream.Push(&git.PushOptions{
+			RemoteName: originName,
+			RefSpecs: []config.RefSpec{
+				config.RefSpec(fmt.Sprintf("%s:%s", commit, draftReferenceName)),
+			},
+			RequireRemoteRefs: []config.RefSpec{},
+		}); err != nil {
+			t.Fatalf("Push failed: %v", err)
+		}
+
+		// Verify draft advanced
+		originDraft := resolveReference(t, upstream, draftReferenceName)
+		if got, want := originDraft.Hash(), commit; got != want {
+			t.Errorf("Updated draft reference at origin: %s, got %s, want %s", originDraft, got, want)
+		}
+	}
+
+	{
+		// Create a competing concurrent in a test branch
+		concurrent := createTestCommit(t, downstream, draftRef.Hash(), "Competing Commit", "test.txt", "competing commit")
+		switch err := downstream.Push(&git.PushOptions{
+			RemoteName: originName,
+			RefSpecs: []config.RefSpec{
+				config.RefSpec(fmt.Sprintf("%s:%s", concurrent, draftReferenceName)),
+			},
+			RequireRemoteRefs: []config.RefSpec{},
+		}); {
+		case err == git.ErrNonFastForwardUpdate:
+			// ok
+		case err == nil:
+			t.Fatalf("Second push failed: %v", err)
+		case strings.Contains(err.Error(), "non-fast-forward update"):
+			// ok
+			// TODO: preferably we get strongly typed error here...
+		default:
+			t.Fatalf("Unexpected error when pushing competing commit: %v", err)
+		}
+	}
+
+	// Verify the commit in both repositories to point at expected value (first commit)
+	originDraftRef := resolveReference(t, upstream, draftReferenceName)
+	localDraftRef := resolveReference(t, downstream, remoteDraftReferenceName)
+
+	if got, want := originDraftRef.Hash(), commit; got != want {
+		t.Errorf("Updated draft reference at origin: %s, got %s, want %s", originDraftRef, got, want)
+	}
+	if got, want := localDraftRef.Hash(), commit; got != want {
+		t.Errorf("Updated draft reference in local repo: %s, got %s, want %s", localDraftRef, got, want)
+	}
+}
+
+// Simulate case where a remote ref (refs/remotes/origin/...) is out of sync
+// with the remote repository and will be force-overwritten on fetch.
+func TestRepoRecovery(t *testing.T) {
+	upstreamDir := t.TempDir()
+	downstreamDir := t.TempDir()
+	upstream, address := ServeGitRepository(t, filepath.Join("testdata", "drafts-repository.tar"), upstreamDir)
+	downstream := initRepositoryWithRemote(t, downstreamDir, address)
+
+	const (
+		draftReferenceName       plumbing.ReferenceName = "refs/heads/drafts/bucket/v1"
+		remoteDraftReferenceName plumbing.ReferenceName = "refs/remotes/origin/drafts/bucket/v1"
+	)
+
+	downstream.Fetch(&git.FetchOptions{
+		RemoteName: originName,
+		Tags:       git.AllTags,
+	})
+
+	upstreamDraftRef := resolveReference(t, upstream, draftReferenceName)
+
+	// Simulate repository data corruption - reset remoteDraftReferenceName to another commit
+	// We will create a new commit for the draft with the shared parent.
+	draftRef := resolveReference(t, downstream, remoteDraftReferenceName)
+	draftCommit := getCommitObject(t, downstream, draftRef.Hash())
+	parent, err := draftCommit.Parent(0)
+	if err != nil {
+		t.Fatalf("Failed to get parent of commit %s: %v", draftRef, err)
+	}
+
+	conflicting := createTestCommit(t, downstream, parent.Hash, "Conflicting Commit", "conflict.txt", "file contents")
+	// Overwrite the remote ref in the downstream repository
+	newRef := plumbing.NewHashReference(remoteDraftReferenceName, conflicting)
+	if err := downstream.Storer.CheckAndSetReference(newRef, draftRef); err != nil {
+		t.Fatalf("Failed to intentionally overwrite a remote reference %s: %v", newRef, err)
+	}
+
+	// Perhaps overly cautious; check the reference value
+	{
+		ref := resolveReference(t, downstream, remoteDraftReferenceName)
+		if got, want := ref.Hash(), conflicting; got != want {
+			t.Errorf("Unexpected ref value %s after overwrite; got %s, want %s", ref, got, want)
+		}
+	}
+
+	// Re-fetch. Expect ref to go back
+	if err := downstream.Fetch(&git.FetchOptions{
+		RemoteName: originName,
+		Tags:       git.AllTags,
+	}); err != nil {
+		t.Fatalf("Failed to fetch into an intentionally corrupted repository: %v", err)
+	}
+
+	// Re-resolve the corrupted reference
+	{
+		ref := resolveReference(t, downstream, remoteDraftReferenceName)
+		if got, want := ref.Hash(), draftRef.Hash(); got != want {
+			t.Errorf("Ref %s was not reset by re-fetch; got %s, want %s", ref, got, want)
+		}
+
+		// Check also against the upstreamDraftRef
+		if got, want := ref.Hash(), upstreamDraftRef.Hash(); got != want {
+			t.Errorf("Ref %s was reset to an unexpected value, not matching upstream repository; got %s, want %s", ref, got, want)
+		}
+	}
+}
+
+func initRepositoryWithRemote(t *testing.T, dir, address string) *git.Repository {
+	repo := InitEmptyRepositoryWithWorktree(t, dir)
+
+	const fetchSpec = "+refs/heads/*:refs/remotes/" + originName + "/*"
+
+	if _, err := repo.CreateRemote(&config.RemoteConfig{
+		Name:  originName,
+		URLs:  []string{address},
+		Fetch: []config.RefSpec{fetchSpec},
+	}); err != nil {
+		t.Fatalf("CreateRemote failed: %v", err)
+	}
+	return repo
+}
+
+func createTestCommit(t *testing.T, repo *git.Repository, parent plumbing.Hash, message, name, contents string) plumbing.Hash {
+	wt, err := repo.Worktree()
+	if err != nil {
+		t.Fatalf("Failed getting worktree: %v", err)
+	}
+	if err := wt.Checkout(&git.CheckoutOptions{
+		Hash:  parent,
+		Force: true,
+		Keep:  false,
+	}); err != nil {
+		t.Fatalf("Failed checking out worktree: %v", err)
+	}
+
+	f, err := wt.Filesystem.Create(name)
+	if err != nil {
+		t.Fatalf("Failed creating file: %v", err)
+	}
+	defer f.Close()
+	if _, err := f.Write([]byte(contents)); err != nil {
+		t.Fatalf("Failed to write file: %v", err)
+	}
+	if _, err := wt.Add(name); err != nil {
+		t.Fatalf("Failed to add file to index: %v", err)
+	}
+	sig := object.Signature{
+		Name:  "Test",
+		Email: "test@kpt.dev",
+		When:  time.Now(),
+	}
+	commit, err := wt.Commit("Hello", &git.CommitOptions{
+		Author:    &sig,
+		Committer: &sig,
+		Parents:   []plumbing.Hash{},
+	})
+	if err != nil {
+		t.Fatalf("Commit failed: %v", err)
+	}
+	return commit
+}

--- a/porch/repository/pkg/git/testing_repo.go
+++ b/porch/repository/pkg/git/testing_repo.go
@@ -64,7 +64,7 @@ func InitEmptyRepositoryWithWorktree(t *testing.T, path string) *gogit.Repositor
 	if err != nil {
 		t.Fatalf("Failed to initialize empty Git repository: %v", err)
 	}
-	if err := RemoveDefaultBranches(repo); err != nil {
+	if err := initializeDefaultBranches(repo); err != nil {
 		t.Fatalf("Failed to remove default branches")
 	}
 	return repo

--- a/porch/repository/pkg/git/testing_repo.go
+++ b/porch/repository/pkg/git/testing_repo.go
@@ -50,6 +50,26 @@ func OpenGitRepositoryFromArchive(t *testing.T, tarfile, tempdir string) *gogit.
 	return git
 }
 
+func OpenGitRepositoryFromArchiveWithWorktree(t *testing.T, tarfile, path string) *gogit.Repository {
+	extractTar(t, tarfile, path)
+	repo, err := gogit.PlainOpen(path)
+	if err != nil {
+		t.Fatalf("Failed to open Git repository extracted from %q: %v", tarfile, err)
+	}
+	return repo
+}
+
+func InitEmptyRepositoryWithWorktree(t *testing.T, path string) *gogit.Repository {
+	repo, err := gogit.PlainInit(path, false)
+	if err != nil {
+		t.Fatalf("Failed to initialize empty Git repository: %v", err)
+	}
+	if err := RemoveDefaultBranches(repo); err != nil {
+		t.Fatalf("Failed to remove default branches")
+	}
+	return repo
+}
+
 func ServeGitRepository(t *testing.T, tarfile, tempdir string) (*gogit.Repository, string) {
 	git := OpenGitRepositoryFromArchive(t, tarfile, tempdir)
 
@@ -212,4 +232,11 @@ func forEachRef(t *testing.T, repo *gogit.Repository, fn func(*plumbing.Referenc
 	if err := refs.ForEach(fn); err != nil {
 		t.Fatalf("References.ForEach faile: %v", err)
 	}
+}
+
+func logRefs(t *testing.T, repo *gogit.Repository, logPrefix string) {
+	forEachRef(t, repo, func(ref *plumbing.Reference) error {
+		t.Logf("%s%s", logPrefix, ref)
+		return nil
+	})
 }


### PR DESCRIPTION
These tests explore low level git primitives for upcoming changes
in Porch git repository management with the goal to harden branch
management, pushes and pulls and reliability via use of

* CheckAndSetReference
* Push without force

Improvements to Git repository intitialization to always remove
default branches as those use non-inclusive language.
