### PR TITLE
Improve Branch Tracking

### DIFF
--- a/e2e/testdata/porch/rpkg-init-deploy/config.yaml
+++ b/e2e/testdata/porch/rpkg-init-deploy/config.yaml
@@ -25,14 +25,14 @@ commands:
       - Test Package Description
       - --keywords=test,package
       - --site
-      - http://kpt.dev/test-package
-      - git:test-package:v0
+      - http://kpt.dev/deploy-package
+      - git:deploy-package:v0
   - args:
       - alpha
       - rpkg
       - pull
       - --namespace=rpkg-init-deploy
-      - git:test-package:v0
+      - git:deploy-package:v0
     stdout: |
       apiVersion: config.kubernetes.io/v1
       items:
@@ -42,7 +42,7 @@ commands:
           keywords:
           - test
           - package
-          site: http://kpt.dev/test-package
+          site: http://kpt.dev/deploy-package
         kind: Kptfile
         metadata:
           annotations:
@@ -51,10 +51,10 @@ commands:
             config.kubernetes.io/path: Kptfile
             internal.config.kubernetes.io/index: "0"
             internal.config.kubernetes.io/path: Kptfile
-          name: test-package
+          name: deploy-package
       - apiVersion: v1
         data:
-          name: test-package
+          name: deploy-package
         kind: ConfigMap
         metadata:
           annotations:

--- a/e2e/testdata/porch/rpkg-init/config.yaml
+++ b/e2e/testdata/porch/rpkg-init/config.yaml
@@ -24,14 +24,14 @@ commands:
       - Test Package Description
       - --keywords=test,package
       - --site
-      - http://kpt.dev/test-package
-      - git:test-package:v0
+      - http://kpt.dev/init-package
+      - git:init-package:v0
   - args:
       - alpha
       - rpkg
       - pull
       - --namespace=rpkg-init
-      - git:test-package:v0
+      - git:init-package:v0
     stdout: |
       apiVersion: config.kubernetes.io/v1
       items:
@@ -41,7 +41,7 @@ commands:
           keywords:
           - test
           - package
-          site: http://kpt.dev/test-package
+          site: http://kpt.dev/init-package
         kind: Kptfile
         metadata:
           annotations:
@@ -50,7 +50,7 @@ commands:
             config.kubernetes.io/path: Kptfile
             internal.config.kubernetes.io/index: "0"
             internal.config.kubernetes.io/path: Kptfile
-          name: test-package
+          name: init-package
       - apiVersion: v1
         data:
           name: example

--- a/porch/apiserver/pkg/e2e/e2e_test.go
+++ b/porch/apiserver/pkg/e2e/e2e_test.go
@@ -360,7 +360,7 @@ func (t *PorchSuite) TestInitTaskPackage(ctx context.Context) {
 func (t *PorchSuite) TestCloneIntoDeploymentRepository(ctx context.Context) {
 	const downstreamRepository = "deployment"
 	const downstreamPackage = "istions"
-	const downstreamRevision = "v1"
+	const downstreamRevision = "v2"
 	const downstreamName = downstreamRepository + ":" + downstreamPackage + ":" + downstreamRevision
 
 	// Register the deployment repository

--- a/porch/repository/pkg/git/commit_test.go
+++ b/porch/repository/pkg/git/commit_test.go
@@ -92,7 +92,7 @@ func TestPackageCommitToMain(t *testing.T) {
 
 	// Commit `bucket`` package from drafts/bucket/v1 into main
 
-	main := resolveReference(t, repo, refMain)
+	main := resolveReference(t, repo, DefaultMainReferenceName)
 	packagePath := "bucket"
 
 	// Confirm no 'bucket' package in main
@@ -143,7 +143,7 @@ func TestCommitWithUser(t *testing.T) {
 	repo := OpenGitRepositoryFromArchive(t, filepath.Join("testdata", "trivial-repository.tar"), tempdir)
 
 	ctx := context.Background()
-	main := resolveReference(t, repo, refMain)
+	main := resolveReference(t, repo, DefaultMainReferenceName)
 
 	{
 		const testEmail = "porch-test@porch-domain.com"

--- a/porch/repository/pkg/git/doc.go
+++ b/porch/repository/pkg/git/doc.go
@@ -18,7 +18,7 @@
 // A local clone of a registered git repository is created in a cache, and
 // periodically refreshed.
 // All package operations happen on the local copy; on completion of an
-// operation// (create, update, delete package revision or its resources)
+// operation (create, update, delete package revision or its resources)
 // any new changes (in one or more commits) are pushed to the remote
 // repository.
 //

--- a/porch/repository/pkg/git/doc.go
+++ b/porch/repository/pkg/git/doc.go
@@ -13,4 +13,28 @@
 // limitations under the License.
 
 // Git Repository Adapter
+//
+// This component implements integration of git into package orchestration.
+// A local clone of a registered git repository is created in a cache, and
+// periodically refreshed.
+// All package operations happen on the local copy; on completion of an
+// operation// (create, update, delete package revision or its resources)
+// any new changes (in one or more commits) are pushed to the remote
+// repository.
+//
+// Branching Strategy
+//
+// Porch doesn't create tracking branches for remotes. This indirection
+// would add a layer of complexity where branches can become out of sync
+// and in need of reconciliation and conflict resolution. Instead, Porch
+// analyzes the remote references (refs/remotes/origin/branch...) to
+// discover packges. These refs are never directly updated by Porch other
+// than by push or fetch to/from remote.
+// Any intermediate commits Porch makes are either in 'detached HEAD'
+// mode, or using temporary branches (these will become relevant if/when
+// Porch implements repository garbage collection).
+//
+// Porch uses the default convention for naming remote branches
+// (refs/remotes/origin/branch...) in order to make direct introspection
+// of the repositories aligned with traditional git repositories.
 package git

--- a/porch/repository/pkg/git/gogit.go
+++ b/porch/repository/pkg/git/gogit.go
@@ -17,6 +17,7 @@ package git
 import (
 	"github.com/go-git/go-billy/v5/osfs"
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/cache"
 	"github.com/go-git/go-git/v5/storage/filesystem"
@@ -42,7 +43,7 @@ func initializeDefaultBranches(repo *git.Repository) error {
 		return err
 	}
 	// gogit points HEAD at a wrong branch; point it at main
-	main := plumbing.NewSymbolicReference(plumbing.HEAD, refMain)
+	main := plumbing.NewSymbolicReference(plumbing.HEAD, DefaultMainReferenceName)
 	if err := repo.Storer.SetReference(main); err != nil {
 		return err
 	}
@@ -53,4 +54,23 @@ func openRepository(path string) (*git.Repository, error) {
 	dot := osfs.New(path)
 	storage := filesystem.NewStorage(dot, cache.NewObjectLRUDefault())
 	return git.Open(storage, dot)
+}
+
+func initializeOrigin(repo *git.Repository, address string) error {
+	cfg, err := repo.Config()
+	if err != nil {
+		return err
+	}
+
+	cfg.Remotes[OriginName] = &config.RemoteConfig{
+		Name:  OriginName,
+		URLs:  []string{address},
+		Fetch: defaultFetchSpec,
+	}
+
+	if err := repo.SetConfig(cfg); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/porch/repository/pkg/git/push.go
+++ b/porch/repository/pkg/git/push.go
@@ -1,0 +1,81 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+import (
+	"fmt"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+type pushHelper struct {
+	repo     *git.Repository
+	pushRefs map[plumbing.ReferenceName]plumbing.Hash
+	cond     map[plumbing.ReferenceName]plumbing.Hash
+}
+
+func newPushHelper(repo *git.Repository) *pushHelper {
+	return &pushHelper{
+		repo:     repo,
+		pushRefs: map[plumbing.ReferenceName]plumbing.Hash{},
+		cond:     map[plumbing.ReferenceName]plumbing.Hash{},
+	}
+}
+
+func (h *pushHelper) Push(hash plumbing.Hash, to plumbing.ReferenceName) {
+	h.pushRefs[to] = hash
+}
+
+func (h *pushHelper) Delete(ref *plumbing.Reference) {
+	if ref != nil {
+		h.Push(plumbing.ZeroHash, ref.Name())
+		h.RequireRef(ref)
+	}
+}
+
+func (h *pushHelper) RequireRef(ref *plumbing.Reference) {
+	if ref != nil {
+		h.cond[ref.Name()] = ref.Hash()
+	}
+}
+
+func (h *pushHelper) CreateSpecs() (push []config.RefSpec, require []config.RefSpec, err error) {
+	for local, hash := range h.pushRefs {
+		remote, err := refInRemoteFromRefInLocal(local)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if !hash.IsZero() {
+			push = append(push, config.RefSpec(fmt.Sprintf("%s:%s", hash, remote)))
+		} else {
+			push = append(push, config.RefSpec(fmt.Sprintf(":%s", remote)))
+		}
+	}
+
+	for local, hash := range h.cond {
+		remote, err := refInRemoteFromRefInLocal(local)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !hash.IsZero() {
+			require = append(require, config.RefSpec(fmt.Sprintf("%s:%s", hash, remote)))
+		}
+	}
+
+	return push, require, nil
+}

--- a/porch/repository/pkg/git/ref.go
+++ b/porch/repository/pkg/git/ref.go
@@ -1,0 +1,146 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+const (
+	MainBranch BranchName = "main"
+
+	branchPrefixInLocalRepo  = "refs/remotes/" + OriginName + "/"
+	branchPrefixInRemoteRepo = "refs/heads/"
+	tagsPrefixInLocalRepo    = "refs/tags/"
+	tagsPrefixInRemoteRepo   = "refs/tags/"
+
+	branchRefSpec config.RefSpec = config.RefSpec("+" + branchPrefixInRemoteRepo + "*:" + branchPrefixInLocalRepo + "*")
+	tagRefSpec    config.RefSpec = config.RefSpec("+" + tagsPrefixInRemoteRepo + "*:" + tagsPrefixInLocalRepo + "*")
+
+	draftsPrefix               = "drafts/"
+	draftsPrefixInLocalRepo    = branchPrefixInLocalRepo + draftsPrefix
+	draftsPrefixInRemoteRepo   = branchPrefixInRemoteRepo + draftsPrefix
+	proposedPrefix             = "proposed/"
+	proposedPrefixInLocalRepo  = branchPrefixInLocalRepo + proposedPrefix
+	proposedPrefixInRemoteRepo = branchPrefixInRemoteRepo + proposedPrefix
+)
+
+var (
+	// The default fetch spec contains both branches and tags.
+	// This enables push of a tag which will automatically update
+	// its local reference, avoiding explicitly setting of refs.
+	defaultFetchSpec []config.RefSpec = []config.RefSpec{
+		branchRefSpec,
+		tagRefSpec,
+	}
+
+	// DO NOT USE for fetches. Used for reverse reference mapping only.
+	reverseFetchSpec []config.RefSpec = []config.RefSpec{
+		config.RefSpec(branchPrefixInLocalRepo + "*:" + branchPrefixInRemoteRepo + "*"),
+		config.RefSpec(tagsPrefixInLocalRepo + "*:" + tagsPrefixInRemoteRepo + "*"),
+	}
+)
+
+// BranchName represents a relative branch name (i.e. 'main', 'drafts/bucket/v1')
+// and supports transformation to the ReferenceName in local (cached) repository
+// (those references are in the form 'refs/remotes/origin/...') or in the remote
+// repository (those references are in the form 'refs/heads/...').
+type BranchName string
+
+func (b BranchName) RefInRemote() plumbing.ReferenceName {
+	return plumbing.ReferenceName(branchPrefixInRemoteRepo + string(b))
+}
+
+func (b BranchName) RefInLocal() plumbing.ReferenceName {
+	return plumbing.ReferenceName(branchPrefixInLocalRepo + string(b))
+}
+
+func (b BranchName) ForceFetchSpec() config.RefSpec {
+	return config.RefSpec(fmt.Sprintf("+%s:%s", b.RefInRemote(), b.RefInLocal()))
+}
+
+func isProposedBranchNameInLocal(n plumbing.ReferenceName) bool {
+	return strings.HasPrefix(n.String(), proposedPrefixInLocalRepo)
+}
+
+func getProposedBranchNameInLocal(n plumbing.ReferenceName) (BranchName, bool) {
+	b, ok := trimOptionalPrefix(n.String(), proposedPrefixInLocalRepo)
+	return BranchName(b), ok
+}
+
+func isDraftBranchNameInLocal(n plumbing.ReferenceName) bool {
+	return strings.HasPrefix(n.String(), draftsPrefixInLocalRepo)
+}
+
+func getDraftBranchNameInLocal(n plumbing.ReferenceName) (BranchName, bool) {
+	b, ok := trimOptionalPrefix(n.String(), draftsPrefixInLocalRepo)
+	return BranchName(b), ok
+}
+
+func isBranchInLocalRepo(n plumbing.ReferenceName) bool {
+	return strings.HasPrefix(n.String(), branchPrefixInLocalRepo)
+}
+
+func getBranchNameInLocalRepo(n plumbing.ReferenceName) (string, bool) {
+	return trimOptionalPrefix(n.String(), branchPrefixInLocalRepo)
+}
+
+func isTagInLocalRepo(n plumbing.ReferenceName) bool {
+	return strings.HasPrefix(n.String(), tagsPrefixInLocalRepo)
+}
+
+func getTagNameInLocalRepo(n plumbing.ReferenceName) (string, bool) {
+	return trimOptionalPrefix(n.String(), tagsPrefixInLocalRepo)
+}
+
+func createDraftName(pkg, rev string) BranchName {
+	return BranchName(draftsPrefix + pkg + "/" + rev)
+}
+
+func createProposedName(pkg, rev string) BranchName {
+	return BranchName(proposedPrefix + pkg + "/" + rev)
+}
+
+func trimOptionalPrefix(s, prefix string) (string, bool) {
+	if strings.HasPrefix(s, prefix) {
+		return strings.TrimPrefix(s, prefix), true
+	}
+	return "", false
+}
+
+func createFinalTagNameInLocal(pkg, rev string) plumbing.ReferenceName {
+	return plumbing.ReferenceName(tagsPrefixInLocalRepo + pkg + "/" + rev)
+}
+
+func refInLocalFromRefInRemote(n plumbing.ReferenceName) (plumbing.ReferenceName, error) {
+	return translateReference(n, defaultFetchSpec)
+}
+
+func refInRemoteFromRefInLocal(n plumbing.ReferenceName) (plumbing.ReferenceName, error) {
+	return translateReference(n, reverseFetchSpec)
+}
+
+func translateReference(n plumbing.ReferenceName, specs []config.RefSpec) (plumbing.ReferenceName, error) {
+	for _, spec := range specs {
+		if spec.Match(n) {
+			return spec.Dst(n), nil
+		}
+	}
+	return "", fmt.Errorf("cannot translate reference %s", n)
+}

--- a/porch/repository/pkg/git/ref_test.go
+++ b/porch/repository/pkg/git/ref_test.go
@@ -1,0 +1,77 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+import (
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing"
+)
+
+func TestBranchNames(t *testing.T) {
+	const main BranchName = "main"
+
+	if got, want := main.RefInRemote(), "refs/heads/main"; string(got) != want {
+		t.Errorf("%s in remote repository: got %s, wnat %s", main, got, want)
+	}
+	if got, want := main.RefInLocal(), "refs/remotes/origin/main"; string(got) != want {
+		t.Errorf("%s in local repository: got %s, wnat %s", main, got, want)
+	}
+}
+
+func TestValidateRefSpecs(t *testing.T) {
+	if err := branchRefSpec.Validate(); err != nil {
+		t.Errorf("%s validation failed: %v", branchRefSpec, err)
+	}
+	if err := tagRefSpec.Validate(); err != nil {
+		t.Errorf("%s validation failed: %v", tagRefSpec, err)
+	}
+}
+
+func TestTranslate(t *testing.T) {
+	for _, tc := range []struct {
+		remote plumbing.ReferenceName
+		local  plumbing.ReferenceName
+	}{
+		{
+			remote: "refs/heads/drafts/bucket/v1",
+			local:  "refs/remotes/origin/drafts/bucket/v1",
+		},
+		{
+			remote: "refs/tags/bucket/v1",
+			local:  "refs/tags/bucket/v1",
+		},
+		{
+			remote: "refs/heads/main",
+			local:  "refs/remotes/origin/main",
+		},
+	} {
+		got, err := refInLocalFromRefInRemote(tc.remote)
+		if err != nil {
+			t.Errorf("refInLocalFromRefInRemote(%s) failed: %v", tc.remote, err)
+		}
+		if want := tc.local; got != want {
+			t.Errorf("refInLocalFromRefInRemote(%s): got %s, want %s", tc.remote, got, want)
+		}
+
+		got, err = refInRemoteFromRefInLocal(tc.local)
+		if err != nil {
+			t.Errorf("refInRemoteFromRefInLocal(%s) failed: %v", tc.local, err)
+		}
+		if want := tc.remote; got != want {
+			t.Errorf("refInRemoteFromRefInLocal(%s): got %s, want %s", tc.local, got, want)
+		}
+	}
+}

--- a/porch/repository/pkg/git/testing_repo.go
+++ b/porch/repository/pkg/git/testing_repo.go
@@ -72,7 +72,10 @@ func InitEmptyRepositoryWithWorktree(t *testing.T, path string) *gogit.Repositor
 
 func ServeGitRepository(t *testing.T, tarfile, tempdir string) (*gogit.Repository, string) {
 	git := OpenGitRepositoryFromArchive(t, tarfile, tempdir)
+	return git, ServeExistingRepository(t, git)
+}
 
+func ServeExistingRepository(t *testing.T, git *gogit.Repository) string {
 	server, err := NewGitServer(git)
 	if err != nil {
 		t.Fatalf("NewGitServer() failed: %v", err)
@@ -101,7 +104,7 @@ func ServeGitRepository(t *testing.T, tarfile, tempdir string) (*gogit.Repositor
 	if !ok {
 		t.Fatalf("Git Server failed to start")
 	}
-	return git, "http://" + address.String()
+	return "http://" + address.String()
 }
 
 func extractTar(t *testing.T, tarfile string, dir string) {
@@ -239,4 +242,13 @@ func logRefs(t *testing.T, repo *gogit.Repository, logPrefix string) {
 		t.Logf("%s%s", logPrefix, ref)
 		return nil
 	})
+}
+
+func fetch(t *testing.T, reop *gogit.Repository) {
+	if err := reop.Fetch(&gogit.FetchOptions{
+		RemoteName: OriginName,
+		Tags:       gogit.NoTags,
+	}); err != nil {
+		t.Fatalf("Fetch failed: %s", err)
+	}
 }


### PR DESCRIPTION
* Initialize fetch specs even on repo reopen to enable healing
  of cached repositories.
* Do not hardcode refMain; use branch registered with the repository
* Take more care with reference names
* Do not use force push.
