### PR TITLE
Package Lifecycle CLI Support

### DIFF
--- a/commands/rpkgcmd.go
+++ b/commands/rpkgcmd.go
@@ -19,11 +19,15 @@ import (
 	"flag"
 	"fmt"
 
+	"github.com/GoogleContainerTools/kpt/internal/cmdrpkgapprove"
 	"github.com/GoogleContainerTools/kpt/internal/cmdrpkgclone"
+	"github.com/GoogleContainerTools/kpt/internal/cmdrpkgdel"
 	"github.com/GoogleContainerTools/kpt/internal/cmdrpkgget"
 	"github.com/GoogleContainerTools/kpt/internal/cmdrpkginit"
+	"github.com/GoogleContainerTools/kpt/internal/cmdrpkgpropose"
 	"github.com/GoogleContainerTools/kpt/internal/cmdrpkgpull"
 	"github.com/GoogleContainerTools/kpt/internal/cmdrpkgpush"
+	"github.com/GoogleContainerTools/kpt/internal/cmdrpkgreject"
 	"github.com/GoogleContainerTools/kpt/internal/util/porch"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -67,6 +71,10 @@ func NewRpkgCommand(ctx context.Context, version string) *cobra.Command {
 		cmdrpkgpush.NewCommand(ctx, kubeflags),
 		cmdrpkgclone.NewCommand(ctx, kubeflags),
 		cmdrpkginit.NewCommand(ctx, kubeflags),
+		cmdrpkgpropose.NewCommand(ctx, kubeflags),
+		cmdrpkgapprove.NewCommand(ctx, kubeflags),
+		cmdrpkgreject.NewCommand(ctx, kubeflags),
+		cmdrpkgdel.NewCommand(ctx, kubeflags),
 	)
 
 	return repo

--- a/e2e/testdata/porch/rpkg-lifecycle/config.yaml
+++ b/e2e/testdata/porch/rpkg-lifecycle/config.yaml
@@ -1,0 +1,96 @@
+commands:
+  - args:
+      - alpha
+      - repo
+      - register
+      - --namespace=rpkg-lifecycle
+      - --name=git
+      - http://git-server.test-git-namespace.svc.cluster.local:8080.git/@main
+  - args:
+      - alpha
+      - rpkg
+      - init
+      - --namespace=rpkg-lifecycle
+      - git:lifecycle-package:v1
+  - args:
+      - alpha
+      - rpkg
+      - propose
+      - --namespace=rpkg-lifecycle
+      - git:lifecycle-package:v1
+    stderr: git:lifecycle-package:v1 is successfully proposed
+  - args:
+      - alpha
+      - rpkg
+      - get
+      - git:lifecycle-package:v1
+      - --namespace=rpkg-lifecycle
+      - --output=custom-columns=NAME:.metadata.name,PKG:.spec.packageName,REPO:.spec.repository,REV:.spec.lifecycle
+    stdout: |
+      NAME                       PKG                 REPO   REV
+      git:lifecycle-package:v1   lifecycle-package   git    Proposed
+  - args:
+      - alpha
+      - rpkg
+      - reject
+      - --namespace=rpkg-lifecycle
+      - git:lifecycle-package:v1
+  - args:
+      - alpha
+      - rpkg
+      - get
+      - git:lifecycle-package:v1
+      - --namespace=rpkg-lifecycle
+      - --output=custom-columns=NAME:.metadata.name,PKG:.spec.packageName,REPO:.spec.repository,REV:.spec.lifecycle
+    stdout: |
+      NAME                       PKG                 REPO   REV
+      git:lifecycle-package:v1   lifecycle-package   git    Draft
+  - args:
+      - alpha
+      - rpkg
+      - propose
+      - --namespace=rpkg-lifecycle
+      - git:lifecycle-package:v1
+    stderr: git:lifecycle-package:v1 is successfully proposed
+  - args:
+      - alpha
+      - rpkg
+      - get
+      - git:lifecycle-package:v1
+      - --namespace=rpkg-lifecycle
+      - --output=custom-columns=NAME:.metadata.name,PKG:.spec.packageName,REPO:.spec.repository,REV:.spec.lifecycle
+    stdout: |
+      NAME                       PKG                 REPO   REV
+      git:lifecycle-package:v1   lifecycle-package   git    Proposed
+  - args:
+      - alpha
+      - rpkg
+      - approve
+      - --namespace=rpkg-lifecycle
+      - git:lifecycle-package:v1
+  - args:
+      - alpha
+      - rpkg
+      - get
+      - git:lifecycle-package:v1
+      - --namespace=rpkg-lifecycle
+      - --output=custom-columns=NAME:.metadata.name,PKG:.spec.packageName,REPO:.spec.repository,REV:.spec.lifecycle
+    stdout: |
+      NAME                       PKG                 REPO   REV
+      git:lifecycle-package:v1   lifecycle-package   git    Final
+  - args:
+      - alpha
+      - rpkg
+      - delete
+      - git:lifecycle-package:v1
+      - --namespace=rpkg-lifecycle
+    stderr: git:lifecycle-package:v1 deleted
+  - args:
+      - alpha
+      - rpkg
+      - get
+      - git:lifecycle-package:v1
+      - --namespace=rpkg-lifecycle
+      - --output=custom-columns=NAME:.metadata.name,PKG:.spec.packageName,REPO:.spec.repository,REV:.spec.lifecycle
+    stderr: "Error: packagerevisions.porch.kpt.dev \"git:lifecycle-package:v1\" not found \n"
+    exitCode: 1

--- a/internal/cmdrpkgapprove/command.go
+++ b/internal/cmdrpkgapprove/command.go
@@ -1,0 +1,101 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdrpkgapprove
+
+import (
+	"context"
+
+	"github.com/GoogleContainerTools/kpt/internal/errors"
+	"github.com/GoogleContainerTools/kpt/internal/util/porch"
+	"github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	command = "cmdrpkgapprove"
+	longMsg = `
+kpt alpha rpkg approve PACKAGE_REVISION
+
+Approves a proposal to finalize a package revision
+`
+)
+
+func NewCommand(ctx context.Context, rcg *genericclioptions.ConfigFlags) *cobra.Command {
+	return newRunner(ctx, rcg).Command
+}
+
+func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner {
+	r := &runner{
+		ctx:    ctx,
+		cfg:    rcg,
+		client: nil,
+	}
+
+	c := &cobra.Command{
+		Use:     "approve PACKAGE_REVISION",
+		Short:   "Approves a proposal to finalize a package revision",
+		Long:    longMsg,
+		Example: "kpt alpha rpkg approve git-repository:package-revision:v3",
+		PreRunE: r.preRunE,
+		RunE:    r.runE,
+		Hidden:  porch.HidePorchCommands,
+	}
+	r.Command = c
+
+	return r
+}
+
+type runner struct {
+	ctx     context.Context
+	cfg     *genericclioptions.ConfigFlags
+	client  rest.Interface
+	Command *cobra.Command
+
+	// Flags
+}
+
+func (r *runner) preRunE(cmd *cobra.Command, args []string) error {
+	const op errors.Op = command + ".preRunE"
+
+	if len(args) < 1 {
+		return errors.E(op, "PACKAGE_REVISION is a required positional argument")
+	}
+
+	client, err := porch.CreateRESTClient(r.cfg)
+	if err != nil {
+		return errors.E(op, err)
+	}
+	r.client = client
+	return nil
+}
+
+func (r *runner) runE(cmd *cobra.Command, args []string) error {
+	const op errors.Op = command + ".runE"
+
+	namespace := *r.cfg.Namespace
+	name := args[0]
+
+	if err := porch.UpdatePackageRevisionApproval(r.ctx, r.client, client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}, v1alpha1.PackageRevisionLifecycleFinal); err != nil {
+		return errors.E(op, err)
+	}
+
+	return nil
+}

--- a/internal/cmdrpkgdel/command.go
+++ b/internal/cmdrpkgdel/command.go
@@ -1,0 +1,119 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdrpkgdel
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/GoogleContainerTools/kpt/internal/errors"
+	"github.com/GoogleContainerTools/kpt/internal/util/porch"
+	porchapi "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	command = "cmdrpkgdel"
+	longMsg = `
+kpt alpha rpkg del[ete] [PACKAGE ...] [flags]
+
+Args:
+
+PACKAGE:
+  Name of the package revision to delete.
+`
+)
+
+func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner {
+	r := &runner{
+		ctx: ctx,
+		cfg: rcg,
+	}
+	c := &cobra.Command{
+		Use:        "del",
+		Aliases:    []string{"delete"},
+		SuggestFor: []string{},
+		Short:      "Deletes one or more packages in registered repositories.",
+		Long:       longMsg,
+		Example:    "kpt alpha rpkg del repository:package:v1 --namespace=default",
+		PreRunE:    r.preRunE,
+		RunE:       r.runE,
+		Hidden:     porch.HidePorchCommands,
+	}
+	r.Command = c
+
+	// Create flags
+
+	return r
+}
+
+func NewCommand(ctx context.Context, rcg *genericclioptions.ConfigFlags) *cobra.Command {
+	return newRunner(ctx, rcg).Command
+}
+
+type runner struct {
+	ctx     context.Context
+	cfg     *genericclioptions.ConfigFlags
+	client  client.Client
+	Command *cobra.Command
+}
+
+func (r *runner) preRunE(cmd *cobra.Command, args []string) error {
+	const op errors.Op = command + ".preRunE"
+
+	client, err := porch.CreateClient(r.cfg)
+	if err != nil {
+		return errors.E(op, err)
+	}
+	r.client = client
+	return nil
+}
+
+func (r *runner) runE(cmd *cobra.Command, args []string) error {
+	const op errors.Op = command + ".runE"
+	var messages []string
+
+	for _, pkg := range args {
+		pr := &porchapi.PackageRevision{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "PackageRevision",
+				APIVersion: porchapi.SchemeGroupVersion.Identifier(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: *r.cfg.Namespace,
+				Name:      pkg,
+			},
+		}
+
+		switch err := r.client.Delete(r.ctx, pr); err {
+		case nil:
+			fmt.Fprintf(r.Command.ErrOrStderr(), "%s deleted", pkg)
+		default:
+			messages = append(messages, err.Error())
+			fmt.Fprintf(r.Command.ErrOrStderr(), "%s failed (%s)", pkg, err)
+		}
+	}
+
+	if len(messages) > 0 {
+		return errors.E(op, fmt.Errorf("errors:\n  %s", strings.Join(messages, "\n  ")))
+	}
+
+	return nil
+}

--- a/internal/cmdrpkgpropose/command.go
+++ b/internal/cmdrpkgpropose/command.go
@@ -1,0 +1,119 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdrpkgpropose
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoogleContainerTools/kpt/internal/errors"
+	"github.com/GoogleContainerTools/kpt/internal/util/porch"
+	"github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	command = "cmdrpkgpropose"
+	longMsg = `
+kpt alpha rpkg propose PACKAGE_REVISION
+
+Proposes a package revision draft to be finalized
+`
+)
+
+func NewCommand(ctx context.Context, rcg *genericclioptions.ConfigFlags) *cobra.Command {
+	return newRunner(ctx, rcg).Command
+}
+
+func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner {
+	r := &runner{
+		ctx:    ctx,
+		cfg:    rcg,
+		client: nil,
+	}
+
+	c := &cobra.Command{
+		Use:     "propose PACKAGE_REVISION",
+		Short:   "Proposes to finalize a package revision draft",
+		Long:    longMsg,
+		Example: "kpt alpha rpkg propose git-repository:package-revision:v3",
+		PreRunE: r.preRunE,
+		RunE:    r.runE,
+		Hidden:  porch.HidePorchCommands,
+	}
+	r.Command = c
+
+	return r
+}
+
+type runner struct {
+	ctx     context.Context
+	cfg     *genericclioptions.ConfigFlags
+	client  client.Client
+	Command *cobra.Command
+
+	// Flags
+}
+
+func (r *runner) preRunE(cmd *cobra.Command, args []string) error {
+	const op errors.Op = command + ".preRunE"
+
+	if len(args) < 1 {
+		return errors.E(op, "PACKAGE_REVISION is a required positional argument")
+	}
+
+	client, err := porch.CreateClient(r.cfg)
+	if err != nil {
+		return errors.E(op, err)
+	}
+	r.client = client
+	return nil
+}
+
+func (r *runner) runE(cmd *cobra.Command, args []string) error {
+	const op errors.Op = command + ".runE"
+
+	namespace := *r.cfg.Namespace
+	name := args[0]
+
+	pr := &v1alpha1.PackageRevision{}
+	if err := r.client.Get(r.ctx, client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}, pr); err != nil {
+		return errors.E(op, err)
+	}
+
+	switch pr.Spec.Lifecycle {
+	case v1alpha1.PackageRevisionLifecycleDraft:
+		// ok
+	case v1alpha1.PackageRevisionLifecycleProposed:
+		fmt.Fprintf(r.Command.OutOrStderr(), "%s is already proposed", name)
+		return nil
+	default:
+		return errors.E(op, fmt.Errorf("cannot propose %s package", pr.Spec.Lifecycle))
+	}
+
+	pr.Spec.Lifecycle = v1alpha1.PackageRevisionLifecycleProposed
+	if err := r.client.Update(r.ctx, pr); err != nil {
+		return errors.E(op, err)
+	}
+
+	fmt.Fprintf(r.Command.OutOrStderr(), "%s is successfully proposed", name)
+
+	return nil
+}

--- a/internal/cmdrpkgreject/command.go
+++ b/internal/cmdrpkgreject/command.go
@@ -1,0 +1,101 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdrpkgreject
+
+import (
+	"context"
+
+	"github.com/GoogleContainerTools/kpt/internal/errors"
+	"github.com/GoogleContainerTools/kpt/internal/util/porch"
+	"github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	command = "cmdrpkgreject"
+	longMsg = `
+kpt alpha rpkg reject PACKAGE_REVISION
+
+Rejects a proposal to finalize a package revision
+`
+)
+
+func NewCommand(ctx context.Context, rcg *genericclioptions.ConfigFlags) *cobra.Command {
+	return newRunner(ctx, rcg).Command
+}
+
+func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner {
+	r := &runner{
+		ctx:    ctx,
+		cfg:    rcg,
+		client: nil,
+	}
+
+	c := &cobra.Command{
+		Use:     "reject PACKAGE_REVISION",
+		Short:   "Rejects a proposal to finalize a package revision",
+		Long:    longMsg,
+		Example: "kpt alpha rpkg reject git-repository:package-revision:v3",
+		PreRunE: r.preRunE,
+		RunE:    r.runE,
+		Hidden:  porch.HidePorchCommands,
+	}
+	r.Command = c
+
+	return r
+}
+
+type runner struct {
+	ctx     context.Context
+	cfg     *genericclioptions.ConfigFlags
+	client  rest.Interface
+	Command *cobra.Command
+
+	// Flags
+}
+
+func (r *runner) preRunE(cmd *cobra.Command, args []string) error {
+	const op errors.Op = command + ".preRunE"
+
+	if len(args) < 1 {
+		return errors.E(op, "PACKAGE_REVISION is a required positional argument")
+	}
+
+	client, err := porch.CreateRESTClient(r.cfg)
+	if err != nil {
+		return errors.E(op, err)
+	}
+	r.client = client
+	return nil
+}
+
+func (r *runner) runE(cmd *cobra.Command, args []string) error {
+	const op errors.Op = command + ".runE"
+
+	namespace := *r.cfg.Namespace
+	name := args[0]
+
+	if err := porch.UpdatePackageRevisionApproval(r.ctx, r.client, client.ObjectKey{
+		Namespace: namespace,
+		Name:      name,
+	}, v1alpha1.PackageRevisionLifecycleDraft); err != nil {
+		return errors.E(op, err)
+	}
+
+	return nil
+}

--- a/internal/util/porch/approval.go
+++ b/internal/util/porch/approval.go
@@ -1,0 +1,59 @@
+package porch
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func UpdatePackageRevisionApproval(ctx context.Context, client rest.Interface, key client.ObjectKey, new v1alpha1.PackageRevisionLifecycle) error {
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.SchemeBuilder.AddToScheme(scheme); err != nil {
+		return err
+	}
+
+	codec := runtime.NewParameterCodec(scheme)
+	var pr v1alpha1.PackageRevision
+	if err := client.Get().
+		Namespace(key.Namespace).
+		Resource("packagerevisions").
+		Name(key.Name).
+		VersionedParams(&metav1.GetOptions{}, codec).
+		Do(ctx).
+		Into(&pr); err != nil {
+		return err
+	}
+
+	switch lifecycle := pr.Spec.Lifecycle; lifecycle {
+	case v1alpha1.PackageRevisionLifecycleProposed:
+		// ok
+	case new:
+		// already correct value
+		return nil
+	default:
+		return fmt.Errorf("cannot change approval from %s to %s", lifecycle, new)
+	}
+
+	// Approve - change the package revision kind to "final".
+	pr.Spec.Lifecycle = new
+
+	opts := metav1.UpdateOptions{}
+	result := &v1alpha1.PackageRevision{}
+	if err := client.Put().
+		Namespace(pr.Namespace).
+		Resource("packagerevisions").
+		Name(pr.Name).
+		SubResource("approval").
+		VersionedParams(&opts, codec).
+		Body(&pr).
+		Do(ctx).
+		Into(result); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Implementation of `kpt alpha rpkg` commands: `propose`, `reject`,
`approve`, `delete`.
