### PR TITLE
feat: Add `--type` flag to `kpt fn eval`

### DIFF
--- a/e2e/testdata/fn-eval/save-fn/validator-type/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/validator-type/.expected/config.yaml
@@ -1,0 +1,23 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+testType: eval
+image: set-namespace:v0.1.3
+args:
+  namespace: staging
+stdErr: |
+  [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3"
+  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s
+  adding function to Kptfile
+  Kptfile updated

--- a/e2e/testdata/fn-eval/save-fn/validator-type/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/save-fn/validator-type/.expected/diff.patch
@@ -1,0 +1,34 @@
+diff --git a/Kptfile b/Kptfile
+index d9e2f05..c6e80ef 100644
+--- a/Kptfile
++++ b/Kptfile
+@@ -2,3 +2,10 @@ apiVersion: kpt.dev/v1
+ kind: Kptfile
+ metadata:
+   name: app
++  namespace: staging
++pipeline:
++  validators:
++    - image: gcr.io/kpt-fn/set-namespace:v0.1.3
++      configMap:
++        namespace: staging
++      name: gcr.io/kpt-fn/set-namespace:v0.1.3
+diff --git a/resources.yaml b/resources.yaml
+index ac634f3..0e09da8 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -15,6 +15,7 @@ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+   name: nginx-deployment
++  namespace: staging
+ spec:
+   replicas: 3
+ ---
+@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
+ kind: Custom
+ metadata:
+   name: custom
++  namespace: staging
+ spec:
+   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/save-fn/validator-type/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/validator-type/.expected/exec.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+kpt fn eval -s -t validator -i set-namespace:v0.1.3 -- namespace=staging

--- a/e2e/testdata/fn-eval/save-fn/validator-type/.krmignore
+++ b/e2e/testdata/fn-eval/save-fn/validator-type/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-eval/save-fn/validator-type/Kptfile
+++ b/e2e/testdata/fn-eval/save-fn/validator-type/Kptfile
@@ -1,0 +1,4 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: app

--- a/e2e/testdata/fn-eval/save-fn/validator-type/resources.yaml
+++ b/e2e/testdata/fn-eval/save-fn/validator-type/resources.yaml
@@ -1,0 +1,26 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+spec:
+  image: nginx:1.2.3


### PR DESCRIPTION
Add new flag `--type` to `kpt fn eval.  This flag works together with `--save` which will add the evaluated functions to the right Kptfile pipeline section ("validators" or "mutators")

Misc: 	
- Add e2e test `save-fn/validator-type`
- Update README and autogenerate the user guides
- Somehow, the doc for a previous flag `--save` is droppped. https://github.com/GoogleContainerTools/kpt/commit/50230e355398b7e472ffe1de7854a1eb84e08a62 Added the doc for `--save` as well.