### PR TITLE
feat: Kpt CLI Function discovery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/GoogleContainerTools/kpt
 go 1.17
 
 require (
-	github.com/GoogleContainerTools/kpt/porch/api v0.0.0-20220404223850-4fe7ba260b65
+	github.com/GoogleContainerTools/kpt/porch/api v0.0.0-20220407000100-7a5545349d71
 	github.com/cpuguy83/go-md2man/v2 v2.0.1
 	github.com/go-errors/errors v1.4.2
 	github.com/google/go-cmp v0.5.7

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
-github.com/GoogleContainerTools/kpt/porch/api v0.0.0-20220404223850-4fe7ba260b65 h1:HTV58N6lLjmq4XNhlxzU/u435HO8zzXIYQET6WJc8aI=
-github.com/GoogleContainerTools/kpt/porch/api v0.0.0-20220404223850-4fe7ba260b65/go.mod h1:cMUBP0fY1F/1noOO1jJoIHM3R8Cp1BYWIG9XAZET5gI=
+github.com/GoogleContainerTools/kpt/porch/api v0.0.0-20220407000100-7a5545349d71 h1:ciqpo48GR1x4CI46l2t0+J1WXTQj0wSKI8ckixStVcQ=
+github.com/GoogleContainerTools/kpt/porch/api v0.0.0-20220407000100-7a5545349d71/go.mod h1:51Vk7QZ+XUzHCvQBi7t9tiWqTXvy6T13cv/inUXJJ0s=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd h1:sjQovDkwrZp8u+gxLtPgKGjk5hCxuy2hrRejBTA9xFU=
 github.com/MakeNowJust/heredoc v0.0.0-20170808103936-bb23615498cd/go.mod h1:64YHyfSL2R96J44Nlwm39UHepQbyR5q10x7iYa1ks2E=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=

--- a/internal/fnruntime/container.go
+++ b/internal/fnruntime/container.go
@@ -179,6 +179,7 @@ func AddDefaultImagePathPrefix(image string) string {
 	if !strings.Contains(image, "/") {
 		return fmt.Sprintf("gcr.io/kpt-fn/%s", image)
 	}
+	// TODO(yuwenma): append porch repo prefix if the image comes from porch function.
 	return image
 }
 

--- a/internal/util/porch/function.go
+++ b/internal/util/porch/function.go
@@ -1,0 +1,144 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package porch
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	// Enable the GCP Authentication plugin
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+)
+
+const expirationNanoSecond = 10
+
+var PorchExpiration = time.Duration(expirationNanoSecond) * time.Second
+
+// FunctionGetter gets the list of v1alpha1.Functions from the cluster.
+type FunctionGetter struct {
+	ctx context.Context
+}
+
+func (f FunctionGetter) Get() []v1alpha1.Function {
+	kubeflags := genericclioptions.NewConfigFlags(true)
+	client, err := CreateRESTClient(kubeflags)
+	if err != nil {
+		return nil
+	}
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.SchemeBuilder.AddToScheme(scheme); err != nil {
+		return nil
+	}
+	codec := runtime.NewParameterCodec(scheme)
+	var functions v1alpha1.FunctionList
+	if err := client.Get().
+		Timeout(PorchExpiration).
+		Resource("functions").
+		VersionedParams(&metav1.GetOptions{}, codec).
+		Do(f.ctx).
+		Into(&functions); err != nil {
+		return nil
+	}
+	return functions.Items
+}
+
+type Matcher interface {
+	Match(v1alpha1.Function) bool
+}
+
+var _ Matcher = TypeMatcher{}
+var _ Matcher = KeywordsMatcher{}
+
+type TypeMatcher struct {
+	FnType string
+}
+
+// Match determines whether the `function` (which can be multi-typed), belongs
+// to the matcher's FnType. type value should only be `validator` or `mutator`.
+func (m TypeMatcher) Match(function v1alpha1.Function) bool {
+	for _, actualType := range function.Spec.FunctionTypes {
+		if string(actualType) == m.FnType {
+			return true
+		}
+	}
+	return false
+}
+
+type KeywordsMatcher struct {
+	Keywords []string
+}
+
+// Match determines whether the `function` has keywords which match the matcher's `Keywords`.
+// Experimental: This logic may change to only if all function keywords are found from  matcher's `Keywords`,
+// can it claims a match (return true).
+func (m KeywordsMatcher) Match(function v1alpha1.Function) bool {
+	if len(m.Keywords) == 0 {
+		// Accept all functions if keywords are not given.
+		return true
+	}
+	for _, actual := range function.Spec.Keywords {
+		for _, expected := range m.Keywords {
+			if actual != expected {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func MatchFunctions(ctx context.Context, matchers ...Matcher) []v1alpha1.Function {
+	var suggestedFunctions []v1alpha1.Function
+	functions := FunctionGetter{ctx: ctx}.Get()
+	for _, function := range functions {
+		for _, matcher := range matchers {
+			if matcher.Match(function) {
+				suggestedFunctions = append(suggestedFunctions, function)
+			}
+		}
+	}
+	return suggestedFunctions
+}
+
+// ToShortNames trims the function image to remove the OCI repo prefix and
+// only show the actual image and tag (or digest).
+// TODO(yuwenma): or may users prefer the Function `meta.name`?
+func ToShortNames(functions []v1alpha1.Function) []string {
+	var shortNameFunctions []string
+	for _, function := range functions {
+		slash := strings.LastIndex(function.Spec.Image, "/")
+		shortNameFunctions = append(shortNameFunctions, function.Spec.Image[slash+1:])
+	}
+	return shortNameFunctions
+}
+
+func UnifyKeywords(functions []v1alpha1.Function) []string {
+	var keywords []string
+	keywordsMap := map[string]bool{}
+	for _, function := range functions {
+		for _, kw := range function.Spec.Keywords {
+			if _, ok := keywordsMap[kw]; !ok {
+				keywordsMap[kw] = true
+				keywords = append(keywords, kw)
+			}
+		}
+	}
+	return keywords
+}

--- a/porch/go.mod
+++ b/porch/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/set-namespace v0.3.1
 	github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/starlark v0.4.0
 	github.com/GoogleContainerTools/kpt-functions-sdk/go/fn v0.0.0-20220405020624-e5817d5d2014
-	github.com/GoogleContainerTools/kpt/porch/api v0.0.0-20220404223850-4fe7ba260b65
+	github.com/GoogleContainerTools/kpt/porch/api v0.0.0-20220407000100-7a5545349d71
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.3-0.20220408232334-4f916225cb2f
 	github.com/google/go-cmp v0.5.7

--- a/porch/repository/pkg/oci/function.go
+++ b/porch/repository/pkg/oci/function.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	ociImagePrefix      = "kpt.dev.fn.meta."
+	ociImagePrefix      = "dev.kpt.fn.meta."
 	FunctionTypesKey    = ociImagePrefix + "types"
 	DescriptionKey      = ociImagePrefix + "description"
 	DocumentationURLKey = ociImagePrefix + "documentationurl"

--- a/porch/repository/pkg/oci/oci.go
+++ b/porch/repository/pkg/oci/oci.go
@@ -215,7 +215,7 @@ func GetSliceFromAnnotation(key string, manifest *v1.Manifest) []string {
 }
 
 func GetSingleFromAnnotation(key string, manifest *v1.Manifest) string {
-	if val, ok := manifest.Annotations[FunctionTypesKey]; ok {
+	if val, ok := manifest.Annotations[key]; ok {
 		return val
 	}
 	return fmt.Sprintf("annotation %v unset", key)


### PR DESCRIPTION
### Description

This PR extends the `kpt fn eval` autocompletion to help user to discover functions by using the porch function fields, which store the OCI image annotations. the work on porch side has been merged  https://github.com/GoogleContainerTools/kpt/pull/2972 

- Define `NewPorchFunctionClient`, which provides the restclient to query porch orchestrator. Set the restulapi call timeout  to be 3 seconds. This timeout is used to determine whether porch is enabled on the cluster side.  
- `ListKeywords` iterates the porch functions' `keywords` field, and suggest users a unique keyword list.
- `ListFunctions` iterates the porch functions and filter functions with the matching function type (default to `mutator`) and the `keywords` (if not given, accept all) a well as  the existing [catalog.kpt.dev](https://catalog.kpt.dev/) functions  
- All suggested functions will be filtered based on the function type (`mutator` or `validator`)/
 
### New UX experience 
- Add `--type` flag to register the autocomplete with value `mutator`, `validator`, and store the evaluated functions to the right kptfile list: `.pipeline.mutators` if mutator type, `.pipeline.validators` if validator type. 
- Add `--keywords` flag which pull the porch functions to get the `function.spec.keywords` and provide users a unique keywords list
- Modify the `--image` autocompletion function to rely on NewPorchFunctionClient to
  -  decide  whether porch is used
  -  autocomplete showing the `keywords` from porch functions
  - autocomplete showing the `functions` from porch and catalog.kpt.dev, filter by function type and keywords. 


### Fixes
- Change the image annotation prefix from `kpt.dev.fn` to `dev.kpt.fn` to follow the reverse domain convention
- Fix the annotation mapping for `description` and `documentationURL`

### Update:
- `--type` related code is merged in https://github.com/GoogleContainerTools/kpt/pull/2975

### TODO:
- Update `AddDefaultImagePathPrefix`  to append porch function prefix.  
- Redesign the kpt-functions-catalog release workflow, add the function meta resource to function OCI image annotation before pushing to [gcr.io/kpt-fn](gcr.io/kpt-fn), including the meta data in [https://catalog.kpt.dev/catalog-v2.json](https://catalog.kpt.dev/catalog-v2.json)
- Modify the existing autocompletion to merge the logic of fetching functions from catalog.kpt.fn with the porch function filtering. Use the same rules (by function type, by keywords) to suggest functions and keywords in `kpt fn eval` autocompletion. 
