### PR TITLE
test-git-server: Support klog flags

### DIFF
--- a/porch/test/git/main.go
+++ b/porch/test/git/main.go
@@ -37,6 +37,8 @@ var (
 )
 
 func main() {
+	klog.InitFlags(nil)
+
 	flag.Parse()
 
 	if err := run(flag.Args()); err != nil {


### PR DESCRIPTION
Needed to enable verbose logging.
