### PR TITLE
Do not use kpt Git URL parsing

### DIFF
--- a/e2e/porch_test.go
+++ b/e2e/porch_test.go
@@ -19,7 +19,6 @@ package e2e
 import (
 	"bytes"
 	"errors"
-	"fmt"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -145,9 +144,7 @@ func startGitServer(t *testing.T, path string) string {
 	porch.KubectlApply(t, config)
 	porch.KubectlWaitForDeployment(t, testGitNamespace, "git-server")
 	porch.KubectlWaitForService(t, testGitNamespace, "git-server")
-	// TODO: kpt git address parsing is strange; the address constructed here is invalid
-	// but required nonetheless to satisfy kpt parsing.
-	porch.KubectlWaitForGitDNS(t, fmt.Sprintf("%s.git/@main", gitRepositoryAddress))
+	porch.KubectlWaitForGitDNS(t, gitRepositoryAddress)
 
 	return gitRepositoryAddress
 }

--- a/e2e/testdata/porch/repo-register/config.yaml
+++ b/e2e/testdata/porch/repo-register/config.yaml
@@ -14,8 +14,8 @@ commands:
       - --namespace=repo-register
       - --output=custom-columns=NAME:.metadata.name,ADDRESS:.spec.git.repo,BRANCH:.spec.git.branch,DIR:.spec.git.directory
     stdout: |
-      NAME              ADDRESS                                      BRANCH   DIR
-      test-blueprints   https://github.com/platkrm/test-blueprints   main     /
+      NAME              ADDRESS                                          BRANCH   DIR
+      test-blueprints   https://github.com/platkrm/test-blueprints.git   main     /
   - args:
       - alpha
       - repo

--- a/e2e/testdata/porch/rpkg-clone/config.yaml
+++ b/e2e/testdata/porch/rpkg-clone/config.yaml
@@ -5,13 +5,15 @@ commands:
       - register
       - --namespace=rpkg-clone
       - --name=git
-      - http://git-server.test-git-namespace.svc.cluster.local:8080.git/@main
+      - http://git-server.test-git-namespace.svc.cluster.local:8080
   - args:
       - alpha
       - rpkg
       - clone
       - --namespace=rpkg-clone
-      - https://github.com/platkrm/test-blueprints.git/basens@basens/v1
+      - https://github.com/platkrm/test-blueprints.git
+      - --directory=basens
+      - --ref=basens/v1
       - git:basens-clone:v0
   - args:
       - alpha
@@ -50,14 +52,14 @@ commands:
           git:
             directory: basens
             ref: basens/v1
-            repo: https://github.com/platkrm/test-blueprints
+            repo: https://github.com/platkrm/test-blueprints.git
           type: git
         upstreamLock:
           git:
             commit: 67f29546028f0a48c6bbb08614934d0e070cdd3a
             directory: basens
             ref: basens/v1
-            repo: https://github.com/platkrm/test-blueprints
+            repo: https://github.com/platkrm/test-blueprints.git
           type: git
       - apiVersion: v1
         kind: Namespace
@@ -93,14 +95,14 @@ commands:
           git:
             directory: empty
             ref: v1
-            repo: https://github.com/platkrm/test-blueprints
+            repo: https://github.com/platkrm/test-blueprints.git
           type: git
         upstreamLock:
           git:
             commit: 3de8635354eda8e7de756494a4e0eb5c12af01ab
             directory: empty
             ref: v1
-            repo: https://github.com/platkrm/test-blueprints
+            repo: https://github.com/platkrm/test-blueprints.git
           type: git
       kind: ResourceList
     yaml: true

--- a/e2e/testdata/porch/rpkg-init-deploy/config.yaml
+++ b/e2e/testdata/porch/rpkg-init-deploy/config.yaml
@@ -6,7 +6,7 @@ commands:
       - --namespace=rpkg-init-deploy
       - --name=git
       - --deployment
-      - http://git-server.test-git-namespace.svc.cluster.local:8080.git/@main
+      - http://git-server.test-git-namespace.svc.cluster.local:8080
   - args:
       - alpha
       - repo

--- a/e2e/testdata/porch/rpkg-init/config.yaml
+++ b/e2e/testdata/porch/rpkg-init/config.yaml
@@ -5,7 +5,7 @@ commands:
       - register
       - --namespace=rpkg-init
       - --name=git
-      - http://git-server.test-git-namespace.svc.cluster.local:8080.git/@main
+      - http://git-server.test-git-namespace.svc.cluster.local:8080
   - args:
       - alpha
       - repo

--- a/e2e/testdata/porch/rpkg-lifecycle/config.yaml
+++ b/e2e/testdata/porch/rpkg-lifecycle/config.yaml
@@ -5,7 +5,7 @@ commands:
       - register
       - --namespace=rpkg-lifecycle
       - --name=git
-      - http://git-server.test-git-namespace.svc.cluster.local:8080.git/@main
+      - http://git-server.test-git-namespace.svc.cluster.local:8080
   - args:
       - alpha
       - rpkg

--- a/e2e/testdata/porch/rpkg-push/config.yaml
+++ b/e2e/testdata/porch/rpkg-push/config.yaml
@@ -5,7 +5,7 @@ commands:
       - register
       - --namespace=rpkg-push
       - --name=git
-      - http://git-server.test-git-namespace.svc.cluster.local:8080.git/@main
+      - http://git-server.test-git-namespace.svc.cluster.local:8080
   - args:
       - alpha
       - rpkg

--- a/internal/cmdreporeg/command_test.go
+++ b/internal/cmdreporeg/command_test.go
@@ -93,11 +93,13 @@ func TestRepoReg(t *testing.T) {
 		{
 			name: "FullRegister",
 			args: []string{
-				"https://github.com/platkrm/test-blueprints.git/catalog@main-branch",
+				"https://github.com/platkrm/test-blueprints.git",
 				"--title=\"Test Repository Title\"",
 				"--name=repository-resource-name",
 				"--description=\"Test Repository Description\"",
 				"--deployment",
+				"--directory=/catalog",
+				"--branch=main-branch",
 				"--namespace=repository-namespace",
 			},
 			actions: []httpAction{

--- a/internal/cmdreporeg/testdata/auth-repository.yaml
+++ b/internal/cmdreporeg/testdata/auth-repository.yaml
@@ -8,7 +8,7 @@ spec:
     git:
         branch: main
         directory: /
-        repo: https://github.com/platkrm/test-blueprints
+        repo: https://github.com/platkrm/test-blueprints.git
         secretRef:
             name: test-blueprints-auth
     type: git

--- a/internal/cmdreporeg/testdata/full-repository.yaml
+++ b/internal/cmdreporeg/testdata/full-repository.yaml
@@ -11,7 +11,7 @@ spec:
     git:
         branch: main-branch
         directory: /catalog
-        repo: https://github.com/platkrm/test-blueprints
+        repo: https://github.com/platkrm/test-blueprints.git
         secretRef:
             name: ""
     title: '"Test Repository Title"'

--- a/internal/util/porch/const.go
+++ b/internal/util/porch/const.go
@@ -15,4 +15,4 @@
 package porch
 
 // Controls whether the Package Orchestration CLI commands are hidden.
-const HidePorchCommands = true
+const HidePorchCommands = false

--- a/internal/util/porch/name.go
+++ b/internal/util/porch/name.go
@@ -69,5 +69,7 @@ func (name PackageName) String() string {
 
 func LastSegment(path string) string {
 	path = strings.TrimRight(path, "/")
-	return path[strings.LastIndex(path, "/")+1:]
+	path = path[strings.LastIndex(path, "/")+1:]
+	path = strings.TrimSuffix(path, ".git")
+	return path
 }


### PR DESCRIPTION
The parser analyzes local environment and has other issues.
Rather, temporarily accept `--directory`, `--branch` and `--ref`
flags for `kpt alpha rpkg clone` and `kpt alpha repo reg`
respectively.
