### PR TITLE
Update Porch API Constants

### DIFF
--- a/e2e/testdata/porch/rpkg-lifecycle/config.yaml
+++ b/e2e/testdata/porch/rpkg-lifecycle/config.yaml
@@ -83,7 +83,7 @@ commands:
       - --output=custom-columns=NAME:.metadata.name,LIFECYCLE:.spec.lifecycle
     stdout: |
       NAME                       LIFECYCLE
-      git:lifecycle-package:v1   Final
+      git:lifecycle-package:v1   Published
   - args:
       - alpha
       - rpkg

--- a/porch/api/porch/types_packagerevisions.go
+++ b/porch/api/porch/types_packagerevisions.go
@@ -43,9 +43,9 @@ type PackageRevisionList struct {
 type PackageRevisionLifecycle string
 
 const (
-	PackageRevisionLifecycleDraft    PackageRevisionLifecycle = "Draft"
-	PackageRevisionLifecycleProposed PackageRevisionLifecycle = "Proposed"
-	PackageRevisionLifecycleFinal    PackageRevisionLifecycle = "Final"
+	PackageRevisionLifecycleDraft     PackageRevisionLifecycle = "Draft"
+	PackageRevisionLifecycleProposed  PackageRevisionLifecycle = "Proposed"
+	PackageRevisionLifecyclePublished PackageRevisionLifecycle = "Published"
 )
 
 // PackageRevisionSpec defines the desired state of PackageRevision

--- a/porch/api/porch/v1alpha1/types_packagerevisions.go
+++ b/porch/api/porch/v1alpha1/types_packagerevisions.go
@@ -44,9 +44,9 @@ type PackageRevisionList struct {
 type PackageRevisionLifecycle string
 
 const (
-	PackageRevisionLifecycleDraft    PackageRevisionLifecycle = "Draft"
-	PackageRevisionLifecycleProposed PackageRevisionLifecycle = "Proposed"
-	PackageRevisionLifecycleFinal    PackageRevisionLifecycle = "Final"
+	PackageRevisionLifecycleDraft     PackageRevisionLifecycle = "Draft"
+	PackageRevisionLifecycleProposed  PackageRevisionLifecycle = "Proposed"
+	PackageRevisionLifecyclePublished PackageRevisionLifecycle = "Published"
 )
 
 // PackageRevisionSpec defines the desired state of PackageRevision

--- a/porch/api/porchconfig/v1alpha1/config.porch.kpt.dev_repositories.yaml
+++ b/porch/api/porchconfig/v1alpha1/config.porch.kpt.dev_repositories.yaml
@@ -52,7 +52,7 @@ spec:
               directly? (or via this API)"
             properties:
               content:
-                description: 'Content stored in the repository (i.e. Function, PackageRevision
+                description: 'Content stored in the repository (i.e. Function, Package
                   - the literal values correspond to the API resource names). TODO:
                   support repository with mixed content?'
                 type: string

--- a/porch/api/porchconfig/v1alpha1/types.go
+++ b/porch/api/porchconfig/v1alpha1/types.go
@@ -41,7 +41,7 @@ type RepositoryContent string
 
 const (
 	RepositoryContentFunction RepositoryContent = "Function"
-	RepositoryContentPackage  RepositoryContent = "PackageRevision"
+	RepositoryContentPackage  RepositoryContent = "Package"
 )
 
 // RepositorySpec defines the desired state of Repository
@@ -57,7 +57,7 @@ type RepositorySpec struct {
 	Deployment bool `json:"deployment,omitempty"`
 	// Type of the repository (i.e. git, OCI)
 	Type RepositoryType `json:"type,omitempty"`
-	// Content stored in the repository (i.e. Function, PackageRevision - the literal values correspond to the API resource names).
+	// Content stored in the repository (i.e. Function, Package - the literal values correspond to the API resource names).
 	// TODO: support repository with mixed content?
 	Content RepositoryContent `json:"content,omitempty"`
 	// Git repository details. Required if `type` is `git`. Ignored if `type` is not `git`.

--- a/porch/apiserver/pkg/e2e/e2e_test.go
+++ b/porch/apiserver/pkg/e2e/e2e_test.go
@@ -623,15 +623,15 @@ func (t *PorchSuite) TestProposeApprove(ctx context.Context) {
 	}
 
 	// Approve using Update should fail.
-	proposed.Spec.Lifecycle = porchapi.PackageRevisionLifecycleFinal
+	proposed.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
 	if err := t.client.Update(ctx, &proposed); err == nil {
 		t.Fatalf("Finalization of a package via Update unexpectedly succeeded")
 	}
 
 	// Approve the package
-	proposed.Spec.Lifecycle = porchapi.PackageRevisionLifecycleFinal
+	proposed.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
 	approved := t.UpdateApprovalF(ctx, &proposed, metav1.UpdateOptions{})
-	if got, want := approved.Spec.Lifecycle, porchapi.PackageRevisionLifecycleFinal; got != want {
+	if got, want := approved.Spec.Lifecycle, porchapi.PackageRevisionLifecyclePublished; got != want {
 		t.Fatalf("Approved package lifecycle value: got %s, want %s", got, want)
 	}
 }
@@ -720,7 +720,7 @@ func (t *PorchSuite) TestDeleteFinal(ctx context.Context) {
 	pkg.Spec.Lifecycle = porchapi.PackageRevisionLifecycleProposed
 	t.UpdateF(ctx, &pkg)
 
-	pkg.Spec.Lifecycle = porchapi.PackageRevisionLifecycleFinal
+	pkg.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
 	t.UpdateApprovalF(ctx, &pkg, metav1.UpdateOptions{})
 
 	t.mustExist(ctx, client.ObjectKey{Namespace: t.namespace, Name: name}, &pkg)

--- a/porch/apiserver/pkg/registry/porch/packagerevision_approval_test.go
+++ b/porch/apiserver/pkg/registry/porch/packagerevision_approval_test.go
@@ -33,26 +33,26 @@ func TestApprovalUpdateStrategy(t *testing.T) {
 		{
 			old:     "",
 			valid:   []api.PackageRevisionLifecycle{},
-			invalid: []api.PackageRevisionLifecycle{"", "Wrong", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed, api.PackageRevisionLifecycleFinal},
+			invalid: []api.PackageRevisionLifecycle{"", "Wrong", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed, api.PackageRevisionLifecyclePublished},
 		},
 		{
 			old:     "Wrong",
 			valid:   []api.PackageRevisionLifecycle{},
-			invalid: []api.PackageRevisionLifecycle{"", "Wrong", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed, api.PackageRevisionLifecycleFinal},
+			invalid: []api.PackageRevisionLifecycle{"", "Wrong", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed, api.PackageRevisionLifecyclePublished},
 		},
 		{
 			old:     api.PackageRevisionLifecycleDraft,
 			valid:   []api.PackageRevisionLifecycle{},
-			invalid: []api.PackageRevisionLifecycle{"", "Wrong", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed, api.PackageRevisionLifecycleFinal},
+			invalid: []api.PackageRevisionLifecycle{"", "Wrong", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed, api.PackageRevisionLifecyclePublished},
 		},
 		{
-			old:     api.PackageRevisionLifecycleFinal,
+			old:     api.PackageRevisionLifecyclePublished,
 			valid:   []api.PackageRevisionLifecycle{},
-			invalid: []api.PackageRevisionLifecycle{"", "Wrong", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed, api.PackageRevisionLifecycleFinal},
+			invalid: []api.PackageRevisionLifecycle{"", "Wrong", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed, api.PackageRevisionLifecyclePublished},
 		},
 		{
 			old:     api.PackageRevisionLifecycleProposed,
-			valid:   []api.PackageRevisionLifecycle{api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleFinal},
+			valid:   []api.PackageRevisionLifecycle{api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecyclePublished},
 			invalid: []api.PackageRevisionLifecycle{"", "Wrong", api.PackageRevisionLifecycleProposed},
 		},
 	} {

--- a/porch/apiserver/pkg/registry/porch/packagerevision_test.go
+++ b/porch/apiserver/pkg/registry/porch/packagerevision_test.go
@@ -33,27 +33,27 @@ func TestUpdateStrategy(t *testing.T) {
 		{
 			old:     "",
 			valid:   []api.PackageRevisionLifecycle{"", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed},
-			invalid: []api.PackageRevisionLifecycle{"Wrong", api.PackageRevisionLifecycleFinal},
+			invalid: []api.PackageRevisionLifecycle{"Wrong", api.PackageRevisionLifecyclePublished},
 		},
 		{
 			old:     api.PackageRevisionLifecycleDraft,
 			valid:   []api.PackageRevisionLifecycle{"", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed},
-			invalid: []api.PackageRevisionLifecycle{"Wrong", api.PackageRevisionLifecycleFinal},
+			invalid: []api.PackageRevisionLifecycle{"Wrong", api.PackageRevisionLifecyclePublished},
 		},
 		{
 			old:     api.PackageRevisionLifecycleProposed,
 			valid:   []api.PackageRevisionLifecycle{"", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed},
-			invalid: []api.PackageRevisionLifecycle{"Wrong", api.PackageRevisionLifecycleFinal},
+			invalid: []api.PackageRevisionLifecycle{"Wrong", api.PackageRevisionLifecyclePublished},
 		},
 		{
-			old:     api.PackageRevisionLifecycleFinal,
+			old:     api.PackageRevisionLifecyclePublished,
 			valid:   []api.PackageRevisionLifecycle{},
-			invalid: []api.PackageRevisionLifecycle{"", "Wrong", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed, api.PackageRevisionLifecycleFinal},
+			invalid: []api.PackageRevisionLifecycle{"", "Wrong", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed, api.PackageRevisionLifecyclePublished},
 		},
 		{
 			old:     "Wrong",
 			valid:   []api.PackageRevisionLifecycle{},
-			invalid: []api.PackageRevisionLifecycle{"", "Wrong", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed, api.PackageRevisionLifecycleFinal},
+			invalid: []api.PackageRevisionLifecycle{"", "Wrong", api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed, api.PackageRevisionLifecyclePublished},
 		},
 	} {
 		for _, new := range tc.valid {

--- a/porch/engine/pkg/engine/engine.go
+++ b/porch/engine/pkg/engine/engine.go
@@ -79,7 +79,7 @@ func (cad *cadEngine) CreatePackageRevision(ctx context.Context, repositoryObj *
 		obj.Spec.Lifecycle = api.PackageRevisionLifecycleDraft
 	case api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed:
 		// These values are ok
-	case api.PackageRevisionLifecycleFinal:
+	case api.PackageRevisionLifecyclePublished:
 		// TODO: generate errors that can be translated to correct HTTP responses
 		return nil, fmt.Errorf("cannot create a package revision with lifecycle value 'Final'")
 	default:
@@ -197,14 +197,14 @@ func (cad *cadEngine) UpdatePackageRevision(ctx context.Context, repositoryObj *
 		return nil, fmt.Errorf("invalid original lifecycle value: %q", lifecycle)
 	case api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed:
 		// Draft or proposed can be updated.
-	case api.PackageRevisionLifecycleFinal:
+	case api.PackageRevisionLifecyclePublished:
 		// TODO: generate errors that can be translated to correct HTTP responses
 		return nil, fmt.Errorf("cannot update a package revision with lifecycle value %q", lifecycle)
 	}
 	switch lifecycle := newObj.Spec.Lifecycle; lifecycle {
 	default:
 		return nil, fmt.Errorf("invalid desired lifecycle value: %q", lifecycle)
-	case api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed, api.PackageRevisionLifecycleFinal:
+	case api.PackageRevisionLifecycleDraft, api.PackageRevisionLifecycleProposed, api.PackageRevisionLifecyclePublished:
 		// These values are ok
 	}
 
@@ -311,7 +311,7 @@ func (cad *cadEngine) UpdatePackageResources(ctx context.Context, repositoryObj 
 		return nil, fmt.Errorf("invalid original lifecycle value: %q", lifecycle)
 	case api.PackageRevisionLifecycleDraft:
 		// Only draf can be updated.
-	case api.PackageRevisionLifecycleProposed, api.PackageRevisionLifecycleFinal:
+	case api.PackageRevisionLifecycleProposed, api.PackageRevisionLifecyclePublished:
 		// TODO: generate errors that can be translated to correct HTTP responses
 		return nil, fmt.Errorf("cannot update a package revision with lifecycle value %q; package must be Draft", lifecycle)
 	}

--- a/porch/engine/pkg/engine/grpcruntime.go
+++ b/porch/engine/pkg/engine/grpcruntime.go
@@ -93,7 +93,7 @@ func (gr *grpcRunner) Run(r io.Reader, w io.Writer) error {
 		Image:        gr.image,
 	})
 	if err != nil {
-		return fmt.Errorf("func eval failed: %w", err)
+		return fmt.Errorf("func eval %q failed: %w", gr.image, err)
 	}
 	if _, err := w.Write(res.ResourceList); err != nil {
 		return fmt.Errorf("failed to write function runner output: %w", err)

--- a/porch/repository/pkg/cache/cache.go
+++ b/porch/repository/pkg/cache/cache.go
@@ -90,8 +90,8 @@ func (c *Cache) OpenRepository(ctx context.Context, repositorySpec *configapi.Re
 		if gitSpec.Repo == "" {
 			return nil, errors.New("git.repo property is required")
 		}
-		if repositorySpec.Spec.Content != configapi.RepositoryContentPackage {
-			return nil, fmt.Errorf("git repository supports PackageRevision content only; got %q", string(repositorySpec.Spec.Content))
+		if !isPackageContent(repositorySpec.Spec.Content) {
+			return nil, fmt.Errorf("git repository supports Package content only; got %q", string(repositorySpec.Spec.Content))
 		}
 		key := "git://" + gitSpec.Repo
 
@@ -114,6 +114,17 @@ func (c *Cache) OpenRepository(ctx context.Context, repositorySpec *configapi.Re
 
 	default:
 		return nil, fmt.Errorf("type %q not supported", repositoryType)
+	}
+}
+
+func isPackageContent(content configapi.RepositoryContent) bool {
+	switch content {
+	case "PackageRevision":
+		return true // TODO: remove this once migration to "Package" is complete.
+	case configapi.RepositoryContentPackage:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/porch/repository/pkg/git/draft.go
+++ b/porch/repository/pkg/git/draft.go
@@ -80,7 +80,7 @@ func (r *gitRepository) closeDraft(ctx context.Context, d *gitPackageDraft) (*gi
 	var newRef *plumbing.Reference
 
 	switch d.lifecycle {
-	case v1alpha1.PackageRevisionLifecycleFinal:
+	case v1alpha1.PackageRevisionLifecyclePublished:
 		// Finalize the package revision. Commit it to main branch.
 		commitHash, newTreeHash, commitBase, err := r.commitPackageToMain(ctx, d)
 		if err != nil {

--- a/porch/repository/pkg/git/git_test.go
+++ b/porch/repository/pkg/git/git_test.go
@@ -129,7 +129,7 @@ func TestGitPackageRoundTrip(t *testing.T) {
 		if err != nil {
 			t.Fatalf("UpdatePackage(%#v failed: %v", original, err)
 		}
-		if err := update.UpdateLifecycle(ctx, v1alpha1.PackageRevisionLifecycleFinal); err != nil {
+		if err := update.UpdateLifecycle(ctx, v1alpha1.PackageRevisionLifecyclePublished); err != nil {
 			t.Fatalf("UpdateLifecycle failed: %v", err)
 		}
 		approved, err := update.Close(ctx)
@@ -467,18 +467,18 @@ func TestListPackagesSimple(t *testing.T) {
 	}
 
 	want := map[string]v1alpha1.PackageRevisionLifecycle{
-		"simple:empty:v1":   v1alpha1.PackageRevisionLifecycleFinal,
-		"simple:basens:v1":  v1alpha1.PackageRevisionLifecycleFinal,
-		"simple:basens:v2":  v1alpha1.PackageRevisionLifecycleFinal,
-		"simple:istions:v1": v1alpha1.PackageRevisionLifecycleFinal,
-		"simple:istions:v2": v1alpha1.PackageRevisionLifecycleFinal,
+		"simple:empty:v1":   v1alpha1.PackageRevisionLifecyclePublished,
+		"simple:basens:v1":  v1alpha1.PackageRevisionLifecyclePublished,
+		"simple:basens:v2":  v1alpha1.PackageRevisionLifecyclePublished,
+		"simple:istions:v1": v1alpha1.PackageRevisionLifecyclePublished,
+		"simple:istions:v2": v1alpha1.PackageRevisionLifecyclePublished,
 
 		// TODO: may want to filter these out, for example by including only those package
 		// revisions from main branch that differ in content (their tree hash) from another
 		// taged revision of the package.
-		"simple:empty:main":   v1alpha1.PackageRevisionLifecycleFinal,
-		"simple:basens:main":  v1alpha1.PackageRevisionLifecycleFinal,
-		"simple:istions:main": v1alpha1.PackageRevisionLifecycleFinal,
+		"simple:empty:main":   v1alpha1.PackageRevisionLifecyclePublished,
+		"simple:basens:main":  v1alpha1.PackageRevisionLifecyclePublished,
+		"simple:istions:main": v1alpha1.PackageRevisionLifecyclePublished,
 	}
 
 	got := map[string]v1alpha1.PackageRevisionLifecycle{}
@@ -522,19 +522,19 @@ func TestListPackagesDrafts(t *testing.T) {
 	}
 
 	want := map[string]v1alpha1.PackageRevisionLifecycle{
-		"drafts:empty:v1":   v1alpha1.PackageRevisionLifecycleFinal,
-		"drafts:basens:v1":  v1alpha1.PackageRevisionLifecycleFinal,
-		"drafts:basens:v2":  v1alpha1.PackageRevisionLifecycleFinal,
-		"drafts:istions:v1": v1alpha1.PackageRevisionLifecycleFinal,
-		"drafts:istions:v2": v1alpha1.PackageRevisionLifecycleFinal,
+		"drafts:empty:v1":   v1alpha1.PackageRevisionLifecyclePublished,
+		"drafts:basens:v1":  v1alpha1.PackageRevisionLifecyclePublished,
+		"drafts:basens:v2":  v1alpha1.PackageRevisionLifecyclePublished,
+		"drafts:istions:v1": v1alpha1.PackageRevisionLifecyclePublished,
+		"drafts:istions:v2": v1alpha1.PackageRevisionLifecyclePublished,
 
 		"drafts:bucket:v1": v1alpha1.PackageRevisionLifecycleDraft,
 		"drafts:none:v1":   v1alpha1.PackageRevisionLifecycleDraft,
 
 		// TODO: filter main branch out? see above
-		"drafts:basens:main":  v1alpha1.PackageRevisionLifecycleFinal,
-		"drafts:empty:main":   v1alpha1.PackageRevisionLifecycleFinal,
-		"drafts:istions:main": v1alpha1.PackageRevisionLifecycleFinal,
+		"drafts:basens:main":  v1alpha1.PackageRevisionLifecyclePublished,
+		"drafts:empty:main":   v1alpha1.PackageRevisionLifecyclePublished,
+		"drafts:istions:main": v1alpha1.PackageRevisionLifecyclePublished,
 	}
 
 	got := map[string]v1alpha1.PackageRevisionLifecycle{}
@@ -588,7 +588,7 @@ func TestApproveDraft(t *testing.T) {
 		t.Fatalf("UpdatePackage failed: %v", err)
 	}
 
-	update.UpdateLifecycle(ctx, v1alpha1.PackageRevisionLifecycleFinal)
+	update.UpdateLifecycle(ctx, v1alpha1.PackageRevisionLifecyclePublished)
 
 	new, err := update.Close(ctx)
 	if err != nil {
@@ -600,7 +600,7 @@ func TestApproveDraft(t *testing.T) {
 		t.Fatalf("GetPackageRevision failed: %v", err)
 	}
 
-	if got, want := rev.Spec.Lifecycle, v1alpha1.PackageRevisionLifecycleFinal; got != want {
+	if got, want := rev.Spec.Lifecycle, v1alpha1.PackageRevisionLifecyclePublished; got != want {
 		t.Errorf("Approved package lifecycle: got %s, want %s", got, want)
 	}
 

--- a/porch/repository/pkg/git/package.go
+++ b/porch/repository/pkg/git/package.go
@@ -148,12 +148,12 @@ func (p *gitPackageRevision) GetUpstreamLock() (kptfile.Upstream, kptfile.Upstre
 func (p *gitPackageRevision) getPackageRevisionLifecycle() v1alpha1.PackageRevisionLifecycle {
 	switch ref := p.ref; {
 	case ref == nil:
-		return v1alpha1.PackageRevisionLifecycleFinal
+		return v1alpha1.PackageRevisionLifecyclePublished
 	case isDraftBranchNameInLocal(ref.Name()):
 		return v1alpha1.PackageRevisionLifecycleDraft
 	case isProposedBranchNameInLocal(ref.Name()):
 		return v1alpha1.PackageRevisionLifecycleProposed
 	default:
-		return v1alpha1.PackageRevisionLifecycleFinal
+		return v1alpha1.PackageRevisionLifecyclePublished
 	}
 }


### PR DESCRIPTION
Based on feedback, updating some names to more intuitive ones:

* Package lifecycle: `Final` --> `Published`
* Repository contents: `PackageRevision` --> `Package` (also ends up
  being more aligned with `Function`)
