### PR TITLE
fix:  `kpt fn eval --save` shouldn't add `name` field for the function

### DIFF
--- a/e2e/testdata/fn-eval/save-fn/exec/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/save-fn/exec/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index d9e2f05..3d2827b 100644
+index d9e2f05..daff2a6 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,3 +2,8 @@ apiVersion: kpt.dev/v1
+@@ -2,3 +2,7 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app
@@ -10,7 +10,6 @@ index d9e2f05..3d2827b 100644
 +  mutators:
 +    - exec: ./function.sh
 +      configPath: fn-config.yaml
-+      name: ./function.sh
 diff --git a/resources.yaml b/resources.yaml
 index 9e9c98f..9adc2f7 100644
 --- a/resources.yaml

--- a/e2e/testdata/fn-eval/save-fn/image/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/save-fn/image/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index d9e2f05..86d4005 100644
+index d9e2f05..bc65066 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,3 +2,10 @@ apiVersion: kpt.dev/v1
+@@ -2,3 +2,9 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app
@@ -12,7 +12,6 @@ index d9e2f05..86d4005 100644
 +    - image: gcr.io/kpt-fn/set-namespace:v0.1.3
 +      configMap:
 +        namespace: staging
-+      name: gcr.io/kpt-fn/set-namespace:v0.1.3
 diff --git a/resources.yaml b/resources.yaml
 index ac634f3..0e09da8 100644
 --- a/resources.yaml

--- a/e2e/testdata/fn-eval/save-fn/match-selector/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/save-fn/match-selector/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index d9e2f05..33c8c8b 100644
+index d9e2f05..eb232bb 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,3 +2,11 @@ apiVersion: kpt.dev/v1
+@@ -2,3 +2,10 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app
@@ -11,7 +11,6 @@ index d9e2f05..33c8c8b 100644
 +    - image: gcr.io/kpt-fn/set-namespace:v0.1.3
 +      configMap:
 +        namespace: staging
-+      name: gcr.io/kpt-fn/set-namespace:v0.1.3
 +      selectors:
 +        - kind: Deployment
 diff --git a/resources.yaml b/resources.yaml

--- a/e2e/testdata/fn-eval/save-fn/override-fn/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/save-fn/override-fn/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index 4a1e2fa..00e5aa8 100644
+index 4a1e2fa..b20f8f5 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,9 +2,10 @@ apiVersion: kpt.dev/v1
+@@ -2,9 +2,9 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app
@@ -16,7 +16,6 @@ index 4a1e2fa..00e5aa8 100644
 +    - image: gcr.io/kpt-fn/set-namespace:v0.1.3
 +      configMap:
 +        namespace: newNs
-+      name: gcr.io/kpt-fn/set-namespace:v0.1.3
 diff --git a/resources.yaml b/resources.yaml
 index ac634f3..80e1b9e 100644
 --- a/resources.yaml

--- a/e2e/testdata/fn-eval/save-fn/validator-type/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/save-fn/validator-type/.expected/diff.patch
@@ -1,8 +1,8 @@
 diff --git a/Kptfile b/Kptfile
-index d9e2f05..c6e80ef 100644
+index d9e2f05..24a44f8 100644
 --- a/Kptfile
 +++ b/Kptfile
-@@ -2,3 +2,10 @@ apiVersion: kpt.dev/v1
+@@ -2,3 +2,9 @@ apiVersion: kpt.dev/v1
  kind: Kptfile
  metadata:
    name: app
@@ -12,7 +12,6 @@ index d9e2f05..c6e80ef 100644
 +    - image: gcr.io/kpt-fn/set-namespace:v0.1.3
 +      configMap:
 +        namespace: staging
-+      name: gcr.io/kpt-fn/set-namespace:v0.1.3
 diff --git a/resources.yaml b/resources.yaml
 index ac634f3..0e09da8 100644
 --- a/resources.yaml

--- a/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
+++ b/thirdparty/cmdconfig/commands/cmdeval/cmdeval.go
@@ -147,10 +147,8 @@ func (r *EvalFnRunner) NewFunction() *kptfile.Function {
 	newFn := &kptfile.Function{}
 	if r.Image != "" {
 		newFn.Image = r.Image
-		newFn.Name = r.Image
 	} else {
 		newFn.Exec = r.Exec
-		newFn.Name = r.Exec
 	}
 	if !r.Selector.IsEmpty() {
 		newFn.Selectors = []kptfile.Selector{r.Selector}


### PR DESCRIPTION
the `name` is for merging key, not function identifier.

Output after the fix:
```bash
kpt fn eval yu -s -i set-namespace:v0.3.2 -- namespace=yu
[RUNNING] "gcr.io/kpt-fn/set-namespace:v0.3.2"
[PASS] "gcr.io/kpt-fn/set-namespace:v0.3.2" in 700ms
  Results:
    [info]: namespace updated 
adding function to Kptfile
Kptfile updated
```

```yaml
# Kptfile
apiVersion: kpt.dev/v1
kind: Kptfile
metadata:
  name: yu
  annotations:
    config.kubernetes.io/local-config: "true"
info:
  description: sample description
pipeline:
  mutators:
    - image: gcr.io/kpt-fn/set-namespace:v0.3.2
      configMap:
        namespace: yu
```