### PR TITLE
Add support for non-ConfigMap configuration

### DIFF
--- a/porch/api/generated/openapi/zz_generated.openapi.go
+++ b/porch/api/generated/openapi/zz_generated.openapi.go
@@ -240,6 +240,13 @@ func schema_porch_api_porch_v1alpha1_FunctionEvalTaskSpec(ref common.ReferenceCa
 							},
 						},
 					},
+					"config": {
+						SchemaProps: spec.SchemaProps{
+							Description: "`Config` specifies the function config, arbitrary KRM resource. Mutually exclusive with ConfigMap.",
+							Default:     map[string]interface{}{},
+							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
+						},
+					},
 					"includeMetaResources": {
 						SchemaProps: spec.SchemaProps{
 							Description: "If enabled, meta resources (i.e. `Kptfile` and `functionConfig`) are included in the input to the function. By default it is disabled.",
@@ -265,7 +272,7 @@ func schema_porch_api_porch_v1alpha1_FunctionEvalTaskSpec(ref common.ReferenceCa
 			},
 		},
 		Dependencies: []string{
-			"github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1.FunctionRef", "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1.Selector"},
+			"github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1.FunctionRef", "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1.Selector", "k8s.io/apimachinery/pkg/runtime.RawExtension"},
 	}
 }
 

--- a/porch/api/porch/types_packagerevisions.go
+++ b/porch/api/porch/types_packagerevisions.go
@@ -16,6 +16,7 @@ package porch
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // +genclient
@@ -192,9 +193,8 @@ type FunctionEvalTaskSpec struct {
 	// `ConfigMap` specifies the function config (https://kpt.dev/reference/cli/fn/eval/). Mutually exclusive with Config.
 	ConfigMap map[string]string `json:"configMap,omitempty"`
 
-	// TODO: openapi generation doesn't work for Unstructured
-	// // `Config` specifies the function config, arbitrary KRM resource. Mutually exclusive with ConfigMap.
-	// Config unstructured.Unstructured `json:"config,omitempty"`
+	// `Config` specifies the function config, arbitrary KRM resource. Mutually exclusive with ConfigMap.
+	Config runtime.RawExtension `json:"config,omitempty"`
 
 	// If enabled, meta resources (i.e. `Kptfile` and `functionConfig`) are included
 	// in the input to the function. By default it is disabled.

--- a/porch/api/porch/v1alpha1/types_packagerevisions.go
+++ b/porch/api/porch/v1alpha1/types_packagerevisions.go
@@ -16,6 +16,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 // +genclient
@@ -193,9 +194,8 @@ type FunctionEvalTaskSpec struct {
 	// `ConfigMap` specifies the function config (https://kpt.dev/reference/cli/fn/eval/). Mutually exclusive with Config.
 	ConfigMap map[string]string `json:"configMap,omitempty"`
 
-	// TODO: openapi generation doesn't work for Unstructured. Use runtime.RawExtension ???
-	// // `Config` specifies the function config, arbitrary KRM resource. Mutually exclusive with ConfigMap.
-	// Config unstructured.Unstructured `json:"config,omitempty"`
+	// `Config` specifies the function config, arbitrary KRM resource. Mutually exclusive with ConfigMap.
+	Config runtime.RawExtension `json:"config,omitempty"`
 
 	// If enabled, meta resources (i.e. `Kptfile` and `functionConfig`) are included
 	// in the input to the function. By default it is disabled.

--- a/porch/api/porch/v1alpha1/zz_generated.conversion.go
+++ b/porch/api/porch/v1alpha1/zz_generated.conversion.go
@@ -344,6 +344,7 @@ func autoConvert_v1alpha1_FunctionEvalTaskSpec_To_porch_FunctionEvalTaskSpec(in 
 	out.Image = in.Image
 	out.FunctionRef = (*porch.FunctionRef)(unsafe.Pointer(in.FunctionRef))
 	out.ConfigMap = *(*map[string]string)(unsafe.Pointer(&in.ConfigMap))
+	out.Config = in.Config
 	out.IncludeMetaResources = in.IncludeMetaResources
 	out.EnableNetwork = in.EnableNetwork
 	if err := Convert_v1alpha1_Selector_To_porch_Selector(&in.Match, &out.Match, s); err != nil {
@@ -362,6 +363,7 @@ func autoConvert_porch_FunctionEvalTaskSpec_To_v1alpha1_FunctionEvalTaskSpec(in 
 	out.Image = in.Image
 	out.FunctionRef = (*FunctionRef)(unsafe.Pointer(in.FunctionRef))
 	out.ConfigMap = *(*map[string]string)(unsafe.Pointer(&in.ConfigMap))
+	out.Config = in.Config
 	out.IncludeMetaResources = in.IncludeMetaResources
 	out.EnableNetwork = in.EnableNetwork
 	if err := Convert_porch_Selector_To_v1alpha1_Selector(&in.Match, &out.Match, s); err != nil {

--- a/porch/api/porch/v1alpha1/zz_generated.deepcopy.go
+++ b/porch/api/porch/v1alpha1/zz_generated.deepcopy.go
@@ -88,6 +88,7 @@ func (in *FunctionEvalTaskSpec) DeepCopyInto(out *FunctionEvalTaskSpec) {
 			(*out)[key] = val
 		}
 	}
+	in.Config.DeepCopyInto(&out.Config)
 	out.Match = in.Match
 	return
 }

--- a/porch/api/porch/zz_generated.deepcopy.go
+++ b/porch/api/porch/zz_generated.deepcopy.go
@@ -88,6 +88,7 @@ func (in *FunctionEvalTaskSpec) DeepCopyInto(out *FunctionEvalTaskSpec) {
 			(*out)[key] = val
 		}
 	}
+	in.Config.DeepCopyInto(&out.Config)
 	out.Match = in.Match
 	return
 }

--- a/porch/engine/pkg/engine/eval.go
+++ b/porch/engine/pkg/engine/eval.go
@@ -52,6 +52,13 @@ func (m *evalFunctionMutation) Apply(ctx context.Context, resources repository.P
 		} else {
 			functionConfig = cm
 		}
+	} else if len(m.task.Eval.Config.Raw) != 0 {
+		// raw is JSON (we expect), but we take advantage of the fact that YAML is a superset of JSON
+		config, err := yaml.Parse(string(m.task.Eval.Config.Raw))
+		if err != nil {
+			return repository.PackageResources{}, nil, fmt.Errorf("error parsing function config: %w", err)
+		}
+		functionConfig = config
 	}
 
 	ff := &runtimeutil.FunctionFilter{


### PR DESCRIPTION
The runtime.RawExtension type allows for passing a CRD to functions.