### PR TITLE
support reusing pods in pod evaluator

### DIFF
--- a/porch/apiserver/pkg/e2e/suite.go
+++ b/porch/apiserver/pkg/e2e/suite.go
@@ -228,6 +228,10 @@ func (t *TestSuite) ListE(ctx context.Context, list client.ObjectList, opts ...c
 	t.list(ctx, list, opts, t.Errorf)
 }
 
+func (t *TestSuite) ListF(ctx context.Context, list client.ObjectList, opts ...client.ListOption) {
+	t.list(ctx, list, opts, t.Fatalf)
+}
+
 func (t *TestSuite) CreateF(ctx context.Context, obj client.Object, opts ...client.CreateOption) {
 	t.create(ctx, obj, opts, t.Fatalf)
 }

--- a/porch/config/deploy/2-function-runner.yaml
+++ b/porch/config/deploy/2-function-runner.yaml
@@ -25,7 +25,7 @@ metadata:
   name: function-runner
   namespace: porch-system
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: function-runner

--- a/porch/config/deploy/5-rbac.yaml
+++ b/porch/config/deploy/5-rbac.yaml
@@ -41,4 +41,4 @@ rules:
   # Needed to launch / read function executor pods
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["create", "delete", "get", "watch", "list"]
+    verbs: ["create", "delete", "patch", "get", "watch", "list"]

--- a/porch/func/internal/podevaluator.go
+++ b/porch/func/internal/podevaluator.go
@@ -17,9 +17,11 @@ package internal
 import (
 	"context"
 	"fmt"
+	"net"
 	"path"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/GoogleContainerTools/kpt/porch/func/evaluator"
@@ -30,6 +32,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -37,25 +40,26 @@ import (
 )
 
 const (
-	defaultWrapperServerPort = 9446
+	defaultWrapperServerPort = "9446"
 	volumeName               = "wrapper-server-tools"
 	volumeMountPath          = "/wrapper-server-tools"
 	wrapperServerBin         = "wrapper-server"
 	gRPCProbeBin             = "grpc-health-probe"
+	krmFunctionLabel         = "fn.kpt.dev/image"
+	lastUseTimeAnnotation    = "fn.kpt.dev/last-use"
+
+	channelBufferSize = 128
 )
 
 type podEvaluator struct {
-	// kubeClient is the kubernetes client
-	kubeClient client.Client
-	// namespace holds the namespace where the executors run
-	namespace string
-	// wrapperServerImage is the image name of the wrapper server
-	wrapperServerImage string
+	requestCh chan *clientConnRequest
+
+	podCacheManager *podCacheManager
 }
 
 var _ Evaluator = &podEvaluator{}
 
-func NewPodEvaluator(namespace, wrapperServerImage string) (Evaluator, error) {
+func NewPodEvaluator(namespace, wrapperServerImage string, interval, ttl time.Duration) (Evaluator, error) {
 	restCfg, err := config.GetConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get rest config: %w", err)
@@ -64,15 +68,256 @@ func NewPodEvaluator(namespace, wrapperServerImage string) (Evaluator, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create client: %w", err)
 	}
-	return &podEvaluator{
-		kubeClient:         cl,
-		namespace:          namespace,
-		wrapperServerImage: wrapperServerImage,
-	}, nil
+
+	reqCh := make(chan *clientConnRequest, channelBufferSize)
+	readyCh := make(chan *imagePodAndGRPCClient, channelBufferSize)
+
+	pe := &podEvaluator{
+		requestCh: reqCh,
+		podCacheManager: &podCacheManager{
+			gcScanInternal: interval,
+			podTTL:         ttl,
+			requestCh:      reqCh,
+			podReadyCh:     readyCh,
+			cache:          map[string]*podAndGRPCClient{},
+			waitlists:      map[string][]chan *clientConnAndError{},
+
+			podManager: &podManager{
+				kubeClient:         cl,
+				namespace:          namespace,
+				wrapperServerImage: wrapperServerImage,
+				podReadyCh:         readyCh,
+			},
+		},
+	}
+	go pe.podCacheManager.podCacheManager()
+	return pe, nil
 }
 
 func (pe *podEvaluator) EvaluateFunction(ctx context.Context, req *evaluator.EvaluateFunctionRequest) (*evaluator.EvaluateFunctionResponse, error) {
-	ref, err := name.ParseReference(req.Image)
+	starttime := time.Now()
+	defer func() {
+		endtime := time.Now()
+		klog.Infof("evaluating %v in pod takes %v", req.Image, endtime.Sub(starttime))
+	}()
+	// make a buffer for the channel to prevent unnecessary blocking when the pod cache manager sends it to multiple waiting gorouthine in batch.
+	ccChan := make(chan *clientConnAndError, 1)
+	// Send a request to request a grpc client.
+	pe.podCacheManager.requestCh <- &clientConnRequest{
+		ctx:          ctx,
+		image:        req.Image,
+		grpcClientCh: ccChan,
+	}
+
+	// Waiting for the client from the channel.
+	cc := <-ccChan
+	if cc.err != nil {
+		return nil, fmt.Errorf("unable to get the grpc client to the pod for %v: %w", req.Image, cc.err)
+	}
+
+	resp, err := evaluator.NewFunctionEvaluatorClient(cc.grpcClient).EvaluateFunction(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("unable to evaluate %v with pod evaluator: %w", req.Image, err)
+	}
+	return resp, nil
+}
+
+type podCacheManager struct {
+	gcScanInternal time.Duration
+	podTTL         time.Duration
+
+	// requestCh is a channel to send the request to cache manager. The cache manager will send back the grpc client in the embedded channel.
+	requestCh chan *clientConnRequest
+	// podReadyCh is a channel to receive the information when a pod is ready.
+	podReadyCh chan *imagePodAndGRPCClient
+
+	cache     map[string]*podAndGRPCClient
+	waitlists map[string][]chan *clientConnAndError
+
+	podManager *podManager
+}
+
+type clientConnRequest struct {
+	ctx   context.Context
+	image string
+
+	unavavilable     bool
+	currClientTarget string
+
+	// grpcConn is a channel that a grpc client should be sent back.
+	grpcClientCh chan *clientConnAndError
+}
+
+type clientConnAndError struct {
+	grpcClient *grpc.ClientConn
+	err        error
+}
+
+type podAndGRPCClient struct {
+	grpcClient *grpc.ClientConn
+	pod        client.ObjectKey
+}
+
+type imagePodAndGRPCClient struct {
+	image string
+	*podAndGRPCClient
+	err error
+}
+
+func (pcm *podCacheManager) podCacheManager() {
+	tick := time.Tick(pcm.gcScanInternal)
+	for {
+		select {
+		case req := <-pcm.requestCh:
+			podAndCl, found := pcm.cache[req.image]
+			if found && podAndCl != nil {
+				// Ensure the pod still exists and is not being deleted before sending the gprc client back to the channel.
+				// We can't simplly return grpc client from the cache and let evaluator try to connect to the pod.
+				// If the pod is deleted by others, it will take ~10 seconds for the evaluator to fail.
+				// Wasting 10 second is so much, so we check if the pod still exist first.
+				pod := &corev1.Pod{}
+				err := pcm.podManager.kubeClient.Get(req.ctx, podAndCl.pod, pod)
+				if err == nil && pod.DeletionTimestamp == nil {
+					klog.Infof("reusing the connection to pod %v/%v to evaluate %v", pod.Namespace, pod.Name, req.image)
+					req.grpcClientCh <- &clientConnAndError{grpcClient: podAndCl.grpcClient}
+					go patchPodWithUnixTimeAnnotation(pcm.podManager.kubeClient, podAndCl.pod)
+					break
+				}
+			}
+			_, found = pcm.waitlists[req.image]
+			if !found {
+				pcm.waitlists[req.image] = []chan *clientConnAndError{}
+			}
+			list := pcm.waitlists[req.image]
+			list = append(list, req.grpcClientCh)
+			pcm.waitlists[req.image] = list
+			go pcm.podManager.getFuncEvalPodClient(req.ctx, req.image)
+		case resp := <-pcm.podReadyCh:
+			if resp.err == nil {
+				pcm.cache[resp.image] = resp.podAndGRPCClient
+				channels := pcm.waitlists[resp.image]
+				delete(pcm.waitlists, resp.image)
+				for i := range channels {
+					// The channel has one buffer size, nothing will be blocking.
+					channels[i] <- &clientConnAndError{grpcClient: resp.grpcClient}
+				}
+			} else {
+				klog.Warningf("received error from the pod manager: %v", resp.err)
+			}
+		case <-tick:
+			// synchronous GC
+			pcm.garbageCollector()
+		}
+	}
+}
+
+// TODO: We can use Watch + periodically reconciliation to manage the pods,
+// the pod evaluator will become a controller.
+func (pcm *podCacheManager) garbageCollector() {
+	var err error
+	podList := &corev1.PodList{}
+	err = pcm.podManager.kubeClient.List(context.Background(), podList, client.InNamespace(pcm.podManager.namespace))
+	if err != nil {
+		klog.Warningf("unable to list pods in namespace %v: %w", pcm.podManager.namespace, err)
+		return
+	}
+	for i, pod := range podList.Items {
+		// If a pod is being deleted, skip it.
+		if pod.DeletionTimestamp != nil {
+			continue
+		}
+		lastUse, found := pod.Annotations[lastUseTimeAnnotation]
+		// If a pod doesn't have a last-use annotation, we patch it.
+		if !found {
+			go patchPodWithUnixTimeAnnotation(pcm.podManager.kubeClient, client.ObjectKeyFromObject(&pod))
+			continue
+		} else {
+			lu, err := strconv.ParseInt(lastUse, 10, 64)
+			// If the annotation is ill-formatted, we patch it with the current time and will try to GC it later.
+			if err != nil {
+				klog.Warningf("unable to convert the Unix time string to int64: %w", err)
+				go patchPodWithUnixTimeAnnotation(pcm.podManager.kubeClient, client.ObjectKeyFromObject(&pod))
+				continue
+			}
+			if time.Unix(lu, 0).Add(pcm.podTTL).Before(time.Now()) {
+				image := pod.Spec.Containers[0].Image
+				podAndCl, found := pcm.cache[image]
+				if found {
+					// We delete the cache entry when its grpc client points to the old pod IP.
+					host, _, err := net.SplitHostPort(podAndCl.grpcClient.Target())
+					if err != nil {
+						klog.Warningf("unable to split the GRPC dialer target to host and port : %w", err)
+						continue
+					}
+					if host == pod.Status.PodIP {
+						delete(pcm.cache, image)
+					}
+				}
+
+				go func(po corev1.Pod) {
+					klog.Infof("deleting pod %v/%v", po.Namespace, po.Name)
+					err := pcm.podManager.kubeClient.Delete(context.Background(), &po)
+					if err != nil {
+						klog.Warningf("unable to delete pod %v/%v: %w", po.Namespace, po.Name, err)
+					}
+				}(podList.Items[i])
+			}
+		}
+	}
+}
+
+type podManager struct {
+	// kubeClient is the kubernetes client
+	kubeClient client.Client
+	// namespace holds the namespace where the executors run
+	namespace string
+	// wrapperServerImage is the image name of the wrapper server
+	wrapperServerImage string
+
+	// podReadyCh is a channel to send the grpc client information.
+	// podCacheManager receives from this channel.
+	podReadyCh chan *imagePodAndGRPCClient
+
+	// entrypointCache is a cache of image name to entrypoint.
+	// Only podManager is allowed to touch this cache.
+	// Its underlying type is map[string][]string.
+	entrypointCache sync.Map
+}
+
+func (pm *podManager) getFuncEvalPodClient(ctx context.Context, image string) {
+	c, err := func() (*podAndGRPCClient, error) {
+		podKey, err := pm.retrieveOrCreatePod(ctx, image)
+		if err != nil {
+			return nil, err
+		}
+		podIP, err := pm.podIpIfRunningAndReady(ctx, podKey)
+		if err != nil {
+			return nil, err
+		}
+		if podIP == "" {
+			return nil, fmt.Errorf("pod %s/%s did not have podIP", podKey.Namespace, podKey.Name)
+		}
+		address := net.JoinHostPort(podIP, defaultWrapperServerPort)
+		cc, err := grpc.Dial(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
+		if err != nil {
+			return nil, fmt.Errorf("failed to dial grpc function evaluator on %q for pod %s/%s: %w", address, podKey.Namespace, podKey.Name, err)
+		}
+		return &podAndGRPCClient{
+			pod:        podKey,
+			grpcClient: cc,
+		}, err
+	}()
+	pm.podReadyCh <- &imagePodAndGRPCClient{
+		image:            image,
+		podAndGRPCClient: c,
+		err:              err,
+	}
+}
+
+func (pm *podManager) imageEntrypoint(image string) ([]string, error) {
+	// Create pod otherwise.
+	var entrypoint []string
+	ref, err := name.ParseReference(image)
 	if err != nil {
 		return nil, err
 	}
@@ -80,24 +325,55 @@ func (pe *podEvaluator) EvaluateFunction(ctx context.Context, req *evaluator.Eva
 	if err != nil {
 		return nil, err
 	}
-	// TODO: cache the config file
 	cf, err := img.ConfigFile()
 	if err != nil {
 		return nil, err
 	}
 
 	cfg := cf.Config
-	var fnCmd []string
+	// TODO: to handle all scenario, we should follow https://docs.docker.com/engine/reference/builder/#understand-how-cmd-and-entrypoint-interact.
 	if len(cfg.Entrypoint) != 0 {
-		fnCmd = cfg.Entrypoint
+		entrypoint = cfg.Entrypoint
 	} else {
-		fnCmd = cfg.Cmd
+		entrypoint = cfg.Cmd
+	}
+	pm.entrypointCache.Store(image, entrypoint)
+	return entrypoint, nil
+}
+
+func (pm *podManager) retrieveOrCreatePod(ctx context.Context, image string) (client.ObjectKey, error) {
+	// Try to retrieve the pod first.
+	// Lookup the pod by label to see if there is a pod that can be reused.
+	// Looking it up locally may not work if there are more than one instance of the function runner,
+	// since the pod may be created by one the other instance and the current instance is not aware of it.
+	// TODO: It's possible to set up a Watch in the fn runner namespace, and always try to maintain a up-to-date local cache.
+	podList := &corev1.PodList{}
+	err := pm.kubeClient.List(ctx, podList, client.InNamespace(pm.namespace), client.MatchingLabels(map[string]string{krmFunctionLabel: transformImageName(image)}))
+	if err == nil && len(podList.Items) > 0 {
+		// TODO: maybe we should randomly pick one that is no being deleted.
+		for _, pod := range podList.Items {
+			if pod.DeletionTimestamp == nil {
+				klog.Infof("retrieved function evaluator pod %v/%v for %q", pod.Namespace, pod.Name, image)
+				return client.ObjectKeyFromObject(&pod), nil
+			}
+		}
+	}
+
+	var entrypoint []string
+	val, found := pm.entrypointCache.Load(image)
+	if !found {
+		entrypoint, err = pm.imageEntrypoint(image)
+		if err != nil {
+			return client.ObjectKey{}, fmt.Errorf("unable to get the entrypoint for %v: %w", image, err)
+		}
+	} else {
+		entrypoint = val.([]string)
 	}
 
 	cmd := append([]string{
 		path.Join(volumeMountPath, wrapperServerBin),
-		"--port", strconv.Itoa(defaultWrapperServerPort), "--",
-	}, fnCmd...)
+		"--port", defaultWrapperServerPort, "--",
+	}, entrypoint...)
 
 	// Create a pod
 	pod := &corev1.Pod{
@@ -106,15 +382,22 @@ func (pe *podEvaluator) EvaluateFunction(ctx context.Context, req *evaluator.Eva
 			Kind:       "Pod",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:    pe.namespace,
+			Namespace:    pm.namespace,
 			GenerateName: "krm-fn-",
-			// TODO: add labels
+			Annotations: map[string]string{
+				lastUseTimeAnnotation: fmt.Sprintf("%v", time.Now().Unix()),
+			},
+			// The function runner can use the label to retrieve the pod
+			// TODO: controller-runtime provides field indexer, we can potentially use it to index spec.containers[*].image field.
+			Labels: map[string]string{
+				krmFunctionLabel: transformImageName(image),
+			},
 		},
 		Spec: corev1.PodSpec{
 			InitContainers: []corev1.Container{
 				{
 					Name:  "copy-wrapper-server",
-					Image: pe.wrapperServerImage,
+					Image: pm.wrapperServerImage,
 					Command: []string{
 						"sh", "-c",
 						fmt.Sprintf("cp /wrapper-server/* %v", volumeMountPath),
@@ -130,7 +413,7 @@ func (pe *podEvaluator) EvaluateFunction(ctx context.Context, req *evaluator.Eva
 			Containers: []corev1.Container{
 				{
 					Name:  "function",
-					Image: req.Image,
+					Image: image,
 					Command: []string{
 						"sh", "-c",
 						strings.Join(cmd, " "),
@@ -140,7 +423,7 @@ func (pe *podEvaluator) EvaluateFunction(ctx context.Context, req *evaluator.Eva
 							Exec: &corev1.ExecAction{
 								Command: []string{
 									path.Join(volumeMountPath, gRPCProbeBin),
-									"-addr", fmt.Sprintf("localhost:%v", strconv.Itoa(defaultWrapperServerPort)),
+									"-addr", net.JoinHostPort("localhost", defaultWrapperServerPort),
 								},
 							},
 						},
@@ -163,25 +446,20 @@ func (pe *podEvaluator) EvaluateFunction(ctx context.Context, req *evaluator.Eva
 			},
 		},
 	}
-	err = pe.kubeClient.Create(ctx, pod)
+	err = pm.kubeClient.Create(ctx, pod)
 	if err != nil {
-		return nil, err
+		return client.ObjectKey{}, err
 	}
-	klog.Infof("created KRM function evaluator pod %v", pod.Name)
+	klog.Infof("created KRM function evaluator pod %v/%v for %q", pod.Namespace, pod.Name, image)
+	return client.ObjectKeyFromObject(pod), nil
+}
 
-	defer func() {
-		// TODO: keep the pod around for some time for potential reuse.
-		klog.Infof("deleting KRM function evaluator pod %v", pod.Name)
-		// We don't use ctx here, since we want the deletion to be completed even the context is canceled.
-		// If we use ctx here, the pod will be orphaned if we cancel the request (e.g. ctrl+C).
-		if err := pe.kubeClient.Delete(context.Background(), pod); err != nil {
-			klog.Warningf("failed to delete KRM function evaluator pod %v: %v", pod.Name, err)
-		}
-	}()
-
+// podIpIfRunningAndReady waits for the pod to be running and ready and returns the pod IP and a potential error.
+func (pm *podManager) podIpIfRunningAndReady(ctx context.Context, podKey client.ObjectKey) (ip string, e error) {
+	var pod corev1.Pod
 	// Wait until the pod is Running
-	if err = wait.PollImmediate(100*time.Millisecond, 60*time.Second, func() (done bool, err error) {
-		err = pe.kubeClient.Get(ctx, client.ObjectKeyFromObject(pod), pod)
+	if e := wait.PollImmediate(100*time.Millisecond, 60*time.Second, func() (done bool, err error) {
+		err = pm.kubeClient.Get(ctx, podKey, &pod)
 		if err != nil {
 			return false, err
 		}
@@ -189,33 +467,27 @@ func (pe *podEvaluator) EvaluateFunction(ctx context.Context, req *evaluator.Eva
 			return false, nil
 		}
 		for _, cond := range pod.Status.Conditions {
-			if cond.Type == corev1.PodReady {
-				return cond.Status == corev1.ConditionTrue, nil
+			if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+				return true, nil
 			}
 		}
 		return false, nil
-	}); err != nil {
-		return nil, fmt.Errorf("error when waiting the pod to be ready: %w", err)
+	}); e != nil {
+		return "", fmt.Errorf("error when waiting the pod to be ready: %w", e)
 	}
+	return pod.Status.PodIP, nil
+}
 
-	podIP := pod.Status.PodIP
-	if podIP == "" {
-		return nil, fmt.Errorf("pod did not have podIP")
+func patchPodWithUnixTimeAnnotation(cl client.Client, podKey client.ObjectKey) {
+	patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{"%v": "%v"}}}`, lastUseTimeAnnotation, time.Now().Unix()))
+	pod := &corev1.Pod{}
+	pod.Namespace = podKey.Namespace
+	pod.Name = podKey.Name
+	if err := cl.Patch(context.Background(), pod, client.RawPatch(types.MergePatchType, patch)); err != nil {
+		klog.Warningf("unable to patch last-use annotation for pod %v/%v: %w", podKey.Namespace, podKey.Name, err)
 	}
-	address := fmt.Sprintf("%v:%v", podIP, defaultWrapperServerPort)
-	klog.Infof("dialing pod function runner %q", address)
+}
 
-	// TODO: pool connections
-	cc, err := grpc.Dial(address, grpc.WithTransportCredentials(insecure.NewCredentials()))
-	if err != nil {
-		return nil, fmt.Errorf("failed to dial grpc function evaluator on %q for pod %s/%s: %w", address, pod.Namespace, pod.Name, err)
-	}
-	defer func() {
-		if err := cc.Close(); err != nil {
-			klog.Warningf("failed to close grpc connection: %v", err)
-		}
-	}()
-
-	client := evaluator.NewFunctionEvaluatorClient(cc)
-	return client.EvaluateFunction(ctx, req)
+func transformImageName(image string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(image, "/", "__"), ":", "___")
 }

--- a/porch/func/server/server.go
+++ b/porch/func/server/server.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"os"
 	"strings"
+	"time"
 
 	pb "github.com/GoogleContainerTools/kpt/porch/func/evaluator"
 	"github.com/GoogleContainerTools/kpt/porch/func/internal"
@@ -37,6 +38,8 @@ var (
 	functions          = flag.String("functions", "./functions", "Path to cached functions.")
 	config             = flag.String("config", "./config.yaml", "Path to the config file.")
 	podNamespace       = flag.String("pod-namespace", "porch-fn-system", "Namespace to run KRM functions pods.")
+	podTTL             = flag.Duration("pod-ttl", 10*time.Minute, "TTL for pods before GC.")
+	scanInterval       = flag.Duration("scan-interval", time.Minute, "The interval of GC between scans.")
 	wrapperServerImage = flag.String("wrapper-server-image", "", "Image name of the wrapper server.")
 	disableRuntimes    = flag.String("disable-runtimes", "", fmt.Sprintf("The runtime(s) to disable. Multiple runtimes should separated by `,`. Available runtimes: `%v`, `%v`.", execRuntime, podRuntime))
 )
@@ -77,7 +80,7 @@ func run() error {
 			}
 			runtimes = append(runtimes, execEval)
 		case podRuntime:
-			podEval, err := internal.NewPodEvaluator(*podNamespace, *wrapperServerImage)
+			podEval, err := internal.NewPodEvaluator(*podNamespace, *wrapperServerImage, *scanInterval, *podTTL)
 			if err != nil {
 				return fmt.Errorf("failed to initialize pod evaluator: %w", err)
 			}


### PR DESCRIPTION
Added a goroutine to manage the cache and handle the coordination.
Use to labels to retrieve old pods.
Set last use time in annotation.
Add GC to delete old pods.

I have manually tested it. Created the PR to get some early feedback.
I'm working on finding a way to test it without making the test setup too complex.
