### PR TITLE
feat: Clean up package resources in kpt alpha sync del command

### DIFF
--- a/internal/util/porch/client.go
+++ b/internal/util/porch/client.go
@@ -51,7 +51,7 @@ func CreateClient(flags *genericclioptions.ConfigFlags) (client.Client, error) {
 	return c, nil
 }
 
-func CreateDynamicClient(flags *genericclioptions.ConfigFlags) (client.Client, error) {
+func CreateDynamicClient(flags *genericclioptions.ConfigFlags) (client.WithWatch, error) {
 	config, err := flags.ToRESTConfig()
 	if err != nil {
 		return nil, err
@@ -62,7 +62,7 @@ func CreateDynamicClient(flags *genericclioptions.ConfigFlags) (client.Client, e
 		return nil, err
 	}
 
-	c, err := client.New(config, client.Options{
+	c, err := client.NewWithWatch(config, client.Options{
 		Scheme: scheme,
 	})
 	if err != nil {


### PR DESCRIPTION
This updates the `kpt alpha sync del` command to remove the resources belonging to a package when the RootSync resource is removed from the cluster. It does this by first updating the repo in the RootSync to an empty repo which will cause Config Sync to prune all resources. Once this is completed (we know by setting up a watch and waiting for the RootSync resource to reconcile), we delete the RootSync resource and optionally the secret.
