### PR TITLE
Use hash for package names

### DIFF
--- a/e2e/testdata/porch/rpkg-clone/config.yaml
+++ b/e2e/testdata/porch/rpkg-clone/config.yaml
@@ -14,7 +14,10 @@ commands:
       - https://github.com/platkrm/test-blueprints.git
       - --directory=basens
       - --ref=basens/v1
-      - git:basens-clone:v0
+      - --repository=git
+      - --revision=v0
+      - basens-clone
+    stdout: git-317a42f437be4e9695da4f043ff2c727f6001156 created
   - args:
       - alpha
       - repo
@@ -24,16 +27,28 @@ commands:
   - args:
       - alpha
       - rpkg
+      - get
+      - --namespace=rpkg-clone
+      - --name=empty
+      - --revision=v1
+      - --output=jsonpath={.metadata.name}
+    stdout: test-blueprints-e78ee77d9560703561c2656c97c77e9abb8c4c53
+  - args:
+      - alpha
+      - rpkg
       - clone
       - --namespace=rpkg-clone
-      - test-blueprints:empty:v1
-      - git:empty-clone:v0
+      - test-blueprints-e78ee77d9560703561c2656c97c77e9abb8c4c53
+      - --repository=git
+      - --revision=v0
+      - empty-clone
+    stdout: git-94533e00ee86a2edd5e8d91cbb76cf8ef295b58c created
   - args:
       - alpha
       - rpkg
       - pull
       - --namespace=rpkg-clone
-      - git:basens-clone:v0
+      - git-317a42f437be4e9695da4f043ff2c727f6001156
     stdout: |
       apiVersion: config.kubernetes.io/v1
       items:
@@ -77,7 +92,7 @@ commands:
       - rpkg
       - pull
       - --namespace=rpkg-clone
-      - git:empty-clone:v0
+      - git-94533e00ee86a2edd5e8d91cbb76cf8ef295b58c
     stdout: |
       apiVersion: config.kubernetes.io/v1
       items:

--- a/e2e/testdata/porch/rpkg-get/config.yaml
+++ b/e2e/testdata/porch/rpkg-get/config.yaml
@@ -12,23 +12,23 @@ commands:
       - rpkg
       - get
       - --namespace=rpkg-get
-      - test-blueprints:basens:v1
       - --output=custom-columns=NAME:.metadata.name,PKG:.spec.packageName,REPO:.spec.repository,REV:.spec.revision
     stdout: |
-      NAME                        PKG      REPO              REV
-      test-blueprints:basens:v1   basens   test-blueprints   v1
+      NAME                                                       PKG      REPO              REV
+      test-blueprints-526fa27229adcc3b6a9a544c455c344a3b4d7597   basens   test-blueprints   v1
+      test-blueprints-e78ee77d9560703561c2656c97c77e9abb8c4c53   empty    test-blueprints   v1
+      test-blueprints-9626794e984ff13c9a4c64df5af0f15ec3a146bf   basens   test-blueprints   main
+      test-blueprints-58fffeb908ead18e2c05c873e61bff11a5292963   empty    test-blueprints   main
   - args:
       - alpha
       - rpkg
       - get
       - --namespace=rpkg-get
+      - test-blueprints-526fa27229adcc3b6a9a544c455c344a3b4d7597
       - --output=custom-columns=NAME:.metadata.name,PKG:.spec.packageName,REPO:.spec.repository,REV:.spec.revision
     stdout: |
-      NAME                          PKG      REPO              REV
-      test-blueprints:basens:v1     basens   test-blueprints   v1
-      test-blueprints:empty:v1      empty    test-blueprints   v1
-      test-blueprints:basens:main   basens   test-blueprints   main
-      test-blueprints:empty:main    empty    test-blueprints   main
+      NAME                                                       PKG      REPO              REV
+      test-blueprints-526fa27229adcc3b6a9a544c455c344a3b4d7597   basens   test-blueprints   v1
   - args:
       - alpha
       - rpkg
@@ -37,6 +37,6 @@ commands:
       - --name=basens
       - --output=custom-columns=NAME:.metadata.name,PKG:.spec.packageName,REPO:.spec.repository,REV:.spec.revision
     stdout: |
-      NAME                          PKG      REPO              REV
-      test-blueprints:basens:v1     basens   test-blueprints   v1
-      test-blueprints:basens:main   basens   test-blueprints   main
+      NAME                                                       PKG      REPO              REV
+      test-blueprints-526fa27229adcc3b6a9a544c455c344a3b4d7597   basens   test-blueprints   v1
+      test-blueprints-9626794e984ff13c9a4c64df5af0f15ec3a146bf   basens   test-blueprints   main

--- a/e2e/testdata/porch/rpkg-init-deploy/config.yaml
+++ b/e2e/testdata/porch/rpkg-init-deploy/config.yaml
@@ -26,13 +26,16 @@ commands:
       - --keywords=test,package
       - --site
       - http://kpt.dev/deploy-package
-      - git:deploy-package:v0
+      - --repository=git
+      - --revision=v0
+      - deploy-package
+    stdout: git-480992fb1bc6d0e30d69d3ae84101d7413e1a5ae created
   - args:
       - alpha
       - rpkg
       - pull
       - --namespace=rpkg-init-deploy
-      - git:deploy-package:v0
+      - git-480992fb1bc6d0e30d69d3ae84101d7413e1a5ae
     stdout: |
       apiVersion: config.kubernetes.io/v1
       items:

--- a/e2e/testdata/porch/rpkg-init/config.yaml
+++ b/e2e/testdata/porch/rpkg-init/config.yaml
@@ -25,13 +25,16 @@ commands:
       - --keywords=test,package
       - --site
       - http://kpt.dev/init-package
-      - git:init-package:v0
+      - --repository=git
+      - --revision=v0
+      - init-package
+    stdout: git-e5041a7290c88ac4ac34182c8b3d658ab97d353d created
   - args:
       - alpha
       - rpkg
       - pull
       - --namespace=rpkg-init
-      - git:init-package:v0
+      - git-e5041a7290c88ac4ac34182c8b3d658ab97d353d
     stdout: |
       apiVersion: config.kubernetes.io/v1
       items:

--- a/e2e/testdata/porch/rpkg-lifecycle/config.yaml
+++ b/e2e/testdata/porch/rpkg-lifecycle/config.yaml
@@ -11,93 +11,95 @@ commands:
       - rpkg
       - init
       - --namespace=rpkg-lifecycle
-      - git:lifecycle-package:v1
+      - --repository=git
+      - --revision=v1
+      - lifecycle-package
+    stdout: git-635026ba389a2dd5417b6e7577430c7ccff30f36 created
   - args:
       - alpha
       - rpkg
       - propose
       - --namespace=rpkg-lifecycle
-      - git:lifecycle-package:v1
+      - git-635026ba389a2dd5417b6e7577430c7ccff30f36
     stderr: |
-      git:lifecycle-package:v1 proposed
+      git-635026ba389a2dd5417b6e7577430c7ccff30f36 proposed
   - args:
       - alpha
       - rpkg
       - get
-      - git:lifecycle-package:v1
+      - git-635026ba389a2dd5417b6e7577430c7ccff30f36
       - --namespace=rpkg-lifecycle
-      - --output=custom-columns=NAME:.metadata.name,LIFECYCLE:.spec.lifecycle
+      - --output=custom-columns=NAME:.metadata.name,PKG:.spec.packageName,REV:.spec.revision,LIFECYCLE:.spec.lifecycle
     stdout: |
-      NAME                       LIFECYCLE
-      git:lifecycle-package:v1   Proposed
+      NAME                                           PKG                 REV   LIFECYCLE
+      git-635026ba389a2dd5417b6e7577430c7ccff30f36   lifecycle-package   v1    Proposed
   - args:
       - alpha
       - rpkg
       - reject
       - --namespace=rpkg-lifecycle
-      - git:lifecycle-package:v1
+      - git-635026ba389a2dd5417b6e7577430c7ccff30f36
     stderr: |
-      git:lifecycle-package:v1 rejected
+      git-635026ba389a2dd5417b6e7577430c7ccff30f36 rejected
   - args:
       - alpha
       - rpkg
       - get
-      - git:lifecycle-package:v1
+      - git-635026ba389a2dd5417b6e7577430c7ccff30f36
       - --namespace=rpkg-lifecycle
-      - --output=custom-columns=NAME:.metadata.name,LIFECYCLE:.spec.lifecycle
+      - --output=custom-columns=NAME:.metadata.name,PKG:.spec.packageName,REV:.spec.revision,LIFECYCLE:.spec.lifecycle
     stdout: |
-      NAME                       LIFECYCLE
-      git:lifecycle-package:v1   Draft
+      NAME                                           PKG                 REV   LIFECYCLE
+      git-635026ba389a2dd5417b6e7577430c7ccff30f36   lifecycle-package   v1    Draft
   - args:
       - alpha
       - rpkg
       - propose
       - --namespace=rpkg-lifecycle
-      - git:lifecycle-package:v1
+      - git-635026ba389a2dd5417b6e7577430c7ccff30f36
     stderr: |
-      git:lifecycle-package:v1 proposed
+      git-635026ba389a2dd5417b6e7577430c7ccff30f36 proposed
   - args:
       - alpha
       - rpkg
       - get
-      - git:lifecycle-package:v1
+      - git-635026ba389a2dd5417b6e7577430c7ccff30f36
       - --namespace=rpkg-lifecycle
-      - --output=custom-columns=NAME:.metadata.name,LIFECYCLE:.spec.lifecycle
+      - --output=custom-columns=NAME:.metadata.name,PKG:.spec.packageName,REV:.spec.revision,LIFECYCLE:.spec.lifecycle
     stdout: |
-      NAME                       LIFECYCLE
-      git:lifecycle-package:v1   Proposed
+      NAME                                           PKG                 REV   LIFECYCLE
+      git-635026ba389a2dd5417b6e7577430c7ccff30f36   lifecycle-package   v1    Proposed
   - args:
       - alpha
       - rpkg
       - approve
       - --namespace=rpkg-lifecycle
-      - git:lifecycle-package:v1
+      - git-635026ba389a2dd5417b6e7577430c7ccff30f36
     stderr: |
-      git:lifecycle-package:v1 approved
+      git-635026ba389a2dd5417b6e7577430c7ccff30f36 approved
   - args:
       - alpha
       - rpkg
       - get
-      - git:lifecycle-package:v1
+      - git-635026ba389a2dd5417b6e7577430c7ccff30f36
       - --namespace=rpkg-lifecycle
-      - --output=custom-columns=NAME:.metadata.name,LIFECYCLE:.spec.lifecycle
+      - --output=custom-columns=NAME:.metadata.name,PKG:.spec.packageName,REV:.spec.revision,LIFECYCLE:.spec.lifecycle
     stdout: |
-      NAME                       LIFECYCLE
-      git:lifecycle-package:v1   Published
+      NAME                                           PKG                 REV   LIFECYCLE
+      git-635026ba389a2dd5417b6e7577430c7ccff30f36   lifecycle-package   v1    Published
   - args:
       - alpha
       - rpkg
       - delete
-      - git:lifecycle-package:v1
+      - git-635026ba389a2dd5417b6e7577430c7ccff30f36
       - --namespace=rpkg-lifecycle
     stderr: |
-      git:lifecycle-package:v1 deleted
+      git-635026ba389a2dd5417b6e7577430c7ccff30f36 deleted
   - args:
       - alpha
       - rpkg
       - get
-      - git:lifecycle-package:v1
+      - git-635026ba389a2dd5417b6e7577430c7ccff30f36
       - --namespace=rpkg-lifecycle
-      - --output=custom-columns=NAME:.metadata.name,LIFECYCLE:.spec.lifecycle
-    stderr: "Error: packagerevisions.porch.kpt.dev \"git:lifecycle-package:v1\" not found \n"
+    stderr: "Error: packagerevisions.porch.kpt.dev \"git-635026ba389a2dd5417b6e7577430c7ccff30f36\" not found \n"
     exitCode: 1

--- a/e2e/testdata/porch/rpkg-push/config.yaml
+++ b/e2e/testdata/porch/rpkg-push/config.yaml
@@ -11,13 +11,16 @@ commands:
       - rpkg
       - init
       - --namespace=rpkg-push
-      - git:test-package:v0
+      - --repository=git
+      - --revision=v0
+      - test-package
+    stdout: git-951628068ed2aee1a62fc568131134c6ec95d0be created
   - args:
       - alpha
       - rpkg
       - pull
       - --namespace=rpkg-push
-      - git:test-package:v0
+      - git-951628068ed2aee1a62fc568131134c6ec95d0be
     stdout: |
       apiVersion: config.kubernetes.io/v1
       items:
@@ -52,7 +55,7 @@ commands:
       - rpkg
       - push
       - --namespace=rpkg-push
-      - git:test-package:v0
+      - git-951628068ed2aee1a62fc568131134c6ec95d0be
     stdin: |
       apiVersion: config.kubernetes.io/v1
       kind: ResourceList
@@ -96,7 +99,7 @@ commands:
       - rpkg
       - pull
       - --namespace=rpkg-push
-      - git:test-package:v0
+      - git-951628068ed2aee1a62fc568131134c6ec95d0be
     stdout: |
       apiVersion: config.kubernetes.io/v1
       items:

--- a/internal/cmdrpkgget/command.go
+++ b/internal/cmdrpkgget/command.go
@@ -44,6 +44,9 @@ Flags:
 --name
   Name of the packages to get. Any package whose name contains this value will be included in the results.
 
+--revision
+  Revision of the package to get. Any package whose revision matches this value will be included in the results.
+
 `
 )
 
@@ -68,6 +71,7 @@ func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner 
 
 	// Create flags
 	c.Flags().StringVar(&r.name, "name", "", "Name of the packages to get. Any package whose name contains this value will be included in the results.")
+	c.Flags().StringVar(&r.revision, "revision", "", "Revision of the packages to get. Any package whose revision matches this value will be included in the results.")
 	r.printFlags.AddFlags(c)
 	return r
 }
@@ -84,6 +88,7 @@ type runner struct {
 
 	// Flags
 	name       string
+	revision   string
 	printFlags *get.PrintFlags
 }
 
@@ -166,5 +171,11 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 }
 
 func (r *runner) match(pr *porchapi.PackageRevision) bool {
-	return strings.Contains(pr.Name, r.name)
+	if !strings.Contains(pr.Spec.PackageName, r.name) {
+		return false
+	}
+	if r.revision != "" && r.revision != pr.Spec.Revision {
+		return false
+	}
+	return true
 }

--- a/internal/util/porch/name.go
+++ b/internal/util/porch/name.go
@@ -15,57 +15,8 @@
 package porch
 
 import (
-	"fmt"
 	"strings"
 )
-
-type PackageName struct {
-	Original   string
-	Repository string
-	Package    string
-	Revision   string
-}
-
-func ParsePackageName(name string) (PackageName, error) {
-	parts := strings.Split(name, ":")
-	if len(parts) != 3 {
-		return PackageName{}, fmt.Errorf("invalid package name: %q", name)
-	}
-	return PackageName{
-		Original:   name,
-		Repository: parts[0],
-		Package:    parts[1],
-		Revision:   parts[2],
-	}, nil
-}
-
-func ParsePartialPackageName(name string) (PackageName, int) {
-	result := PackageName{
-		Original: name,
-	}
-
-	parts := strings.Split(name, ":")
-	count := len(parts)
-
-	if count > 0 {
-		result.Repository = parts[0]
-	}
-	if count > 1 {
-		result.Package = parts[1]
-	}
-	if count > 2 {
-		result.Revision = parts[2]
-	}
-	return result, count
-}
-
-func (name PackageName) Identifier() string {
-	return name.String()
-}
-
-func (name PackageName) String() string {
-	return fmt.Sprintf("%s:%s:%s", name.Repository, name.Package, name.Revision)
-}
 
 func LastSegment(path string) string {
 	path = strings.TrimRight(path, "/")

--- a/porch/apiserver/pkg/registry/porch/name.go
+++ b/porch/apiserver/pkg/registry/porch/name.go
@@ -20,9 +20,9 @@ import (
 )
 
 func ParseRepositoryName(name string) (string, error) {
-	firstIndex := strings.Index(name, ":")
-	if firstIndex < 0 {
-		return "", fmt.Errorf("invalid name %q - insufficient colons", name)
+	lastDash := strings.LastIndex(name, "-")
+	if lastDash < 0 {
+		return "", fmt.Errorf("malformed package revision name; expected at least one hyphen: %q", name)
 	}
-	return name[:firstIndex], nil
+	return name[:lastDash], nil
 }

--- a/porch/apiserver/pkg/registry/porch/packagerevision.go
+++ b/porch/apiserver/pkg/registry/porch/packagerevision.go
@@ -98,6 +98,9 @@ func (r *packageRevisions) Create(ctx context.Context, runtimeObject runtime.Obj
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("expected PackageRevision object, got %T", runtimeObject))
 	}
 
+	// TODO: Accpept some form of client-provided name, for example using GenerateName
+	// and figure out where we can store it (in Kptfile?). Porch can then append unique
+	// suffix to the names while respecting client-provided value as well.
 	if obj.Name != "" {
 		klog.Warningf("Client provided metadata.name %q", obj.Name)
 	}

--- a/porch/engine/pkg/engine/clone.go
+++ b/porch/engine/pkg/engine/clone.go
@@ -185,9 +185,9 @@ func (m *clonePackageMutation) cloneFromOci(ctx context.Context, ociPackage *api
 }
 
 func parseUpstreamRepository(name string) (string, error) {
-	firstIndex := strings.Index(name, ":")
-	if firstIndex < 0 {
-		return "", fmt.Errorf("invalid name %q - insufficient colons", name)
+	lastDash := strings.LastIndex(name, "-")
+	if lastDash < 0 {
+		return "", fmt.Errorf("malformed package revision name; expected at least one hyphen: %q", name)
 	}
-	return name[:firstIndex], nil
+	return name[:lastDash], nil
 }

--- a/porch/repository/pkg/oci/oci.go
+++ b/porch/repository/pkg/oci/oci.go
@@ -16,6 +16,8 @@ package oci
 
 import (
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -336,7 +338,8 @@ func (p *ociPackageRevision) GetResources(ctx context.Context) (*v1alpha1.Packag
 }
 
 func (p *ociPackageRevision) Name() string {
-	return p.parent.name + ":" + p.packageName + ":" + p.revision
+	hash := sha1.Sum([]byte(fmt.Sprintf("%s:%s:%s", p.parent.name, p.packageName, p.revision)))
+	return p.parent.name + "-" + hex.EncodeToString(hash[:])
 }
 
 func (p *ociPackageRevision) Key() repository.PackageRevisionKey {


### PR DESCRIPTION
Kubernetes resources have constrained naming convention and we cannot
therefore reflect package path in the name correctly. Therefore we compute
a hash for package identity and convey the package path, repository, and revision
in the `PackageRevision.Spec`
