### PR TITLE
Add ability to read file to commit helper

### DIFF
--- a/porch/repository/pkg/git/commit_test.go
+++ b/porch/repository/pkg/git/commit_test.go
@@ -37,7 +37,7 @@ func TestPackageCommitEmptyRepo(t *testing.T) {
 	parent := plumbing.ZeroHash      // Empty repository
 	packageTree := plumbing.ZeroHash // Empty package
 	packagePath := "catalog/namespaces/istions"
-	ch, err := newCommitHelper(repo.Storer, userInfoProvider, parent, packagePath, packageTree)
+	ch, err := newCommitHelper(repo, userInfoProvider, parent, packagePath, packageTree)
 	if err != nil {
 		t.Fatalf("newCommitHelper(%q) failed: %v", packagePath, err)
 	}
@@ -107,7 +107,7 @@ func TestPackageCommitToMain(t *testing.T) {
 	draftTree := getCommitTree(t, repo, draft.Hash())
 	bucketEntry := findTreeEntry(t, draftTree, packagePath)
 	bucketTree := bucketEntry.Hash
-	ch, err := newCommitHelper(repo.Storer, userInfoProvider, main.Hash(), packagePath, bucketTree)
+	ch, err := newCommitHelper(repo, userInfoProvider, main.Hash(), packagePath, bucketTree)
 	if err != nil {
 		t.Fatalf("Failed to create commit helper: %v", err)
 	}
@@ -158,7 +158,7 @@ func TestCommitWithUser(t *testing.T) {
 
 		var zeroHash plumbing.Hash
 		const packagePath = "testpackage"
-		ch, err := newCommitHelper(repo.Storer, userInfoProvider, main.Hash(), packagePath, zeroHash)
+		ch, err := newCommitHelper(repo, userInfoProvider, main.Hash(), packagePath, zeroHash)
 		if err != nil {
 			t.Fatalf("newCommitHelper(%q) failed: %v", packagePath, err)
 		}
@@ -201,7 +201,7 @@ func TestCommitWithUser(t *testing.T) {
 
 		var zeroHash plumbing.Hash
 		const packagePath = "testpackage-nouser"
-		ch, err := newCommitHelper(repo.Storer, userInfoProvider, main.Hash(), packagePath, zeroHash)
+		ch, err := newCommitHelper(repo, userInfoProvider, main.Hash(), packagePath, zeroHash)
 		if err != nil {
 			t.Fatalf("newCommitHelper(%q) failed: %v", packagePath, err)
 		}

--- a/porch/repository/pkg/git/draft.go
+++ b/porch/repository/pkg/git/draft.go
@@ -42,7 +42,7 @@ type gitPackageDraft struct {
 var _ repository.PackageDraft = &gitPackageDraft{}
 
 func (d *gitPackageDraft) UpdateResources(ctx context.Context, new *v1alpha1.PackageRevisionResources, change *v1alpha1.Task) error {
-	ch, err := newCommitHelper(d.parent.repo.Storer, d.parent.userInfoProvider, d.commit, d.path, plumbing.ZeroHash)
+	ch, err := newCommitHelper(d.parent.repo, d.parent.userInfoProvider, d.commit, d.path, plumbing.ZeroHash)
 	if err != nil {
 		return fmt.Errorf("failed to commit packgae: %w", err)
 	}
@@ -190,7 +190,7 @@ func (r *gitRepository) commitPackageToMain(ctx context.Context, d *gitPackageDr
 
 	// TODO: Check for out-of-band update of the package in main branch
 	// (compare package tree in target branch and common base)
-	ch, err := newCommitHelper(repo.Storer, r.userInfoProvider, headCommit.Hash, packagePath, packageTree)
+	ch, err := newCommitHelper(repo, r.userInfoProvider, headCommit.Hash, packagePath, packageTree)
 	if err != nil {
 		return zero, zero, nil, fmt.Errorf("failed to initialize commit of package %s to %s", packagePath, localRef)
 	}

--- a/porch/repository/pkg/git/git.go
+++ b/porch/repository/pkg/git/git.go
@@ -720,7 +720,7 @@ func (r *gitRepository) createPackageDeleteCommit(ctx context.Context, branch pl
 
 	// Create commit helper. Use zero hash for the initial package tree. Commit helper will initialize trees
 	// without TreeEntry for this package present - the package is deleted.
-	ch, err := newCommitHelper(repo.Storer, r.userInfoProvider, commit.Hash, packagePath, zero)
+	ch, err := newCommitHelper(repo, r.userInfoProvider, commit.Hash, packagePath, zero)
 	if err != nil {
 		return zero, fmt.Errorf("failed to initialize commit of package %q to %q: %w", packagePath, ref, err)
 	}


### PR DESCRIPTION
We can use this e.g. for manipulating the Kptfile or other metadata files.