### PR TITLE
Remove Repository.title field

### DIFF
--- a/internal/cmdreporeg/command.go
+++ b/internal/cmdreporeg/command.go
@@ -47,9 +47,6 @@ Flags:
 --name
   Name of the package repository. If unspecified, will use the name portion (last segment) of the repository URL.
 
---title
-  Title of the package repository.
-
 --deployment
   Repository is a deployment repository; packages in a deployment repository are considered deployment-ready.
 
@@ -85,7 +82,6 @@ func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner 
 	}
 	r.Command = c
 
-	c.Flags().StringVar(&r.title, "title", "", "Title of the package repository.")
 	c.Flags().StringVar(&r.directory, "directory", "/", "Directory within the repository where to look for packages.")
 	c.Flags().StringVar(&r.branch, "branch", "main", "Branch in the repository where finalized packages are committed.")
 	c.Flags().StringVar(&r.name, "name", "", "Name of the package repository. If unspecified, will use the name portion (last segment) of the repository URL.")
@@ -108,7 +104,6 @@ type runner struct {
 	Command *cobra.Command
 
 	// Flags
-	title       string
 	directory   string
 	branch      string
 	name        string
@@ -205,7 +200,6 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 			Namespace: *r.cfg.Namespace,
 		},
 		Spec: configapi.RepositorySpec{
-			Title:       r.title,
 			Description: r.description,
 			Type:        rt,
 			Content:     configapi.RepositoryContentPackage,

--- a/internal/cmdreporeg/command_test.go
+++ b/internal/cmdreporeg/command_test.go
@@ -95,7 +95,6 @@ func TestRepoReg(t *testing.T) {
 			name: "FullRegister",
 			args: []string{
 				"https://github.com/platkrm/test-blueprints.git",
-				"--title=\"Test Repository Title\"",
 				"--name=repository-resource-name",
 				"--description=\"Test Repository Description\"",
 				"--deployment",

--- a/internal/cmdreporeg/testdata/full-repository.yaml
+++ b/internal/cmdreporeg/testdata/full-repository.yaml
@@ -14,6 +14,5 @@ spec:
         repo: https://github.com/platkrm/test-blueprints.git
         secretRef:
             name: ""
-    title: '"Test Repository Title"'
     type: git
 status: {}

--- a/porch/api/porchconfig/v1alpha1/config.porch.kpt.dev_repositories.yaml
+++ b/porch/api/porchconfig/v1alpha1/config.porch.kpt.dev_repositories.yaml
@@ -148,9 +148,6 @@ spec:
                 required:
                 - registry
                 type: object
-              title:
-                description: Title of the repository for display in the UIs.
-                type: string
               type:
                 description: Type of the repository (i.e. git, OCI)
                 type: string

--- a/porch/api/porchconfig/v1alpha1/types.go
+++ b/porch/api/porchconfig/v1alpha1/types.go
@@ -49,8 +49,6 @@ const (
 // Notes:
 //  * deployment repository - in KRM API ConfigSync would be configured directly? (or via this API)
 type RepositorySpec struct {
-	// Title of the repository for display in the UIs.
-	Title string `json:"title,omitempty"`
 	// User-friendly description of the repository
 	Description string `json:"description,omitempty"`
 	// The repository is a deployment repository; final packages in this repository are deployment ready.

--- a/porch/apiserver/pkg/e2e/e2e_test.go
+++ b/porch/apiserver/pkg/e2e/e2e_test.go
@@ -528,7 +528,6 @@ func (t *PorchSuite) TestFunctionRepository(ctx context.Context) {
 			Namespace: t.namespace,
 		},
 		Spec: configapi.RepositorySpec{
-			Title:       "Function Repository",
 			Description: "Test Function Repository",
 			Type:        configapi.RepositoryTypeOCI,
 			Content:     configapi.RepositoryContentFunction,
@@ -780,10 +779,8 @@ func (t *PorchSuite) TestCloneLeadingSlash(ctx context.Context) {
 func (t *PorchSuite) TestRegisterRepository(ctx context.Context) {
 	const (
 		repository = "register"
-		title      = "Test Register Repository"
 	)
 	t.registerMainGitRepositoryF(ctx, repository,
-		withTitle(title),
 		withContent(configapi.RepositoryContentPackage),
 		withType(configapi.RepositoryTypeGit),
 		withDeployment())
@@ -794,9 +791,6 @@ func (t *PorchSuite) TestRegisterRepository(ctx context.Context) {
 		Name:      repository,
 	}, &repo)
 
-	if got, want := repo.Spec.Title, title; got != want {
-		t.Errorf("Repo Title: got %q, want %q", got, want)
-	}
 	if got, want := repo.Spec.Content, configapi.RepositoryContentPackage; got != want {
 		t.Errorf("Repo Content: got %q, want %q", got, want)
 	}
@@ -1051,7 +1045,6 @@ func (t *PorchSuite) registerGitRepositoryF(ctx context.Context, repo, name stri
 			Namespace: t.namespace,
 		},
 		Spec: configapi.RepositorySpec{
-			Title:   "Public Git Repository",
 			Type:    configapi.RepositoryTypeGit,
 			Content: configapi.RepositoryContentPackage,
 			Git: &configapi.GitRepository{
@@ -1114,7 +1107,6 @@ func (t *PorchSuite) registerMainGitRepositoryF(ctx context.Context, name string
 			Namespace: t.namespace,
 		},
 		Spec: configapi.RepositorySpec{
-			Title:       "Porch Test Repository",
 			Description: "Porch Test Repository Description",
 			Type:        configapi.RepositoryTypeGit,
 			Content:     configapi.RepositoryContentPackage,
@@ -1150,12 +1142,6 @@ func (t *PorchSuite) registerMainGitRepositoryF(ctx context.Context, name string
 func withDeployment() repositoryOption {
 	return func(r *configapi.Repository) {
 		r.Spec.Deployment = true
-	}
-}
-
-func withTitle(title string) repositoryOption {
-	return func(r *configapi.Repository) {
-		r.Spec.Title = title
 	}
 }
 

--- a/porch/config/samples/deployment-repository.yaml
+++ b/porch/config/samples/deployment-repository.yaml
@@ -18,7 +18,6 @@ metadata:
   name: deployment
   namespace: default
 spec:
-  title: Deployment
   deployment: true
   description: Deployment Repository for testing Porch.
   content: PackageRevision # TODO: Deployment or similar?

--- a/porch/config/samples/function-repository.yaml
+++ b/porch/config/samples/function-repository.yaml
@@ -18,7 +18,6 @@ metadata:
   name: kpt-functions
   namespace: default
 spec:
-  title: Standard KPT Function Library
   description: Standard library of core kpt functions to manipulate KRM blueprints.
   content: Function
   type: oci

--- a/porch/config/samples/git-repository.yaml
+++ b/porch/config/samples/git-repository.yaml
@@ -18,7 +18,6 @@ metadata:
   name: blueprints
   namespace: default
 spec:
-  title: Blueprints
   description: Blueprints Git Repository
   content: PackageRevision
   type: git

--- a/porch/config/samples/oci-repository.yaml
+++ b/porch/config/samples/oci-repository.yaml
@@ -18,7 +18,6 @@ metadata:
   name: blueprints
   namespace: default
 spec:
-  title: Blueprints
   description: OCI Blueprints Repository for testing Porch.
   content: PackageRevision
   type: oci


### PR DESCRIPTION
Given that we have `metadata.name` and `spec.description` the `title`
field was redundant.
