### PR TITLE
Respect Repository Registration Directory

### DIFF
--- a/porch/repository/pkg/git/dir.go
+++ b/porch/repository/pkg/git/dir.go
@@ -1,0 +1,33 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+import "strings"
+
+// Determines whether a package specified by a path is in a directory given.
+func packageInDirectory(pkg, dir string) bool {
+	if dir == "" {
+		return true
+	}
+	if strings.HasPrefix(pkg, dir) {
+		if len(pkg) == len(dir) {
+			return true
+		}
+		if pkg[len(dir)] == '/' {
+			return true
+		}
+	}
+	return false
+}

--- a/porch/repository/pkg/git/dir_test.go
+++ b/porch/repository/pkg/git/dir_test.go
@@ -1,0 +1,68 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+import "testing"
+
+func TestPackageInDirectory(t *testing.T) {
+	for _, tc := range []struct {
+		pkg, dir string
+		want     bool
+	}{
+		{
+			pkg:  "root/nested",
+			dir:  "",
+			want: true,
+		}, {
+			pkg:  "catalog/package",
+			dir:  "cat",
+			want: false,
+		},
+		{
+			pkg:  "catalog/package",
+			dir:  "catalog",
+			want: true,
+		},
+		{
+			pkg:  "catalog/package/nested",
+			dir:  "catalog/packages",
+			want: false,
+		},
+		{
+			pkg:  "catalog/package/nested",
+			dir:  "catalog/package",
+			want: true,
+		},
+		{
+			pkg:  "catalog/package/nested",
+			dir:  "catalog/package/nest",
+			want: false,
+		},
+		{
+			pkg:  "catalog/package/nested",
+			dir:  "catalog/package/nested",
+			want: true,
+		},
+		{
+			pkg:  "catalog/package/nested",
+			dir:  "catalog/package/nested/even-more",
+			want: false,
+		},
+	} {
+		if got, want := packageInDirectory(tc.pkg, tc.dir), tc.want; got != want {
+			t.Errorf("packageInDirectory(%q, %q): got %t, want %t", tc.pkg, tc.dir, got, want)
+		}
+	}
+}


### PR DESCRIPTION
If a sub-directory is specified at repository registration, the repository will
only include package revisions in the specified directory. Likewise, it will
only create packages in the specified subdirectory.

In order to maintain stable resource names within the repo (regardless of the
registration parameters), the package names are unaffected by the directory
projection.
