### PR TITLE
Update Repository Resource Status

### DIFF
--- a/porch/api/porchconfig/v1alpha1/config.porch.kpt.dev_repositories.yaml
+++ b/porch/api/porchconfig/v1alpha1/config.porch.kpt.dev_repositories.yaml
@@ -29,7 +29,11 @@ spec:
     singular: repository
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Available')].status
+      name: Ready
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Repository
@@ -338,6 +342,8 @@ spec:
         type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/porch/api/porchconfig/v1alpha1/config.porch.kpt.dev_repositories.yaml
+++ b/porch/api/porchconfig/v1alpha1/config.porch.kpt.dev_repositories.yaml
@@ -30,7 +30,7 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=='Available')].status
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
       name: Ready
       type: string
     name: v1alpha1

--- a/porch/api/porchconfig/v1alpha1/types.go
+++ b/porch/api/porchconfig/v1alpha1/types.go
@@ -21,7 +21,7 @@ import (
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:resource:path=repositories,singular=repository
-//+kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=='Available')].status`
+//+kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=='Ready')].status`
 
 // Repository
 type Repository struct {
@@ -146,7 +146,7 @@ type FunctionRef struct {
 
 const (
 	// Type of the Repository condition.
-	RepositoryAvailable = "Available"
+	RepositoryReady = "Ready"
 
 	// Reason for the condition is error.
 	ReasonError = "Error"

--- a/porch/api/porchconfig/v1alpha1/types.go
+++ b/porch/api/porchconfig/v1alpha1/types.go
@@ -19,7 +19,9 @@ import (
 )
 
 //+kubebuilder:object:root=true
+//+kubebuilder:subresource:status
 //+kubebuilder:resource:path=repositories,singular=repository
+//+kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=='Available')].status`
 
 // Repository
 type Repository struct {
@@ -141,6 +143,16 @@ type FunctionRef struct {
 	// `Name` is the name of the `Function` resource referenced. The resource is expected to be within the same namespace.
 	Name string `json:"name"`
 }
+
+const (
+	// Type of the Repository condition.
+	RepositoryAvailable = "Available"
+
+	// Reason for the condition is error.
+	ReasonError = "Error"
+	// Reason for the condition is the repository is ready.
+	ReasonReady = "Ready"
+)
 
 // RepositoryStatus defines the observed state of Repository
 type RepositoryStatus struct {

--- a/porch/apiserver/pkg/e2e/e2e_test.go
+++ b/porch/apiserver/pkg/e2e/e2e_test.go
@@ -1084,7 +1084,7 @@ func (t *PorchSuite) TestRepositoryError(ctx context.Context) {
 			Name:      repositoryName,
 		}, &repository)
 
-		available := meta.FindStatusCondition(repository.Status.Conditions, configapi.RepositoryAvailable)
+		available := meta.FindStatusCondition(repository.Status.Conditions, configapi.RepositoryReady)
 		if available == nil {
 			// Condition not yet set
 			t.Logf("Repository condition not yet available")

--- a/porch/apiserver/pkg/registry/porch/background.go
+++ b/porch/apiserver/pkg/registry/porch/background.go
@@ -173,7 +173,7 @@ func (b *background) cacheRepository(ctx context.Context, repo *configapi.Reposi
 	var condition v1.Condition
 	if _, err := b.cache.OpenRepository(ctx, repo); err == nil {
 		condition = v1.Condition{
-			Type:               configapi.RepositoryAvailable,
+			Type:               configapi.RepositoryReady,
 			Status:             v1.ConditionTrue,
 			ObservedGeneration: repo.Generation,
 			LastTransitionTime: v1.Now(),
@@ -181,7 +181,7 @@ func (b *background) cacheRepository(ctx context.Context, repo *configapi.Reposi
 		}
 	} else {
 		condition = v1.Condition{
-			Type:               configapi.RepositoryAvailable,
+			Type:               configapi.RepositoryReady,
 			Status:             v1.ConditionFalse,
 			ObservedGeneration: repo.Generation,
 			LastTransitionTime: v1.Now(),

--- a/porch/apiserver/pkg/registry/porch/background.go
+++ b/porch/apiserver/pkg/registry/porch/background.go
@@ -19,13 +19,13 @@ import (
 	"fmt"
 	"time"
 
+	configapi "github.com/GoogleContainerTools/kpt/porch/api/porchconfig/v1alpha1"
+	"github.com/GoogleContainerTools/kpt/porch/repository/pkg/cache"
+	"k8s.io/apimachinery/pkg/api/meta"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	configapi "github.com/GoogleContainerTools/kpt/porch/api/porchconfig/v1alpha1"
-	"github.com/GoogleContainerTools/kpt/porch/repository/pkg/cache"
 )
 
 func RunBackground(ctx context.Context, coreClient client.WithWatch, cache *cache.Cache) {
@@ -161,15 +161,38 @@ func (b *background) runOnce(ctx context.Context) error {
 			}
 		}
 
-		b.cacheRepository(ctx, repo)
+		if err := b.cacheRepository(ctx, repo); err != nil {
+			klog.Errorf("Failed to cache repository: %v", err)
+		}
 	}
 
 	return nil
 }
 
 func (b *background) cacheRepository(ctx context.Context, repo *configapi.Repository) error {
-	if _, err := b.cache.OpenRepository(ctx, repo); err != nil {
-		return fmt.Errorf("error opening repository: %w", err)
+	var condition v1.Condition
+	if _, err := b.cache.OpenRepository(ctx, repo); err == nil {
+		condition = v1.Condition{
+			Type:               configapi.RepositoryAvailable,
+			Status:             v1.ConditionTrue,
+			ObservedGeneration: repo.Generation,
+			LastTransitionTime: v1.Now(),
+			Reason:             configapi.ReasonReady,
+		}
+	} else {
+		condition = v1.Condition{
+			Type:               configapi.RepositoryAvailable,
+			Status:             v1.ConditionFalse,
+			ObservedGeneration: repo.Generation,
+			LastTransitionTime: v1.Now(),
+			Reason:             configapi.ReasonError,
+			Message:            err.Error(),
+		}
+	}
+
+	meta.SetStatusCondition(&repo.Status.Conditions, condition)
+	if err := b.coreClient.Status().Update(ctx, repo); err != nil {
+		return fmt.Errorf("error updating repository status: %w", err)
 	}
 	return nil
 }

--- a/porch/config/deploy/5-rbac.yaml
+++ b/porch/config/deploy/5-rbac.yaml
@@ -25,7 +25,7 @@ rules:
       ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
     verbs: ["get", "watch", "list"]
   - apiGroups: ["config.porch.kpt.dev"]
-    resources: ["repositories"]
+    resources: ["repositories", "repositories/status"]
     verbs: ["get", "list", "watch", "create", "update", "patch"]
   # Needed for priority and fairness
   - apiGroups: ["flowcontrol.apiserver.k8s.io"]

--- a/porch/repository/pkg/cache/cache.go
+++ b/porch/repository/pkg/cache/cache.go
@@ -109,6 +109,11 @@ func (c *Cache) OpenRepository(ctx context.Context, repositorySpec *configapi.Re
 				cr = newRepository(key, r)
 				c.repositories[key] = cr
 			}
+		} else {
+			// If there is an error from the background refresh goroutine, return it.
+			if err := cr.getRefreshError(); err != nil {
+				return nil, err
+			}
 		}
 		return cr, nil
 


### PR DESCRIPTION
When repository interactions encounter errors, we update status
of the repository with a failure condition. Likewise, on successful
resync of the repository we set a success condition.
