### PR TITLE
user friendly --type behavior

### DIFF
--- a/e2e/testdata/fn-eval/save-fn/exec/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/exec/.expected/exec.sh
@@ -14,4 +14,4 @@
 # limitations under the License.
 set -eo pipefail
 
-kpt fn eval -s --exec ./function.sh --fn-config=fn-config.yaml
+kpt fn eval -s -t mutator --exec ./function.sh --fn-config=fn-config.yaml

--- a/e2e/testdata/fn-eval/save-fn/image/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/image/.expected/exec.sh
@@ -15,4 +15,4 @@
 
 set -eo pipefail
 
-kpt fn eval -s -i set-namespace:v0.1.3 -- namespace=staging
+kpt fn eval -s -t mutator -i set-namespace:v0.1.3 -- namespace=staging

--- a/e2e/testdata/fn-eval/save-fn/match-selector/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/match-selector/.expected/exec.sh
@@ -16,4 +16,4 @@
 
 set -eo pipefail
 
-kpt fn eval -s -i set-namespace:v0.1.3 --match-kind Deployment -- namespace=staging
+kpt fn eval -s -t mutator -i set-namespace:v0.1.3 --match-kind Deployment -- namespace=staging

--- a/e2e/testdata/fn-eval/save-fn/no-save-when-fail/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/no-save-when-fail/.expected/exec.sh
@@ -15,4 +15,4 @@
 
 set -eo pipefail
 
-kpt fn eval -s -i set-namespace:v0.1.3 -- namespace=staging
+kpt fn eval -s -t mutator -i set-namespace:v0.1.3 -- namespace=staging

--- a/e2e/testdata/fn-eval/save-fn/override-fn/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/override-fn/.expected/exec.sh
@@ -15,4 +15,4 @@
 
 set -eo pipefail
 
-kpt fn eval -s -i set-namespace:v0.1.3 -- namespace=newNs
+kpt fn eval -s -t mutator -i set-namespace:v0.1.3 -- namespace=newNs

--- a/internal/util/cmdutil/cmdutil.go
+++ b/internal/util/cmdutil/cmdutil.go
@@ -188,6 +188,9 @@ func GetKeywordsFromFlag(cmd *cobra.Command) []string {
 	splitted := strings.Split(flagVal, ",")
 	var trimmed []string
 	for _, val := range splitted {
+		if strings.TrimSpace(val) == "" {
+			continue
+		}
 		trimmed = append(trimmed, strings.TrimSpace(val))
 	}
 	return trimmed

--- a/internal/util/function/matcher.go
+++ b/internal/util/function/matcher.go
@@ -34,6 +34,10 @@ type TypeMatcher struct {
 // Match determines whether the `function` (which can be multi-typed), belongs
 // to the matcher's FnType. type value should only be `validator` or `mutator`.
 func (m TypeMatcher) Match(function v1alpha1.Function) bool {
+	if m.FnType == "" {
+		// type is not given, shown all functions.
+		return true
+	}
 	for _, actualType := range function.Spec.FunctionTypes {
 		if string(actualType) == m.FnType {
 			return true


### PR DESCRIPTION
Related to #3014

- --type is default to "" (rather than "mutator") with autocompletion enabled to suggest "validator" and "mutator".
- Matching functions by type accepts the "--type" to be empty string "", in such case suggest all functions.
- Only when "--save" is true, will require and validate "--type". 

Output 1: type required if save
```bash
kpt fn eval -s -i set-namespace:v0.3.3 
error: --type is required if saving functions to Kptfile (--save=true)
```
Outout 2: invalid type
```bash
kpt fn eval -s -t bad -i set-namespace:v0.3.3
error: --type can only be `mutator` or `validator`
```
Output 3: Autocomplete all
```bash
kpt fn eval -k
annotation   gcp          helm         label        name-suffix  replacement  terraform    
config-sync  generate     image        name         namespace    setters      viewer       
gatekeeper   generator    kubeval      name-prefix  project-id   starlark 
```
Output 4: Automplete filter by validator
```bash
kpt fn eval -t validator -k
gatekeeper  kubeval     starlark
```