### PR TITLE
Implement fieldSelectors on PackageRevision

### DIFF
--- a/porch/apiserver/pkg/registry/porch/fieldselector.go
+++ b/porch/apiserver/pkg/registry/porch/fieldselector.go
@@ -1,0 +1,103 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package porch
+
+import (
+	"fmt"
+
+	"github.com/GoogleContainerTools/kpt/porch/repository/pkg/repository"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/selection"
+)
+
+// convertPackageRevisionFieldSelector is the schema conversion function for normalizing the the FieldSelector for PackageRevision
+func convertPackageRevisionFieldSelector(label, value string) (internalLabel, internalValue string, err error) {
+	switch label {
+	case "metadata.name":
+		return label, value, nil
+	case "metadata.namespace":
+		return label, value, nil
+	case "spec.revision", "spec.packageName", "spec.repository":
+		return label, value, nil
+	default:
+		return "", "", fmt.Errorf("%q is not a known field selector", label)
+	}
+}
+
+// convertPackageRevisionResourcesFieldSelector is the schema conversion function for normalizing the the FieldSelector for PackageRevisionResources
+func convertPackageRevisionResourcesFieldSelector(label, value string) (internalLabel, internalValue string, err error) {
+	return convertPackageRevisionFieldSelector(label, value)
+}
+
+// packageFilter filters packages, extending repository.ListPackageRevisionFilter
+type packageFilter struct {
+	repository.ListPackageRevisionFilter
+
+	// Namespace filters by the namespace of the objects
+	Namespace string
+
+	// Repository restricts to repositories with the given name.
+	Repository string
+}
+
+// parsePackageRevisionFieldSelector parses client-provided fields.Selector into a packageFilter
+func parsePackageRevisionFieldSelector(fieldSelector fields.Selector) (packageFilter, error) {
+	var filter packageFilter
+
+	if fieldSelector == nil {
+		return filter, nil
+	}
+
+	requirements := fieldSelector.Requirements()
+	for _, requirement := range requirements {
+
+		switch requirement.Operator {
+		case selection.Equals, selection.DoesNotExist:
+			if requirement.Value == "" {
+				return filter, apierrors.NewBadRequest(fmt.Sprintf("unsupported fieldSelector value %q for field %q with operator %q", requirement.Value, requirement.Field, requirement.Operator))
+			}
+		default:
+			return filter, apierrors.NewBadRequest(fmt.Sprintf("unsupported fieldSelector operator %q for field %q", requirement.Operator, requirement.Field))
+		}
+
+		switch requirement.Field {
+		case "metadata.name":
+			filter.KubeObjectName = requirement.Value
+
+		case "metadata.namespace":
+			filter.Namespace = requirement.Value
+
+		case "spec.revision":
+			filter.Revision = requirement.Value
+		case "spec.packageName":
+			filter.Package = requirement.Value
+		case "spec.repository":
+			filter.Repository = requirement.Value
+
+		default:
+			return filter, apierrors.NewBadRequest(fmt.Sprintf("unknown fieldSelector field %q", requirement.Field))
+		}
+	}
+
+	return filter, nil
+}
+
+// parsePackageRevisionResourcesFieldSelector parses client-provided fields.Selector into a packageFilter
+func parsePackageRevisionResourcesFieldSelector(fieldSelector fields.Selector) (packageFilter, error) {
+	// TOOD: This is a little weird, because we don't have the same fields on PackageRevisionResources.
+	// But we probably should have the key fields
+	return parsePackageRevisionFieldSelector(fieldSelector)
+}

--- a/porch/apiserver/pkg/registry/porch/packagerevision.go
+++ b/porch/apiserver/pkg/registry/porch/packagerevision.go
@@ -67,7 +67,12 @@ func (r *packageRevisions) List(ctx context.Context, options *metainternalversio
 		},
 	}
 
-	if err := r.packageCommon.listPackages(ctx, func(p repository.PackageRevision) error {
+	filter, err := parsePackageRevisionFieldSelector(options.FieldSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := r.packageCommon.listPackages(ctx, filter, func(p repository.PackageRevision) error {
 		item, err := p.GetPackageRevision()
 		if err != nil {
 			return err

--- a/porch/apiserver/pkg/registry/porch/packagerevisionresources.go
+++ b/porch/apiserver/pkg/registry/porch/packagerevisionresources.go
@@ -64,7 +64,12 @@ func (r *packageRevisionResources) List(ctx context.Context, options *metaintern
 		},
 	}
 
-	if err := r.packageCommon.listPackages(ctx, func(p repository.PackageRevision) error {
+	filter, err := parsePackageRevisionResourcesFieldSelector(options.FieldSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := r.packageCommon.listPackages(ctx, filter, func(p repository.PackageRevision) error {
 		item, err := p.GetResources(ctx)
 		if err != nil {
 			return err

--- a/porch/apiserver/pkg/registry/porch/storage.go
+++ b/porch/apiserver/pkg/registry/porch/storage.go
@@ -19,6 +19,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/porch/engine/pkg/engine"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -69,6 +70,25 @@ func NewRESTStorage(scheme *runtime.Scheme, codecs serializer.CodecFactory, cad 
 			"packagerevisionresources":  packageRevisionResources,
 			"functions":                 functions,
 		},
+	}
+
+	{
+		gvk := schema.GroupVersionKind{
+			Group:   porch.GroupName,
+			Version: "v1alpha1",
+			Kind:    "PackageRevision",
+		}
+
+		scheme.AddFieldLabelConversionFunc(gvk, convertPackageRevisionFieldSelector)
+	}
+	{
+		gvk := schema.GroupVersionKind{
+			Group:   porch.GroupName,
+			Version: "v1alpha1",
+			Kind:    "PackageRevisionResources",
+		}
+
+		scheme.AddFieldLabelConversionFunc(gvk, convertPackageRevisionResourcesFieldSelector)
 	}
 
 	return group, nil

--- a/porch/engine/pkg/engine/clone.go
+++ b/porch/engine/pkg/engine/clone.go
@@ -86,14 +86,14 @@ func (m *clonePackageMutation) cloneFromRegisteredRepository(ctx context.Context
 		return repository.PackageResources{}, err
 	}
 
-	revisions, err := open.ListPackageRevisions(ctx)
+	revisions, err := open.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{KubeObjectName: ref.Name})
 	if err != nil {
 		return repository.PackageResources{}, err
 	}
 
 	var revision repository.PackageRevision
 	for _, rev := range revisions {
-		if rev.Name() == ref.Name {
+		if rev.KubeObjectName() == ref.Name {
 			revision = rev
 			break
 		}

--- a/porch/repository/pkg/cache/cache_test.go
+++ b/porch/repository/pkg/cache/cache_test.go
@@ -22,6 +22,7 @@ import (
 	api "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
 	"github.com/GoogleContainerTools/kpt/porch/api/porchconfig/v1alpha1"
 	"github.com/GoogleContainerTools/kpt/porch/repository/pkg/git"
+	"github.com/GoogleContainerTools/kpt/porch/repository/pkg/repository"
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -63,7 +64,7 @@ func TestLatestPackages(t *testing.T) {
 		"catalog/namespace/basens":  "v3",
 		"catalog/namespace/istions": "v3",
 	}
-	revisions, err := cachedGit.ListPackageRevisions(ctx)
+	revisions, err := cachedGit.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{})
 	if err != nil {
 		t.Fatalf("ListPackageRevisions failed: %v", err)
 	}

--- a/porch/repository/pkg/git/package.go
+++ b/porch/repository/pkg/git/package.go
@@ -50,7 +50,7 @@ var _ repository.PackageRevision = &gitPackageRevision{}
 // name in order to aide package discovery on the server. With improvements to caching
 // layer, the prefix will be removed (this may happen without notice) so it should not
 // be relied upon by clients.
-func (p *gitPackageRevision) Name() string {
+func (p *gitPackageRevision) KubeObjectName() string {
 	hash := sha1.Sum([]byte(fmt.Sprintf("%s:%s:%s", p.parent.name, p.path, p.revision)))
 	return p.parent.name + "-" + hex.EncodeToString(hash[:])
 }
@@ -74,7 +74,7 @@ func (p *gitPackageRevision) GetPackageRevision() (*v1alpha1.PackageRevision, er
 			APIVersion: v1alpha1.SchemeGroupVersion.Identifier(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            p.Name(),
+			Name:            p.KubeObjectName(),
 			Namespace:       p.parent.namespace,
 			UID:             p.uid(),
 			ResourceVersion: p.commit.String(),
@@ -125,7 +125,7 @@ func (p *gitPackageRevision) GetResources(ctx context.Context) (*v1alpha1.Packag
 			APIVersion: v1alpha1.SchemeGroupVersion.Identifier(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            p.Name(),
+			Name:            p.KubeObjectName(),
 			Namespace:       p.parent.namespace,
 			UID:             p.uid(),
 			ResourceVersion: p.commit.String(),

--- a/porch/repository/pkg/git/testing_repo.go
+++ b/porch/repository/pkg/git/testing_repo.go
@@ -201,7 +201,7 @@ func packageMustNotExist(t *testing.T, revisions []repository.PackageRevision, k
 }
 
 func repositoryMustHavePackageRevision(t *testing.T, git GitRepository, name repository.PackageRevisionKey) {
-	list, err := git.ListPackageRevisions(context.Background())
+	list, err := git.ListPackageRevisions(context.Background(), repository.ListPackageRevisionFilter{})
 	if err != nil {
 		t.Fatalf("ListPackageRevisions failed: %v", err)
 	}
@@ -209,7 +209,7 @@ func repositoryMustHavePackageRevision(t *testing.T, git GitRepository, name rep
 }
 
 func repositoryMustNotHavePackageRevision(t *testing.T, git GitRepository, name repository.PackageRevisionKey) {
-	list, err := git.ListPackageRevisions(context.Background())
+	list, err := git.ListPackageRevisions(context.Background(), repository.ListPackageRevisionFilter{})
 	if err != nil {
 		t.Fatalf("ListPackageRevisions failed: %v", err)
 	}


### PR DESCRIPTION
This lets us query objects by their "key fields", such as package /
revision / repository.

This is more important now that the name is no longer restricted.
