### PR TITLE
Rationalize git package construction

### DIFF
--- a/porch/repository/pkg/git/draft.go
+++ b/porch/repository/pkg/git/draft.go
@@ -17,6 +17,7 @@ package git
 import (
 	"context"
 	"fmt"
+	"os"
 	"path"
 	"time"
 
@@ -50,6 +51,16 @@ func (d *gitPackageDraft) UpdateResources(ctx context.Context, new *v1alpha1.Pac
 
 	for k, v := range new.Spec.Resources {
 		ch.storeFile(path.Join(d.path, k), v)
+	}
+
+	// Because we can't read the package back without a Kptfile, make sure one is present
+	{
+		p := path.Join(d.path, "Kptfile")
+		_, err := ch.readFile(p)
+		if os.IsNotExist(err) {
+			// We could write the file here; currently we return an error
+			return fmt.Errorf("package must contain Kptfile at root")
+		}
 	}
 
 	annotation := &gitAnnotation{

--- a/porch/repository/pkg/git/git.go
+++ b/porch/repository/pkg/git/git.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -32,7 +31,6 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/plumbing/filemode"
 	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/go-git/go-git/v5/plumbing/transport/http"
@@ -403,37 +401,22 @@ func (r *gitRepository) loadPackageRevision(ctx context.Context, version, path s
 	}
 	lock.Commit = commit.Hash.String()
 
-	commitTree, err := commit.Tree()
-	if err != nil {
-		return nil, lock, fmt.Errorf("cannot resolve git reference %s (hash %s) to tree: %w", version, hash, err)
-	}
-	treeHash := commitTree.Hash
-	if path != "" {
-		te, err := commitTree.FindEntry(path)
-		if err != nil {
-			return nil, lock, fmt.Errorf("cannot find package %s@%s: %w", path, version, err)
-		}
-		if te.Mode != filemode.Dir {
-			return nil, lock, fmt.Errorf("path %s@%s is not a directory", path, version)
-		}
-		treeHash = te.Hash
-	}
-
-	tasks, err := r.loadTasks(ctx, commit, path)
+	krmPackage, err := r.FindPackage(commit, path)
 	if err != nil {
 		return nil, lock, err
 	}
 
-	return &gitPackageRevision{
-		parent:   r,
-		path:     path,
-		revision: version,
-		updated:  commit.Author.When,
-		ref:      nil, // Cannot determine ref; this package will be considered final (immutable).
-		tree:     treeHash,
-		commit:   hash,
-		tasks:    tasks,
-	}, lock, nil
+	if krmPackage == nil {
+		return nil, lock, fmt.Errorf("cannot find package %s@%s", path, version)
+	}
+
+	var ref *plumbing.Reference = nil // Cannot determine ref; this package will be considered final (immutable).
+
+	packageRevision, err := krmPackage.buildGitPackageRevision(ctx, version, ref)
+	if err != nil {
+		return nil, lock, err
+	}
+	return packageRevision, lock, nil
 }
 
 func (r *gitRepository) discoverFinalizedPackages(ctx context.Context, ref *plumbing.Reference) ([]repository.PackageRevision, error) {
@@ -441,20 +424,6 @@ func (r *gitRepository) discoverFinalizedPackages(ctx context.Context, ref *plum
 	commit, err := git.CommitObject(ref.Hash())
 	if err != nil {
 		return nil, err
-	}
-	tree, err := commit.Tree()
-	if err != nil {
-		return nil, err
-	}
-
-	var result []repository.PackageRevision
-
-	// Recurse into the specified directory
-	if r.directory != "" {
-		tree, err = tree.Tree(r.directory)
-		if err == object.ErrDirectoryNotFound {
-			return result, nil
-		}
 	}
 
 	var revision string
@@ -467,57 +436,20 @@ func (r *gitRepository) discoverFinalizedPackages(ctx context.Context, ref *plum
 		return nil, fmt.Errorf("cannot determine revision from ref: %q", rev)
 	}
 
-	if err := discoverPackagesInTree(git, tree, r.directory, func(dir string, tree, kptfile plumbing.Hash) error {
-		tasks, err := r.loadTasks(ctx, commit, dir)
-		if err != nil {
-			return err
-		}
-
-		result = append(result, &gitPackageRevision{
-			parent:   r,
-			path:     dir,
-			revision: revision,
-			updated:  commit.Author.When,
-			ref:      ref,
-			tree:     tree,
-			commit:   ref.Hash(),
-			tasks:    tasks,
-		})
-		return nil
-	}); err != nil {
+	krmPackages, err := r.DiscoverPackagesInTree(commit, DiscoverPackagesOptions{FilterPrefix: r.directory, Recurse: true})
+	if err != nil {
 		return nil, err
 	}
-	return result, nil
-}
 
-type foundPackageCallback func(dir string, tree, kptfile plumbing.Hash) error
-
-func discoverPackagesInTree(r *git.Repository, tree *object.Tree, dir string, found foundPackageCallback) error {
-	for _, e := range tree.Entries {
-		if e.Mode.IsRegular() && e.Name == "Kptfile" {
-			// Found a package
-			klog.Infof("Found package %q with Kptfile hash %q", path.Join(dir, e.Name), e.Hash)
-			if err := found(dir, tree.Hash, e.Hash); err != nil {
-				return err
-			}
-		}
-	}
-
-	for _, e := range tree.Entries {
-		if e.Mode != filemode.Dir {
-			continue
-		}
-
-		dirTree, err := r.TreeObject(e.Hash)
+	var result []repository.PackageRevision
+	for _, krmPackage := range krmPackages.packages {
+		packageRevision, err := krmPackage.buildGitPackageRevision(ctx, revision, ref)
 		if err != nil {
-			return fmt.Errorf("error getting git tree %v: %w", e.Hash, err)
+			return nil, err
 		}
-
-		if err := discoverPackagesInTree(r, dirTree, path.Join(dir, e.Name), found); err != nil {
-			return err
-		}
+		result = append(result, packageRevision)
 	}
-	return nil
+	return result, nil
 }
 
 // loadDraft will load the draft package.  If the package isn't found (we now require a Kptfile), it will return (nil, nil)
@@ -536,51 +468,23 @@ func (r *gitRepository) loadDraft(ctx context.Context, ref *plumbing.Reference) 
 	if err != nil {
 		return nil, fmt.Errorf("cannot resolve draft branch to commit (corrupted repository?): %w", err)
 	}
-	tree, err := commit.Tree()
-	if err != nil {
-		return nil, fmt.Errorf("cannot resolve package commit to tree (corrupted repository?): %w", err)
-	}
 
-	dirTree, err := tree.Tree(name)
-	if err != nil {
-		switch err {
-		case object.ErrDirectoryNotFound, object.ErrEntryNotFound:
-			// empty package
-			return nil, nil
-
-		default:
-			return nil, fmt.Errorf("error when looking for package in the repository: %w", err)
-		}
-	}
-
-	packageTree := dirTree.Hash
-	kptfileEntry, err := dirTree.FindEntry("Kptfile")
-	if err != nil {
-		if err == object.ErrEntryNotFound {
-			return nil, nil
-		} else {
-			return nil, fmt.Errorf("error finding Kptfile: %w", err)
-		}
-	}
-	if !kptfileEntry.Mode.IsRegular() {
-		return nil, fmt.Errorf("found Kptfile which is not a regular file: %s", kptfileEntry.Mode)
-	}
-
-	tasks, err := r.loadTasks(ctx, commit, name)
+	krmPackage, err := r.FindPackage(commit, name)
 	if err != nil {
 		return nil, err
 	}
 
-	return &gitPackageRevision{
-		parent:   r,
-		path:     name,
-		revision: revision,
-		updated:  commit.Author.When,
-		ref:      ref,
-		tree:     packageTree,
-		commit:   ref.Hash(),
-		tasks:    tasks,
-	}, nil
+	if krmPackage == nil {
+		klog.Warningf("draft package %q was not found", name)
+		return nil, nil
+	}
+
+	packageRevision, err := krmPackage.buildGitPackageRevision(ctx, revision, ref)
+	if err != nil {
+		return nil, err
+	}
+
+	return packageRevision, nil
 }
 
 func parseDraftName(draft *plumbing.Reference) (name, revision string, err error) {
@@ -625,42 +529,27 @@ func (r *gitRepository) loadTaggedPackages(ctx context.Context, tag *plumbing.Re
 	if err != nil {
 		return nil, fmt.Errorf("cannot resolve tag %q to commit (corrupted repository?): %w", name, err)
 	}
-	tree, err := commit.Tree()
-	if err != nil {
-		return nil, fmt.Errorf("cannot resolve tag %q to tree (corrupted repository?): %w", name, err)
-	}
 
-	dirTree, err := tree.Tree(path)
+	krmPackage, err := r.FindPackage(commit, path)
 	if err != nil {
 		klog.Warningf("Skipping %q; cannot find %q (corrupted repository?): %w", name, path, err)
 		return nil, nil
 	}
 
-	if kptfileEntry, err := dirTree.FindEntry("Kptfile"); err != nil {
+	if krmPackage == nil {
 		klog.Warningf("Skipping %q: Kptfile not found: %w", name, err)
-		return nil, nil
-	} else if !kptfileEntry.Mode.IsRegular() {
-		klog.Warningf("Skippping %q: Kptfile is not a file", name)
 		return nil, nil
 	}
 
-	tasks, err := r.loadTasks(ctx, commit, path)
+	packageRevision, err := krmPackage.buildGitPackageRevision(ctx, revision, tag)
 	if err != nil {
 		return nil, err
 	}
 
 	return []repository.PackageRevision{
-		&gitPackageRevision{
-			parent:   r,
-			path:     path,
-			revision: revision,
-			updated:  commit.Author.When,
-			ref:      tag,
-			tree:     dirTree.Hash,
-			commit:   tag.Hash(),
-			tasks:    tasks,
-		},
+		packageRevision,
 	}, nil
+
 }
 
 func (r *gitRepository) dumpAllRefs() {
@@ -858,6 +747,7 @@ func (r *gitRepository) pushAndCleanup(ctx context.Context, ph *pushRefSpecBuild
 		return err
 	}
 
+	klog.Infof("pushing refs: %v", specs)
 	if err := r.repo.Push(&git.PushOptions{
 		RemoteName:        OriginName,
 		RefSpecs:          specs,

--- a/porch/repository/pkg/git/package_tree.go
+++ b/porch/repository/pkg/git/package_tree.go
@@ -1,0 +1,170 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+import (
+	"context"
+	"fmt"
+	"path"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/filemode"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"k8s.io/klog/v2"
+)
+
+// packageList holds a list of packages in the git repository
+type packageList struct {
+	// parent is the gitRepository of which this is part
+	parent *gitRepository
+
+	// commit is the commit at which we scanned for packages
+	commit *object.Commit
+
+	// packages holds the packages we found
+	packages map[string]*packageListEntry
+}
+
+// packageListEntry is a single package found in a git repository
+type packageListEntry struct {
+	// parent is the packageList of which we are part
+	parent *packageList
+
+	// path is the relative path to the root of the package (directory containing the Kptfile)
+	path string
+
+	// treeHash is the git-hash of the git tree corresponding to Path
+	treeHash plumbing.Hash
+}
+
+// buildGitPackageRevision creates a gitPackageRevision for the packageListEntry
+// TODO: Can packageListEntry just _be_ a gitPackageRevision?
+func (p *packageListEntry) buildGitPackageRevision(ctx context.Context, revision string, ref *plumbing.Reference) (*gitPackageRevision, error) {
+	repo := p.parent.parent
+	tasks, err := repo.loadTasks(ctx, p.parent.commit, p.path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &gitPackageRevision{
+		parent:   repo,
+		path:     p.path,
+		revision: revision,
+		updated:  p.parent.commit.Author.When,
+		ref:      ref,
+		tree:     p.treeHash,
+		commit:   p.parent.commit.Hash,
+		tasks:    tasks,
+	}, nil
+}
+
+// DiscoveryPackagesOptions holds the configuration for walking a git tree
+type DiscoverPackagesOptions struct {
+	// FilterPrefix restricts package discovery to a particular subdirectory.
+	// The subdirectory is not required to exist (we will return an empty list of packages).
+	FilterPrefix string
+
+	// Recurse enables recursive traversal of the git tree.
+	Recurse bool
+}
+
+// FindPackage finds the packages in the git repository, under commit, if it is exists at path.
+// If no package is found at that path, returns nil, nil
+func (r *gitRepository) FindPackage(commit *object.Commit, packagePath string) (*packageListEntry, error) {
+	t, err := r.DiscoverPackagesInTree(commit, DiscoverPackagesOptions{FilterPrefix: packagePath, Recurse: false})
+	if err != nil {
+		return nil, err
+	}
+	return t.packages[packagePath], nil
+}
+
+// DiscoverPackagesInTree finds the packages in the git repository, under commit.
+// If filterPrefix is non-empty, only packages with the specified prefix will be returned.
+// It is not an error if filterPrefix matches no packages or even is not a real directory name;
+// we will simply return an empty list of packages.
+func (r *gitRepository) DiscoverPackagesInTree(commit *object.Commit, opt DiscoverPackagesOptions) (*packageList, error) {
+	t := &packageList{
+		parent:   r,
+		commit:   commit,
+		packages: make(map[string]*packageListEntry),
+	}
+
+	rootTree, err := commit.Tree()
+	if err != nil {
+		return nil, fmt.Errorf("cannot resolve commit %v to tree (corrupted repository?): %w", commit.Hash, err)
+	}
+
+	if opt.FilterPrefix != "" {
+		tree, err := rootTree.Tree(opt.FilterPrefix)
+		if err != nil {
+			if err == object.ErrDirectoryNotFound {
+				// We treat the filter prefix as a filter, the path doesn't have to exist
+				klog.Warningf("could not find filterPrefix %q in commit %v; returning no packages", opt.FilterPrefix, commit.Hash)
+				return t, nil
+			} else {
+				return nil, fmt.Errorf("error getting tree %s: %w", opt.FilterPrefix, err)
+			}
+		}
+		rootTree = tree
+	}
+
+	if err := t.discoverPackages(rootTree, opt.FilterPrefix, opt.Recurse); err != nil {
+		return nil, err
+	}
+
+	klog.V(2).Infof("discovered packages @%v with prefix %q: %#v", commit.Hash, opt.FilterPrefix, t.packages)
+	return t, nil
+}
+
+// discoverPackages is the recursive function we use to traverse the tree and find packages.
+// tree is the git-tree we are search, treePath is the repo-relative-path to tree.
+func (t *packageList) discoverPackages(tree *object.Tree, treePath string, recurse bool) error {
+	for _, e := range tree.Entries {
+		if e.Name == "Kptfile" {
+			p := path.Join(treePath, e.Name)
+			if !e.Mode.IsRegular() {
+				klog.Warningf("skipping %q: Kptfile is not a file", p)
+				continue
+			}
+
+			// Found a package
+			klog.Infof("found package %q with Kptfile hash %q", p, e.Hash)
+			t.packages[treePath] = &packageListEntry{
+				path:     treePath,
+				treeHash: tree.Hash,
+				parent:   t,
+			}
+		}
+	}
+
+	if recurse {
+		for _, e := range tree.Entries {
+			if e.Mode != filemode.Dir {
+				continue
+			}
+
+			dirTree, err := t.parent.repo.TreeObject(e.Hash)
+			if err != nil {
+				return fmt.Errorf("error getting git tree %v: %w", e.Hash, err)
+			}
+
+			if err := t.discoverPackages(dirTree, path.Join(treePath, e.Name), recurse); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
We now have a single codepath for discovering git packages in the
tree; this allows us to include tasks in future.
