### PR TITLE
Cleanup Function Errors

### DIFF
--- a/porch/api/porch/v1alpha1/register.go
+++ b/porch/api/porch/v1alpha1/register.go
@@ -30,6 +30,7 @@ var (
 
 	PackageRevisionGVR          = SchemeGroupVersion.WithResource("packagerevisions")
 	PackageRevisionResourcesGVR = SchemeGroupVersion.WithResource("packagerevisionresources")
+	FunctionGVR                 = SchemeGroupVersion.WithResource("functions")
 )
 
 func init() {

--- a/porch/apiserver/pkg/registry/porch/functions.go
+++ b/porch/apiserver/pkg/registry/porch/functions.go
@@ -22,7 +22,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
 	configapi "github.com/GoogleContainerTools/kpt/porch/api/porchconfig/v1alpha1"
 	"github.com/GoogleContainerTools/kpt/porch/engine/pkg/engine"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -90,21 +90,21 @@ func (f *functions) List(ctx context.Context, options *metainternalversion.ListO
 func (f *functions) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	var repositoryKey client.ObjectKey
 	if ns, ok := request.NamespaceFrom(ctx); !ok {
-		return nil, errors.NewBadRequest("namespace must be specified")
+		return nil, apierrors.NewBadRequest("namespace must be specified")
 	} else {
 		repositoryKey.Namespace = ns
 	}
 
 	if fn, err := parseFunctionName(name); err != nil {
-		return nil, errors.NewNotFound(v1alpha1.FunctionGVR.GroupResource(), name)
+		return nil, apierrors.NewNotFound(v1alpha1.FunctionGVR.GroupResource(), name)
 	} else {
 		repositoryKey.Name = fn.repository
 	}
 
 	var repository configapi.Repository
 	if err := f.coreClient.Get(ctx, repositoryKey, &repository); err != nil {
-		if errors.IsNotFound(err) {
-			return nil, errors.NewNotFound(v1alpha1.FunctionGVR.GroupResource(), name)
+		if apierrors.IsNotFound(err) {
+			return nil, apierrors.NewNotFound(v1alpha1.FunctionGVR.GroupResource(), name)
 		}
 		return nil, fmt.Errorf("error getting repository %s: %w", repositoryKey, err)
 	}
@@ -121,7 +121,7 @@ func (f *functions) Get(ctx context.Context, name string, options *metav1.GetOpt
 		}
 	}
 
-	return nil, errors.NewNotFound(v1alpha1.FunctionGVR.GroupResource(), name)
+	return nil, apierrors.NewNotFound(v1alpha1.FunctionGVR.GroupResource(), name)
 }
 
 type functionName struct {


### PR DESCRIPTION
Return apiserver errors from Function registry to return clearer errors to the
client, rather than Internal errors.
