### PR TITLE
Add key fields to PackageRevisionResources

### DIFF
--- a/porch/api/generated/openapi/zz_generated.openapi.go
+++ b/porch/api/generated/openapi/zz_generated.openapi.go
@@ -837,9 +837,31 @@ func schema_porch_api_porch_v1alpha1_PackageRevisionResourcesSpec(ref common.Ref
 				Description: "PackageRevisionResourcesSpec represents resources (as ResourceList serialized as yaml string) of the PackageRevision.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
+					"packageName": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PackageName identifies the package in the repository.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"revision": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Revision identifies the version of the package.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"repository": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RepositoryName is the name of the Repository object containing this package.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"resources": {
 						SchemaProps: spec.SchemaProps{
-							Type: []string{"object"},
+							Description: "Resources are the content of the package.",
+							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,
 								Schema: &spec.Schema{
@@ -867,26 +889,29 @@ func schema_porch_api_porch_v1alpha1_PackageRevisionSpec(ref common.ReferenceCal
 				Properties: map[string]spec.Schema{
 					"packageName": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "PackageName identifies the package in the repository.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"revision": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
+							Description: "Revision identifies the version of the package.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"repository": {
+						SchemaProps: spec.SchemaProps{
+							Description: "RepositoryName is the name of the Repository object containing this package.",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"parent": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Parent references a package that provides resources to us",
 							Ref:         ref("github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1.ParentReference"),
-						},
-					},
-					"repository": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
 						},
 					},
 					"lifecycle": {

--- a/porch/api/porch/types_packagerevisionresources.go
+++ b/porch/api/porch/types_packagerevisionresources.go
@@ -42,5 +42,15 @@ type PackageRevisionResourcesList struct {
 
 // PackageRevisionResourcesSpec represents resources (as ResourceList serialized as yaml string) of the PackageRevision.
 type PackageRevisionResourcesSpec struct {
+	// PackageName identifies the package in the repository.
+	PackageName string `json:"packageName,omitempty"`
+
+	// Revision identifies the version of the package.
+	Revision string `json:"revision,omitempty"`
+
+	// RepositoryName is the name of the Repository object containing this package.
+	RepositoryName string `json:"repository,omitempty"`
+
+	// Resources are the content of the package.
 	Resources map[string]string `json:"resources,omitempty"`
 }

--- a/porch/api/porch/types_packagerevisions.go
+++ b/porch/api/porch/types_packagerevisions.go
@@ -51,13 +51,17 @@ const (
 
 // PackageRevisionSpec defines the desired state of PackageRevision
 type PackageRevisionSpec struct {
+	// PackageName identifies the package in the repository.
 	PackageName string `json:"packageName,omitempty"`
-	Revision    string `json:"revision,omitempty"`
+
+	// Revision identifies the version of the package.
+	Revision string `json:"revision,omitempty"`
+
+	// RepositoryName is the name of the Repository object containing this package.
+	RepositoryName string `json:"repository,omitempty"`
 
 	// Parent references a package that provides resources to us
 	Parent *ParentReference `json:"parent,omitempty"`
-
-	RepositoryName string `json:"repository,omitempty"`
 
 	Lifecycle PackageRevisionLifecycle `json:"lifecycle,omitempty"`
 

--- a/porch/api/porch/v1alpha1/types_packagerevisionresources.go
+++ b/porch/api/porch/v1alpha1/types_packagerevisionresources.go
@@ -42,5 +42,15 @@ type PackageRevisionResourcesList struct {
 
 // PackageRevisionResourcesSpec represents resources (as ResourceList serialized as yaml string) of the PackageRevision.
 type PackageRevisionResourcesSpec struct {
+	// PackageName identifies the package in the repository.
+	PackageName string `json:"packageName,omitempty"`
+
+	// Revision identifies the version of the package.
+	Revision string `json:"revision,omitempty"`
+
+	// RepositoryName is the name of the Repository object containing this package.
+	RepositoryName string `json:"repository,omitempty"`
+
+	// Resources are the content of the package.
 	Resources map[string]string `json:"resources,omitempty"`
 }

--- a/porch/api/porch/v1alpha1/types_packagerevisions.go
+++ b/porch/api/porch/v1alpha1/types_packagerevisions.go
@@ -59,13 +59,17 @@ const (
 
 // PackageRevisionSpec defines the desired state of PackageRevision
 type PackageRevisionSpec struct {
+	// PackageName identifies the package in the repository.
 	PackageName string `json:"packageName,omitempty"`
-	Revision    string `json:"revision,omitempty"`
+
+	// Revision identifies the version of the package.
+	Revision string `json:"revision,omitempty"`
+
+	// RepositoryName is the name of the Repository object containing this package.
+	RepositoryName string `json:"repository,omitempty"`
 
 	// Parent references a package that provides resources to us
 	Parent *ParentReference `json:"parent,omitempty"`
-
-	RepositoryName string `json:"repository,omitempty"`
 
 	Lifecycle PackageRevisionLifecycle `json:"lifecycle,omitempty"`
 

--- a/porch/api/porch/v1alpha1/zz_generated.conversion.go
+++ b/porch/api/porch/v1alpha1/zz_generated.conversion.go
@@ -738,6 +738,9 @@ func Convert_porch_PackageRevisionResourcesList_To_v1alpha1_PackageRevisionResou
 }
 
 func autoConvert_v1alpha1_PackageRevisionResourcesSpec_To_porch_PackageRevisionResourcesSpec(in *PackageRevisionResourcesSpec, out *porch.PackageRevisionResourcesSpec, s conversion.Scope) error {
+	out.PackageName = in.PackageName
+	out.Revision = in.Revision
+	out.RepositoryName = in.RepositoryName
 	out.Resources = *(*map[string]string)(unsafe.Pointer(&in.Resources))
 	return nil
 }
@@ -748,6 +751,9 @@ func Convert_v1alpha1_PackageRevisionResourcesSpec_To_porch_PackageRevisionResou
 }
 
 func autoConvert_porch_PackageRevisionResourcesSpec_To_v1alpha1_PackageRevisionResourcesSpec(in *porch.PackageRevisionResourcesSpec, out *PackageRevisionResourcesSpec, s conversion.Scope) error {
+	out.PackageName = in.PackageName
+	out.Revision = in.Revision
+	out.RepositoryName = in.RepositoryName
 	out.Resources = *(*map[string]string)(unsafe.Pointer(&in.Resources))
 	return nil
 }
@@ -760,8 +766,8 @@ func Convert_porch_PackageRevisionResourcesSpec_To_v1alpha1_PackageRevisionResou
 func autoConvert_v1alpha1_PackageRevisionSpec_To_porch_PackageRevisionSpec(in *PackageRevisionSpec, out *porch.PackageRevisionSpec, s conversion.Scope) error {
 	out.PackageName = in.PackageName
 	out.Revision = in.Revision
-	out.Parent = (*porch.ParentReference)(unsafe.Pointer(in.Parent))
 	out.RepositoryName = in.RepositoryName
+	out.Parent = (*porch.ParentReference)(unsafe.Pointer(in.Parent))
 	out.Lifecycle = porch.PackageRevisionLifecycle(in.Lifecycle)
 	out.Tasks = *(*[]porch.Task)(unsafe.Pointer(&in.Tasks))
 	return nil
@@ -775,8 +781,8 @@ func Convert_v1alpha1_PackageRevisionSpec_To_porch_PackageRevisionSpec(in *Packa
 func autoConvert_porch_PackageRevisionSpec_To_v1alpha1_PackageRevisionSpec(in *porch.PackageRevisionSpec, out *PackageRevisionSpec, s conversion.Scope) error {
 	out.PackageName = in.PackageName
 	out.Revision = in.Revision
-	out.Parent = (*ParentReference)(unsafe.Pointer(in.Parent))
 	out.RepositoryName = in.RepositoryName
+	out.Parent = (*ParentReference)(unsafe.Pointer(in.Parent))
 	out.Lifecycle = PackageRevisionLifecycle(in.Lifecycle)
 	out.Tasks = *(*[]Task)(unsafe.Pointer(&in.Tasks))
 	return nil

--- a/porch/repository/pkg/git/package.go
+++ b/porch/repository/pkg/git/package.go
@@ -69,6 +69,8 @@ func (p *gitPackageRevision) uid() types.UID {
 }
 
 func (p *gitPackageRevision) GetPackageRevision() (*v1alpha1.PackageRevision, error) {
+	key := p.Key()
+
 	return &v1alpha1.PackageRevision{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PackageRevision",
@@ -84,11 +86,12 @@ func (p *gitPackageRevision) GetPackageRevision() (*v1alpha1.PackageRevision, er
 			},
 		},
 		Spec: v1alpha1.PackageRevisionSpec{
-			PackageName:    p.path,
-			Revision:       p.revision,
-			RepositoryName: p.parent.name,
-			Lifecycle:      p.Lifecycle(),
-			Tasks:          p.tasks,
+			PackageName:    key.Package,
+			Revision:       key.Revision,
+			RepositoryName: key.Repository,
+
+			Lifecycle: p.Lifecycle(),
+			Tasks:     p.tasks,
 		},
 		Status: v1alpha1.PackageRevisionStatus{},
 	}, nil
@@ -120,6 +123,9 @@ func (p *gitPackageRevision) GetResources(ctx context.Context) (*v1alpha1.Packag
 			//resources[path.Join(p.path, file.Name)] = content
 		}
 	}
+
+	key := p.Key()
+
 	return &v1alpha1.PackageRevisionResources{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PackageRevisionResources",
@@ -136,6 +142,10 @@ func (p *gitPackageRevision) GetResources(ctx context.Context) (*v1alpha1.Packag
 			OwnerReferences: []metav1.OwnerReference{}, // TODO: should point to repository resource
 		},
 		Spec: v1alpha1.PackageRevisionResourcesSpec{
+			PackageName:    key.Package,
+			Revision:       key.Revision,
+			RepositoryName: key.Repository,
+
 			Resources: resources,
 		},
 	}, nil

--- a/porch/repository/pkg/oci/oci.go
+++ b/porch/repository/pkg/oci/oci.go
@@ -319,6 +319,8 @@ func (p *ociPackageRevision) GetResources(ctx context.Context) (*v1alpha1.Packag
 		return nil, err
 	}
 
+	key := p.Key()
+
 	return &v1alpha1.PackageRevisionResources{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PackageRevisionResources",
@@ -334,6 +336,10 @@ func (p *ociPackageRevision) GetResources(ctx context.Context) (*v1alpha1.Packag
 			UID:             p.uid,
 		},
 		Spec: v1alpha1.PackageRevisionResourcesSpec{
+			PackageName:    key.Package,
+			Revision:       key.Revision,
+			RepositoryName: key.Repository,
+
 			Resources: resources.Contents,
 		},
 	}, nil
@@ -353,6 +359,8 @@ func (p *ociPackageRevision) Key() repository.PackageRevisionKey {
 }
 
 func (p *ociPackageRevision) GetPackageRevision() (*v1alpha1.PackageRevision, error) {
+	key := p.Key()
+
 	return &v1alpha1.PackageRevision{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PackageRevision",
@@ -368,10 +376,11 @@ func (p *ociPackageRevision) GetPackageRevision() (*v1alpha1.PackageRevision, er
 			UID:             p.uid,
 		},
 		Spec: v1alpha1.PackageRevisionSpec{
-			PackageName:    p.packageName,
-			Revision:       p.revision,
-			RepositoryName: p.parent.name,
-			Tasks:          p.tasks,
+			PackageName:    key.Package,
+			Revision:       key.Revision,
+			RepositoryName: key.Repository,
+
+			Tasks: p.tasks,
 		},
 	}, nil
 }


### PR DESCRIPTION
As discussed in the fieldSelector PR, we should have these fields if we're going to allow selecting on them.