### PR TITLE
Fix duplicate drafts in package revision list

### DIFF
--- a/porch/repository/pkg/git/git.go
+++ b/porch/repository/pkg/git/git.go
@@ -213,7 +213,7 @@ func (r *gitRepository) ListPackageRevisions(ctx context.Context, filter reposit
 
 	for _, p := range drafts {
 		if filter.Matches(p) {
-			result = append(result, drafts...)
+			result = append(result, p)
 		}
 	}
 


### PR DESCRIPTION
The code should append individual draft when it matches the filter, not
all of them.
