### PR TITLE
use 2 instances of func runners

### DIFF
--- a/porch/config/deploy/2-function-runner.yaml
+++ b/porch/config/deploy/2-function-runner.yaml
@@ -25,7 +25,7 @@ metadata:
   name: function-runner
   namespace: porch-system
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: function-runner


### PR DESCRIPTION
When doing fishfooding, I just realized that this change sneaked in accidentally in https://github.com/GoogleContainerTools/kpt/pull/2997
I changed it to 1 locally to aid debugging, since I was doing `kubectl logs -f` and I want all the event to be happening in one place.
But I don't want replicas to be 1 in production.
