### PR TITLE
Test Various Git Branches

### DIFF
--- a/porch/repository/pkg/git/testing.go
+++ b/porch/repository/pkg/git/testing.go
@@ -38,10 +38,6 @@ import (
 	"k8s.io/klog/v2"
 )
 
-const (
-	Main plumbing.ReferenceName = "refs/heads/main"
-)
-
 // GitServer is a mock git server implementing "just enough" of the git protocol
 type GitServer struct {
 	repo *gogit.Repository


### PR DESCRIPTION
Rather than relying on the customary `main` branch only, run the Git
tests while registering the repository with various branche names
to make sure that there is no hidden dependency on the `man` branch in
Porch code.
