### PR TITLE
Test for edit package

### DIFF
--- a/porch/engine/pkg/engine/edit_test.go
+++ b/porch/engine/pkg/engine/edit_test.go
@@ -1,0 +1,133 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	kptfile "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
+	"github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
+	configapi "github.com/GoogleContainerTools/kpt/porch/api/porchconfig/v1alpha1"
+	"github.com/GoogleContainerTools/kpt/porch/engine/pkg/engine/fake"
+	"github.com/GoogleContainerTools/kpt/porch/repository/pkg/repository"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestEdit(t *testing.T) {
+	packageName := "foo-1234567890"
+	packageRevision := &fake.PackageRevision{
+		Name: packageName,
+		Resources: &v1alpha1.PackageRevisionResources{
+			Spec: v1alpha1.PackageRevisionResourcesSpec{
+				PackageName:    packageName,
+				Revision:       "v1",
+				RepositoryName: "foo",
+				Resources: map[string]string{
+					kptfile.KptFileName: strings.TrimSpace(`
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: example
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: sample description
+					`),
+				},
+			},
+		},
+	}
+	repo := &fake.Repository{
+		PackageRevisions: []repository.PackageRevision{
+			packageRevision,
+		},
+	}
+	cad := &fakeCaD{
+		repository: repo,
+	}
+
+	epm := editPackageMutation{
+		task: &v1alpha1.Task{
+			Type: "edit",
+			Edit: &v1alpha1.PackageEditTaskSpec{
+				Source: &v1alpha1.PackageRevisionRef{
+					Name: packageName,
+				},
+			},
+		},
+		namespace:         "test-namespace",
+		name:              "test-package",
+		referenceResolver: &fakeReferenceResolver{},
+		cad:               cad,
+	}
+
+	res, _, err := epm.Apply(context.Background(), repository.PackageResources{})
+	if err != nil {
+		t.Errorf("task apply failed: %v", err)
+	}
+
+	want := strings.TrimSpace(`
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: test-package
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: sample description
+	`)
+	got := strings.TrimSpace(res.Contents[kptfile.KptFileName])
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("result mismatch (-want +got):\n%s", diff)
+	}
+}
+
+// Implementation of the ReferenceResolver interface for testing.
+type fakeReferenceResolver struct{}
+
+func (f *fakeReferenceResolver) ResolveReference(ctx context.Context, namespace, name string, result Object) error {
+	return nil
+}
+
+// Implementation of the engine.CaDEngine interface for testing.
+type fakeCaD struct {
+	repository repository.Repository
+}
+
+func (f *fakeCaD) OpenRepository(context.Context, *configapi.Repository) (repository.Repository, error) {
+	return f.repository, nil
+}
+
+func (f *fakeCaD) CreatePackageRevision(context.Context, *configapi.Repository, *v1alpha1.PackageRevision) (repository.PackageRevision, error) {
+	return nil, nil
+}
+
+func (f *fakeCaD) UpdatePackageRevision(_ context.Context, _ *configapi.Repository, _ repository.PackageRevision, _, _ *v1alpha1.PackageRevision) (repository.PackageRevision, error) {
+	return nil, nil
+}
+
+func (f *fakeCaD) UpdatePackageResources(_ context.Context, _ *configapi.Repository, _ repository.PackageRevision, _, _ *v1alpha1.PackageRevisionResources) (repository.PackageRevision, error) {
+	return nil, nil
+}
+
+func (f *fakeCaD) DeletePackageRevision(context.Context, *configapi.Repository, repository.PackageRevision) error {
+	return nil
+}
+
+func (f *fakeCaD) ListFunctions(context.Context, *configapi.Repository) ([]repository.Function, error) {
+	return []repository.Function{}, nil
+}

--- a/porch/engine/pkg/engine/fake/packagerevision.go
+++ b/porch/engine/pkg/engine/fake/packagerevision.go
@@ -1,0 +1,58 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"context"
+
+	kptfile "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
+	"github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
+	"github.com/GoogleContainerTools/kpt/porch/repository/pkg/repository"
+)
+
+// Implementation of the repository.PackageRevision interface for testing.
+type PackageRevision struct {
+	Name               string
+	PackageRevisionKey repository.PackageRevisionKey
+	PackageLifecycle   v1alpha1.PackageRevisionLifecycle
+	PackageRevision    *v1alpha1.PackageRevision
+	Resources          *v1alpha1.PackageRevisionResources
+	Upstream           kptfile.Upstream
+	UpstreamLock       kptfile.UpstreamLock
+}
+
+func (pr *PackageRevision) KubeObjectName() string {
+	return pr.Name
+}
+
+func (pr *PackageRevision) Key() repository.PackageRevisionKey {
+	return pr.PackageRevisionKey
+}
+
+func (pr *PackageRevision) Lifecycle() v1alpha1.PackageRevisionLifecycle {
+	return pr.PackageLifecycle
+}
+
+func (pr *PackageRevision) GetPackageRevision() *v1alpha1.PackageRevision {
+	return nil
+}
+
+func (f *PackageRevision) GetResources(context.Context) (*v1alpha1.PackageRevisionResources, error) {
+	return f.Resources, nil
+}
+
+func (f *PackageRevision) GetUpstreamLock() (kptfile.Upstream, kptfile.UpstreamLock, error) {
+	return kptfile.Upstream{}, kptfile.UpstreamLock{}, nil
+}

--- a/porch/engine/pkg/engine/fake/repository.go
+++ b/porch/engine/pkg/engine/fake/repository.go
@@ -1,0 +1,44 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"context"
+
+	"github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
+	"github.com/GoogleContainerTools/kpt/porch/repository/pkg/repository"
+)
+
+// Implementation of the repository.Repository interface for testing.
+// TODO(mortent): Implement stub functionality for all functions from the interface.
+type Repository struct {
+	PackageRevisions []repository.PackageRevision
+}
+
+func (r *Repository) ListPackageRevisions(context.Context, repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error) {
+	return r.PackageRevisions, nil
+}
+
+func (r *Repository) CreatePackageRevision(_ context.Context, pr *v1alpha1.PackageRevision) (repository.PackageDraft, error) {
+	return nil, nil
+}
+
+func (r *Repository) DeletePackageRevision(context.Context, repository.PackageRevision) error {
+	return nil
+}
+
+func (r *Repository) UpdatePackage(context.Context, repository.PackageRevision) (repository.PackageDraft, error) {
+	return nil, nil
+}


### PR DESCRIPTION
This adds a unit test for the `editPackageMutation`. I'm looking to add some additional tests for error conditions, but want to verify the approach first.

This required adding stub implementations of several interfaces. I'm open to ideas about how we can make this easier.