### PR TITLE
make wrapper server work with distroless-based images

### DIFF
--- a/porch/config/deploy/2-function-runner.yaml
+++ b/porch/config/deploy/2-function-runner.yaml
@@ -40,9 +40,13 @@ spec:
           image: gcr.io/example-google-project-id/porch-function-runner:latest
           imagePullPolicy: IfNotPresent
           command:
-            - sh
-            - -c
-            - /server --config=/config.yaml --functions=/functions --pod-namespace=porch-fn-system --wrapper-server-image=gcr.io/example-google-project-id/porch-wrapper-server:latest
+            - /server
+            - --config=/config.yaml
+            - --functions=/functions
+            - --pod-namespace=porch-fn-system
+          env:
+            - name: WRAPPER_SERVER_IMAGE
+              value: gcr.io/example-google-project-id/porch-wrapper-server:latest
           ports:
             - containerPort: 9445
           # Add grpc readiness probe to ensure the cache is ready

--- a/porch/func/Dockerfile-wrapperserver
+++ b/porch/func/Dockerfile-wrapperserver
@@ -2,6 +2,9 @@ FROM golang:1.17.8-alpine3.15 as builder
 
 WORKDIR /go/src/github.com/GoogleContainerTools/kpt
 
+# Ensure the wrapper server and grpc-health-probe is statically linked so that they works in distroless-based images.
+ENV CGO_ENABLED=0
+
 COPY go.mod go.sum ./
 COPY porch/go.mod porch/go.sum porch/
 COPY porch/api/go.mod porch/api/go.sum porch/api/


### PR DESCRIPTION
Creating this PR sooner to unblock other folks.
I will add an distroless-base KRM function in `gcr.io/kpt-fn-demo` and then add an e2e test for it.
Alternatively, we can use something like `gcr.io/cad-demo-sdk/set-namespace:latest`, but I'm not sure if `gcr.io/cad-demo-sdk` will be deleted later.
We can also consider mirroring an image from `gcr.io/cad-demo-sdk` to `gcr.io/kpt-fn-demo` for testing purpose only.
