### PR TITLE
Let `sync get` and `sync del` use config-management-system by default

### DIFF
--- a/internal/cmdsync/common.go
+++ b/internal/cmdsync/common.go
@@ -1,0 +1,19 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdsync
+
+const (
+	RootSyncNamespace = "config-management-system"
+)

--- a/internal/cmdsync/create/command.go
+++ b/internal/cmdsync/create/command.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/GoogleContainerTools/kpt/internal/cmdsync"
 	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/util/porch"
 	porchapi "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
@@ -45,7 +46,6 @@ Flags:
 --package
   Package revision to sync into the deployment cluster. Required flag.
 `
-	rootSyncNamespace = "config-management-system"
 )
 
 func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner {
@@ -147,7 +147,7 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("%s-auth", syncName),
-				Namespace: rootSyncNamespace,
+				Namespace: cmdsync.RootSyncNamespace,
 			},
 			Data: map[string][]byte{
 				"username": repositorySecret.Data["username"],
@@ -180,7 +180,7 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 			"kind":       "RootSync",
 			"metadata": map[string]interface{}{
 				"name":      syncName,
-				"namespace": rootSyncNamespace,
+				"namespace": cmdsync.RootSyncNamespace,
 			},
 			"spec": map[string]interface{}{
 				"sourceFormat": "unstructured",

--- a/internal/cmdsync/delete/command.go
+++ b/internal/cmdsync/delete/command.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/GoogleContainerTools/kpt/internal/cmdsync"
 	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/util/porch"
 	"github.com/spf13/cobra"
@@ -123,7 +124,10 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 	}
 
 	name := args[0]
-	namespace := *r.cfg.Namespace
+	namespace := cmdsync.RootSyncNamespace
+	if *r.cfg.Namespace != "" {
+		namespace = *r.cfg.Namespace
+	}
 	key := client.ObjectKey{
 		Namespace: namespace,
 		Name:      name,

--- a/internal/cmdsync/get/command.go
+++ b/internal/cmdsync/get/command.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/GoogleContainerTools/kpt/internal/cmdsync"
 	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/util/porch"
 	"github.com/spf13/cobra"
@@ -51,7 +52,7 @@ func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner 
 		Aliases: []string{"register"},
 		Short:   "Gets a RootSync resource with which package was deployed.",
 		Long:    longMsg,
-		Example: "kpt alpha sync get sync-resource --namespace=default",
+		Example: "kpt alpha sync get sync-resource",
 		PreRunE: r.preRunE,
 		RunE:    r.runE,
 		Hidden:  porch.HidePorchCommands,
@@ -96,8 +97,12 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 	}
 
 	name := args[0]
+	namespace := cmdsync.RootSyncNamespace
+	if *r.cfg.Namespace != "" {
+		namespace = *r.cfg.Namespace
+	}
 	key := client.ObjectKey{
-		Namespace: *r.cfg.Namespace,
+		Namespace: namespace,
 		Name:      name,
 	}
 	rs := unstructured.Unstructured{


### PR DESCRIPTION
Updates the `sync get` and `sync del` to use the `config-management-system namespace by default so users don't have to provide it.
