### PR TITLE
Support MVP watch

### DIFF
--- a/porch/pkg/cache/objectcache.go
+++ b/porch/pkg/cache/objectcache.go
@@ -1,0 +1,105 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"context"
+	"sync"
+
+	"github.com/GoogleContainerTools/kpt/porch/pkg/repository"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/klog/v2"
+)
+
+// ObjectCache caches objects across repositories, and allows for watching.
+type ObjectCache interface {
+	WatchPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter, callback ObjectWatcher) error
+}
+
+// ObjectWatcher is the callback interface for watchers.
+type ObjectWatcher interface {
+	OnPackageRevisionChange(eventType watch.EventType, obj repository.PackageRevision) bool
+}
+
+// objectCache implements ObjectCache
+type objectCache struct {
+	mutex sync.Mutex
+
+	// watchers is a list of all the change-listeners.
+	// As an optimization, values in this slice can be nil; we use this when the watch ends.
+	watchers []*watcher
+}
+
+// watcher is a single change listener.
+type watcher struct {
+	// isDoneFunction should return non-nil when the watcher is finished.
+	// This is normally bound to ctx.Err()
+	isDoneFunction func() error
+
+	// callback is called for each object change.
+	callback ObjectWatcher
+
+	// filter can limit the objects reported.
+	filter repository.ListPackageRevisionFilter
+}
+
+// WatchPackageRevision adds a change-listener that will be called for all changes.
+func (r *objectCache) WatchPackageRevisions(ctx context.Context, filter repository.ListPackageRevisionFilter, callback ObjectWatcher) error {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	w := &watcher{
+		isDoneFunction: ctx.Err,
+		callback:       callback,
+		filter:         filter,
+	}
+
+	// See if we have an empty slot in the watchers list
+	inserted := false
+	for i, watcher := range r.watchers {
+		if watcher == nil {
+			r.watchers[i] = w
+			inserted = true
+		}
+	}
+
+	if !inserted {
+		// We didn't slot it in to an existing slot, append it
+		r.watchers = append(r.watchers, w)
+	}
+
+	return nil
+}
+
+// notifyPackageRevisionChange is called to send a change notification to all interested listeners.
+func (r *objectCache) notifyPackageRevisionChange(eventType watch.EventType, obj repository.PackageRevision) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	for i, watcher := range r.watchers {
+		if watcher == nil {
+			continue
+		}
+		if err := watcher.isDoneFunction(); err != nil {
+			klog.Infof("stopping watcher in response to error %v", err)
+			r.watchers[i] = nil
+			continue
+		}
+		if keepGoing := watcher.callback.OnPackageRevisionChange(eventType, obj); !keepGoing {
+			klog.Infof("stopping watcher in response to !keepGoing")
+			r.watchers[i] = nil
+		}
+	}
+}

--- a/porch/pkg/engine/edit_test.go
+++ b/porch/pkg/engine/edit_test.go
@@ -22,6 +22,7 @@ import (
 	kptfile "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
 	configapi "github.com/GoogleContainerTools/kpt/porch/api/porchconfig/v1alpha1"
+	"github.com/GoogleContainerTools/kpt/porch/pkg/cache"
 	"github.com/GoogleContainerTools/kpt/porch/pkg/engine/fake"
 	"github.com/GoogleContainerTools/kpt/porch/pkg/repository"
 	"github.com/google/go-cmp/cmp"
@@ -57,6 +58,7 @@ info:
 		},
 	}
 	cad := &fakeCaD{
+		cache:      cache.NewCache("", cache.CacheOptions{}),
 		repository: repo,
 	}
 
@@ -104,10 +106,15 @@ func (f *fakeReferenceResolver) ResolveReference(ctx context.Context, namespace,
 
 // Implementation of the engine.CaDEngine interface for testing.
 type fakeCaD struct {
+	cache      *cache.Cache
 	repository repository.Repository
 }
 
 var _ CaDEngine = &fakeCaD{}
+
+func (f *fakeCaD) ObjectCache() cache.ObjectCache {
+	return f.cache.ObjectCache()
+}
 
 func (f *fakeCaD) OpenRepository(context.Context, *configapi.Repository) (repository.Repository, error) {
 	return f.repository, nil

--- a/porch/pkg/engine/engine.go
+++ b/porch/pkg/engine/engine.go
@@ -39,6 +39,9 @@ import (
 var tracer = otel.Tracer("engine")
 
 type CaDEngine interface {
+	// ObjectCache() is a cache of all our objects.
+	ObjectCache() cache.ObjectCache
+
 	OpenRepository(ctx context.Context, repositorySpec *configapi.Repository) (repository.Repository, error)
 	UpdatePackageResources(ctx context.Context, repositoryObj *configapi.Repository, oldPackage repository.PackageRevision, old, new *api.PackageRevisionResources) (repository.PackageRevision, error)
 	ListFunctions(ctx context.Context, repositoryObj *configapi.Repository) ([]repository.Function, error)
@@ -75,6 +78,11 @@ var _ CaDEngine = &cadEngine{}
 
 type mutation interface {
 	Apply(ctx context.Context, resources repository.PackageResources) (repository.PackageResources, *api.Task, error)
+}
+
+// ObjectCache is a cache of all our objects.
+func (cad *cadEngine) ObjectCache() cache.ObjectCache {
+	return cad.cache.ObjectCache()
 }
 
 func (cad *cadEngine) OpenRepository(ctx context.Context, repositorySpec *configapi.Repository) (repository.Repository, error) {

--- a/porch/pkg/registry/porch/packagecommon.go
+++ b/porch/pkg/registry/porch/packagecommon.go
@@ -21,6 +21,7 @@ import (
 	unversionedapi "github.com/GoogleContainerTools/kpt/porch/api/porch"
 	api "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
 	configapi "github.com/GoogleContainerTools/kpt/porch/api/porchconfig/v1alpha1"
+	"github.com/GoogleContainerTools/kpt/porch/pkg/cache"
 	"github.com/GoogleContainerTools/kpt/porch/pkg/engine"
 	"github.com/GoogleContainerTools/kpt/porch/pkg/repository"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -125,6 +126,14 @@ func (r *packageCommon) listPackages(ctx context.Context, filter packageFilter, 
 			}
 		}
 	}
+	return nil
+}
+
+func (r *packageCommon) watchPackages(ctx context.Context, filter packageRevisionFilter, callback cache.ObjectWatcher) error {
+	if err := r.cad.ObjectCache().WatchPackageRevisions(ctx, filter.ListPackageRevisionFilter, callback); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/porch/pkg/registry/porch/packagerevisionresources.go
+++ b/porch/pkg/registry/porch/packagerevisionresources.go
@@ -44,6 +44,7 @@ var _ rest.Lister = &packageRevisionResources{}
 var _ rest.Getter = &packageRevisionResources{}
 var _ rest.Scoper = &packageRevisionResources{}
 var _ rest.Updater = &packageRevisionResources{}
+var _ rest.Watcher = &packageRevisionResources{}
 
 func (r *packageRevisionResources) New() runtime.Object {
 	return &api.PackageRevisionResources{}

--- a/porch/pkg/registry/porch/watch.go
+++ b/porch/pkg/registry/porch/watch.go
@@ -1,0 +1,226 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package porch
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/GoogleContainerTools/kpt/porch/pkg/repository"
+	"go.opentelemetry.io/otel/trace"
+	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	"k8s.io/apimachinery/pkg/watch"
+	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/klog/v2"
+)
+
+// Watch supports watching for changes.
+func (r *packageRevisionResources) Watch(ctx context.Context, options *metainternalversion.ListOptions) (watch.Interface, error) {
+	// 'label' selects on labels; 'field' selects on the object's fields. Not all fields
+	// are supported; an error should be returned if 'field' tries to select on a field that
+	// isn't supported. 'resourceVersion' allows for continuing/starting a watch at a
+	// particular version.
+
+	ctx, span := tracer.Start(ctx, "packageRevisionResources::Watch", trace.WithAttributes())
+	defer span.End()
+
+	filter, err := parsePackageRevisionResourcesFieldSelector(options.FieldSelector)
+	if err != nil {
+		return nil, err
+	}
+
+	if ns, namespaced := genericapirequest.NamespaceFrom(ctx); namespaced {
+		if filter.Namespace != "" && ns != filter.Namespace {
+			return nil, fmt.Errorf("conflicting namespaces specified: %q and %q", ns, filter.Namespace)
+		}
+		filter.Namespace = ns
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+
+	w := &watcher{
+		cancel:     cancel,
+		resultChan: make(chan watch.Event, 64),
+	}
+
+	go w.listAndWatch(ctx, r, filter)
+
+	return w, nil
+}
+
+// watcher implements watch.Interface, and holds the state for an active watch.
+type watcher struct {
+	cancel func()
+
+	resultChan chan watch.Event
+
+	mutex         sync.Mutex
+	eventCallback func(eventType watch.EventType, pr repository.PackageRevision) bool
+}
+
+var _ watch.Interface = &watcher{}
+
+// Stop stops watching. Will close the channel returned by ResultChan(). Releases
+// any resources used by the watch.
+func (w *watcher) Stop() {
+	w.cancel()
+}
+
+// ResultChan returns a chan which will receive all the events. If an error occurs
+// or Stop() is called, the implementation will close this channel and
+// release any resources used by the watch.
+func (w *watcher) ResultChan() <-chan watch.Event {
+	return w.resultChan
+}
+
+// listAndWatch implements watch by doing a list, then sending any observed changes.
+// This is not a compliant implementation of watch, but it is a good-enough start for most controllers.
+// One trick is that we start the watch _before_ we perform the list, so we don't miss changes that happen immediately after the list.
+func (w *watcher) listAndWatch(ctx context.Context, r *packageRevisionResources, filter packageRevisionFilter) {
+	if err := w.listAndWatchInner(ctx, r, filter); err != nil {
+		// TODO: We need to populate the object on this error
+		klog.Warningf("sending error to watch stream")
+		ev := watch.Event{
+			Type: watch.Error,
+		}
+		w.resultChan <- ev
+	}
+	w.cancel()
+	close(w.resultChan)
+}
+
+func (w *watcher) listAndWatchInner(ctx context.Context, r *packageRevisionResources, filter packageRevisionFilter) error {
+	errorResult := make(chan error, 4)
+	done := false
+
+	var backlog []watch.Event
+	w.eventCallback = func(eventType watch.EventType, pr repository.PackageRevision) bool {
+		if done {
+			return false
+		}
+		obj, err := pr.GetResources(ctx)
+		if err != nil {
+			done = true
+			errorResult <- err
+			return false
+		}
+
+		backlog = append(backlog, watch.Event{
+			Type:   eventType,
+			Object: obj,
+		})
+
+		return true
+	}
+	klog.Infof("starting watch before listing")
+	if err := r.packageCommon.watchPackages(ctx, filter, w); err != nil {
+		return err
+	}
+
+	// TODO: Only if rv == 0?
+	if err := r.packageCommon.listPackageRevisions(ctx, filter, func(p repository.PackageRevision) error {
+		obj, err := p.GetResources(ctx)
+		if err != nil {
+			done = true
+			return err
+		}
+		// TODO: Check resource version?
+		ev := watch.Event{
+			Type:   watch.Added,
+			Object: obj,
+		}
+		w.sendWatchEvent(ev)
+		return nil
+	}); err != nil {
+		done = true
+		return err
+	}
+	klog.Infof("finished list")
+
+	// Repeatedly flush the backlog until we catch up
+	for {
+		w.mutex.Lock()
+		chunk := backlog
+		backlog = nil
+		w.mutex.Unlock()
+
+		if len(chunk) == 0 {
+			break
+		}
+
+		klog.Infof("flushing backlog chunk of length %d", len(chunk))
+
+		for _, ev := range chunk {
+			// TODO: Check resource version?
+
+			w.sendWatchEvent(ev)
+		}
+	}
+
+	w.mutex.Lock()
+	// Pick up anything that squeezed in
+	for _, ev := range backlog {
+		// TODO: Check resource version?
+
+		w.sendWatchEvent(ev)
+	}
+
+	klog.Infof("moving watch into streaming mode")
+	w.eventCallback = func(eventType watch.EventType, pr repository.PackageRevision) bool {
+		if done {
+			return false
+		}
+		obj, err := pr.GetResources(ctx)
+		if err != nil {
+			done = true
+			errorResult <- err
+			return false
+		}
+		// TODO: Check resource version?
+		ev := watch.Event{
+			Type:   eventType,
+			Object: obj,
+		}
+		w.sendWatchEvent(ev)
+		return true
+	}
+	w.mutex.Unlock()
+
+	select {
+	case <-ctx.Done():
+		done = true
+		return ctx.Err()
+
+	case err := <-errorResult:
+		done = true
+		return err
+	}
+
+}
+
+func (w *watcher) sendWatchEvent(ev watch.Event) {
+	// TODO: Handle the case that the watch channel is full?
+	klog.Infof("sending watch event %v", ev)
+	w.resultChan <- ev
+}
+
+// OnPackageRevisionChange is the callback called when a PackageRevision changes.
+func (w *watcher) OnPackageRevisionChange(eventType watch.EventType, pr repository.PackageRevision) bool {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	return w.eventCallback(eventType, pr)
+}


### PR DESCRIPTION
We can support a simple form of watch, backed by our polling logic.

Currently only on PackageRevisionResources, and doesn't fulfill all
the nuances of a watch implementation (e.g. resourceVersion)
