### PR TITLE
Recognize latest package revision on publishing

### DIFF
--- a/porch/pkg/cache/cache_test.go
+++ b/porch/pkg/cache/cache_test.go
@@ -23,39 +23,15 @@ import (
 	"github.com/GoogleContainerTools/kpt/porch/api/porchconfig/v1alpha1"
 	"github.com/GoogleContainerTools/kpt/porch/pkg/git"
 	"github.com/GoogleContainerTools/kpt/porch/pkg/repository"
+	gogit "github.com/go-git/go-git/v5"
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestLatestPackages(t *testing.T) {
-	tempdir := t.TempDir()
-	tarfile := filepath.Join("..", "git", "testdata", "nested-repository.tar")
-	_, address := git.ServeGitRepository(t, tarfile, tempdir)
-
 	ctx := context.Background()
-
-	cache := NewCache(t.TempDir(), CacheOptions{})
-	cachedGit, err := cache.OpenRepository(ctx, &v1alpha1.Repository{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       v1alpha1.RepositoryGVK.Kind,
-			APIVersion: v1alpha1.RepositoryGVK.GroupVersion().Identifier(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "nested",
-			Namespace: "default",
-		},
-		Spec: v1alpha1.RepositorySpec{
-			Deployment: false,
-			Type:       v1alpha1.RepositoryTypeGit,
-			Content:    v1alpha1.RepositoryContentPackage,
-			Git: &v1alpha1.GitRepository{
-				Repo: address,
-			},
-		},
-	})
-	if err != nil {
-		t.Fatalf("OpenRepository(%q) of %q failed; %v", address, tarfile, err)
-	}
+	tarfile := filepath.Join("..", "git", "testdata", "nested-repository.tar")
+	_, cachedGit := openRepositoryFromArchive(t, ctx, tarfile, "nested")
 
 	wantLatest := map[string]string{
 		"sample":                    "v2",
@@ -92,4 +68,79 @@ func TestLatestPackages(t *testing.T) {
 	if !cmp.Equal(wantLatest, gotLatest) {
 		t.Errorf("Latest package revisions differ (-want,+got): %s", cmp.Diff(wantLatest, gotLatest))
 	}
+}
+
+func TestPublishedLatest(t *testing.T) {
+	ctx := context.Background()
+	tarfile := filepath.Join("..", "git", "testdata", "nested-repository.tar")
+	_, cached := openRepositoryFromArchive(t, ctx, tarfile, "publish-test")
+
+	revisions, err := cached.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{
+		Package:  "catalog/gcp/bucket",
+		Revision: "v2",
+	})
+	if err != nil {
+		t.Fatalf("ListPackageRevisions failed: %v", err)
+	}
+
+	// Expect a single result
+	if got, want := len(revisions), 1; got != want {
+		t.Fatalf("ListPackageRevisions returned %d packages; want %d", got, want)
+	}
+
+	bucket := revisions[0]
+	// Expect draft package
+	if got, want := bucket.Lifecycle(), api.PackageRevisionLifecycleDraft; got != want {
+		t.Fatalf("Bucket package lifecycle: got %s, want %s", got, want)
+	}
+
+	update, err := cached.UpdatePackage(ctx, bucket)
+	if err != nil {
+		t.Fatalf("UpdatePackaeg(%s) failed: %v", bucket.Key(), err)
+	}
+	if err := update.UpdateLifecycle(ctx, api.PackageRevisionLifecyclePublished); err != nil {
+		t.Fatalf("UpdateLifecycle failed; %v", err)
+	}
+	closed, err := update.Close(ctx)
+	if err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+	resource := closed.GetPackageRevision()
+	if got, ok := resource.Labels[api.LatestPackageRevisionKey]; !ok {
+		t.Errorf("Label %s not found as expected", api.LatestPackageRevisionKey)
+	} else if want := api.LatestPackageRevisionValue; got != want {
+		t.Errorf("Latest label: got %s, want %s", got, want)
+	}
+}
+
+func openRepositoryFromArchive(t *testing.T, ctx context.Context, tarfile, name string) (*gogit.Repository, *cachedRepository) {
+	t.Helper()
+
+	tempdir := t.TempDir()
+	repo, address := git.ServeGitRepository(t, tarfile, tempdir)
+
+	cache := NewCache(t.TempDir(), CacheOptions{})
+	cachedGit, err := cache.OpenRepository(ctx, &v1alpha1.Repository{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       v1alpha1.RepositoryGVK.Kind,
+			APIVersion: v1alpha1.RepositoryGVK.GroupVersion().Identifier(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: v1alpha1.RepositorySpec{
+			Deployment: false,
+			Type:       v1alpha1.RepositoryTypeGit,
+			Content:    v1alpha1.RepositoryContentPackage,
+			Git: &v1alpha1.GitRepository{
+				Repo: address,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("OpenRepository(%q) of %q failed; %v", address, tarfile, err)
+	}
+
+	return repo, cachedGit
 }

--- a/porch/pkg/cache/draft.go
+++ b/porch/pkg/cache/draft.go
@@ -31,7 +31,6 @@ func (cd *cachedDraft) Close(ctx context.Context) (repository.PackageRevision, e
 	if closed, err := cd.PackageDraft.Close(ctx); err != nil {
 		return nil, err
 	} else {
-		cd.cache.update(closed)
-		return closed, nil
+		return cd.cache.update(closed), nil
 	}
 }

--- a/porch/pkg/cache/repository.go
+++ b/porch/pkg/cache/repository.go
@@ -193,13 +193,15 @@ func (r *cachedRepository) UpdatePackage(ctx context.Context, old repository.Pac
 	}, nil
 }
 
-func (r *cachedRepository) update(closed repository.PackageRevision) {
+func (r *cachedRepository) update(closed repository.PackageRevision) *cachedPackageRevision {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 
-	r.cachedPackages = updateOrAppend(r.cachedPackages, &cachedPackageRevision{PackageRevision: closed})
+	cached := &cachedPackageRevision{PackageRevision: closed}
+	r.cachedPackages = updateOrAppend(r.cachedPackages, cached)
 	// Recompute latest package revisions.
 	identifyLatestRevisions(r.cachedPackages)
+	return cached
 }
 
 func updateOrAppend(revisions []*cachedPackageRevision, new *cachedPackageRevision) []*cachedPackageRevision {


### PR DESCRIPTION
When package is published, make sure to recognize its latest status
