### PR TITLE
use kpt git parsing in `rpkg clone`

### DIFF
--- a/e2e/testdata/porch/rpkg-clone/config.yaml
+++ b/e2e/testdata/porch/rpkg-clone/config.yaml
@@ -11,9 +11,7 @@ commands:
       - rpkg
       - clone
       - --namespace=rpkg-clone
-      - https://github.com/platkrm/test-blueprints.git
-      - --directory=basens
-      - --ref=basens/v1
+      - https://github.com/platkrm/test-blueprints.git/basens@basens/v1
       - --repository=git
       - --revision=v0
       - basens-clone

--- a/internal/cmdrpkgclone/command.go
+++ b/internal/cmdrpkgclone/command.go
@@ -43,9 +43,11 @@ SOURCE_PACKAGE:
     * oci://oci-repository/package-name
     * http://git-repository.git/package-name
     * package-revision-name
-  With git URLs containing the ".git" suffix, you can optionally include the package directory 
-  and ref in the source package:
-    * http://git-repository.git/package-name/directory@main
+
+  With git URLs, you can either include the package directory and ref in SOURCE_PACKAGE, or
+  you can individually specify the repo, ref, and directory using flags:
+    * kpt alpha rpkg clone http://git-repository.git/package-name@main target --repository=repo
+    * kpt alpha rpkg clone http://git-repository.git target --directory=package-name --ref=main --repository=repo
 
 NAME:
   Target package revision name (downstream package)
@@ -165,10 +167,12 @@ func (r *runner) preRunE(cmd *cobra.Command, args []string) error {
 			}
 			// throw error if values set by flags contradict values parsed from SOURCE_PACKAGE
 			if r.directory != "" && dir != "" && r.directory != dir {
-				return errors.E(op, fmt.Errorf("directory specified by --directory contradicts directory specified by SOURCE_PACKAGE"))
+				return errors.E(op, fmt.Errorf("directory %s specified by --directory contradicts directory %s specified by SOURCE_PACKAGE",
+					r.directory, dir))
 			}
 			if r.ref != "" && ref != "" && r.ref != ref {
-				return errors.E(op, fmt.Errorf("ref specified by --ref contradicts ref specified by SOURCE_PACKAGE"))
+				return errors.E(op, fmt.Errorf("ref %s specified by --ref contradicts ref %s specified by SOURCE_PACKAGE",
+					r.ref, ref))
 			}
 			// grab the values parsed from SOURCE_PACKAGE
 			if r.directory == "" {

--- a/internal/cmdrpkgclone/command.go
+++ b/internal/cmdrpkgclone/command.go
@@ -151,7 +151,7 @@ func (r *runner) preRunE(cmd *cobra.Command, args []string) error {
 		}
 		r.clone.Upstream.Type = porchapi.RepositoryTypeGit
 		r.clone.Upstream.Git = &porchapi.GitPackage{
-			Repo:      gitArgs.Repo,
+			Repo:      gitArgs.Repo + ".git",
 			Ref:       gitArgs.Ref,
 			Directory: gitArgs.Directory,
 		}

--- a/internal/util/parse/parse.go
+++ b/internal/util/parse/parse.go
@@ -93,6 +93,9 @@ func targetFromPkgURL(ctx context.Context, pkgURL string, dest string) (Target, 
 	if err != nil {
 		return g, err
 	}
+	if dir == "" {
+		dir = "/"
+	}
 	if ref == "" {
 		gur, err := gitutil.NewGitUpstreamRepo(ctx, repo)
 		if err != nil {
@@ -121,7 +124,7 @@ func ParseURL(pkgURL string) (repo string, dir string, ref string, err error) {
 	index := strings.Index(pkgURL, parts[0])
 	repo = strings.Join([]string{pkgURL[:index], parts[0]}, "")
 	switch {
-	case len(parts) == 1:
+	case len(parts) == 1 || parts[1] == "":
 		// do nothing
 	case strings.Contains(parts[1], "@"):
 		parts := strings.Split(parts[1], "@")

--- a/internal/util/parse/parse_test.go
+++ b/internal/util/parse/parse_test.go
@@ -201,7 +201,7 @@ func Test_parseURL(t *testing.T) {
 		},
 		"no ref": {
 			ghURL:    "https://github.com/GoogleContainerTools/kpt-functions-catalog.git/examples/apply-replacements-simple",
-			expected: expected{repo: "https://github.com/GoogleContainerTools/kpt-functions-catalog", dir: "/examples/apply-replacements-simple", version: "master"},
+			expected: expected{repo: "https://github.com/GoogleContainerTools/kpt-functions-catalog", dir: "/examples/apply-replacements-simple", version: ""},
 		},
 		".git appears in the middle": {
 			ghURL:    "https://my-site.com/root.gitops.git/foo@main",
@@ -211,8 +211,7 @@ func Test_parseURL(t *testing.T) {
 	for name, test := range tests {
 		test := test // capture range variable
 		t.Run(name, func(t *testing.T) {
-			ctx := printer.WithContext(context.Background(), printer.New(nil, nil))
-			repo, dir, version, err := parseURL(ctx, test.ghURL)
+			repo, dir, version, err := ParseURL(test.ghURL)
 			assert.NoError(t, err)
 			assert.Equal(t, expected{repo: repo, dir: dir, version: version}, test.expected)
 		})


### PR DESCRIPTION
For `kpt alpha rpkg clone`, make using the `--ref` and `--directory` flags optional when using git URLs, instead allow something like 

```
kpt alpha rpkg clone https://github.com/GoogleCloudPlatform/blueprints.git/catalog/bucket@main cloned-bucket \
  --repository=deployments \
  --namespace=default
```

Throw errors if the ref/directory are both present in the URL and set via flags, and they don't match.