### PR TITLE
update kpt alpha rpkg get help

### DIFF
--- a/internal/cmdrpkgget/command.go
+++ b/internal/cmdrpkgget/command.go
@@ -66,7 +66,7 @@ func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner 
 		SuggestFor: []string{},
 		Short:      "Gets or lists packages in registered repositories.",
 		Long:       longMsg,
-		Example:    "kpt alpha rpkg get repository:package:v1 --namespace=default",
+		Example:    "kpt alpha rpkg get package-name --namespace=default",
 		PreRunE:    r.preRunE,
 		RunE:       r.runE,
 		Hidden:     porch.HidePorchCommands,


### PR DESCRIPTION
From what I can tell from https://github.com/GoogleContainerTools/kpt/commit/72aa7a3d060cdf70f486b6bb283c34ade05588f4 and https://github.com/GoogleContainerTools/kpt/commit/94da3ee6055f6a025f061b1ebddcd605baa5fc09, the format for the package name has changed from `repo:package:v1` to `repo-<hash>`. 

This is a 1-line change to update the `kpt alpha rpkg get` help page accordingly. 