### PR TITLE
Update the auth flags for registering repositories

### DIFF
--- a/docs/design-docs/07-package-orchestration.md
+++ b/docs/design-docs/07-package-orchestration.md
@@ -509,8 +509,8 @@ GITHUB_TOKEN=<GitHub Personal Access Token>
 
 $ kpt alpha repo register \
   --namespace default \
-  --repo-username=${GITHUB_USERNAME} \
-  --repo-password=${GITHUB_TOKEN} \
+  --repo-basic-username=${GITHUB_USERNAME} \
+  --repo-basic-password=${GITHUB_TOKEN} \
   https://github.com/${GITHUB_USERNAME}/blueprints.git
 ```
 
@@ -526,8 +526,8 @@ All command line flags supported:
 * `--deployment` - Boolean value; If specified, repository is a deployment
   repository; published packages in a deployment repository are considered
   deployment-ready.
-* `--repo-username` - Username for repository authentication.
-* `--repo-password` - Password for repository authentication.
+* `--repo-basic-username` - Username for repository authentication using basic auth.
+* `--repo-basic-password` - Password for repository authentication using basic auth.
 
 Additionally, common `kubectl` command line flags for controlling aspects of
 interaction with the Kubernetes apiserver, logging, and more (this is true for

--- a/internal/cmdreporeg/command.go
+++ b/internal/cmdreporeg/command.go
@@ -50,11 +50,11 @@ Flags:
 --deployment
   Repository is a deployment repository; packages in a deployment repository are considered deployment-ready.
 
---repo-username
-  Username for repository authentication.
+--repo-basic-username
+  Username for repository authentication with basic auth.
 
---repo-password
-  Password for repository authentication.
+--repo-basic-password
+  Password for repository authentication with basic auth.
 
 --directory
   Directory within the repository where to look for packages.
@@ -87,8 +87,8 @@ func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner 
 	c.Flags().StringVar(&r.name, "name", "", "Name of the package repository. If unspecified, will use the name portion (last segment) of the repository URL.")
 	c.Flags().StringVar(&r.description, "description", "", "Brief description of the package repository.")
 	c.Flags().BoolVar(&r.deployment, "deployment", false, "Repository is a deployment repository; packages in a deployment repository are considered deployment-ready.")
-	c.Flags().StringVar(&r.username, "repo-username", "", "Username for repository authentication.")
-	c.Flags().StringVar(&r.password, "repo-password", "", "Password for repository authentication.")
+	c.Flags().StringVar(&r.username, "repo-basic-username", "", "Username for repository authentication using basic auth.")
+	c.Flags().StringVar(&r.password, "repo-basic-password", "", "Password for repository authentication using basic auth.")
 
 	return r
 }

--- a/internal/cmdreporeg/command_test.go
+++ b/internal/cmdreporeg/command_test.go
@@ -75,7 +75,7 @@ func TestRepoReg(t *testing.T) {
 		},
 		{
 			name: "AuthRegister",
-			args: []string{"https://github.com/platkrm/test-blueprints.git", "--repo-username=test-username", "--repo-password=test-password"},
+			args: []string{"https://github.com/platkrm/test-blueprints.git", "--repo-basic-username=test-username", "--repo-basic-password=test-password"},
 			actions: []httpAction{
 				{
 					method:       http.MethodPost,


### PR DESCRIPTION
We will eventually add support for other auth types than just basic auth. Therefore we need a convention for how we name the flags used for authentication against package repositories. This updates the current flags to follow the following convention:
* Flags used the format: `repo-<auth type>-<input>`
  * Every flag use the `repo-` prefix to make it clear it pertains to repository auth (rather than cluster) and to avoid conflicts with existing flags we inherit from kubectl (examples are username and password).
  * The auth type section tells which type of authentication this flag is used for. Currently we only support basic auth.
  * The last part contains the name of data needed for the specified auth type. For example, for basic auth, we need username and password.

Following this convention, the flags for specifying username and password for basic auth results in the flags `repo-basic-username` and `repo-basic-password`.