### PR TITLE
Fix reference to value for name

### DIFF
--- a/site/book/04-using-functions/01-declarative-function-execution.md
+++ b/site/book/04-using-functions/01-declarative-function-execution.md
@@ -225,7 +225,7 @@ Resources that are selected are passed as input to the function.
 Resources that are not selected are passed through unchanged.
 
 For example, let's add a function to the pipeline that adds an annotation to 
-resources with name `mysql` only:
+resources with name `wordpress-mysql` only:
 
 ```yaml
 # wordpress/Kptfile (Excerpt)


### PR DESCRIPTION
Description: Example yaml shows `- name: wordpress-mysql` while text refers to "name `mysql`" which I believe is incorrect in this context.
Motivation: I believe documentation should be as concise as possible.