### PR TITLE
Fix guide links in README

### DIFF
--- a/site/guides/README.md
+++ b/site/guides/README.md
@@ -1,8 +1,7 @@
 # Reference
 
-- [The Rationale behind kpt](guides/rationale.md)
-- [The Rationale behind kpt](guides/rationale.md)
-- [Namespace provisioning CLI](guides/namespace-provisioning-cli.md)
-- [Namespace provisioning UI](guides/namespace-provisioning-ui.md)
-- [Porch Installation Guide](guides/porch-installation.md)
-- [Porch User Guide](guides/porch-user-guide.md)
+- [The Rationale behind kpt](rationale.md)
+- [Namespace provisioning CLI](namespace-provisioning-cli.md)
+- [Namespace provisioning UI](namespace-provisioning-ui.md)
+- [Porch Installation Guide](porch-installation.md)
+- [Porch User Guide](porch-user-guide.md)


### PR DESCRIPTION
This pull request corrects the guide links in the README. Currently the links refer to a `guides` subfolder although the guides exist within the same folder as the README. This pull request also removes a duplicate link from the README.