### PR TITLE
Revert "Fix guide links in README"

### DIFF
--- a/site/guides/README.md
+++ b/site/guides/README.md
@@ -1,7 +1,8 @@
 # Reference
 
-- [The Rationale behind kpt](rationale.md)
-- [Namespace provisioning CLI](namespace-provisioning-cli.md)
-- [Namespace provisioning UI](namespace-provisioning-ui.md)
-- [Porch Installation Guide](porch-installation.md)
-- [Porch User Guide](porch-user-guide.md)
+- [The Rationale behind kpt](guides/rationale.md)
+- [The Rationale behind kpt](guides/rationale.md)
+- [Namespace provisioning CLI](guides/namespace-provisioning-cli.md)
+- [Namespace provisioning UI](guides/namespace-provisioning-ui.md)
+- [Porch Installation Guide](guides/porch-installation.md)
+- [Porch User Guide](guides/porch-user-guide.md)


### PR DESCRIPTION
Although this corrects the links when viewing the README directly on GitHub, https://github.com/GoogleContainerTools/kpt/blob/main/site/guides/README.md, this change does break the links on kpt.dev, therefore reverting this change.