### PR TITLE
add troubleshooting section to local porch doc

### DIFF
--- a/porch/docs/running-locally.md
+++ b/porch/docs/running-locally.md
@@ -107,3 +107,8 @@ To stop Porch and all associated Docker containers, including the Docker network
 ```sh
 make stop
 ```
+
+## Troubleshooting
+
+If you run into issues that look like `git: authentication required`, make sure you have SSH
+keys set up on your local machine.


### PR DESCRIPTION
Seems like an obvious thing, but I rarely use my cloudtop and it took a while for me to consider the fact that I'd never bothered to set up ssh keys on it. Maybe future new people can learn from my troubles.