### PR TITLE
docs: updated coverpage to embed video and why-kpt

### DIFF
--- a/site/contact/README.md
+++ b/site/contact/README.md
@@ -14,5 +14,5 @@ We'd love to hear from you!
 
 - Join our [Slack channel](https://kubernetes.slack.com/channels/kpt)
 - Join our [email list](https://groups.google.com/forum/?oldui=1#!forum/kpt-users)
-- Follow us on [@kptdev](https://twitter.com/kptdev)
+- Follow us on [Twitter](https://twitter.com/kptdev)
 - Subscribe to our [Youtube channel](https://www.youtube.com/channel/UCE6EvJ37y6Z8Xu_cDykhlnw)

--- a/site/contact/README.md
+++ b/site/contact/README.md
@@ -14,3 +14,5 @@ We'd love to hear from you!
 
 - Join our [Slack channel](https://kubernetes.slack.com/channels/kpt)
 - Join our [email list](https://groups.google.com/forum/?oldui=1#!forum/kpt-users)
+- Follow us on [@kptdev](https://twitter.com/kptdev)
+- Subscribe to our [Youtube channel](https://www.youtube.com/channel/UCE6EvJ37y6Z8Xu_cDykhlnw)

--- a/site/coverpage.md
+++ b/site/coverpage.md
@@ -6,4 +6,9 @@
 > by manipulating declarative Configuration as Data, 
 > separated from the code that transforms it.
 
-[Learn More](?id=overview)
+<iframe id="ytplayer" type="text/html" width="550" height="360"
+    src="https://www.youtube.com/embed/L_x7z4CXHDw"> </iframe>
+
+
+[Why kpt](/guides/rationale.md)
+[Get Started](?id=overview)

--- a/site/coverpage.md
+++ b/site/coverpage.md
@@ -10,5 +10,5 @@
     src="https://www.youtube.com/embed/L_x7z4CXHDw"> </iframe>
 
 
-[Why kpt](/guides/rationale.md)
+[Why kpt](guides/rationale.md)
 [Get Started](?id=overview)


### PR DESCRIPTION
This PR makes following changes to the `kpt.dev` homepage:
 - Shows how to embed demo video
 - Add `Why kpt`
 - Changes the text for `Learn more` to `Get Started`

![image](https://user-images.githubusercontent.com/172029/167965512-caf21e7f-f6c4-44a5-a5ba-a93f9edf7824.png)
