### PR TITLE
docs: updated installation guides to use kpt v1.0.0-beta.15 version

### DIFF
--- a/Formula/kpt.rb
+++ b/Formula/kpt.rb
@@ -15,8 +15,8 @@
 class Kpt < Formula
   desc "Toolkit to manage,and apply Kubernetes Resource config data files"
   homepage "https://googlecontainertools.github.io/kpt"
-  url "https://github.com/GoogleContainerTools/kpt/archive/v1.0.0-beta.13.tar.gz"
-  sha256 "d98a95f1de38fc8c7dee861ec249874ea3ddf03f5a28ae7fc4a0364d3578667b"
+  url "https://github.com/GoogleContainerTools/kpt/archive/v1.0.0-beta.15.tar.gz"
+  sha256 "5e3a73f9eb2d6db02ecdb237972cd1b618a5ab784dae85949768680573d272e3"
 
   depends_on "go" => :build
 

--- a/site/installation/kpt-cli.md
+++ b/site/installation/kpt-cli.md
@@ -2,9 +2,6 @@
 
 Users can get kpt CLI in a variety of ways:
 
-?> If you are migrating from kpt CLI `v0.39`, please follow the [migration guide] to
-kpt `v1.0+` binary.
-
 ## Binaries
 
 Download pre-compiled binaries:
@@ -93,7 +90,7 @@ Use one of the kpt docker images.
 ### `kpt`
 
 ```shell
-$ docker run gcr.io/kpt-dev/kpt:v1.0.0-beta.13 version
+$ docker run gcr.io/kpt-dev/kpt:v1.0.0-beta.15 version
 ```
 
 ### `kpt-gcloud`
@@ -101,7 +98,7 @@ $ docker run gcr.io/kpt-dev/kpt:v1.0.0-beta.13 version
 An image which includes kpt based upon the Google [cloud-sdk] alpine image.
 
 ```shell
-$ docker run gcr.io/kpt-dev/kpt-gcloud:v1.0.0-beta.13 version
+$ docker run gcr.io/kpt-dev/kpt-gcloud:v1.0.0-beta.15 version
 ```
 
 ## Source
@@ -124,8 +121,8 @@ $ kpt version
   https://console.cloud.google.com/gcr/images/kpt-dev/GLOBAL/kpt-gcloud?gcrImageListsize=30
 [cloud-sdk]: https://github.com/GoogleCloudPlatform/cloud-sdk-docker
 [linux]:
-  https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.13/kpt_linux_amd64
+  https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.15/kpt_linux_amd64
 [darwin]:
-  https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.13/kpt_darwin_amd64
+  https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.15/kpt_darwin_amd64
 [migration guide]: /installation/migration
 [bash-completion]: https://github.com/scop/bash-completion#installation


### PR DESCRIPTION
This PR:
 - updates the homebrew formula to make `kpt v1.0.0-beta.15` version available
 - Updates the installation guides to use `kpt v1.0.0-beta.15`