### PR TITLE
feat: cache upstream during update

### DIFF
--- a/internal/gitutil/gitutil.go
+++ b/internal/gitutil/gitutil.go
@@ -179,6 +179,14 @@ type GitUpstreamRepo struct {
 	fetchedRefs map[string]bool
 }
 
+func (gur *GitUpstreamRepo) GetFetchedRefs() []string {
+	fetchedRefs := make([]string, 0, len(gur.fetchedRefs))
+	for ref := range gur.fetchedRefs {
+		fetchedRefs = append(fetchedRefs, ref)
+	}
+	return fetchedRefs
+}
+
 // updateRefs fetches all refs from the upstream git repo, parses the results
 // and caches all refs and the commit they reference. Not that this doesn't
 // download any objects, only refs.

--- a/internal/gitutil/gitutil.go
+++ b/internal/gitutil/gitutil.go
@@ -394,10 +394,9 @@ loop:
 		// commit sha.
 		validFullSha := s == strings.TrimSpace(rr.Stdout)
 		_, resolved := gur.ResolveRef(s)
-		// fetchedRefWithURI is the cache key created from repo URI SHA and ref
-		fetchedRefWithURI := fmt.Sprintf("%s-%s", uriSha, s)
 		// check if ref was previously fetched
-		_, fetched := gur.fetchedRefs[fetchedRefWithURI]
+		// we use the ref s as the cache key
+		_, fetched := gur.fetchedRefs[s]
 		switch {
 		case fetched:
 			// skip refetching if previously fetched
@@ -414,7 +413,7 @@ loop:
 				return "", errors.E(op, errors.Git, fmt.Errorf(
 					"error running `git fetch` for ref %q: %w", s, err))
 			}
-			gur.fetchedRefs[fetchedRefWithURI] = true
+			gur.fetchedRefs[s] = true
 		default:
 			// In other situations (like a short commit sha), we have to do
 			// a full fetch from the remote.
@@ -434,7 +433,7 @@ loop:
 				return "", errors.E(op, errors.Git, fmt.Errorf(
 					"error verifying results from fetch: %w", err))
 			}
-			gur.fetchedRefs[fetchedRefWithURI] = true
+			gur.fetchedRefs[s] = true
 			// If we did a full fetch, we already have all refs, so we can just
 			// exit the loop.
 			break loop

--- a/internal/util/fetch/fetch.go
+++ b/internal/util/fetch/fetch.go
@@ -138,6 +138,8 @@ func (c *Cloner) cloneAndCopy(ctx context.Context, dest string) error {
 		return errors.E(op, errors.Git, types.UniquePath(dest), err)
 	}
 	defer os.RemoveAll(c.repoSpec.Dir)
+	// update cache before removing clone dir
+	defer delete(c.cachedRepo, *c.repoSpec)
 
 	sourcePath := filepath.Join(c.repoSpec.Dir, c.repoSpec.Path)
 	pr.Printf("Adding package %q.\n", strings.TrimPrefix(c.repoSpec.Path, "/"))

--- a/internal/util/update/update.go
+++ b/internal/util/update/update.go
@@ -104,8 +104,8 @@ type Command struct {
 	// Strategy is the update strategy to use
 	Strategy kptfilev1.UpdateStrategyType
 
-	// cachedUpstreamRepos is an upstream repo already fetched for a given repoSpec
-	cachedUpstreamRepos map[git.RepoSpec]*gitutil.GitUpstreamRepo
+	// cachedUpstreamRepos is an upstream repo already fetched for a given repoSpec CloneRef
+	cachedUpstreamRepos map[string]*gitutil.GitUpstreamRepo
 }
 
 // Run runs the Command.
@@ -138,7 +138,7 @@ func (u *Command) Run(ctx context.Context) error {
 		return errors.E(op, u.Pkg.UniquePath, err)
 	}
 	if u.cachedUpstreamRepos == nil {
-		u.cachedUpstreamRepos = make(map[git.RepoSpec]*gitutil.GitUpstreamRepo)
+		u.cachedUpstreamRepos = make(map[string]*gitutil.GitUpstreamRepo)
 	}
 	packageCount := 0
 
@@ -189,7 +189,7 @@ func (u *Command) Run(ctx context.Context) error {
 }
 
 // GetCachedUpstreamRepos returns repos cached during update
-func (u Command) GetCachedUpstreamRepos() map[git.RepoSpec]*gitutil.GitUpstreamRepo {
+func (u Command) GetCachedUpstreamRepos() map[string]*gitutil.GitUpstreamRepo {
 	return u.cachedUpstreamRepos
 }
 

--- a/internal/util/update/update_test.go
+++ b/internal/util/update/update_test.go
@@ -86,8 +86,7 @@ func TestCommand_Run_noRefChanges(t *testing.T) {
 			}
 
 			// Expect cached contents
-			assert.Equal(t, 1, len(cmd.GetCachedUpstreamRepos()))
-			assert.Equal(t, 1, len(cmd.GetFetchedRefs()))
+			assert.Equal(t, 2, len(cmd.GetCachedUpstreamRepos()))
 
 			// Expect the local package to have Dataset2
 			if !g.AssertLocalDataEquals(testutil.Dataset2, true) {

--- a/internal/util/update/update_test.go
+++ b/internal/util/update/update_test.go
@@ -76,14 +76,18 @@ func TestCommand_Run_noRefChanges(t *testing.T) {
 				return
 			}
 			upstreamRepo := g.Repos[testutil.Upstream]
-
-			// Update the local package
-			if !assert.NoError(t, Command{
+			cmd := &Command{
 				Pkg:      pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
 				Strategy: strategy,
-			}.Run(fake.CtxWithDefaultPrinter())) {
+			}
+			// Update the local package
+			if !assert.NoError(t, cmd.Run(fake.CtxWithDefaultPrinter())) {
 				return
 			}
+
+			// Expect cached contents
+			assert.Equal(t, 1, len(cmd.GetCachedUpstreamRepos()))
+			assert.Equal(t, 1, len(cmd.GetFetchedRefs()))
 
 			// Expect the local package to have Dataset2
 			if !g.AssertLocalDataEquals(testutil.Dataset2, true) {
@@ -129,11 +133,11 @@ func TestCommand_Run_subDir(t *testing.T) {
 			upstreamRepo := g.Repos[testutil.Upstream]
 
 			// Update the local package
-			if !assert.NoError(t, Command{
+			if !assert.NoError(t, (&Command{
 				Pkg:      pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
 				Ref:      "v1.2",
 				Strategy: strategy,
-			}.Run(fake.CtxWithDefaultPrinter())) {
+			}).Run(fake.CtxWithDefaultPrinter())) {
 				return
 			}
 
@@ -185,10 +189,10 @@ func TestCommand_Run_noChanges(t *testing.T) {
 			upstreamRepo := g.Repos[testutil.Upstream]
 
 			// Update the local package
-			err := Command{
+			err := (&Command{
 				Pkg:      pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
 				Strategy: u.updater,
-			}.Run(fake.CtxWithDefaultPrinter())
+			}).Run(fake.CtxWithDefaultPrinter())
 			if u.err == "" {
 				if !assert.NoError(t, err) {
 					return
@@ -367,11 +371,11 @@ func TestCommand_Run_localPackageChanges(t *testing.T) {
 			}
 
 			// run the command
-			err = Command{
+			err = (&Command{
 				Pkg:      pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
 				Ref:      masterBranch,
 				Strategy: tc.strategy,
-			}.Run(fake.CtxWithDefaultPrinter())
+			}).Run(fake.CtxWithDefaultPrinter())
 
 			// check the error response
 			if tc.expectedErr == "" {
@@ -437,11 +441,11 @@ func TestCommand_Run_toBranchRef(t *testing.T) {
 			upstreamRepo := g.Repos[testutil.Upstream]
 
 			// Update the local package
-			if !assert.NoError(t, Command{
+			if !assert.NoError(t, (&Command{
 				Pkg:      pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
 				Strategy: strategy,
 				Ref:      "exp",
-			}.Run(fake.CtxWithDefaultPrinter())) {
+			}).Run(fake.CtxWithDefaultPrinter())) {
 				return
 			}
 
@@ -801,11 +805,11 @@ func TestCommand_Run_toBranchRefWithSubpkgs(t *testing.T) {
 			}
 
 			// Update the local package
-			if !assert.NoError(t, Command{
+			if !assert.NoError(t, (&Command{
 				Pkg:      pkgtest.CreatePkgOrFail(t, path.Join(g.LocalWorkspace.FullPackagePath(), tc.updateSubPkg)),
 				Strategy: tc.strategy,
 				Ref:      tc.updateRef,
-			}.Run(fake.CtxWithDefaultPrinter())) {
+			}).Run(fake.CtxWithDefaultPrinter())) {
 				return
 			}
 			expectedPath := tc.expectedLocal.ExpandPkgWithName(t,
@@ -847,11 +851,11 @@ func TestCommand_Run_toTagRef(t *testing.T) {
 			upstreamRepo := g.Repos[testutil.Upstream]
 
 			// Update the local package
-			if !assert.NoError(t, Command{
+			if !assert.NoError(t, (&Command{
 				Pkg:      pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
 				Strategy: strategy,
 				Ref:      "v1.0",
-			}.Run(fake.CtxWithDefaultPrinter())) {
+			}).Run(fake.CtxWithDefaultPrinter())) {
 				return
 			}
 
@@ -904,11 +908,11 @@ func TestCommand_ResourceMerge_NonKRMUpdates(t *testing.T) {
 			upstreamRepo := g.Repos[testutil.Upstream]
 
 			// Update the local package
-			if !assert.NoError(t, Command{
+			if !assert.NoError(t, (&Command{
 				Pkg:      pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
 				Strategy: strategy,
 				Ref:      "v1.0",
-			}.Run(fake.CtxWithDefaultPrinter())) {
+			}).Run(fake.CtxWithDefaultPrinter())) {
 				t.FailNow()
 			}
 
@@ -947,9 +951,9 @@ func TestCommand_Run_noUpstreamReference(t *testing.T) {
 	testutil.AddKptfileToWorkspace(t, w, kf)
 
 	// Update the local package
-	err := Command{
+	err := (&Command{
 		Pkg: pkgtest.CreatePkgOrFail(t, w.FullPackagePath()),
-	}.Run(fake.CtxWithDefaultPrinter())
+	}).Run(fake.CtxWithDefaultPrinter())
 
 	assert.Contains(t, err.Error(), "must have an upstream reference")
 
@@ -961,10 +965,10 @@ func TestCommand_Run_failInvalidPath(t *testing.T) {
 		strategy := kptfilev1.UpdateStrategies[i]
 		t.Run(string(strategy), func(t *testing.T) {
 			path := filepath.Join("fake", "path")
-			err := Command{
+			err := (&Command{
 				Pkg:      pkgtest.CreatePkgOrFail(t, path),
 				Strategy: strategy,
-			}.Run(fake.CtxWithDefaultPrinter())
+			}).Run(fake.CtxWithDefaultPrinter())
 			if assert.Error(t, err) {
 				assert.Contains(t, err.Error(), "no such file or directory")
 			}
@@ -1026,9 +1030,9 @@ func TestCommand_Run_badUpstreamLock(t *testing.T) {
 			}
 
 			// Update the local package.
-			err = Command{
+			err = (&Command{
 				Pkg: pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
-			}.Run(fake.CtxWithDefaultPrinter())
+			}).Run(fake.CtxWithDefaultPrinter())
 
 			if assert.Error(t, err) {
 				assert.Contains(t, err.Error(), tc.expectedErrorMsg)
@@ -1061,11 +1065,11 @@ func TestCommand_Run_failInvalidRef(t *testing.T) {
 				return
 			}
 
-			err := Command{
+			err := (&Command{
 				Pkg:      pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
 				Ref:      "exp",
 				Strategy: strategy,
-			}.Run(fake.CtxWithDefaultPrinter())
+			}).Run(fake.CtxWithDefaultPrinter())
 			if !assert.Error(t, err) {
 				return
 			}
@@ -1119,9 +1123,9 @@ func TestCommand_Run_manualChange(t *testing.T) {
 		return
 	}
 
-	err := Command{
+	err := (&Command{
 		Pkg: pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
-	}.Run(fake.CtxWithDefaultPrinter())
+	}).Run(fake.CtxWithDefaultPrinter())
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
@@ -1173,9 +1177,9 @@ func TestCommand_Run_symlinks(t *testing.T) {
 	}
 	upstreamRepo := g.Repos[testutil.Upstream]
 
-	err := Command{
+	err := (&Command{
 		Pkg: pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
-	}.Run(fake.CtxWithDefaultPrinter())
+	}).Run(fake.CtxWithDefaultPrinter())
 	if !assert.NoError(t, err) {
 		t.FailNow()
 	}
@@ -1221,10 +1225,10 @@ func TestCommand_Run_badStrategy(t *testing.T) {
 	}
 
 	// Update the local package
-	err := Command{
+	err := (&Command{
 		Pkg:      pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
 		Strategy: strategy,
-	}.Run(fake.CtxWithDefaultPrinter())
+	}).Run(fake.CtxWithDefaultPrinter())
 	if !assert.Error(t, err, strategy) {
 		return
 	}
@@ -2000,10 +2004,10 @@ func TestCommand_Run_local_subpackages(t *testing.T) {
 					return
 				}
 
-				err := Command{
+				err := (&Command{
 					Pkg:      pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
 					Strategy: strategy,
-				}.Run(fake.CtxWithDefaultPrinter())
+				}).Run(fake.CtxWithDefaultPrinter())
 
 				result := findExpectedResultForStrategy(test.expectedResults, strategy)
 
@@ -3540,9 +3544,9 @@ func TestRun_remote_subpackages(t *testing.T) {
 				return
 			}
 
-			err := Command{
+			err := (&Command{
 				Pkg: pkgtest.CreatePkgOrFail(t, g.LocalWorkspace.FullPackagePath()),
-			}.Run(fake.CtxWithDefaultPrinter())
+			}).Run(fake.CtxWithDefaultPrinter())
 
 			if tc.expectedErrMsg != "" {
 				if !assert.Error(t, err) {
@@ -3685,9 +3689,9 @@ func TestRootPackageIsUnfetched(t *testing.T) {
 			}
 			testutil.AddKptfileToWorkspace(t, w, kf)
 
-			err := Command{
+			err := (&Command{
 				Pkg: pkgtest.CreatePkgOrFail(t, w.FullPackagePath()),
-			}.Run(fake.CtxWithDefaultPrinter())
+			}).Run(fake.CtxWithDefaultPrinter())
 			if !assert.NoError(t, err) {
 				t.FailNow()
 			}

--- a/porch/pkg/kpt/pkgupdate.go
+++ b/porch/pkg/kpt/pkgupdate.go
@@ -86,7 +86,7 @@ func PkgUpdate(ctx context.Context, ref string, packageDir string, opts PkgUpdat
 		// 	return errors.E(op, p.UniquePath, err)
 		// }
 		updated := *upstream
-		if err := fetch.ClonerUsingGitExec(ctx, &updated); err != nil {
+		if err := fetch.NewCloner(&updated).ClonerUsingGitExec(ctx); err != nil {
 			return err
 		}
 		defer os.RemoveAll(updated.AbsPath())
@@ -102,7 +102,7 @@ func PkgUpdate(ctx context.Context, ref string, packageDir string, opts PkgUpdat
 			// if err := fetch.ClonerUsingGitExec(ctx, originRepoSpec); err != nil {
 			// 	return errors.E(op, p.UniquePath, err)
 			// }
-			if err := fetch.ClonerUsingGitExec(ctx, originRepoSpec); err != nil {
+			if err := fetch.NewCloner(originRepoSpec).ClonerUsingGitExec(ctx); err != nil {
 				return err //errors.E(op, p.UniquePath, err)
 			}
 			originDir = originRepoSpec.AbsPath()


### PR DESCRIPTION
fixes https://github.com/GoogleContainerTools/kpt/issues/2988

This introduces caching for upstream repos so we can skip some git exec commands like `ls-remote` and `fetch` for repos that are already upto date. Looking for some early feedback on the approach and happy to add additional tests/benchmarks. Currently packages are not updated in parallel so I haven't investigated a thread safe approach.