### PR TITLE
align video in kpt.dev home page

### DIFF
--- a/site/coverpage.md
+++ b/site/coverpage.md
@@ -6,8 +6,8 @@
 > by manipulating declarative Configuration as Data, 
 > separated from the code that transforms it.
 
-<iframe id="ytplayer" type="text/html" width="550" height="360"
-    src="https://www.youtube.com/embed/L_x7z4CXHDw" allowFullScreen="allowFullScreen"> </iframe>
+<iframe id="ytplayer" type="text/html" width="330" height="216"
+    src="https://www.youtube.com/embed/L_x7z4CXHDw" align="left" allowFullScreen="allowFullScreen"> </iframe>
 
 
 [Why kpt](guides/rationale.md)


### PR DESCRIPTION
Super nit, the current video alignment squeezes the "Get Started" and "Why kpt" and makes it feel a little bit crowded in the centre.

Before
<img width="1434" alt="Screen Shot 2022-05-13 at 12 49 25" src="https://user-images.githubusercontent.com/5606098/168379918-62d03aaf-af5c-460f-812b-868fc07aa6a6.png">
After
<img width="1430" alt="Screen Shot 2022-05-13 at 12 49 10" src="https://user-images.githubusercontent.com/5606098/168379933-ced92e25-9bdc-47a2-af52-8bef936e178a.png">
