### PR TITLE
chore: fix lint whitespace failure

### DIFF
--- a/pkg/live/planner/cluster.go
+++ b/pkg/live/planner/cluster.go
@@ -96,9 +96,12 @@ func (r *ClusterPlanner) BuildPlan(ctx context.Context, inv inventory.Info, obje
 	}, nil
 }
 
-func (r *ClusterPlanner) dryRunForPlan(ctx context.Context, inv inventory.Info,
-	objects []*unstructured.Unstructured, o Options) ([]planv1alpha1.Action, error) {
-
+func (r *ClusterPlanner) dryRunForPlan(
+	ctx context.Context,
+	inv inventory.Info,
+	objects []*unstructured.Unstructured,
+	o Options,
+) ([]planv1alpha1.Action, error) {
 	eventCh := r.applier.Run(ctx, inv, objects, apply.ApplierOptions{
 		DryRunStrategy:    common.DryRunServer,
 		ServerSideOptions: o.ServerSideOptions,


### PR DESCRIPTION
Someone merged a PR without rebasing, so they didn't have the whitespace litter enabled.