### PR TITLE
fix: Adjust kpt.dev homepage video size to fit mobile display

### DIFF
--- a/site/coverpage.md
+++ b/site/coverpage.md
@@ -5,9 +5,10 @@
 > which simplifies managing Kubernetes platforms and KRM-driven infrastructure at scale 
 > by manipulating declarative Configuration as Data, 
 > separated from the code that transforms it.
-
-<iframe id="ytplayer" type="text/html" width="330" height="216"
+<div class="container">
+<iframe id="ytplayer" type="text/html" width="330" height="216" scrolling="auto" class="video"
     src="https://www.youtube.com/embed/L_x7z4CXHDw" align="left" allowFullScreen="allowFullScreen"> </iframe>
+</div>
 
 
 [Why kpt](guides/rationale.md)

--- a/site/static/css/site.css
+++ b/site/static/css/site.css
@@ -19,6 +19,20 @@
   --pagination-title-font-size: 0px;
 }
 
+.container {
+  position: relative;
+  width: 100%;
+  height: 0;
+  padding-bottom: 56.25%;
+}
+.video {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
 .close,
 .close:focus,
 .close:hover {


### PR DESCRIPTION
This shall improve the Mobile display problem as described in  #3178 

To better improve the responsive design of kpt.dev, we can also consider using [iframe-resize](https://github.com/davidjbradshaw/iframe-resizer), which may gives a better display, but requires much more work and may need some Frontend expertise to help.

Before
<img width="360" alt="Screen Shot 2022-05-14 at 16 48 55" src="https://user-images.githubusercontent.com/5606098/168451604-22186ad4-9f72-4eba-8ffe-c3db3ee09f86.png">
 
After
<img width="360" alt="Screen Shot 2022-05-14 at 17 00 00" src="https://user-images.githubusercontent.com/5606098/168451843-298cdca7-3a6c-4db8-b1a1-3489173da0bd.png">

