### PR TITLE
docs: add kubernetes on slack link

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,5 +73,6 @@ If you are interested in contributing please start with
 
 We would love to keep in touch:
 
-1. Join our [Slack channel](https://kubernetes.slack.com/channels/kpt)
+1. Join our [Slack channel](https://kubernetes.slack.com/channels/kpt). You'll
+   need to join [Kubernetes on Slack](https://slack.k8s.io/) first.
 1. Join our [email list](https://groups.google.com/forum/?oldui=1#!forum/kpt-users)


### PR DESCRIPTION
This pull request adds the Kubernetes on Slack link to the README since a user needs to be a member of the Kubernetes workspace prior to joining the kpt channel.