### PR TITLE
disabled check-site action

### DIFF
--- a/.github/workflows/checkSite.yml
+++ b/.github/workflows/checkSite.yml
@@ -25,21 +25,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/checkout@v2
-        with:
-          repository: etefera/href-checker
-          ref: docsify
-          path: href-checker
+# disabling href checker https://github.com/GoogleContainerTools/kpt/issues/3157
+# Re-enable it by replacing it with robust mechanism
+#      - uses: actions/checkout@v2
+#        with:
+#          repository: etefera/href-checker
+#          ref: docsify
+#          path: href-checker
       - uses: actions/setup-node@v2
         with:
           node-version: '16'
       - name: Lint site content
         run: npm i && npm run lint-check
         working-directory: site
-      - name: Install Site Checker
-        run: yarn install
-        working-directory: href-checker
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Run Site Checker
-        run: make site-check
+#      - name: Install Site Checker
+#        run: yarn install
+#        working-directory: href-checker
+#      - name: Set up Docker Buildx
+#        uses: docker/setup-buildx-action@v1
+#      - name: Run Site Checker
+#        run: make site-check

--- a/site/installation/kpt-cli.md
+++ b/site/installation/kpt-cli.md
@@ -28,6 +28,7 @@ $ kpt version
 
 kpt provides auto-completion support for several of the common shells.
 To see the options for enabling shell auto-completion:
+
 ```shell
 $ kpt completion -h
 ```
@@ -35,9 +36,11 @@ $ kpt completion -h
 ### Prerequisites
 Previous installations of kpt completion may have added the following line to
 the shell's config file (e.g. `.bashrc`, `.zshrc`, etc.):
+
 ```shell
-complete -C <KPT_PATH> kpt
+$ complete -C <KPT_PATH> kpt
 ```
+
 This line needs to be removed for kpt's completion implementation to function
 properly.
 


### PR DESCRIPTION
This PR disables the href-checker in the check-site CI step because it is very slow and flaky. See https://github.com/GoogleContainerTools/kpt/issues/3157 for more details.

Made some minor changes under `site/` to test if disabling is in effect.