### PR TITLE
Don't trigger kpt CLI e2e test when it's doc only changes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,6 +15,16 @@
 name: Go
 on:
   pull_request:
+    paths-ignore:
+      - "Formula/**"
+      - "demos/**"
+      - "docs/**"
+      - "firebase/**"
+      - "logo/**"
+      - "package-examples/**"
+      - "release/**"
+      - "site/**"
+      - "**.md"
   push:
 
 jobs:


### PR DESCRIPTION
Make kpt CLI e2e test CI ignores some doc related directories.

Related discussion: https://github.com/GoogleContainerTools/kpt/pull/3133#discussion_r871673713
