### PR TITLE
preserve comments in `kpt fn eval --save`

### DIFF
--- a/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/.expected/config.yaml
+++ b/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/.expected/config.yaml
@@ -1,0 +1,22 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+testType: eval
+image: set-namespace:v0.1.3
+args:
+  namespace: staging
+stdErr: |
+  [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.1.3"
+  [PASS] "gcr.io/kpt-fn/set-namespace:v0.1.3" in 0s
+  Added "gcr.io/kpt-fn/set-namespace:v0.1.3" as mutator in the Kptfile.

--- a/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/.expected/diff.patch
+++ b/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/.expected/diff.patch
@@ -1,0 +1,33 @@
+diff --git a/Kptfile b/Kptfile
+index 08afd4c..9a0803a 100644
+--- a/Kptfile
++++ b/Kptfile
+@@ -4,3 +4,9 @@ kind: Kptfile # comment 1
+ metadata:
+   # comment 2
+   name: app # comment 3
++  namespace: staging
++pipeline:
++  mutators:
++    - image: gcr.io/kpt-fn/set-namespace:v0.1.3
++      configMap:
++        namespace: staging
+diff --git a/resources.yaml b/resources.yaml
+index ac634f3..0e09da8 100644
+--- a/resources.yaml
++++ b/resources.yaml
+@@ -15,6 +15,7 @@ apiVersion: apps/v1
+ kind: Deployment
+ metadata:
+   name: nginx-deployment
++  namespace: staging
+ spec:
+   replicas: 3
+ ---
+@@ -22,5 +23,6 @@ apiVersion: custom.io/v1
+ kind: Custom
+ metadata:
+   name: custom
++  namespace: staging
+ spec:
+   image: nginx:1.2.3

--- a/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/.expected/exec.sh
+++ b/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/.expected/exec.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eo pipefail
+
+kpt fn eval -s -t mutator -i set-namespace:v0.1.3 -- namespace=staging

--- a/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/.krmignore
+++ b/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/.krmignore
@@ -1,0 +1,1 @@
+.expected

--- a/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/Kptfile
+++ b/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/Kptfile
@@ -1,0 +1,6 @@
+# header comment
+apiVersion: kpt.dev/v1
+kind: Kptfile # comment 1
+metadata:
+  # comment 2
+  name: app # comment 3

--- a/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/resources.yaml
+++ b/e2e/testdata/fn-eval/save-fn/preserve-kptfile-comments/resources.yaml
@@ -1,0 +1,26 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  replicas: 3
+---
+apiVersion: custom.io/v1
+kind: Custom
+metadata:
+  name: custom
+spec:
+  image: nginx:1.2.3

--- a/pkg/kptfile/kptfileutil/util.go
+++ b/pkg/kptfile/kptfileutil/util.go
@@ -34,7 +34,7 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/yaml/merge3"
 )
 
-func WriteFile(dir string, k *kptfilev1.KptFile) error {
+func WriteFile(dir string, k interface{}) error {
 	const op errors.Op = "kptfileutil.WriteFile"
 	b, err := yaml.MarshalWithOptions(k, &yaml.EncoderOptions{SeqIndent: yaml.WideSequenceStyle})
 	if err != nil {


### PR DESCRIPTION
There is some existing code in kyaml to preserve comments and field order. This PR utilizes it for preserving those in `kpt fn eval --save`.

Fixes https://github.com/GoogleContainerTools/kpt/issues/2952