### PR TITLE
update package examples to book

### DIFF
--- a/package-examples/nginx/deployment.yaml
+++ b/package-examples/nginx/deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: "nginx:1.16.1"
+          image: "nginx:1.18.0"
           ports:
             - protocol: TCP
               containerPort: 80

--- a/package-examples/wordpress/deployment/volume.yaml
+++ b/package-examples/wordpress/deployment/volume.yaml
@@ -20,6 +20,6 @@ metadata:
 spec:
   resources:
     requests:
-      storage: 3Gi
+      storage: 4Gi
   accessModes:
     - ReadWriteOnce


### PR DESCRIPTION
Between tag `package-examples/nginx/v0.7` and `package-examples/nginx/v0.8`, we have the following diff:

```shell
diff --git a/deployment.yaml b/deployment.yaml
index 478a6b7..e22dff9 100644
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
         - name: nginx
-          image: "nginx:1.14.2"
+          image: "nginx:1.16.1"
           ports:
             - protocol: TCP
               containerPort: 80
```

Between tag `package-examples/wordpress/v0.7` and `package-examples/wordpress/v0.8`, we have the following diff:

```shell
diff --git a/deployment/volume.yaml b/deployment/volume.yaml
index 16d89b3..460873f 100644
--- a/deployment/volume.yaml
+++ b/deployment/volume.yaml
@@ -20,6 +20,6 @@ metadata: # kpt-merge: /wp-pv-claim
 spec:
   resources:
     requests:
-      storage: 2Gi
+      storage: 3Gi
   accessModes:
     - ReadWriteOnce
```

To fix our doc (e.g. https://github.com/GoogleContainerTools/kpt/issues/3151), we need to tag `package-examples/nginx/v0.9` and `package-examples/nginx/v0.10` for the nginx package and  `package-examples/wordpress/v0.9` and `package-examples/wordpress/v0.10` for the wordpress package. And we should maintain some diff between tags so that users can try the `kpt pkg update` workflow.

I have tagged `package-examples/nginx/v0.9` and `package-examples/wordpress/v0.9` already.
After this PR merges, I will `v0.10` for these 2 packages.
