### PR TITLE
update to book to use the updated packages

### DIFF
--- a/site/book/01-getting-started/02-quickstart.md
+++ b/site/book/01-getting-started/02-quickstart.md
@@ -9,7 +9,7 @@ package of configuration using the underlying Git version control system.
 First, let's fetch the _kpt package_ from Git to your local filesystem:
 
 ```shell
-$ kpt pkg get https://github.com/GoogleContainerTools/kpt/package-examples/nginx@v0.7
+$ kpt pkg get https://github.com/GoogleContainerTools/kpt/package-examples/nginx@v0.9
 ```
 
 Subsequent commands are run from the `nginx` directory:
@@ -87,7 +87,7 @@ using their OpenAPI schema.
 ```yaml
 pipeline:
   validators:
-    - image: gcr.io/kpt-fn/kubeval:v0.1
+    - image: gcr.io/kpt-fn/kubeval:v0.3
 ```
 
 You might want to label all resources in the package. To achieve that, you can
@@ -155,10 +155,10 @@ First, commit your local changes:
 $ git add .; git commit -m "My customizations"
 ```
 
-Then update to version `v0.8`:
+Then update to version `v0.10`:
 
 ```shell
-$ kpt pkg update @v0.8
+$ kpt pkg update @v0.10
 ```
 
 This merges the upstream changes with your local changes using a schema-aware

--- a/site/book/02-concepts/01-packages.md
+++ b/site/book/02-concepts/01-packages.md
@@ -11,7 +11,7 @@ a _subpackage_.
 Let's take a look at the wordpress package as an example:
 
 ```shell
-$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/wordpress@v0.7
+$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/wordpress@v0.9
 ```
 
 View the package hierarchy using the `tree` command:

--- a/site/book/03-packages/01-getting-a-package.md
+++ b/site/book/03-packages/01-getting-a-package.md
@@ -4,11 +4,11 @@ committing them to a Git repository. Consumers fork the package to use it.
 Let's revisit the Wordpress example:
 
 ```shell
-$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/wordpress@v0.7
+$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/wordpress@v0.9
 ```
 
 A package in a Git repo can be fetched by specifying a branch, tag, or commit
-SHA. In this case, we are specifying tag `v0.7`.
+SHA. In this case, we are specifying tag `v0.9`.
 
 ?> Refer to the [get command reference][get-doc] for usage.
 
@@ -26,15 +26,15 @@ upstream:
   git:
     repo: https://github.com/GoogleContainerTools/kpt
     directory: /package-examples/wordpress
-    ref: v0.7
+    ref: v0.9
   updateStrategy: resource-merge
 upstreamLock:
   type: git
   git:
     repo: https://github.com/GoogleContainerTools/kpt
     directory: /package-examples/wordpress
-    ref: package-examples/wordpress/v0.7
-    commit: cbd342d350b88677e522bf0d9faa0675edb8bbc1
+    ref: package-examples/wordpress/v0.9
+    commit: b9ea0bca019dafa9f9f91fd428385597c708518c
 info:
   emails:
     - kpt-team@google.com
@@ -45,7 +45,7 @@ pipeline:
       configMap:
         app: wordpress
   validators:
-    - image: gcr.io/kpt-fn/kubeval:v0.1
+    - image: gcr.io/kpt-fn/kubeval:v0.3
 ```
 
 The `Kptfile` contains two sections to keep track of the upstream package:
@@ -101,7 +101,7 @@ For example, the following fetches the packages to a directory named
 `mywordpress`:
 
 ```shell
-$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/wordpress@v0.7 mywordpress
+$ kpt pkg get https://github.com/GoogleContainerTools/kpt.git/package-examples/wordpress@v0.9 mywordpress
 ```
 
 The _name of a package_ is given by its directory name. Since the Kptfile is a

--- a/site/book/03-packages/05-updating-a-package.md
+++ b/site/book/03-packages/05-updating-a-package.md
@@ -20,10 +20,10 @@ $ git add .; git commit -m "My changes"
 
 ## Update the package
 
-For example, you can update to version `v0.8` of the `wordpress` package:
+For example, you can update to version `v0.10` of the `wordpress` package:
 
 ```shell
-$ kpt pkg update wordpress@v0.8
+$ kpt pkg update wordpress@v0.10
 ```
 
 This is a porcelain for manually updating the `upstream` section in the
@@ -35,8 +35,8 @@ upstream:
   git:
     repo: https://github.com/GoogleContainerTools/kpt
     directory: /package-examples/wordpress
-    # Change this from v0.7 to v0.8
-    ref: v0.8
+    # Change this from v0.9 to v0.10
+    ref: v0.10
   updateStrategy: resource-merge
 ```
 
@@ -47,7 +47,7 @@ $ kpt pkg update wordpress
 ```
 
 The `update` command updates the local `wordpress` package and the dependent
-`mysql` package to the upstream version `v0.8` by doing a 3-way merge between:
+`mysql` package to the upstream version `v0.10` by doing a 3-way merge between:
 
 1. Original upstream commit
 2. New upstream commit
@@ -64,7 +64,7 @@ resource using OpenAPI schema.
 Once you have successfully updated the package, commit the changes:
 
 ```shell
-$ git add .; git commit -m "Updated wordpress to v0.8"
+$ git add .; git commit -m "Updated wordpress to v0.10"
 ```
 
 [update-doc]: /reference/cli/pkg/update/


### PR DESCRIPTION
The updated packages use `kubeval:v0.3` to work with the latest kpt CLI.

Fixes: https://github.com/GoogleContainerTools/kpt/issues/3151

