### PR TITLE
docs: Update docs for inventory metadata in resourcegroup manifest

### DIFF
--- a/internal/docs/generated/livedocs/docs.go
+++ b/internal/docs/generated/livedocs/docs.go
@@ -15,8 +15,8 @@ Args:
 
   PKG_PATH | -:
     Path to the local package which should be applied to the cluster. It must
-    contain a Kptfile with inventory information. Defaults to the current working
-    directory.
+    contain a Kptfile or a ResourceGroup manifest with inventory metadata.
+    Defaults to the current working directory.
     Using '-' as the package path will cause kpt to read resources from stdin.
 
 Flags:
@@ -114,8 +114,8 @@ Args:
 
   PKG_PATH | -:
     Path to the local package which should be deleted from the cluster. It must
-    contain a Kptfile with inventory information. Defaults to the current working
-    directory.
+    contain a Kptfile or a ResourceGroup manifest with inventory metadata.
+    Defaults to the current working directory.
     Using '-' as the package path will cause kpt to read resources from stdin.
 
 Flags:
@@ -188,6 +188,10 @@ Flags:
     for the package. If not provided, kpt will check if all the resources
     in the package belong in the same namespace. If they do, that namespace will
     be used. If they do not, the namespace in the user's context will be chosen.
+  
+  --rg-file:
+    The name used for the file created for the ResourceGroup CR. Defaults to
+    'resourcegroup.yaml'.
 `
 var InitExamples = `
   # initialize a package in the current directory.
@@ -213,8 +217,9 @@ var MigrateLong = `
 Args:
 
   PKG_PATH:
-    Path to the local package. It must have a Kptfile and an existing inventory
-    template in the root of the package. It defaults to the current directory.
+    Path to the local package. It must have a Kptfile and inventory metadata
+    in the package in either the ConfigMap, Kptfile or ResourceGroup format.
+    It defaults to the current directory.
 
 Flags:
 
@@ -222,18 +227,18 @@ Flags:
     Go through the steps of migration, but don't make any changes.
   
   --force:
-    Forces the inventory values in the Kptfile to be updated, even if they are
-    already set. Defaults to false.
+    Forces the inventory values in the ResourceGroup manfiest to be updated,
+    even if they are already set. Defaults to false.
   
   --name:
     The name for the ResourceGroup resource that contains the inventory
-    for the package. Defaults to the same name as the existing ConfigMap
-    inventory object.
+    for the package. Defaults to the same name as the existing inventory
+    object.
   
   --namespace:
     The namespace for the ResourceGroup resource that contains the inventory
     for the package. If not provided, it defaults to the same namespace as the
-    existing ConfigMap inventory object.
+    existing inventory object.
 `
 var MigrateExamples = `
   # Migrate the package in the current directory.
@@ -248,7 +253,8 @@ Args:
 
   PKG_PATH | -:
     Path to the local package for which the status of the package in the cluster
-    should be displayed. It must contain a Kptfile with inventory information.
+    should be displayed. It must contain either a Kptfile or a ResourceGroup CR
+    with inventory metadata.
     Defaults to the current working directory.
     Using '-' as the package path will cause kpt to read resources from stdin.
 

--- a/site/book/06-deploying-packages/01-initializing-a-package-for-apply.md
+++ b/site/book/06-deploying-packages/01-initializing-a-package-for-apply.md
@@ -1,24 +1,26 @@
 Before you can apply the package to the cluster, it needs to be initialized
 using `live init`. This is a one-time client-side operation that adds metadata
-to the `Kptfile` specifying a `ResourceGroup` resource on the cluster associated
-with this package. The `ResourceGroup`resource will be created by the
-`live apply` command.
+to the `ResourceGroup` CR (by default located in `resourcegroup.yaml` file)
+specifying the name, namespace and inventoryID of the `ResourceGroup` resource
+`live apply` command will use to store the inventory (list of the resources applied).
 
 Let's initialize the `wordpress` package:
 
 ```shell
 $ kpt live init wordpress
-initializing Kptfile inventory info (namespace: default)...success
+initializing "resourcegroup.yaml" inventory info (namespace: default)...success
 ```
 
-This adds the `inventory` section to the `Kptfile`:
+This creates the `ResourceGroup` CR in the `resourcegroup.yaml` file:
 
 ```yaml
-# wordpress/Kptfile (Excerpt)
-inventory:
+apiVersion: kpt.dev/v1alpha1
+kind: ResourceGroup
+metadata:
+  name: inventory-74096247
   namespace: default
-  name: inventory-10285025
-  inventoryID: 06ca0268f3ccda82bfd44bec273530a4f72fa9a7-1623278424452000000
+  labels:
+    cli-utils.sigs.k8s.io/inventory-id: 0a32e2c0200b4bd4c19cd3e097086b4648b8902d-1653113657067255815
 ```
 
 `ResourceGroup` is a namespace-scoped resource. By default, `live init` command
@@ -30,7 +32,7 @@ and namespace of the `ResourceGroup` resource.
 ?> Refer to the [init command reference][init-doc] for usage.
 
 !> Once a package is applied to the cluster, you do not want to change the
-metadata in the `inventory` section; doing so severs the association between the
-package and the `ResourceGroup`, leading to destructive operations.
+`ResourceGroup` CR; doing so severs the association between the
+package and the inventory in the cluster, leading to destructive operations.
 
 [init-doc]: /reference/cli/live/init/

--- a/site/reference/cli/live/apply/README.md
+++ b/site/reference/cli/live/apply/README.md
@@ -26,8 +26,8 @@ kpt live apply [PKG_PATH | -] [flags]
 ```
 PKG_PATH | -:
   Path to the local package which should be applied to the cluster. It must
-  contain a Kptfile with inventory information. Defaults to the current working
-  directory.
+  contain a Kptfile or a ResourceGroup manifest with inventory metadata.
+  Defaults to the current working directory.
   Using '-' as the package path will cause kpt to read resources from stdin.
 ```
 

--- a/site/reference/cli/live/destroy/README.md
+++ b/site/reference/cli/live/destroy/README.md
@@ -25,8 +25,8 @@ kpt live destroy [PKG_PATH | -]
 ```
 PKG_PATH | -:
   Path to the local package which should be deleted from the cluster. It must
-  contain a Kptfile with inventory information. Defaults to the current working
-  directory.
+  contain a Kptfile or a ResourceGroup manifest with inventory metadata.
+  Defaults to the current working directory.
   Using '-' as the package path will cause kpt to read resources from stdin.
 ```
 

--- a/site/reference/cli/live/init/README.md
+++ b/site/reference/cli/live/init/README.md
@@ -50,6 +50,10 @@ PKG_PATH:
   for the package. If not provided, kpt will check if all the resources
   in the package belong in the same namespace. If they do, that namespace will
   be used. If they do not, the namespace in the user's context will be chosen.
+
+--rg-file:
+  The name used for the file created for the ResourceGroup CR. Defaults to
+  'resourcegroup.yaml'.
 ```
 
 <!--mdtogo-->

--- a/site/reference/cli/live/migrate/README.md
+++ b/site/reference/cli/live/migrate/README.md
@@ -12,13 +12,19 @@ Migrate a package and the inventory object to use the ResourceGroup CRD.
 
 `migrate` moves the inventory list, which contains the Group, Kind, Name and
 Namespace for every resource in the cluster that belongs to a package, into a
-`ResourceGroup` CR and moves the inventory information into the `Kptfile`.
+`ResourceGroup` CR and moves the inventory information into the a `ResourceGroup`
+manifest on local disk.
 
-Previous versions of `kpt` uses `ConfigMap` resources for storing the inventory
-list and relies on an inventory template being among the applied resources. The
-inventory template is just a regular `ConfigMap` manifest with a special
-annotation that includes the information needed to look up any existing
-inventory lists.
+0.39.x or earlier versions of `kpt` stored the inventory metadata in a
+`ConfigMap` manifest in the package, and stored the inventory list in a
+`ConfigMap` resource in the cluster. Running this command will move the
+metadata into a `ResourceGroup` manifest in the `resourcegroup.yaml` file
+and move the inventory list into a `ResourceGroup` CR.
+
+Previous 1.0.0-alpha or 1.0.0-beta versions of kpt would store the inventory
+metadata in the `Kptfile`. Running this command will move the metadata from
+the `Kptfile` in a `ResourceGroup` manifest in the `resourcegroup.yaml` file.
+
 
 ### Synopsis
 
@@ -32,8 +38,9 @@ kpt live migrate [PKG_PATH] [flags]
 
 ```
 PKG_PATH:
-  Path to the local package. It must have a Kptfile and an existing inventory
-  template in the root of the package. It defaults to the current directory.
+  Path to the local package. It must have a Kptfile and inventory metadata
+  in the package in either the ConfigMap, Kptfile or ResourceGroup format.
+  It defaults to the current directory.
 ```
 
 #### Flags
@@ -43,18 +50,18 @@ PKG_PATH:
   Go through the steps of migration, but don't make any changes.
 
 --force:
-  Forces the inventory values in the Kptfile to be updated, even if they are
-  already set. Defaults to false.
+  Forces the inventory values in the ResourceGroup manfiest to be updated,
+  even if they are already set. Defaults to false.
 
 --name:
   The name for the ResourceGroup resource that contains the inventory
-  for the package. Defaults to the same name as the existing ConfigMap
-  inventory object.
+  for the package. Defaults to the same name as the existing inventory
+  object.
 
 --namespace:
   The namespace for the ResourceGroup resource that contains the inventory
   for the package. If not provided, it defaults to the same namespace as the
-  existing ConfigMap inventory object.
+  existing inventory object.
 ```
 
 <!--mdtogo-->

--- a/site/reference/cli/live/status/README.md
+++ b/site/reference/cli/live/status/README.md
@@ -25,7 +25,8 @@ kpt live status [PKG_PATH | -] [flags]
 ```
 PKG_PATH | -:
   Path to the local package for which the status of the package in the cluster
-  should be displayed. It must contain a Kptfile with inventory information.
+  should be displayed. It must contain either a Kptfile or a ResourceGroup CR
+  with inventory metadata.
   Defaults to the current working directory.
   Using '-' as the package path will cause kpt to read resources from stdin.
 ```


### PR DESCRIPTION
Update book and cli reference to reflect changes in https://github.com/GoogleContainerTools/kpt/pull/3172