### PR TITLE
Updated kpt version to v1.0.0-beta.16

### DIFF
--- a/Formula/kpt.rb
+++ b/Formula/kpt.rb
@@ -15,8 +15,8 @@
 class Kpt < Formula
   desc "Toolkit to manage,and apply Kubernetes Resource config data files"
   homepage "https://googlecontainertools.github.io/kpt"
-  url "https://github.com/GoogleContainerTools/kpt/archive/v1.0.0-beta.15.tar.gz"
-  sha256 "5e3a73f9eb2d6db02ecdb237972cd1b618a5ab784dae85949768680573d272e3"
+  url "https://github.com/GoogleContainerTools/kpt/archive/v1.0.0-beta.16.tar.gz"
+  sha256 "d7bbf9cf7b1b3ad5ed3b5e7715cf000238a4aab669d8d2c6689611d95a2130b8"
 
   depends_on "go" => :build
 

--- a/site/installation/kpt-cli.md
+++ b/site/installation/kpt-cli.md
@@ -93,7 +93,7 @@ Use one of the kpt docker images.
 ### `kpt`
 
 ```shell
-$ docker run gcr.io/kpt-dev/kpt:v1.0.0-beta.15 version
+$ docker run gcr.io/kpt-dev/kpt:v1.0.0-beta.16 version
 ```
 
 ### `kpt-gcloud`
@@ -101,7 +101,7 @@ $ docker run gcr.io/kpt-dev/kpt:v1.0.0-beta.15 version
 An image which includes kpt based upon the Google [cloud-sdk] alpine image.
 
 ```shell
-$ docker run gcr.io/kpt-dev/kpt-gcloud:v1.0.0-beta.15 version
+$ docker run gcr.io/kpt-dev/kpt-gcloud:v1.0.0-beta.16 version
 ```
 
 ## Source
@@ -124,8 +124,8 @@ $ kpt version
   https://console.cloud.google.com/gcr/images/kpt-dev/GLOBAL/kpt-gcloud?gcrImageListsize=30
 [cloud-sdk]: https://github.com/GoogleCloudPlatform/cloud-sdk-docker
 [linux]:
-  https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.15/kpt_linux_amd64
+  https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.16/kpt_linux_amd64
 [darwin]:
-  https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.15/kpt_darwin_amd64
+  https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.16/kpt_darwin_amd64
 [migration guide]: /installation/migration
 [bash-completion]: https://github.com/scop/bash-completion#installation


### PR DESCRIPTION
This PR does the following:

- Updates the `homebrew` formula to use kpt v1.0.0-beta.16 version.
- Updates installation guide to use v1.0.0-beta.16 version.
