### PR TITLE
[WIP] Add restore functionality to porch

### DIFF
--- a/porch/api/porch/types_packagerevisions.go
+++ b/porch/api/porch/types_packagerevisions.go
@@ -83,20 +83,22 @@ type PackageRevisionStatus struct {
 type TaskType string
 
 const (
-	TaskTypeInit  TaskType = "init"
-	TaskTypeClone TaskType = "clone"
-	TaskTypePatch TaskType = "patch"
-	TaskTypeEdit  TaskType = "edit"
-	TaskTypeEval  TaskType = "eval"
+	TaskTypeInit    TaskType = "init"
+	TaskTypeClone   TaskType = "clone"
+	TaskTypePatch   TaskType = "patch"
+	TaskTypeEdit    TaskType = "edit"
+	TaskTypeRestore TaskType = "restore"
+	TaskTypeEval    TaskType = "eval"
 )
 
 type Task struct {
-	Type  TaskType              `json:"type"`
-	Init  *PackageInitTaskSpec  `json:"init,omitempty"`
-	Clone *PackageCloneTaskSpec `json:"clone,omitempty"`
-	Patch *PackagePatchTaskSpec `json:"patch,omitempty"`
-	Edit  *PackageEditTaskSpec  `json:"edit,omitempty"`
-	Eval  *FunctionEvalTaskSpec `json:"eval,omitempty"`
+	Type     TaskType                `json:"type"`
+	Init     *PackageInitTaskSpec    `json:"init,omitempty"`
+	Clone    *PackageCloneTaskSpec   `json:"clone,omitempty"`
+	Patch    *PackagePatchTaskSpec   `json:"patch,omitempty"`
+	Edit     *PackageEditTaskSpec    `json:"edit,omitempty"`
+	Rollback *PackageRestoreTaskSpec `json:"restore,omitempty"`
+	Eval     *FunctionEvalTaskSpec   `json:"eval,omitempty"`
 }
 
 // PackageInitTaskSpec defines the package initialization task.
@@ -156,6 +158,10 @@ type PatchSpec struct {
 }
 
 type PackageEditTaskSpec struct {
+	Source *PackageRevisionRef `json:"sourceRef,omitempty"`
+}
+
+type PackageRestoreTaskSpec struct {
 	Source *PackageRevisionRef `json:"sourceRef,omitempty"`
 }
 

--- a/porch/api/porch/v1alpha1/types_packagerevisions.go
+++ b/porch/api/porch/v1alpha1/types_packagerevisions.go
@@ -91,20 +91,22 @@ type PackageRevisionStatus struct {
 type TaskType string
 
 const (
-	TaskTypeInit  TaskType = "init"
-	TaskTypeClone TaskType = "clone"
-	TaskTypePatch TaskType = "patch"
-	TaskTypeEdit  TaskType = "edit"
-	TaskTypeEval  TaskType = "eval"
+	TaskTypeInit    TaskType = "init"
+	TaskTypeClone   TaskType = "clone"
+	TaskTypePatch   TaskType = "patch"
+	TaskTypeEdit    TaskType = "edit"
+	TaskTypeRestore TaskType = "restore"
+	TaskTypeEval    TaskType = "eval"
 )
 
 type Task struct {
-	Type  TaskType              `json:"type"`
-	Init  *PackageInitTaskSpec  `json:"init,omitempty"`
-	Clone *PackageCloneTaskSpec `json:"clone,omitempty"`
-	Patch *PackagePatchTaskSpec `json:"patch,omitempty"`
-	Edit  *PackageEditTaskSpec  `json:"edit,omitempty"`
-	Eval  *FunctionEvalTaskSpec `json:"eval,omitempty"`
+	Type    TaskType                `json:"type"`
+	Init    *PackageInitTaskSpec    `json:"init,omitempty"`
+	Clone   *PackageCloneTaskSpec   `json:"clone,omitempty"`
+	Patch   *PackagePatchTaskSpec   `json:"patch,omitempty"`
+	Edit    *PackageEditTaskSpec    `json:"edit,omitempty"`
+	Restore *PackageRestoreTaskSpec `json:"restore,omitempty"`
+	Eval    *FunctionEvalTaskSpec   `json:"eval,omitempty"`
 }
 
 // PackageInitTaskSpec defines the package initialization task.
@@ -164,6 +166,10 @@ type PatchSpec struct {
 }
 
 type PackageEditTaskSpec struct {
+	Source *PackageRevisionRef `json:"sourceRef,omitempty"`
+}
+
+type PackageRestoreTaskSpec struct {
 	Source *PackageRevisionRef `json:"sourceRef,omitempty"`
 }
 


### PR DESCRIPTION
This is a WIP for adding support for restoring previous revisions of a package. The requirements this is based on is:
* Restore means taking a previous published version of a package and making it the "latest" revision of the package. Latest here means that the revision string used will cause it to be chosen as the latest by the porch api. TODO: Document the rules here.
* Restore means creating a new package revision that is identical to a previous one.
* Restored package revisions are immediately considered Published. This also means that it is only possible to do a restore based on already published packages, otherwise there would be a way to circumvent the approval process.

There are several issues with this implementation, so it is mostly meant to be the basis for a discussion on how we should implement it:
* The `Restore` task added here is almost identical to the `Edit` task, and both seems to put us on a path with a large number of tasks, and that doesn't seem like a good direction.
* It uses the presence of a `Restore` task to determine whether we should set the Lifecycle of the revision to `Published`. This seems like a bad way to handle this, but currently the tasks only have access to the package content and can't update the lifecycle.
