### PR TITLE
Update packages in porch

### DIFF
--- a/commands/rpkgcmd.go
+++ b/commands/rpkgcmd.go
@@ -29,6 +29,7 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/cmdrpkgpull"
 	"github.com/GoogleContainerTools/kpt/internal/cmdrpkgpush"
 	"github.com/GoogleContainerTools/kpt/internal/cmdrpkgreject"
+	"github.com/GoogleContainerTools/kpt/internal/cmdrpkgupdate"
 	"github.com/GoogleContainerTools/kpt/internal/docs/generated/rpkgdocs"
 	"github.com/GoogleContainerTools/kpt/internal/util/porch"
 	"github.com/spf13/cobra"
@@ -78,6 +79,7 @@ func NewRpkgCommand(ctx context.Context, version string) *cobra.Command {
 		cmdrpkgreject.NewCommand(ctx, kubeflags),
 		cmdrpkgdel.NewCommand(ctx, kubeflags),
 		cmdrpkgcopy.NewCommand(ctx, kubeflags),
+		cmdrpkgupdate.NewCommand(ctx, kubeflags),
 	)
 
 	return repo

--- a/e2e/testdata/porch/rpkg-get/config.yaml
+++ b/e2e/testdata/porch/rpkg-get/config.yaml
@@ -18,6 +18,7 @@ commands:
       test-blueprints-9626794e984ff13c9a4c64df5af0f15ec3a146bf   basens   test-blueprints   main
       test-blueprints-526fa27229adcc3b6a9a544c455c344a3b4d7597   basens   test-blueprints   v1
       test-blueprints-499689d1e0c6fced058158330d922c004367d6cd   basens   test-blueprints   v2
+      test-blueprints-913ab85d2d49621636a0ffa514a2a008e6a7012e   basens   test-blueprints   v3
       test-blueprints-58fffeb908ead18e2c05c873e61bff11a5292963   empty    test-blueprints   main
       test-blueprints-e78ee77d9560703561c2656c97c77e9abb8c4c53   empty    test-blueprints   v1
   - args:
@@ -39,4 +40,5 @@ commands:
       NAME                                                       PACKAGE   REVISION   LATEST   LIFECYCLE   REPOSITORY
       test-blueprints-9626794e984ff13c9a4c64df5af0f15ec3a146bf   basens    main       false    Published   test-blueprints
       test-blueprints-526fa27229adcc3b6a9a544c455c344a3b4d7597   basens    v1         false    Published   test-blueprints
-      test-blueprints-499689d1e0c6fced058158330d922c004367d6cd   basens    v2         true     Published   test-blueprints
+      test-blueprints-499689d1e0c6fced058158330d922c004367d6cd   basens    v2         false    Published   test-blueprints
+      test-blueprints-913ab85d2d49621636a0ffa514a2a008e6a7012e   basens    v3         true     Published   test-blueprints

--- a/internal/cmdrpkgupdate/command.go
+++ b/internal/cmdrpkgupdate/command.go
@@ -1,0 +1,175 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdrpkgupdate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoogleContainerTools/kpt/internal/errors"
+	"github.com/GoogleContainerTools/kpt/internal/util/porch"
+	porchapi "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	command = "cmdrpkgupdate"
+)
+
+func NewCommand(ctx context.Context, rcg *genericclioptions.ConfigFlags) *cobra.Command {
+	return newRunner(ctx, rcg).Command
+}
+
+func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner {
+	r := &runner{
+		ctx: ctx,
+		cfg: rcg,
+	}
+	r.Command = &cobra.Command{
+		Use:     "update SOURCE_PACKAGE",
+		PreRunE: r.preRunE,
+		RunE:    r.runE,
+		Hidden:  porch.HidePorchCommands,
+	}
+	r.Command.Flags().StringVar(&r.revision, "revision", "", "Revision of the upstream package to update to.")
+
+	return r
+}
+
+type runner struct {
+	ctx     context.Context
+	cfg     *genericclioptions.ConfigFlags
+	client  client.Client
+	Command *cobra.Command
+
+	revision string // Target package revision
+}
+
+func (r *runner) preRunE(cmd *cobra.Command, args []string) error {
+	const op errors.Op = command + ".preRunE"
+	client, err := porch.CreateClient(r.cfg)
+	if err != nil {
+		return errors.E(op, err)
+	}
+	r.client = client
+
+	if len(args) < 1 {
+		return errors.E(op, fmt.Errorf("SOURCE_PACKAGE is a required positional argument"))
+	}
+	if len(args) > 1 {
+		return errors.E(op, fmt.Errorf("too many arguments; SOURCE_PACKAGE is the only accepted positional arguments"))
+	}
+
+	// TODO: This should use the latest available revision if one isn't specified.
+	if r.revision == "" {
+		return errors.E(op, fmt.Errorf("revision is required"))
+	}
+
+	return nil
+}
+
+func (r *runner) runE(cmd *cobra.Command, args []string) error {
+	const op errors.Op = command + ".runE"
+
+	var pr porchapi.PackageRevision
+	err := r.client.Get(r.ctx, client.ObjectKey{
+		Namespace: *r.cfg.Namespace,
+		Name:      args[0],
+	}, &pr)
+	if err != nil {
+		return errors.E(op, err)
+	}
+
+	cloneTask, found := r.findCloneTask(&pr)
+	if !found {
+		err := fmt.Errorf("upstream source not found. Only cloned packages can be updated")
+		return errors.E(op, err)
+	}
+
+	switch cloneTask.Clone.Upstream.Type {
+	case porchapi.RepositoryTypeGit:
+		cloneTask.Clone.Upstream.Git.Ref = r.revision
+	case porchapi.RepositoryTypeOCI:
+		err := fmt.Errorf("update not implemented for oci packages")
+		return errors.E(op, err)
+	default:
+		upstreamPr, err := r.findPackageRevision(cloneTask.Clone.Upstream.UpstreamRef.Name)
+		if err != nil {
+			err := fmt.Errorf("error fetch package revisions: %w", err)
+			return errors.E(op, err)
+		}
+		if upstreamPr == nil {
+			err := fmt.Errorf("upstream package revision %s no longer exists", cloneTask.Clone.Upstream.UpstreamRef.Name)
+			return errors.E(op, err)
+		}
+		newUpstreamPr, err := r.findPackageRevisionForRef(upstreamPr.Spec.PackageName)
+		if err != nil {
+			err := fmt.Errorf("error fetching package revisions: %w", err)
+			return errors.E(op, err)
+		}
+		if newUpstreamPr == nil {
+			err := fmt.Errorf("revision %s does not exist for package %s", r.revision, pr.Spec.PackageName)
+			return errors.E(op, err)
+		}
+		cloneTask.Clone.Upstream.UpstreamRef.Name = newUpstreamPr.Name
+	}
+
+	if err := r.client.Update(r.ctx, &pr); err != nil {
+		return errors.E(op, err)
+	}
+	return nil
+}
+
+func (r *runner) findCloneTask(pr *porchapi.PackageRevision) (*porchapi.Task, bool) {
+	for i := len(pr.Spec.Tasks) - 1; i >= 0; i-- {
+		t := pr.Spec.Tasks[i]
+		if t.Type == porchapi.TaskTypeClone {
+			return &t, true
+		}
+	}
+	return nil, false
+}
+
+func (r *runner) findPackageRevision(prName string) (*porchapi.PackageRevision, error) {
+	var prList porchapi.PackageRevisionList
+	if err := r.client.List(r.ctx, &prList, &client.ListOptions{}); err != nil {
+		return nil, err
+	}
+
+	for i := range prList.Items {
+		pr := prList.Items[i]
+		if pr.Name == prName {
+			return &pr, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *runner) findPackageRevisionForRef(name string) (*porchapi.PackageRevision, error) {
+	var prList porchapi.PackageRevisionList
+	if err := r.client.List(r.ctx, &prList, &client.ListOptions{}); err != nil {
+		return nil, err
+	}
+
+	for i := range prList.Items {
+		pr := prList.Items[i]
+		if pr.Spec.PackageName == name && pr.Spec.Revision == r.revision {
+			return &pr, nil
+		}
+	}
+	return nil, nil
+}

--- a/porch/build/Dockerfile.porch
+++ b/porch/build/Dockerfile.porch
@@ -54,6 +54,6 @@ COPY porch/func porch/func
 RUN cd porch; go build -v -o /porch ./cmd/porch
 
 FROM debian:bullseye
-RUN apt update && apt install -y ca-certificates && rm -rf /var/lib/apt && rm -rf /var/cache/apt
+RUN apt update && apt install -y ca-certificates && apt install -y git && rm -rf /var/lib/apt && rm -rf /var/cache/apt
 COPY --from=builder /porch /porch
 ENTRYPOINT ["/porch"]


### PR DESCRIPTION
This updates porch and the kpt cli for updates.

In order to update a package, the client needs to update the upstream reference in the clone task and update the package revision resource in porch. 
In this change, updating a package will lead to an additional clone task (followed by a render task) in the task history for the package. Thus, the task list for a package revision can contain multiple clone tasks. When updating a package, it is required that the last clone task in the package is updated, otherwise it is an error. I'm not sure if this is a good way to do this, but we probably do need some kind of task to associate with the commit corresponding to the update.