### PR TITLE
porch: improve package update machinery

### DIFF
--- a/internal/cmdrpkgupdate/command.go
+++ b/internal/cmdrpkgupdate/command.go
@@ -46,7 +46,6 @@ func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner 
 		Hidden:  porch.HidePorchCommands,
 	}
 	r.Command.Flags().StringVar(&r.revision, "revision", "", "Revision of the upstream package to update to.")
-
 	return r
 }
 

--- a/porch/pkg/engine/clone.go
+++ b/porch/pkg/engine/clone.go
@@ -86,7 +86,7 @@ func (m *clonePackageMutation) cloneFromRegisteredRepository(ctx context.Context
 		return repository.PackageResources{}, fmt.Errorf("upstreamRef.name is required")
 	}
 
-	revision, err := (&PackageFetcher{
+	upstreamRevision, err := (&PackageFetcher{
 		cad:               m.cad,
 		referenceResolver: m.referenceResolver,
 	}).FetchRevision(ctx, ref, m.namespace)
@@ -94,17 +94,12 @@ func (m *clonePackageMutation) cloneFromRegisteredRepository(ctx context.Context
 		return repository.PackageResources{}, fmt.Errorf("failed to fetch package revision %q: %w", ref.Name, err)
 	}
 
-	resources, err := revision.GetResources(ctx)
+	resources, err := upstreamRevision.GetResources(ctx)
 	if err != nil {
 		return repository.PackageResources{}, fmt.Errorf("cannot read contents of package %q: %w", ref.Name, err)
 	}
 
-	// If the upstream we cloned from has its own upstream information, we need to clear and replace it
-	if err := kpt.UpdateKptfileUpstream(m.name, resources.Spec.Resources, v1.Upstream{}, v1.UpstreamLock{}); err != nil {
-		return repository.PackageResources{}, fmt.Errorf("failed to clear upstream lock to package %q: %w", ref.Name, err)
-	}
-
-	upstream, lock, err := revision.GetUpstreamLock()
+	upstream, lock, err := upstreamRevision.GetLock()
 	if err != nil {
 		return repository.PackageResources{}, fmt.Errorf("cannot determine upstream lock for package %q: %w", ref.Name, err)
 	}

--- a/porch/pkg/engine/fake/packagerevision.go
+++ b/porch/pkg/engine/fake/packagerevision.go
@@ -56,3 +56,7 @@ func (f *PackageRevision) GetResources(context.Context) (*v1alpha1.PackageRevisi
 func (f *PackageRevision) GetUpstreamLock() (kptfile.Upstream, kptfile.UpstreamLock, error) {
 	return kptfile.Upstream{}, kptfile.UpstreamLock{}, nil
 }
+
+func (f *PackageRevision) GetLock() (kptfile.Upstream, kptfile.UpstreamLock, error) {
+	return kptfile.Upstream{}, kptfile.UpstreamLock{}, nil
+}

--- a/porch/pkg/engine/mergekey.go
+++ b/porch/pkg/engine/mergekey.go
@@ -1,0 +1,59 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoogleContainerTools/kpt/internal/util/addmergecomment"
+	"github.com/GoogleContainerTools/kpt/porch/pkg/repository"
+	"sigs.k8s.io/kustomize/kyaml/kio"
+)
+
+// addMergeKeyMutation adds merge-key comment directive to reconcile
+// identity of resources in a downstream package with the ones in upstream package
+// This is required to ensure package update is able to merge resources in
+// downstream package with upstream.
+func ensureMergeKey(ctx context.Context, resources repository.PackageResources) (repository.PackageResources, error) {
+	pr := &packageReader{
+		input: resources,
+		extra: map[string]string{},
+	}
+
+	result := repository.PackageResources{
+		Contents: map[string]string{},
+	}
+
+	amc := &addmergecomment.AddMergeComment{}
+
+	pipeline := kio.Pipeline{
+		Inputs:  []kio.Reader{pr},
+		Filters: []kio.Filter{kio.FilterAll(amc)},
+		Outputs: []kio.Writer{&packageWriter{
+			output: result,
+		}},
+	}
+
+	if err := pipeline.Execute(); err != nil {
+		return repository.PackageResources{}, fmt.Errorf("failed to add merge-key directive: %w", err)
+	}
+
+	for k, v := range pr.extra {
+		result.Contents[k] = v
+	}
+
+	return result, nil
+}

--- a/porch/pkg/engine/testdata/update/local/Kptfile
+++ b/porch/pkg/engine/testdata/update/local/Kptfile
@@ -1,0 +1,27 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: backend
+  annotations:
+    config.kubernetes.io/local-config: "true"
+upstream:
+  type: git
+  git:
+    repo: https://github.com/droot/pkg-catalog.git
+    directory: basens
+    ref: basens/v0
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/droot/pkg-catalog.git
+    directory: basens
+    ref: basens/v0
+    commit: b3e1d439516a5e8d49adc0c82d3e95578570dbfa
+info:
+  description: kpt package for provisioning namespace
+pipeline:
+  mutators:
+  - image: gcr.io/kpt-fn/set-namespace:v0.3.4
+    configPath: package-context.yaml
+  - image: gcr.io/kpt-fn/apply-replacements:v0.1.0
+    configPath: update-rolebinding.yaml

--- a/porch/pkg/engine/testdata/update/local/README.md
+++ b/porch/pkg/engine/testdata/update/local/README.md
@@ -1,0 +1,21 @@
+# basens
+
+## Description
+kpt package for provisioning namespace
+
+## Usage
+
+### Fetch the package
+`kpt pkg get REPO_URI[.git]/PKG_PATH[@VERSION] basens`
+Details: https://kpt.dev/reference/cli/pkg/get/
+
+### View package content
+`kpt pkg tree basens`
+Details: https://kpt.dev/reference/cli/pkg/tree/
+
+### Apply the package
+```
+kpt live init basens
+kpt live apply basens --reconcile-timeout=2m --output=table
+```
+Details: https://kpt.dev/reference/cli/live/

--- a/porch/pkg/engine/testdata/update/local/namespace.yaml
+++ b/porch/pkg/engine/testdata/update/local/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata: # kpt-merge: example
+  name: backend
+spec: {}

--- a/porch/pkg/engine/testdata/update/local/package-context.yaml
+++ b/porch/pkg/engine/testdata/update/local/package-context.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kptfile.kpt.dev
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  name: backend

--- a/porch/pkg/engine/testdata/update/local/resourcequota.yaml
+++ b/porch/pkg/engine/testdata/update/local/resourcequota.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata: # kpt-merge: example/default
+  name: default
+  namespace: backend
+spec:
+  hard:
+    cpu: "40"
+    memory: 40G

--- a/porch/pkg/engine/testdata/update/local/rolebinding.yaml
+++ b/porch/pkg/engine/testdata/update/local/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: # kpt-merge: example/app-admin
+  name: app-admin
+  namespace: backend
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: app-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: backend.admin@bigco.com

--- a/porch/pkg/engine/testdata/update/local/update-rolebinding.yaml
+++ b/porch/pkg/engine/testdata/update/local/update-rolebinding.yaml
@@ -1,0 +1,20 @@
+apiVersion: fn.kpt.dev/v1alpha1
+kind: ApplyReplacements
+metadata: # kpt-merge: example/update-rolebinding
+  name: update-rolebinding
+  annotations:
+    config.kubernetes.io/local-config: "true"
+replacements:
+- source:
+    kind: ConfigMap
+    name: kptfile.kpt.dev
+    fieldPath: data.name
+  targets:
+  - select:
+      name: app-admin
+      kind: RoleBinding
+    fieldPaths:
+    - subjects.[kind=Group].name
+    options:
+      delimiter: '.'
+      index: 0

--- a/porch/pkg/engine/testdata/update/original/Kptfile
+++ b/porch/pkg/engine/testdata/update/original/Kptfile
@@ -1,0 +1,14 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: basens
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: kpt package for provisioning namespace
+pipeline:
+  mutators:
+    - image: gcr.io/kpt-fn/set-namespace:v0.3.4
+      configPath: package-context.yaml
+    - image: gcr.io/kpt-fn/apply-replacements:v0.1.0
+      configPath: update-rolebinding.yaml

--- a/porch/pkg/engine/testdata/update/original/README.md
+++ b/porch/pkg/engine/testdata/update/original/README.md
@@ -1,0 +1,21 @@
+# basens
+
+## Description
+kpt package for provisioning namespace
+
+## Usage
+
+### Fetch the package
+`kpt pkg get REPO_URI[.git]/PKG_PATH[@VERSION] basens`
+Details: https://kpt.dev/reference/cli/pkg/get/
+
+### View package content
+`kpt pkg tree basens`
+Details: https://kpt.dev/reference/cli/pkg/tree/
+
+### Apply the package
+```
+kpt live init basens
+kpt live apply basens --reconcile-timeout=2m --output=table
+```
+Details: https://kpt.dev/reference/cli/live/

--- a/porch/pkg/engine/testdata/update/original/namespace.yaml
+++ b/porch/pkg/engine/testdata/update/original/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example
+spec: {}

--- a/porch/pkg/engine/testdata/update/original/package-context.yaml
+++ b/porch/pkg/engine/testdata/update/original/package-context.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kptfile.kpt.dev
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  name: example

--- a/porch/pkg/engine/testdata/update/original/resourcequota.yaml
+++ b/porch/pkg/engine/testdata/update/original/resourcequota.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: default
+  namespace: example
+spec:
+  hard:
+    cpu: "40"
+    memory: 40G

--- a/porch/pkg/engine/testdata/update/original/rolebinding.yaml
+++ b/porch/pkg/engine/testdata/update/original/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: app-admin
+  namespace: example
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: app-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: example.admin@bigco.com

--- a/porch/pkg/engine/testdata/update/original/update-rolebinding.yaml
+++ b/porch/pkg/engine/testdata/update/original/update-rolebinding.yaml
@@ -1,0 +1,20 @@
+apiVersion: fn.kpt.dev/v1alpha1
+kind: ApplyReplacements
+metadata:
+  name: update-rolebinding
+  annotations:
+    config.kubernetes.io/local-config: "true"
+replacements:
+- source:
+    kind: ConfigMap
+    name: kptfile.kpt.dev
+    fieldPath: data.name
+  targets:
+  - select:
+      name: app-admin
+      kind: RoleBinding
+    fieldPaths:
+    - subjects.[kind=Group].name
+    options:
+      delimiter: '.'
+      index: 0

--- a/porch/pkg/engine/testdata/update/updated/Kptfile
+++ b/porch/pkg/engine/testdata/update/updated/Kptfile
@@ -1,0 +1,27 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: backend
+  annotations:
+    config.kubernetes.io/local-config: "true"
+upstream:
+  type: git
+  git:
+    repo: https://github.com/droot/pkg-catalog.git
+    directory: basens
+    ref: basens/v0
+upstreamLock:
+  type: git
+  git:
+    repo: https://github.com/droot/pkg-catalog.git
+    directory: basens
+    ref: basens/v0
+    commit: b3e1d439516a5e8d49adc0c82d3e95578570dbfa
+info:
+  description: kpt package for provisioning namespace
+pipeline:
+  mutators:
+  - image: gcr.io/kpt-fn/set-namespace:v0.3.4
+    configPath: package-context.yaml
+  - image: gcr.io/kpt-fn/apply-replacements:v0.1.0
+    configPath: update-rolebinding.yaml

--- a/porch/pkg/engine/testdata/update/updated/README.md
+++ b/porch/pkg/engine/testdata/update/updated/README.md
@@ -1,0 +1,21 @@
+# basens
+
+## Description
+kpt package for provisioning namespace
+
+## Usage
+
+### Fetch the package
+`kpt pkg get REPO_URI[.git]/PKG_PATH[@VERSION] basens`
+Details: https://kpt.dev/reference/cli/pkg/get/
+
+### View package content
+`kpt pkg tree basens`
+Details: https://kpt.dev/reference/cli/pkg/tree/
+
+### Apply the package
+```
+kpt live init basens
+kpt live apply basens --reconcile-timeout=2m --output=table
+```
+Details: https://kpt.dev/reference/cli/live/

--- a/porch/pkg/engine/testdata/update/updated/namespace.yaml
+++ b/porch/pkg/engine/testdata/update/updated/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata: # kpt-merge: example
+  name: backend
+spec: {}

--- a/porch/pkg/engine/testdata/update/updated/package-context.yaml
+++ b/porch/pkg/engine/testdata/update/updated/package-context.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kptfile.kpt.dev
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  name: backend

--- a/porch/pkg/engine/testdata/update/updated/resourcequota.yaml
+++ b/porch/pkg/engine/testdata/update/updated/resourcequota.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata: # kpt-merge: example/default
+  name: default
+  namespace: backend
+spec:
+  hard:
+    cpu: "40"
+    memory: 60G

--- a/porch/pkg/engine/testdata/update/updated/rolebinding.yaml
+++ b/porch/pkg/engine/testdata/update/updated/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata: # kpt-merge: example/app-admin
+  name: app-admin
+  namespace: backend
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: app-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: backend.admin@bigco.com

--- a/porch/pkg/engine/testdata/update/updated/update-rolebinding.yaml
+++ b/porch/pkg/engine/testdata/update/updated/update-rolebinding.yaml
@@ -1,0 +1,20 @@
+apiVersion: fn.kpt.dev/v1alpha1
+kind: ApplyReplacements
+metadata: # kpt-merge: example/update-rolebinding
+  name: update-rolebinding
+  annotations:
+    config.kubernetes.io/local-config: "true"
+replacements:
+- source:
+    kind: ConfigMap
+    name: kptfile.kpt.dev
+    fieldPath: data.name
+  targets:
+  - select:
+      name: app-admin
+      kind: RoleBinding
+    fieldPaths:
+    - subjects.[kind=Group].name
+    options:
+      delimiter: '.'
+      index: 0

--- a/porch/pkg/engine/testdata/update/upstream/Kptfile
+++ b/porch/pkg/engine/testdata/update/upstream/Kptfile
@@ -1,0 +1,14 @@
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: basens
+  annotations:
+    config.kubernetes.io/local-config: "true"
+info:
+  description: kpt package for provisioning namespace
+pipeline:
+  mutators:
+  - image: gcr.io/kpt-fn/set-namespace:v0.3.4
+    configPath: package-context.yaml
+  - image: gcr.io/kpt-fn/apply-replacements:v0.1.0
+    configPath: update-rolebinding.yaml

--- a/porch/pkg/engine/testdata/update/upstream/README.md
+++ b/porch/pkg/engine/testdata/update/upstream/README.md
@@ -1,0 +1,21 @@
+# basens
+
+## Description
+kpt package for provisioning namespace
+
+## Usage
+
+### Fetch the package
+`kpt pkg get REPO_URI[.git]/PKG_PATH[@VERSION] basens`
+Details: https://kpt.dev/reference/cli/pkg/get/
+
+### View package content
+`kpt pkg tree basens`
+Details: https://kpt.dev/reference/cli/pkg/tree/
+
+### Apply the package
+```
+kpt live init basens
+kpt live apply basens --reconcile-timeout=2m --output=table
+```
+Details: https://kpt.dev/reference/cli/live/

--- a/porch/pkg/engine/testdata/update/upstream/namespace.yaml
+++ b/porch/pkg/engine/testdata/update/upstream/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example
+spec: {}

--- a/porch/pkg/engine/testdata/update/upstream/package-context.yaml
+++ b/porch/pkg/engine/testdata/update/upstream/package-context.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kptfile.kpt.dev
+  annotations:
+    config.kubernetes.io/local-config: "true"
+data:
+  name: example

--- a/porch/pkg/engine/testdata/update/upstream/resourcequota.yaml
+++ b/porch/pkg/engine/testdata/update/upstream/resourcequota.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: default
+  namespace: example
+spec:
+  hard:
+    cpu: "40"
+    memory: 60G

--- a/porch/pkg/engine/testdata/update/upstream/rolebinding.yaml
+++ b/porch/pkg/engine/testdata/update/upstream/rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: app-admin
+  namespace: example
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: app-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: example.admin@bigco.com

--- a/porch/pkg/engine/testdata/update/upstream/update-rolebinding.yaml
+++ b/porch/pkg/engine/testdata/update/upstream/update-rolebinding.yaml
@@ -1,0 +1,20 @@
+apiVersion: fn.kpt.dev/v1alpha1
+kind: ApplyReplacements
+metadata:
+  name: update-rolebinding
+  annotations:
+    config.kubernetes.io/local-config: "true"
+replacements:
+- source:
+    kind: ConfigMap
+    name: kptfile.kpt.dev
+    fieldPath: data.name
+  targets:
+  - select:
+      name: app-admin
+      kind: RoleBinding
+    fieldPaths:
+    - subjects.[kind=Group].name
+    options:
+      delimiter: '.'
+      index: 0

--- a/porch/pkg/engine/update.go
+++ b/porch/pkg/engine/update.go
@@ -1,0 +1,105 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/GoogleContainerTools/kpt/internal/printer"
+	"github.com/GoogleContainerTools/kpt/internal/util/update"
+	"github.com/GoogleContainerTools/kpt/porch/pkg/repository"
+)
+
+// packageUpdater knows how to update a local package given original and upstream package resources.
+type packageUpdater interface {
+	Update(ctx context.Context, localResources, originalResources, upstreamResources repository.PackageResources) (updatedResources repository.PackageResources, err error)
+}
+
+// defaultPackageUpdater implements packageUpdater interface.
+type defaultPackageUpdater struct{}
+
+func (m *defaultPackageUpdater) Update(
+	ctx context.Context,
+	localResources,
+	originalResources,
+	upstreamResources repository.PackageResources) (updatedResources repository.PackageResources, err error) {
+
+	localDir, err := ioutil.TempDir("", "kpt-pkg-update-*")
+	if err != nil {
+		return repository.PackageResources{}, err
+	}
+	defer os.RemoveAll(localDir)
+
+	originalDir, err := ioutil.TempDir("", "kpt-pkg-update-*")
+	if err != nil {
+		return repository.PackageResources{}, err
+	}
+	defer os.RemoveAll(originalDir)
+
+	upstreamDir, err := ioutil.TempDir("", "kpt-pkg-update-*")
+	if err != nil {
+		return repository.PackageResources{}, err
+	}
+	defer os.RemoveAll(upstreamDir)
+
+	if err := writeResourcesToDirectory(localDir, localResources); err != nil {
+		return repository.PackageResources{}, err
+	}
+
+	if err := writeResourcesToDirectory(originalDir, originalResources); err != nil {
+		return repository.PackageResources{}, err
+	}
+
+	if err := writeResourcesToDirectory(upstreamDir, upstreamResources); err != nil {
+		return repository.PackageResources{}, err
+	}
+
+	if err := m.do(ctx, localDir, originalDir, upstreamDir); err != nil {
+		return repository.PackageResources{}, err
+	}
+
+	return loadResourcesFromDirectory(localDir)
+}
+
+// PkgUpdate is a wrapper around `kpt pkg update`, running it against the package in packageDir
+func (m *defaultPackageUpdater) do(ctx context.Context, localPkgDir, originalPkgDir, upstreamPkgDir string) error {
+	// TODO: Printer should be a logr
+	pr := printer.New(os.Stdout, os.Stderr)
+	ctx = printer.WithContext(ctx, pr)
+
+	{
+		relPath := "."
+		localPath := filepath.Join(localPkgDir, relPath)
+		updatedPath := filepath.Join(upstreamPkgDir, relPath)
+		originPath := filepath.Join(originalPkgDir, relPath)
+		isRoot := true
+
+		updateOptions := update.Options{
+			RelPackagePath: relPath,
+			LocalPath:      localPath,
+			UpdatedPath:    updatedPath,
+			OriginPath:     originPath,
+			IsRoot:         isRoot,
+		}
+		updater := update.ResourceMergeUpdater{}
+		if err := updater.Update(updateOptions); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/porch/pkg/engine/update_test.go
+++ b/porch/pkg/engine/update_test.go
@@ -1,0 +1,65 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestPkgUpdate(t *testing.T) {
+	dfUpdater := &defaultPackageUpdater{}
+
+	testdata, err := filepath.Abs(filepath.Join(".", "testdata", "update"))
+	if err != nil {
+		t.Fatalf("Failed to find testdata: %v", err)
+	}
+
+	localResources, err := loadResourcesFromDirectory(filepath.Join(testdata, "local"))
+	if err != nil {
+		t.Fatalf("failed to read local resources: %v", err)
+	}
+
+	originalResources, err := loadResourcesFromDirectory(filepath.Join(testdata, "original"))
+	if err != nil {
+		t.Fatalf("failed to read original resources: %v", err)
+	}
+
+	upstreamResources, err := loadResourcesFromDirectory(filepath.Join(testdata, "upstream"))
+	if err != nil {
+		t.Fatalf("failed to read upstream resources: %v", err)
+	}
+
+	expectedResources, err := loadResourcesFromDirectory(filepath.Join(testdata, "updated"))
+	if err != nil {
+		t.Fatalf("failed to read expected updated resources: %v", err)
+	}
+
+	updatedResources, err := dfUpdater.Update(context.Background(), localResources, originalResources, upstreamResources)
+	if err != nil {
+		t.Errorf("unexpected err: %v", err)
+	}
+
+	for k, v := range updatedResources.Contents {
+		want := expectedResources.Contents[k]
+		if diff := cmp.Diff(want, v); diff != "" && k != "Kptfile" {
+			// TODO(droot): figure out correct expectation for Kptfile
+			t.Errorf("file: %s unexpected result (-want, +got): %s", k, diff)
+		}
+	}
+}

--- a/porch/pkg/git/draft.go
+++ b/porch/pkg/git/draft.go
@@ -175,7 +175,7 @@ func (r *gitRepository) closeDraft(ctx context.Context, d *gitPackageDraft) (*gi
 	}
 
 	return &gitPackageRevision{
-		parent:   d.parent,
+		repo:     d.parent,
 		path:     d.path,
 		revision: d.revision,
 		updated:  d.updated,

--- a/porch/pkg/git/package.go
+++ b/porch/pkg/git/package.go
@@ -203,6 +203,10 @@ func (p *gitPackageRevision) GetUpstreamLock() (kptfile.Upstream, kptfile.Upstre
 	return *kf.Upstream, *kf.UpstreamLock, nil
 }
 
+func (p *gitPackageRevision) GetLock() (kptfile.Upstream, kptfile.UpstreamLock, error) {
+	return p.findParent()
+}
+
 func (p *gitPackageRevision) findParent() (kptfile.Upstream, kptfile.UpstreamLock, error) {
 	repo, err := p.parent.getRepo()
 	if err != nil {

--- a/porch/pkg/git/package.go
+++ b/porch/pkg/git/package.go
@@ -33,7 +33,7 @@ import (
 )
 
 type gitPackageRevision struct {
-	parent   *gitRepository
+	repo     *gitRepository // repo is repo containing the package
 	path     string
 	revision string
 	updated  time.Time
@@ -54,13 +54,13 @@ var _ repository.PackageRevision = &gitPackageRevision{}
 // layer, the prefix will be removed (this may happen without notice) so it should not
 // be relied upon by clients.
 func (p *gitPackageRevision) KubeObjectName() string {
-	hash := sha1.Sum([]byte(fmt.Sprintf("%s:%s:%s", p.parent.name, p.path, p.revision)))
-	return p.parent.name + "-" + hex.EncodeToString(hash[:])
+	hash := sha1.Sum([]byte(fmt.Sprintf("%s:%s:%s", p.repo.name, p.path, p.revision)))
+	return p.repo.name + "-" + hex.EncodeToString(hash[:])
 }
 
 func (p *gitPackageRevision) Key() repository.PackageRevisionKey {
 	return repository.PackageRevisionKey{
-		Repository: p.parent.name,
+		Repository: p.repo.name,
 		Package:    p.path,
 		Revision:   p.revision,
 	}
@@ -75,17 +75,20 @@ func (p *gitPackageRevision) GetPackageRevision() *v1alpha1.PackageRevision {
 
 	_, lock, _ := p.GetUpstreamLock()
 
+	lockCopy := &v1alpha1.UpstreamLock{}
 	// TODO: Use kpt definition of UpstreamLock in the package revision status
 	// when https://github.com/GoogleContainerTools/kpt/issues/3297 is complete.
 	// Until then, we have to translate from one type to another.
-	lockCopy := &v1alpha1.UpstreamLock{
-		Type: v1alpha1.OriginType(lock.Type),
-		Git: &v1alpha1.GitLock{
-			Repo:      lock.Git.Repo,
-			Directory: lock.Git.Directory,
-			Commit:    lock.Git.Commit,
-			Ref:       lock.Git.Ref,
-		},
+	if lock.Git != nil {
+		lockCopy = &v1alpha1.UpstreamLock{
+			Type: v1alpha1.OriginType(lock.Type),
+			Git: &v1alpha1.GitLock{
+				Repo:      lock.Git.Repo,
+				Directory: lock.Git.Directory,
+				Commit:    lock.Git.Commit,
+				Ref:       lock.Git.Ref,
+			},
+		}
 	}
 
 	return &v1alpha1.PackageRevision{
@@ -95,7 +98,7 @@ func (p *gitPackageRevision) GetPackageRevision() *v1alpha1.PackageRevision {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            p.KubeObjectName(),
-			Namespace:       p.parent.namespace,
+			Namespace:       p.repo.namespace,
 			UID:             p.uid(),
 			ResourceVersion: p.commit.String(),
 			CreationTimestamp: metav1.Time{
@@ -119,7 +122,7 @@ func (p *gitPackageRevision) GetPackageRevision() *v1alpha1.PackageRevision {
 func (p *gitPackageRevision) GetResources(ctx context.Context) (*v1alpha1.PackageRevisionResources, error) {
 	resources := map[string]string{}
 
-	tree, err := p.parent.repo.TreeObject(p.tree)
+	tree, err := p.repo.repo.TreeObject(p.tree)
 	if err == nil {
 		// Files() iterator iterates recursively over all files in the tree.
 		fit := tree.Files()
@@ -152,7 +155,7 @@ func (p *gitPackageRevision) GetResources(ctx context.Context) (*v1alpha1.Packag
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            p.KubeObjectName(),
-			Namespace:       p.parent.namespace,
+			Namespace:       p.repo.namespace,
 			UID:             p.uid(),
 			ResourceVersion: p.commit.String(),
 			CreationTimestamp: metav1.Time{
@@ -170,16 +173,7 @@ func (p *gitPackageRevision) GetResources(ctx context.Context) (*v1alpha1.Packag
 	}, nil
 }
 
-// GetUpstreamLock returns the upstream for a package revision. The logic here is a little convoluted because
-// the upstream can come from different places depending on the task.
-// When cloning, the upstream is not available yet in the Kptfile, and is instead stored in the `parent` pointer.
-// When editing, the upstream is available in the Kptfile, and the `parent` pointer doesn't point
-// to the upstream (it points to the previous package revision that we have edited/copied from).
-// What we do here for now is to treat the Kptfile as the source of truth, and only look at `parent` if we
-// cannot get the upstream information from the Kptfile. When we do a clone task, we clear the Kptfile's upstream
-// field so that when we call GetUpstreamLock we end up looking at `parent`.
-// We may want to revisit this implementation in the future to make it easier to understand what is happening.
-// See discussion here https://github.com/GoogleContainerTools/kpt/pull/3301/files#r896190293.
+// GetUpstreamLock returns the upstreamLock info present in the Kptfile of the package.
 func (p *gitPackageRevision) GetUpstreamLock() (kptfile.Upstream, kptfile.UpstreamLock, error) {
 	resources, err := p.GetResources(context.Background())
 	if err != nil {
@@ -196,19 +190,17 @@ func (p *gitPackageRevision) GetUpstreamLock() (kptfile.Upstream, kptfile.Upstre
 	}
 
 	if kf.Upstream == nil || kf.UpstreamLock == nil || kf.Upstream.Git == nil {
-		// upstream information is not in Kptfile yet (this can happen when we clone from the upstream for the first time),
-		// so we get it from the parent repo instead.
-		return p.findParent()
+		// the package doesn't have any upstream package.
+		return kptfile.Upstream{}, kptfile.UpstreamLock{}, nil
 	}
 	return *kf.Upstream, *kf.UpstreamLock, nil
 }
 
+// GetLock returns the self version of the package. Think of it as the Git commit information
+// that represent the package revision of this package. Please note that it uses Upstream types
+// to represent this information but it has no connection with the associated upstream package (if any).
 func (p *gitPackageRevision) GetLock() (kptfile.Upstream, kptfile.UpstreamLock, error) {
-	return p.findParent()
-}
-
-func (p *gitPackageRevision) findParent() (kptfile.Upstream, kptfile.UpstreamLock, error) {
-	repo, err := p.parent.getRepo()
+	repo, err := p.repo.getRepo()
 	if err != nil {
 		return kptfile.Upstream{}, kptfile.UpstreamLock{}, fmt.Errorf("cannot determine package lock: %w", err)
 	}

--- a/porch/pkg/git/package_test.go
+++ b/porch/pkg/git/package_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-func (g GitSuite) TestUpstreamLock(t *testing.T) {
+func (g GitSuite) TestLock(t *testing.T) {
 	tempdir := t.TempDir()
 	tarfile := filepath.Join("testdata", "drafts-repository.tar")
 	repo, address := ServeGitRepositoryWithBranch(t, tarfile, tempdir, g.branch)
@@ -69,7 +69,7 @@ func (g GitSuite) TestUpstreamLock(t *testing.T) {
 			continue
 		}
 
-		upstream, lock, err := rev.GetUpstreamLock()
+		upstream, lock, err := rev.GetLock()
 		if err != nil {
 			t.Errorf("GetUpstreamLock(%q) failed: %v", rev.Key(), err)
 		}

--- a/porch/pkg/git/package_tree.go
+++ b/porch/pkg/git/package_tree.go
@@ -59,7 +59,7 @@ func (p *packageListEntry) buildGitPackageRevision(ctx context.Context, revision
 	}
 
 	return &gitPackageRevision{
-		parent:   repo,
+		repo:     repo,
 		path:     p.path,
 		revision: revision,
 		updated:  p.parent.commit.Author.When,

--- a/porch/pkg/kpt/clone.go
+++ b/porch/pkg/kpt/clone.go
@@ -34,7 +34,9 @@ func UpdateUpstream(kptfileContents string, name string, upstream kptfilev1.Upst
 	// populate the cloneFrom values so we know where the package came from
 	kptfile.UpstreamLock = &lock
 	kptfile.Upstream = &upstream
-	kptfile.Name = name
+	if name != "" {
+		kptfile.Name = name
+	}
 
 	b, err := yaml.MarshalWithOptions(kptfile, &yaml.EncoderOptions{SeqIndent: yaml.WideSequenceStyle})
 	if err != nil {

--- a/porch/pkg/oci/oci.go
+++ b/porch/pkg/oci/oci.go
@@ -389,6 +389,10 @@ func (p *ociPackageRevision) GetUpstreamLock() (kptfile.Upstream, kptfile.Upstre
 	return kptfile.Upstream{}, kptfile.UpstreamLock{}, fmt.Errorf("UpstreamLock is not supported for OCI packages (%s)", p.KubeObjectName())
 }
 
+func (p *ociPackageRevision) GetLock() (kptfile.Upstream, kptfile.UpstreamLock, error) {
+	return kptfile.Upstream{}, kptfile.UpstreamLock{}, fmt.Errorf("Lock is not supported for OCI packages (%s)", p.KubeObjectName())
+}
+
 func (p *ociPackageRevision) Lifecycle() v1alpha1.PackageRevisionLifecycle {
 	// TODO: implement package lifecycle for OCI.
 	return v1alpha1.PackageRevisionLifecyclePublished

--- a/porch/pkg/repository/repository.go
+++ b/porch/pkg/repository/repository.go
@@ -59,6 +59,10 @@ type PackageRevision interface {
 
 	// GetUpstreamLock returns the kpt lock information.
 	GetUpstreamLock() (kptfile.Upstream, kptfile.UpstreamLock, error)
+
+	// GetLock returns the current revision's lock information.
+	// This will be the upstream info for downstream revisions.
+	GetLock() (kptfile.Upstream, kptfile.UpstreamLock, error)
 }
 
 type PackageDraft interface {


### PR DESCRIPTION
This PR does the following:
 - Ensures `#kpt-merge` comments are added to package resources on `cloning` . This is required for `pkg update` to establish identity of resources across downstream/upstream packages.
 - improves the package update logic ( the `updatePackageMutation` code) in following ways:
   - support for upgrading to porch registered upstream packages with better error checking etc.
   - no longer depends on `git` command line to fetch the upstream package resources.
   - Ensures `merge-key` is added upon 'update` for new resources
   - Introduces `PkgUpdater` interface (and default implementation) that makes `updater` to be pluggable and testable. Added unit tests for it. This should help us evolve update functionality without impacting rest of the porch machinery. 
 - Misc renaming/refactoring around self-lock and upstream-lock information

 