### PR TITLE
Add task annotation to commits for published packages

### DIFF
--- a/internal/cmdrpkgcopy/command.go
+++ b/internal/cmdrpkgcopy/command.go
@@ -26,9 +26,8 @@ import (
 	porchapi "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -98,6 +97,7 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return errors.E(op, err)
 	}
+
 	pr := &porchapi.PackageRevision{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PackageRevision",
@@ -116,23 +116,11 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 }
 
 func (r *runner) getPackageRevisionSpec() (*porchapi.PackageRevisionSpec, error) {
-	newScheme := runtime.NewScheme()
-	if err := porchapi.SchemeBuilder.AddToScheme(newScheme); err != nil {
-		return nil, err
-	}
-	restClient, err := porch.CreateRESTClient(r.cfg)
-	if err != nil {
-		return nil, err
-	}
-
 	packageRevision := porchapi.PackageRevision{}
-	err = restClient.
-		Get().
-		Namespace(*r.cfg.Namespace).
-		Resource("packagerevisions").
-		Name(r.copy.Source.Name).
-		Do(r.ctx).
-		Into(&packageRevision)
+	err := r.client.Get(r.ctx, types.NamespacedName{
+		Name:      r.copy.Source.Name,
+		Namespace: *r.cfg.Namespace,
+	}, &packageRevision)
 	if err != nil {
 		return nil, err
 	}
@@ -142,7 +130,6 @@ func (r *runner) getPackageRevisionSpec() (*porchapi.PackageRevisionSpec, error)
 		r.revision, err = r.defaultPackageRevision(
 			packageRevision.Spec.PackageName,
 			packageRevision.Spec.RepositoryName,
-			restClient,
 		)
 		if err != nil {
 			return nil, err
@@ -154,22 +141,17 @@ func (r *runner) getPackageRevisionSpec() (*porchapi.PackageRevisionSpec, error)
 		Revision:       r.revision,
 		RepositoryName: packageRevision.Spec.RepositoryName,
 	}
-	spec.Tasks = []porchapi.Task{{Type: porchapi.TaskTypeEdit, Edit: &r.copy}}
+	spec.Tasks = packageRevision.Spec.Tasks
 	return spec, nil
 }
 
 // defaultPackageRevision attempts to return a default package revision number
 // of "latest + 1" given a package name, repository, and namespace. It only
 // understands revisions following `v[0-9]+` formats.
-func (r *runner) defaultPackageRevision(packageName, repository string, restClient rest.Interface) (string, error) {
+func (r *runner) defaultPackageRevision(packageName, repository string) (string, error) {
 	// get all package revisions
 	packageRevisionList := porchapi.PackageRevisionList{}
-	err := restClient.
-		Get().
-		Namespace(*r.cfg.Namespace).
-		Resource("packagerevisions").
-		Do(r.ctx).
-		Into(&packageRevisionList)
+	err := r.client.List(r.ctx, &packageRevisionList, client.InNamespace(*r.cfg.Namespace))
 	if err != nil {
 		return "", err
 	}

--- a/porch/pkg/git/annotation.go
+++ b/porch/pkg/git/annotation.go
@@ -33,8 +33,15 @@ type gitAnnotation struct {
 	// without having to check file paths.
 	PackagePath string `json:"package,omitempty"`
 
-	// Tasks holds the task we performed, if a task caused the commit.
+	// Revision hold the revision of the package revision the commit
+	// belongs to.
+	Revision string `json:"revision,omitempty"`
+
+	// Task holds the task we performed, if a task caused the commit.
 	Task *v1alpha1.Task `json:"task,omitempty"`
+
+	// Tasks holds the tasks performed if there are more than one.
+	Tasks []*v1alpha1.Task `json:"tasks,omitempty"`
 }
 
 // ExtractGitAnnotations reads the gitAnnotations from the given commit.

--- a/porch/pkg/git/package_tree.go
+++ b/porch/pkg/git/package_tree.go
@@ -53,7 +53,7 @@ type packageListEntry struct {
 // TODO: Can packageListEntry just _be_ a gitPackageRevision?
 func (p *packageListEntry) buildGitPackageRevision(ctx context.Context, revision string, ref *plumbing.Reference) (*gitPackageRevision, error) {
 	repo := p.parent.parent
-	tasks, err := repo.loadTasks(ctx, p.parent.commit, p.path)
+	tasks, err := repo.loadTasks(ctx, p.parent.commit, p.path, revision)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This updates Porch to store the tasks for Package Revisions in commits for Published packages. Up until now, the tasks were not included in the commit generated as part of publishing a package.

This achieves this by adding the list of tasks to the commit annotation, so while it keeps the tasks, the changes caused by each task is no longer separated into separate commits. It also adds the revision of the package revision to the annotation, which allows us to only find the tasks that belong to a specific package revision. If we want to look at the tasks further back, those will be available by following the reference to the upstream package in the clone task.

This doesn't preserve the individual commits after approval, but I think we can address that separately.
