### PR TITLE
feat: disable client-side throttling

### DIFF
--- a/commands/factory.go
+++ b/commands/factory.go
@@ -15,18 +15,25 @@
 package commands
 
 import (
+	"context"
 	"flag"
 	"fmt"
+	"time"
 
 	"github.com/GoogleContainerTools/kpt/internal/util/cfgflags"
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 	cluster "k8s.io/kubectl/pkg/cmd/util"
+	"sigs.k8s.io/cli-utils/pkg/flowcontrol"
 )
 
 func newFactory(cmd *cobra.Command, version string) cluster.Factory {
 	flags := cmd.PersistentFlags()
-	kubeConfigFlags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
+	kubeConfigFlags := genericclioptions.NewConfigFlags(true).
+		WithDeprecatedPasswordFlag().
+		WithWrapConfigFn(UpdateQPS)
 	kubeConfigFlags.AddFlags(flags)
 	userAgentKubeConfigFlags := &cfgflags.UserAgentKubeConfigFlags{
 		Delegate:  kubeConfigFlags,
@@ -34,4 +41,48 @@ func newFactory(cmd *cobra.Command, version string) cluster.Factory {
 	}
 	cmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 	return cluster.NewFactory(userAgentKubeConfigFlags)
+}
+
+// UpdateQPS modifies a rest.Config to update the client-side throttling QPS and
+// Burst QPS.
+//
+// If Flow Control is enabled on the apiserver, client-side throttling is
+// disabled!
+//
+// If Flow Control is disabled or undetected on the apiserver, client-side
+// throttling QPS will be increased to at least 30 (burst: 60).
+//
+// Flow Control is enabled by default on Kubernetes v1.20+.
+// https://kubernetes.io/docs/concepts/cluster-administration/flow-control/
+func UpdateQPS(config *rest.Config) *rest.Config {
+	// Timeout if the query takes too long, defaulting to the lower QPS limits.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	enabled, err := flowcontrol.IsEnabled(ctx, config)
+	if err != nil {
+		klog.Warning("Failed to query apiserver to check for flow control enablement: %v", err)
+		// Default to the lower QPS limits.
+	}
+	if enabled {
+		config.QPS = -1
+		config.Burst = -1
+		klog.V(1).Infof("Flow control enabled on apiserver: client-side throttling QPS set to %.0f (burst: %d)", config.QPS, config.Burst)
+	} else {
+		config.QPS = maxIfNotNegative(config.QPS, 30)
+		config.Burst = int(maxIfNotNegative(float32(config.Burst), 60))
+		klog.V(1).Infof("Flow control disabled on apiserver: client-side throttling QPS set to %.0f (burst: %d)", config.QPS, config.Burst)
+	}
+	return config
+}
+
+func maxIfNotNegative(a, b float32) float32 {
+	switch {
+	case a < 0:
+		return a
+	case a > b:
+		return a
+	default:
+		return b
+	}
 }


### PR DESCRIPTION
- Disable client-side throttling when server-side throttling is enabled.
  Otherwise default to 30 QPS (60 burst QPS).
  This is an increase from the rest.Config default of 5 QPS.

Based on my local performance testing, it looks like kpt v1.0.0-beta.16 has a performance regression that defaults the applier to 5 QPS. I haven't quite figured out why, but earlier versions (like v1.0.0-beta.15) are much faster.

This change both fixes the regression and removes the QPS limit on servers where server-side throttling is enabled. The beta feature flag is enabled by default on K8s v1.20+.