### PR TITLE
function test harness option to skip tests locally

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           git config --global user.email you@example.com
           git config --global user.name Your Name
-          make all
-          make test-docker
+          IN_CI=true make all
+          IN_CI=true make test-docker
         env:
           KPT_FN_RUNTIME: ${{ matrix.runtime }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           git config --global user.email you@example.com
           git config --global user.name Your Name
-          IN_CI=true make all
-          IN_CI=true make test-docker
+          make all
+          make test-docker
         env:
           KPT_FN_RUNTIME: ${{ matrix.runtime }}

--- a/pkg/test/runner/README.md
+++ b/pkg/test/runner/README.md
@@ -22,6 +22,7 @@ in `.expected`:
     used to run the test. Default: `render`.
   - `exitCode`: The expected exit code for the command. Default: 0.
   - `skip`: Runner will skip the test if `skip` is set to true. Default: false.
+  - `skipIfLocal`: Runner will skip the test if the env var IN_CI is "false" or not set. Default: false.
   - `sequential`: This test case should be run sequentially. Default: false.
   - `runtimes`: If the current runtime doesn't match any of the desired runtimes
     here, the test case will be skipped. Valid values are `docker` and `podman`.

--- a/pkg/test/runner/README.md
+++ b/pkg/test/runner/README.md
@@ -22,7 +22,7 @@ in `.expected`:
     used to run the test. Default: `render`.
   - `exitCode`: The expected exit code for the command. Default: 0.
   - `skip`: Runner will skip the test if `skip` is set to true. Default: false.
-  - `skipIfLocal`: Runner will skip the test if the env var IN_CI is "false" or not set. Default: false.
+  - `skipLocal`: Runner will skip the test if the env var CI is "false" or not set. Default: false.
   - `sequential`: This test case should be run sequentially. Default: false.
   - `runtimes`: If the current runtime doesn't match any of the desired runtimes
     here, the test case will be skipped. Valid values are `docker` and `podman`.

--- a/pkg/test/runner/config.go
+++ b/pkg/test/runner/config.go
@@ -85,8 +85,8 @@ type TestCaseConfig struct {
 	// Skip means should this test case be skipped. Default: false
 	Skip bool `json:"skip,omitempty" yaml:"skip,omitempty"`
 
-	// SkipIfLocal means should this test case be skipped if the env var IN_CI is "false" or not set. Default: false
-	SkipIfLocal bool `json:"skipIfLocal,omitempty" yaml:"skipIfLocal,omitempty"`
+	// SkipLocal means this test case should be skipped if the env var CI is "false" or not set. Default: false
+	SkipLocal bool `json:"skipLocal,omitempty" yaml:"skipLocal,omitempty"`
 
 	// Debug means will the debug behavior be enabled. Default: false
 	// Debug behavior:

--- a/pkg/test/runner/config.go
+++ b/pkg/test/runner/config.go
@@ -85,6 +85,9 @@ type TestCaseConfig struct {
 	// Skip means should this test case be skipped. Default: false
 	Skip bool `json:"skip,omitempty" yaml:"skip,omitempty"`
 
+	// SkipIfLocal means should this test case be skipped if the env var IN_CI is "false" or not set. Default: false
+	SkipIfLocal bool `json:"skipIfLocal,omitempty" yaml:"skipIfLocal,omitempty"`
+
 	// Debug means will the debug behavior be enabled. Default: false
 	// Debug behavior:
 	//  1. Keep the temporary directory used to run the test cases

--- a/pkg/test/runner/runner.go
+++ b/pkg/test/runner/runner.go
@@ -503,13 +503,13 @@ func (r *Runner) Skip() bool {
 	if r.testCase.Config.Skip {
 		return true
 	}
-	if r.testCase.Config.SkipIfLocal {
-		// default to the value of env var IS_CI
+	if r.testCase.Config.SkipLocal {
+		// default to the value of env var CI
 		var inCI bool
-		if value, exists := os.LookupEnv("IN_CI"); exists {
+		if value, exists := os.LookupEnv("CI"); exists {
 			inCI, _ = strconv.ParseBool(strings.TrimSpace(value))
 		}
-		// if IN_CI is false, we are running locally, and we should skip the test.
+		// if CI is false, we are running locally, and we should skip the test.
 		return !inCI
 	}
 	return false

--- a/pkg/test/runner/runner.go
+++ b/pkg/test/runner/runner.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -499,7 +500,19 @@ func (r *Runner) compareOutput(stdout string, stderr string) error {
 }
 
 func (r *Runner) Skip() bool {
-	return r.testCase.Config.Skip
+	if r.testCase.Config.Skip {
+		return true
+	}
+	if r.testCase.Config.SkipIfLocal {
+		// default to the value of env var IS_CI
+		var inCI bool
+		if value, exists := os.LookupEnv("IN_CI"); exists {
+			inCI, _ = strconv.ParseBool(strings.TrimSpace(value))
+		}
+		// if IN_CI is false, we are running locally, and we should skip the test.
+		return !inCI
+	}
+	return false
 }
 
 func readActualResults(resultsPath string) (string, error) {


### PR DESCRIPTION
Add option to function test config: `skipIfLocal`. If this is set, then the test runner will check for an env variable `IN_CI`. If `IN_CI` is not set to true, then we assume that we are running the test locally and skip the test.

This also sets `IN_CI=true` to the CI job. 