### PR TITLE
Fix broken porch cli e2e tests

### DIFF
--- a/e2e/testdata/porch/rpkg-get/config.yaml
+++ b/e2e/testdata/porch/rpkg-get/config.yaml
@@ -17,6 +17,7 @@ commands:
       NAME                                                       PKG      REPO              REV
       test-blueprints-9626794e984ff13c9a4c64df5af0f15ec3a146bf   basens   test-blueprints   main
       test-blueprints-526fa27229adcc3b6a9a544c455c344a3b4d7597   basens   test-blueprints   v1
+      test-blueprints-499689d1e0c6fced058158330d922c004367d6cd   basens   test-blueprints   v2
       test-blueprints-58fffeb908ead18e2c05c873e61bff11a5292963   empty    test-blueprints   main
       test-blueprints-e78ee77d9560703561c2656c97c77e9abb8c4c53   empty    test-blueprints   v1
   - args:
@@ -27,7 +28,7 @@ commands:
       - test-blueprints-526fa27229adcc3b6a9a544c455c344a3b4d7597
     stdout: |
       NAME                                                       PACKAGE   REVISION   LATEST   LIFECYCLE   REPOSITORY
-      test-blueprints-526fa27229adcc3b6a9a544c455c344a3b4d7597   basens    v1         true     Published   test-blueprints
+      test-blueprints-526fa27229adcc3b6a9a544c455c344a3b4d7597   basens    v1         false    Published   test-blueprints
   - args:
       - alpha
       - rpkg
@@ -37,4 +38,5 @@ commands:
     stdout: |
       NAME                                                       PACKAGE   REVISION   LATEST   LIFECYCLE   REPOSITORY
       test-blueprints-9626794e984ff13c9a4c64df5af0f15ec3a146bf   basens    main       false    Published   test-blueprints
-      test-blueprints-526fa27229adcc3b6a9a544c455c344a3b4d7597   basens    v1         true     Published   test-blueprints
+      test-blueprints-526fa27229adcc3b6a9a544c455c344a3b4d7597   basens    v1         false    Published   test-blueprints
+      test-blueprints-499689d1e0c6fced058158330d922c004367d6cd   basens    v2         true     Published   test-blueprints


### PR DESCRIPTION
This fixes the broken porch cli e2e tests. The cause of the test failures is that I added an additional revision to the test repo used in the tests