### PR TITLE
rewrite and expose the git implementation of finding the upstreamLock

### DIFF
--- a/porch/api/porch/v1alpha1/types_packagerevisions.go
+++ b/porch/api/porch/v1alpha1/types_packagerevisions.go
@@ -86,6 +86,7 @@ type ParentReference struct {
 
 // PackageRevisionStatus defines the observed state of PackageRevision
 type PackageRevisionStatus struct {
+	UpstreamLock *UpstreamLock
 }
 
 type TaskType string
@@ -261,4 +262,38 @@ type Selector struct {
 	Name string `json:"name,omitempty"`
 	// Namespace of the target resources
 	Namespace string `json:"namespace,omitempty"`
+}
+
+// The following types (UpstreamLock, OriginType, and GitLock) are duplicates from the kpt library.
+// We are repeating them here to avoid cyclic dependencies, but these duplicate type should be removed when
+// https://github.com/GoogleContainerTools/kpt/issues/3297 is resolved.
+
+type OriginType string
+
+// UpstreamLock is a resolved locator for the last fetch of the package.
+type UpstreamLock struct {
+	// Type is the type of origin.
+	Type OriginType `yaml:"type,omitempty" json:"type,omitempty"`
+
+	// Git is the resolved locator for a package on Git.
+	Git *GitLock `yaml:"git,omitempty" json:"git,omitempty"`
+}
+
+// GitLock is the resolved locator for a package on Git.
+type GitLock struct {
+	// Repo is the git repository that was fetched.
+	// e.g. 'https://github.com/kubernetes/examples.git'
+	Repo string `yaml:"repo,omitempty" json:"repo,omitempty"`
+
+	// Directory is the sub directory of the git repository that was fetched.
+	// e.g. 'staging/cockroachdb'
+	Directory string `yaml:"directory,omitempty" json:"directory,omitempty"`
+
+	// Ref can be a Git branch, tag, or a commit SHA-1 that was fetched.
+	// e.g. 'master'
+	Ref string `yaml:"ref,omitempty" json:"ref,omitempty"`
+
+	// Commit is the SHA-1 for the last fetch of the package.
+	// This is set by kpt for bookkeeping purposes.
+	Commit string `yaml:"commit,omitempty" json:"commit,omitempty"`
 }

--- a/porch/pkg/engine/clone.go
+++ b/porch/pkg/engine/clone.go
@@ -89,6 +89,11 @@ func (m *clonePackageMutation) cloneFromRegisteredRepository(ctx context.Context
 		return repository.PackageResources{}, fmt.Errorf("cannot read contents of package %q: %w", ref.Name, err)
 	}
 
+	// If the upstream we cloned from has its own upstream information, we need to clear and replace it
+	if err := kpt.UpdateKptfileUpstream(m.name, resources.Spec.Resources, v1.Upstream{}, v1.UpstreamLock{}); err != nil {
+		return repository.PackageResources{}, fmt.Errorf("failed to clear upstream lock to package %q: %w", ref.Name, err)
+	}
+
 	upstream, lock, err := revision.GetUpstreamLock()
 	if err != nil {
 		return repository.PackageResources{}, fmt.Errorf("cannot determine upstream lock for package %q: %w", ref.Name, err)
@@ -96,7 +101,7 @@ func (m *clonePackageMutation) cloneFromRegisteredRepository(ctx context.Context
 
 	// Update Kptfile
 	if err := kpt.UpdateKptfileUpstream(m.name, resources.Spec.Resources, upstream, lock); err != nil {
-		return repository.PackageResources{}, fmt.Errorf("failed to apply upstream lock to pakcage %q: %w", ref.Name, err)
+		return repository.PackageResources{}, fmt.Errorf("failed to apply upstream lock to package %q: %w", ref.Name, err)
 	}
 
 	return repository.PackageResources{

--- a/porch/pkg/git/package.go
+++ b/porch/pkg/git/package.go
@@ -20,8 +20,10 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
+	"github.com/GoogleContainerTools/kpt/internal/pkg"
 	kptfile "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
 	"github.com/GoogleContainerTools/kpt/porch/pkg/repository"
@@ -71,6 +73,21 @@ func (p *gitPackageRevision) uid() types.UID {
 func (p *gitPackageRevision) GetPackageRevision() *v1alpha1.PackageRevision {
 	key := p.Key()
 
+	_, lock, _ := p.GetUpstreamLock()
+
+	// TODO: Use kpt definition of UpstreamLock in the package revision status
+	// when https://github.com/GoogleContainerTools/kpt/issues/3297 is complete.
+	// Until then, we have to translate from one type to another.
+	lockCopy := &v1alpha1.UpstreamLock{
+		Type: v1alpha1.OriginType(lock.Type),
+		Git: &v1alpha1.GitLock{
+			Repo:      lock.Git.Repo,
+			Directory: lock.Git.Directory,
+			Commit:    lock.Git.Commit,
+			Ref:       lock.Git.Ref,
+		},
+	}
+
 	return &v1alpha1.PackageRevision{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "PackageRevision",
@@ -93,7 +110,9 @@ func (p *gitPackageRevision) GetPackageRevision() *v1alpha1.PackageRevision {
 			Lifecycle: p.Lifecycle(),
 			Tasks:     p.tasks,
 		},
-		Status: v1alpha1.PackageRevisionStatus{},
+		Status: v1alpha1.PackageRevisionStatus{
+			UpstreamLock: lockCopy,
+		},
 	}
 }
 
@@ -152,6 +171,29 @@ func (p *gitPackageRevision) GetResources(ctx context.Context) (*v1alpha1.Packag
 }
 
 func (p *gitPackageRevision) GetUpstreamLock() (kptfile.Upstream, kptfile.UpstreamLock, error) {
+	resources, err := p.GetResources(context.Background())
+	if err != nil {
+		return kptfile.Upstream{}, kptfile.UpstreamLock{}, fmt.Errorf("cannot determine package lock; cannot retrieve resources: %w", err)
+	}
+
+	// get the upstream package URL from the Kptfile
+	var kf *kptfile.KptFile
+	if contents, found := resources.Spec.Resources[kptfile.KptFileName]; found {
+		kf, err = pkg.DecodeKptfile(strings.NewReader(contents))
+		if err != nil {
+			return kptfile.Upstream{}, kptfile.UpstreamLock{}, fmt.Errorf("cannot decode Kptfile: %w", err)
+		}
+	}
+
+	if kf.Upstream == nil || kf.UpstreamLock == nil || kf.Upstream.Git == nil {
+		// upstream information is not in Kptfile yet (this can happen when we clone from the upstream for the first time),
+		// so we get it from the parent repo instead.
+		return p.findParent()
+	}
+	return *kf.Upstream, *kf.UpstreamLock, nil
+}
+
+func (p *gitPackageRevision) findParent() (kptfile.Upstream, kptfile.UpstreamLock, error) {
 	repo, err := p.parent.getRepo()
 	if err != nil {
 		return kptfile.Upstream{}, kptfile.UpstreamLock{}, fmt.Errorf("cannot determine package lock: %w", err)


### PR DESCRIPTION
The git implementation of `GetUpstreamLock()` seems to assume that the upstream repo is stored in the `parent` field. But with my testing, this isn't always the case.

For example, say we have an upstream `blueprint` and from that we create downstream package `deployment` with revision `v0`. Then we do `rpkg edit` on the downstream package, creating a new downstream package `deployment` with a revision `v1`. The upstream of the new package should still be `blueprint`, but the `parent` instead points at the `deployment v0` package it was copied from. 

I think in most cases we have to look at the Kptfile to determine the upstreamLock, so this code modifies `GetUpstreamLock` to do that. It's only when we clone a package for the first time that we will need to look at `parent` so that we can populate the Kptfile with the right upstream information. 