### PR TITLE
Add support for workload identity with Porch

### DIFF
--- a/porch/deployments/porch/5-rbac.yaml
+++ b/porch/deployments/porch/5-rbac.yaml
@@ -35,6 +35,20 @@ rules:
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+  name: aggregated-apiserver-role
+  namespace: porch-system
+rules:
+  # Needed for workload identity
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    verbs: ["create"]
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
   name: porch-function-executor
   namespace: porch-fn-system
 rules:

--- a/porch/deployments/porch/6-rbac-bind.yaml
+++ b/porch/deployments/porch/6-rbac-bind.yaml
@@ -28,6 +28,20 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
+  name: sample-apiserver-rolebinding
+  namespace: porch-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: aggregated-apiserver-role
+subjects:
+  - kind: ServiceAccount
+    name: porch-server
+    namespace: porch-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
   name: porch-function-executor
   namespace: porch-fn-system
 roleRef:

--- a/porch/go.mod
+++ b/porch/go.mod
@@ -10,6 +10,7 @@ replace (
 
 require (
 	cloud.google.com/go/container v1.2.0
+	cloud.google.com/go/iam v0.3.0
 	github.com/GoogleContainerTools/kpt v0.0.0-00010101000000-000000000000
 	github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/apply-replacements v0.1.1
 	github.com/GoogleContainerTools/kpt-functions-catalog/functions/go/apply-setters v0.2.0
@@ -20,11 +21,13 @@ require (
 	github.com/bluekeyes/go-gitdiff v0.6.1
 	github.com/go-git/go-billy/v5 v5.3.1
 	github.com/go-git/go-git/v5 v5.4.3-0.20220408232334-4f916225cb2f
+	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.7
 	github.com/google/go-containerregistry v0.8.0
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/pflag v1.0.5
+	github.com/stretchr/testify v1.7.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.20.0
 	go.opentelemetry.io/otel v0.20.0
 	go.opentelemetry.io/otel/exporters/otlp v0.20.0
@@ -34,6 +37,7 @@ require (
 	go.opentelemetry.io/otel/trace v0.20.0
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3
 	golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5
+	google.golang.org/api v0.70.0
 	google.golang.org/genproto v0.0.0-20220222213610-43724f9ea8cf
 	google.golang.org/grpc v1.44.0
 	google.golang.org/protobuf v1.28.0
@@ -98,7 +102,6 @@ require (
 	github.com/go-openapi/swag v0.21.1 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
-	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/btree v1.0.1 // indirect
 	github.com/google/gnostic v0.6.9 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
@@ -134,6 +137,7 @@ require (
 	github.com/paulmach/orb v0.1.5 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
@@ -167,7 +171,6 @@ require (
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
-	google.golang.org/api v0.70.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect

--- a/porch/go.sum
+++ b/porch/go.sum
@@ -45,6 +45,8 @@ cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=
 cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqClKRT5SZwBmk=
 cloud.google.com/go/firestore v1.6.1/go.mod h1:asNXNOzBdyVQmEU+ggO8UPodTkEVFW5Qx+rwHnAz+EY=
+cloud.google.com/go/iam v0.3.0 h1:exkAomrVUuzx9kWFI1wm3KI0uoDeUFPB4kKGzx6x+Gc=
+cloud.google.com/go/iam v0.3.0/go.mod h1:XzJPvDayI+9zsASAFO68Hk07u3z+f+JrT2xXNdp4bnY=
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/pubsub v1.1.0/go.mod h1:EwwdRX2sKPjnvnqCa270oGRyludottCI76h+R3AArQw=
 cloud.google.com/go/pubsub v1.2.0/go.mod h1:jhfEVHT8odbXTkndysNHCcx0awwzvfOlguIAii9o8iA=

--- a/porch/pkg/registry/porch/secret.go
+++ b/porch/pkg/registry/porch/secret.go
@@ -17,20 +17,44 @@ package porch
 import (
 	"context"
 	"fmt"
+	"sync"
+	"time"
 
+	"github.com/GoogleContainerTools/kpt/porch/pkg/registry/porch/wi"
 	"github.com/GoogleContainerTools/kpt/porch/pkg/repository"
+	"golang.org/x/oauth2"
+	stsv1 "google.golang.org/api/sts/v1"
 	core "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func NewCredentialResolver(coreClient client.Reader) repository.CredentialResolver {
+const (
+	// Values for scret types supported by porch.
+	BasicAuthType            = core.SecretTypeBasicAuth
+	WorkloadIdentityAuthType = "kpt.dev/workload-identity-auth"
+
+	// Annotation used to specify the gsa for a ksa.
+	WIGCPSAAnnotation = "iam.gke.io/gcp-service-account"
+)
+
+func NewCredentialResolver(coreClient client.Reader, resolverChain []Resolver) repository.CredentialResolver {
 	return &secretResolver{
-		coreClient: coreClient,
+		coreClient:    coreClient,
+		resolverChain: resolverChain,
 	}
 }
 
 type secretResolver struct {
-	coreClient client.Reader
+	resolverChain []Resolver
+	coreClient    client.Reader
+}
+
+type Resolver interface {
+	Resolve(ctx context.Context, secret core.Secret) (repository.Credential, bool, error)
 }
 
 var _ repository.CredentialResolver = &secretResolver{}
@@ -44,7 +68,144 @@ func (r *secretResolver) ResolveCredential(ctx context.Context, namespace, name 
 		return repository.Credential{}, fmt.Errorf("cannot resolve credentials in a secret %s/%s: %w", namespace, name, err)
 	}
 
+	for _, resolver := range r.resolverChain {
+		cred, found, err := resolver.Resolve(ctx, secret)
+		if err != nil {
+			return repository.Credential{}, fmt.Errorf("error resolving credential: %w", err)
+		}
+		if found {
+			return cred, nil
+		}
+	}
+	return repository.Credential{}, &NoMatchingResolverError{
+		Type: string(secret.Type),
+	}
+}
+
+type NoMatchingResolverError struct {
+	Type string
+}
+
+func (e *NoMatchingResolverError) Error() string {
+	return fmt.Sprintf("no resolver for secret with type %s", e.Type)
+}
+
+func (e *NoMatchingResolverError) Is(err error) bool {
+	nmre, ok := err.(*NoMatchingResolverError)
+	if !ok {
+		return false
+	}
+	return nmre.Type == e.Type
+}
+
+func NewBasicAuthResolver() Resolver {
+	return &BasicAuthResolver{}
+}
+
+var _ Resolver = &BasicAuthResolver{}
+
+type BasicAuthResolver struct{}
+
+func (b *BasicAuthResolver) Resolve(_ context.Context, secret core.Secret) (repository.Credential, bool, error) {
+	if secret.Type != BasicAuthType {
+		return repository.Credential{}, false, nil
+	}
+
 	return repository.Credential{
 		Data: secret.Data,
-	}, nil
+	}, true, nil
+}
+
+func NewGcloudWIResolver(corev1Client *corev1client.CoreV1Client, stsClient *stsv1.Service) Resolver {
+	return &GcloudWIResolver{
+		coreV1Client: corev1Client,
+		exchanger:    wi.NewWITokenExchanger(corev1Client, stsClient),
+		tokenCache:   make(map[tokenCacheKey]*oauth2.Token),
+	}
+}
+
+var _ Resolver = &GcloudWIResolver{}
+
+type GcloudWIResolver struct {
+	coreV1Client *corev1client.CoreV1Client
+	exchanger    *wi.WITokenExchanger
+
+	mutex      sync.Mutex
+	tokenCache map[tokenCacheKey]*oauth2.Token
+}
+
+type tokenCacheKey struct {
+	ksa types.NamespacedName
+	gsa string
+}
+
+var porchKSA = types.NamespacedName{
+	Name:      "porch-server",
+	Namespace: "porch-system",
+}
+
+func (g *GcloudWIResolver) Resolve(ctx context.Context, secret core.Secret) (repository.Credential, bool, error) {
+	if secret.Type != WorkloadIdentityAuthType {
+		return repository.Credential{}, false, nil
+	}
+
+	token, err := g.getToken(ctx)
+	if err != nil {
+		return repository.Credential{}, true, err
+	}
+	return repository.Credential{
+		Data: map[string][]byte{
+			"username": []byte("token"), // username doesn't matter here.
+			"password": []byte(token.AccessToken),
+		},
+	}, true, nil
+}
+
+func (g *GcloudWIResolver) getToken(ctx context.Context) (*oauth2.Token, error) {
+	gsa, err := g.lookupGSAEmail(ctx, porchKSA.Name, porchKSA.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenKey := tokenCacheKey{
+		ksa: porchKSA,
+		gsa: gsa,
+	}
+
+	g.mutex.Lock()
+	token, found := g.tokenCache[tokenKey]
+	g.mutex.Unlock()
+
+	if found {
+		timeLeft := time.Until(token.Expiry)
+		if timeLeft > 5*time.Minute {
+			return token, nil
+		}
+	}
+
+	token, err = g.exchanger.Exchange(ctx, porchKSA, gsa)
+	if err != nil {
+		return nil, err
+	}
+
+	g.mutex.Lock()
+	g.tokenCache[tokenKey] = token
+	g.mutex.Unlock()
+
+	return token, nil
+}
+
+func (g *GcloudWIResolver) lookupGSAEmail(ctx context.Context, name, namespace string) (string, error) {
+	sa, err := g.coreV1Client.ServiceAccounts(namespace).Get(ctx, name, v1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return "", fmt.Errorf("porch service account %s/%s not found", namespace, name)
+		}
+		return "", fmt.Errorf("error looking up porch service account %s/%s: %w", namespace, name, err)
+	}
+	gsa, found := sa.Annotations[WIGCPSAAnnotation]
+	if !found {
+		return "", fmt.Errorf("%s annotation not found on porch sa", WIGCPSAAnnotation)
+	}
+	return gsa, nil
 }

--- a/porch/pkg/registry/porch/secret_test.go
+++ b/porch/pkg/registry/porch/secret_test.go
@@ -1,0 +1,142 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package porch
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/GoogleContainerTools/kpt/porch/pkg/repository"
+	"github.com/stretchr/testify/assert"
+	core "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	secretName      = "secret"
+	secretNamespace = "porch-system"
+)
+
+func TestCredentialResolver(t *testing.T) {
+	secretNotFoundError := apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, "secret")
+
+	testCases := map[string]struct {
+		readerSecret *core.Secret
+		readerErr    error
+
+		resolverCredential repository.Credential
+		resolverResolved   bool
+		resolverErr        error
+
+		expectedCredential repository.Credential
+		expectedErr        error
+	}{
+		"no secret found": {
+			readerErr:   secretNotFoundError,
+			expectedErr: secretNotFoundError,
+		},
+		"secret is of type kubernetes.io/basic-auth": {
+			readerSecret: &core.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: secretNamespace,
+				},
+				Type: core.SecretTypeBasicAuth,
+				Data: map[string][]byte{
+					"username": []byte("username"),
+					"password": []byte("password"),
+				},
+			},
+			expectedCredential: repository.Credential{
+				Data: map[string][]byte{
+					"username": []byte("username"),
+					"password": []byte("password"),
+				},
+			},
+		},
+		"no resolver for secret type": {
+			readerSecret: &core.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      secretName,
+					Namespace: secretNamespace,
+				},
+				Type: "notSupported",
+				Data: map[string][]byte{},
+			},
+			expectedErr: &NoMatchingResolverError{
+				Type: "notSupported",
+			},
+		},
+	}
+
+	for tn := range testCases {
+		tc := testCases[tn]
+		t.Run(tn, func(t *testing.T) {
+			reader := &fakeReader{
+				expectedSecret: tc.readerSecret,
+				expectedErr:    tc.readerErr,
+			}
+			credResolver := NewCredentialResolver(reader, []Resolver{
+				NewBasicAuthResolver(),
+				&fakeResolver{
+					credential: tc.resolverCredential,
+					resolved:   tc.resolverResolved,
+					err:        tc.resolverErr,
+				},
+			})
+
+			cred, err := credResolver.ResolveCredential(context.Background(), secretNamespace, secretName)
+
+			assert.ErrorIs(t, err, tc.expectedErr)
+			assert.Equal(t, tc.expectedCredential, cred)
+
+		})
+	}
+}
+
+type fakeReader struct {
+	expectedSecret *core.Secret
+	expectedErr    error
+}
+
+func (f *fakeReader) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	if f.expectedErr != nil {
+		return f.expectedErr
+	}
+	in, ok := obj.(*core.Secret)
+	if !ok {
+		return fmt.Errorf("object is not of type *core.Secret")
+	}
+	f.expectedSecret.DeepCopyInto(in)
+	return nil
+}
+
+func (f *fakeReader) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	return nil
+}
+
+type fakeResolver struct {
+	credential repository.Credential
+	resolved   bool
+	err        error
+}
+
+func (fr *fakeResolver) Resolve(ctx context.Context, secret core.Secret) (repository.Credential, bool, error) {
+	return fr.credential, fr.resolved, fr.err
+}

--- a/porch/pkg/registry/porch/wi/gcptokensource/gcptokensource.go
+++ b/porch/pkg/registry/porch/wi/gcptokensource/gcptokensource.go
@@ -1,0 +1,81 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcptokensource
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	iamv1 "cloud.google.com/go/iam/credentials/apiv1"
+	"github.com/golang/protobuf/ptypes"
+	"golang.org/x/oauth2"
+	"google.golang.org/api/option"
+	iampb "google.golang.org/genproto/googleapis/iam/credentials/v1"
+	"k8s.io/klog/v2"
+)
+
+// New returns an oauth2.TokenSource that exchanges tokens from ts for tokens
+// that authenticate as GCP Service Accounts.
+func New(gcpServiceAccount string, scopes []string, tokenSource oauth2.TokenSource) oauth2.TokenSource {
+	// The cloud-platform scope is always required for the token exchange.
+	scopes = append(scopes, "https://www.googleapis.com/auth/cloud-platform")
+	return &gcpTokenSource{
+		gcpServiceAccount: gcpServiceAccount,
+		scopes:            scopes,
+		tokenSource:       tokenSource,
+	}
+}
+
+// gcpTokenSource produces tokens that authenticate as GCP ServiceAccounts.
+type gcpTokenSource struct {
+	gcpServiceAccount string
+	scopes            []string
+	tokenSource       oauth2.TokenSource
+}
+
+// ensure gcpTokenSource implements oauth2.TokenSource
+var _ oauth2.TokenSource = &gcpTokenSource{}
+
+// Token exchanges the input token for a GCP SA token.
+func (ts *gcpTokenSource) Token() (*oauth2.Token, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// use the provided token source to make the request
+	c, err := iamv1.NewIamCredentialsClient(ctx, option.WithTokenSource(ts.tokenSource))
+	if err != nil {
+		return nil, fmt.Errorf("failed to construct IAM client: %w", err)
+	}
+	resp, err := c.GenerateAccessToken(ctx,
+		&iampb.GenerateAccessTokenRequest{
+			Name:  "projects/-/serviceAccounts/" + ts.gcpServiceAccount,
+			Scope: ts.scopes,
+		})
+	if err != nil {
+		return nil, fmt.Errorf("token exchange for GCP serviceaccount %q failed: %w", ts.gcpServiceAccount, err)
+	}
+
+	klog.Infof("got GCP token for %v", ts.gcpServiceAccount)
+
+	expiry, err := ptypes.Timestamp(resp.ExpireTime)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse expire time on returned token: %w", err)
+	}
+	return &oauth2.Token{
+		AccessToken: resp.AccessToken,
+		Expiry:      expiry,
+	}, nil
+}

--- a/porch/pkg/registry/porch/wi/ksaimpersonationtokensource/ksaimpersonation.go
+++ b/porch/pkg/registry/porch/wi/ksaimpersonationtokensource/ksaimpersonation.go
@@ -1,0 +1,87 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ksaimpersonationtokensource
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"golang.org/x/oauth2"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog/v2"
+)
+
+// New returns an oauth2.TokenSource that exchanges the KSA token at ksaTokenPath
+// for a GCP access token.
+func New(corev1Client corev1client.CoreV1Interface, serviceAccount types.NamespacedName, audiences []string) oauth2.TokenSource {
+	return &ksaImpersonationTokenSource{
+		corev1Client:   corev1Client,
+		serviceAccount: serviceAccount,
+		audiences:      audiences,
+	}
+}
+
+// ksaImpersonationTokenSource implements oauth2.TokenSource for exchanging KSA tokens for
+// GCP tokens. It can be wrapped in a ReuseTokenSource to cache tokens until
+// expiry.
+type ksaImpersonationTokenSource struct {
+	corev1Client corev1client.CoreV1Interface
+
+	// serviceAccount is the name of the serviceAccount to impersonate
+	serviceAccount types.NamespacedName
+
+	// audiences is the set of audiences to request
+	audiences []string
+}
+
+// ksaTokenSource implements oauth2.TokenSource
+var _ oauth2.TokenSource = &ksaImpersonationTokenSource{}
+
+// Token exchanges a KSA token for a GCP access token, returning the GCP token.
+func (ts *ksaImpersonationTokenSource) Token() (*oauth2.Token, error) {
+	tokenRequest := &authenticationv1.TokenRequest{
+		Spec: authenticationv1.TokenRequestSpec{
+			Audiences: ts.audiences,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	klog.V(2).Infof("getting token for kubernetes serviceaccount %v", ts.serviceAccount)
+	response, err := ts.corev1Client.ServiceAccounts(ts.serviceAccount.Namespace).CreateToken(ctx, ts.serviceAccount.Name, tokenRequest, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to CreateToken for %s: %w", ts.serviceAccount, err)
+	}
+
+	exchangeTime := time.Now()
+
+	serviceAccountToken := &oauth2.Token{
+		AccessToken: response.Status.Token,
+		TokenType:   "Bearer",
+	}
+
+	if response.Spec.ExpirationSeconds != nil {
+		serviceAccountToken.Expiry = exchangeTime.Add(time.Duration(*response.Spec.ExpirationSeconds) * time.Second)
+	} else {
+		klog.Warningf("service account token did not include expirationSeconds")
+		serviceAccountToken.Expiry = exchangeTime
+	}
+
+	return serviceAccountToken, nil
+}

--- a/porch/pkg/registry/porch/wi/ksatokensource/ksatokensource.go
+++ b/porch/pkg/registry/porch/wi/ksatokensource/ksatokensource.go
@@ -1,0 +1,130 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ksatokensource
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"golang.org/x/oauth2"
+	stsv1 "google.golang.org/api/sts/v1"
+)
+
+// New returns an oauth2.TokenSource that exchanges the KSA token from ksaToken
+// for a GCP access token.
+func New(stsService *stsv1.Service, ksaToken oauth2.TokenSource, workloadIdentityPool, identityProvider string) oauth2.TokenSource {
+	return &ksaTokenSource{
+		ksaToken:             ksaToken,
+		workloadIdentityPool: workloadIdentityPool,
+		identityProvider:     identityProvider,
+		stsService:           stsService,
+	}
+}
+
+// ksaTokenSource implements oauth2.TokenSource for exchanging KSA tokens for
+// GCP tokens. It can be wrapped in a ReuseTokenSource to cache tokens until
+// expiry.
+type ksaTokenSource struct {
+	// ksaToken is the source of the kubernetes serviceaccount token.
+	ksaToken oauth2.TokenSource
+	// workloadIdentityPool is the Workload Identity Pool to use when exchanging the KSA
+	// token for a GCP token.
+	workloadIdentityPool string
+	// identityProvider is the Identity Provider to use when exchanging the KSA
+	// token for a GCP token.
+	identityProvider string
+
+	stsService *stsv1.Service
+}
+
+// ksaTokenSource implements oauth2.TokenSource
+var _ oauth2.TokenSource = &ksaTokenSource{}
+
+// Token exchanges a KSA token for a GCP access token, returning the GCP token.
+func (ts *ksaTokenSource) Token() (*oauth2.Token, error) {
+	ksaToken, err := ts.ksaToken.Token()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	exchangeTime := time.Now()
+	workloadIdentityPool := ts.workloadIdentityPool
+	identityProvider := ts.identityProvider
+
+	audience := fmt.Sprintf("identitynamespace:%s:%s", workloadIdentityPool, identityProvider)
+
+	request := &stsv1.GoogleIdentityStsV1ExchangeTokenRequest{
+		GrantType:          "urn:ietf:params:oauth:grant-type:token-exchange",
+		SubjectTokenType:   "urn:ietf:params:oauth:token-type:jwt",
+		SubjectToken:       ksaToken.AccessToken,
+		RequestedTokenType: "urn:ietf:params:oauth:token-type:access_token",
+		Audience:           audience,
+		Scope:              "https://www.googleapis.com/auth/iam",
+	}
+
+	response, err := ts.stsService.V1.Token(request).Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get federated token from STS: %w", err)
+	}
+
+	token := &oauth2.Token{
+		AccessToken: response.AccessToken,
+		TokenType:   response.TokenType,
+		Expiry:      exchangeTime.Add(time.Duration(response.ExpiresIn) * time.Second),
+	}
+	return token, nil
+
+}
+
+// ExtractIsssuer will extract the issuer field from the provided JWT token
+func ExtractIssuer(jwtToken string) (string, error) {
+	return ExtractJWTString(jwtToken, "iss")
+}
+
+// ExtractJWTString extracts the named field from the provided JWT token.
+func ExtractJWTString(jwtToken string, key string) (string, error) {
+	tokens := strings.Split(jwtToken, ".")
+	if len(tokens) != 3 {
+		// Don't log the token as it may be sensitive
+		return "", fmt.Errorf("error getting identity provider from JWT (unexpected number of tokens)")
+	}
+	b, err := base64.RawURLEncoding.DecodeString(tokens[1])
+	if err != nil {
+		// Don't log the token as it may be sensitive
+		return "", fmt.Errorf("error getting identity provider from JWT (cannot decode base64)")
+	}
+	m := make(map[string]interface{})
+	if err := json.Unmarshal(b, &m); err != nil {
+		// Don't log the token as it may be sensitive
+		return "", fmt.Errorf("error getting identity provider from JWT (cannot decode json)")
+	}
+	val := m[key]
+	if val == nil {
+		// Don't log the token as it may be sensitive
+		return "", fmt.Errorf("error getting identity provider from JWT (key %q not found)", key)
+	}
+	s, ok := val.(string)
+	if !ok {
+		// Don't log the token as it may be sensitive
+		return "", fmt.Errorf("error getting identity provider from JWT (key %q was not string)", key)
+	}
+	return s, nil
+}

--- a/porch/pkg/registry/porch/wi/wi.go
+++ b/porch/pkg/registry/porch/wi/wi.go
@@ -1,0 +1,123 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wi
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+
+	"github.com/GoogleContainerTools/kpt/porch/pkg/registry/porch/wi/gcptokensource"
+	"github.com/GoogleContainerTools/kpt/porch/pkg/registry/porch/wi/ksaimpersonationtokensource"
+	"github.com/GoogleContainerTools/kpt/porch/pkg/registry/porch/wi/ksatokensource"
+	"golang.org/x/oauth2"
+	stsv1 "google.golang.org/api/sts/v1"
+	"k8s.io/apimachinery/pkg/types"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/klog/v2"
+)
+
+func NewWITokenExchanger(corev1Client *corev1client.CoreV1Client, stsClient *stsv1.Service) *WITokenExchanger {
+	return &WITokenExchanger{
+		corev1Client: corev1Client,
+		stsClient:    stsClient,
+	}
+}
+
+type WITokenExchanger struct {
+	corev1Client *corev1client.CoreV1Client
+	stsClient    *stsv1.Service
+}
+
+func (w *WITokenExchanger) Exchange(ctx context.Context, ksa types.NamespacedName, gsa string) (*oauth2.Token, error) {
+	workloadIdentityPool, identityProvider, err := w.findWorkloadIdentityPool(ctx, ksa)
+	if err != nil {
+		return nil, err
+	}
+
+	impersonated := ksaimpersonationtokensource.New(w.corev1Client, ksa, []string{workloadIdentityPool})
+
+	ksaToken := ksatokensource.New(w.stsClient, impersonated, workloadIdentityPool, identityProvider)
+
+	var scopes []string
+	gcpToken := gcptokensource.New(gsa, scopes, ksaToken)
+
+	token, err := gcpToken.Token()
+	if err != nil {
+		return nil, fmt.Errorf("unable to get token: %w", err)
+	}
+
+	return token, nil
+}
+
+func (w *WITokenExchanger) findWorkloadIdentityPool(ctx context.Context, kubeServiceAccount types.NamespacedName) (string, string, error) {
+	accessToken := ""
+
+	// First, see if we have a valid token mounted locally in our pod
+	{
+		const tokenFilePath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+		tokenBytes, err := ioutil.ReadFile(tokenFilePath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				klog.V(2).Infof("token file not found at %q", tokenFilePath)
+			} else {
+				klog.Warningf("error reading token file from %q: %v", tokenFilePath, err)
+			}
+		} else {
+			klog.Infof("found token at %q", tokenFilePath)
+			accessToken = string(tokenBytes)
+		}
+	}
+
+	// We could also query the kube apiserver at /.well-known/openid-configuration
+	// kubectl get --raw /.well-known/openid-configuration
+	// {"issuer":"https://container.googleapis.com/v1/projects/example-project-id/locations/us-central1/clusters/krmapihost-control","jwks_uri":"https://172.16.0.130:443/openid/v1/jwks","response_types_supported":["id_token"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"]}
+
+	if accessToken == "" {
+		// We get a token for our own service account, so we can extract the issuer
+		klog.Infof("token not found at well-known path, requesting token from apiserver")
+		impersonated := ksaimpersonationtokensource.New(w.corev1Client, kubeServiceAccount, nil /* unspecified/default audience */)
+
+		token, err := impersonated.Token()
+		if err != nil {
+			return "", "", fmt.Errorf("failed to get kube token for %s: %w", kubeServiceAccount, err)
+		} else {
+			accessToken = token.AccessToken
+		}
+	}
+
+	issuer, err := ksatokensource.ExtractIssuer(accessToken)
+	if err != nil {
+		return "", "", err
+	}
+
+	if strings.HasPrefix(issuer, "https://container.googleapis.com/") {
+		path := strings.TrimPrefix(issuer, "https://container.googleapis.com/")
+		tokens := strings.Split(path, "/")
+		for i := 0; i+1 < len(tokens); i++ {
+			if tokens[i] == "projects" {
+				workloadIdentityPool := tokens[i+1] + ".svc.id.goog"
+				klog.Infof("inferred workloadIdentityPool as %q", workloadIdentityPool)
+				return workloadIdentityPool, issuer, nil
+			}
+		}
+		return "", "", fmt.Errorf("could not extract project from issue %q", issuer)
+	} else {
+		return "", "", fmt.Errorf("unknown issuer %q", issuer)
+	}
+}


### PR DESCRIPTION
This adds support for authenticating against git repos with GCP Workload Identity.

In order to allow porch to be configured with multiple different auth schemes, this implementation used the `Type` field in the auth-secret used by porch to configure the auth mechanism that should be used. Currently porch supports Basic Auth which is configured by setting the `Type` field to `kubernetes.io/basic-auth` and provide the username and password in the `Data` field of the secret referenced in the `Repository` object. To configure porch to use Workload Identity, the secret should have the type `kpt.dev/workload-identity-auth` and doesn't need any content in the `Data` field. An alternative would be to configure the auth scheme through a field on the `Repository` resource itself.

The `CredentialResolver` goes through a list of resolvers to find one that supports resolving credentials for the specified auth type in the secret. If no match is found, it is considered an error.

This adds tests for the `CredentialResolver`, but doesn't add tests for the code needed to exchange tokens. I think we ideally want to test this through a e2e tests against a CSR repo, but that requires running porch on a GKE cluster for the test.

Fixes: https://github.com/GoogleContainerTools/kpt/issues/3231