### PR TITLE
Set task correctly from initMutation

### DIFF
--- a/porch/pkg/engine/engine.go
+++ b/porch/pkg/engine/engine.go
@@ -116,9 +116,11 @@ func (cad *cadEngine) CreatePackageRevision(ctx context.Context, repositoryObj *
 	if len(tasks) == 0 || (tasks[0].Type != api.TaskTypeInit && tasks[0].Type != api.TaskTypeClone) {
 		mutations = append(mutations, &initPackageMutation{
 			name: obj.Spec.PackageName,
-			spec: api.PackageInitTaskSpec{
-				Subpackage:  "",
-				Description: fmt.Sprintf("%s description", obj.Spec.PackageName),
+			task: &api.Task{
+				Init: &api.PackageInitTaskSpec{
+					Subpackage:  "",
+					Description: fmt.Sprintf("%s description", obj.Spec.PackageName),
+				},
 			},
 		})
 	}
@@ -165,7 +167,7 @@ func (cad *cadEngine) mapTaskToMutation(ctx context.Context, obj *api.PackageRev
 		}
 		return &initPackageMutation{
 			name: obj.Spec.PackageName,
-			spec: *task.Init,
+			task: task,
 		}, nil
 	case api.TaskTypeClone:
 		if task.Clone == nil {

--- a/porch/pkg/engine/init.go
+++ b/porch/pkg/engine/init.go
@@ -30,7 +30,7 @@ import (
 type initPackageMutation struct {
 	kptpkg.DefaultInitializer
 	name string
-	spec api.PackageInitTaskSpec
+	task *api.Task
 }
 
 var _ mutation = &initPackageMutation{}
@@ -42,8 +42,9 @@ func (m *initPackageMutation) Apply(ctx context.Context, resources repository.Pa
 	fs := filesys.MakeFsInMemory()
 	// virtual fs expected a rooted filesystem
 	pkgPath := "/"
-	if m.spec.Subpackage != "" {
-		pkgPath = "/" + m.spec.Subpackage
+
+	if m.task.Init.Subpackage != "" {
+		pkgPath = "/" + m.task.Init.Subpackage
 	}
 	if err := fs.Mkdir(pkgPath); err != nil {
 		return repository.PackageResources{}, nil, err
@@ -51,9 +52,9 @@ func (m *initPackageMutation) Apply(ctx context.Context, resources repository.Pa
 	err := m.Initialize(printer.WithContext(ctx, &fake.Printer{}), fs, kptpkg.InitOptions{
 		PkgPath:  pkgPath,
 		PkgName:  m.name,
-		Desc:     m.spec.Description,
-		Keywords: m.spec.Keywords,
-		Site:     m.spec.Site,
+		Desc:     m.task.Init.Description,
+		Keywords: m.task.Init.Keywords,
+		Site:     m.task.Init.Site,
 	})
 	if err != nil {
 		return repository.PackageResources{}, nil, fmt.Errorf("failed to initialize pkg %q: %w", m.name, err)
@@ -64,5 +65,5 @@ func (m *initPackageMutation) Apply(ctx context.Context, resources repository.Pa
 		return repository.PackageResources{}, nil, err
 	}
 
-	return result, &api.Task{}, nil
+	return result, m.task, nil
 }

--- a/porch/pkg/engine/init_test.go
+++ b/porch/pkg/engine/init_test.go
@@ -28,10 +28,12 @@ import (
 func TestInit(t *testing.T) {
 	init := &initPackageMutation{
 		name: "testpkg",
-		spec: api.PackageInitTaskSpec{
-			Description: "test package",
-			Keywords:    []string{"test", "kpt", "pkg"},
-			Site:        "http://kpt.dev/testpkg",
+		task: &api.Task{
+			Init: &api.PackageInitTaskSpec{
+				Description: "test package",
+				Keywords:    []string{"test", "kpt", "pkg"},
+				Site:        "http://kpt.dev/testpkg",
+			},
 		},
 	}
 


### PR DESCRIPTION
This updates the InitMutation to include the InitTask and also return it after running the mutation. This means that task recorded in the git commit will be the correct one.

Fixes: https://github.com/GoogleContainerTools/kpt/issues/3318