### PR TITLE
generate pkg context without mutation

### DIFF
--- a/e2e/testdata/porch/rpkg-init-deploy/config.yaml
+++ b/e2e/testdata/porch/rpkg-init-deploy/config.yaml
@@ -57,7 +57,7 @@ commands:
           name: deploy-package
       - apiVersion: v1
         data:
-          name: deploy-package
+          name: example
         kind: ConfigMap
         metadata:
           annotations:

--- a/porch/pkg/engine/builtin.go
+++ b/porch/pkg/engine/builtin.go
@@ -81,11 +81,5 @@ func (m *builtinEvalMutation) Apply(ctx context.Context, resources repository.Pa
 		result.Contents[k] = v
 	}
 
-	return result, &api.Task{
-		Type: api.TaskTypeEval,
-		Eval: &api.FunctionEvalTaskSpec{
-			Image:                m.function,
-			IncludeMetaResources: true,
-		},
-	}, nil
+	return result, nil, nil
 }


### PR DESCRIPTION
package context generation was being run as a mutation which leads to a separate task and a commit. The way `pkg context generation` is being invoked in porch, it isn't really replayable and we don't need it to be replayed anyway because this needs to be executed only once when deployment instance is created.



Note: the logic of invoking a builtin function in porch is little bit awkward and I think it can be simplified, but will be handling that separately.
