### PR TITLE
Remove suffix from filenames in generated patches

### DIFF
--- a/porch/pkg/engine/patchgen.go
+++ b/porch/pkg/engine/patchgen.go
@@ -34,7 +34,7 @@ import (
 // GeneratePatch returns patch operations for transforming from oldV to newV.
 func GeneratePatch(fileName string, oldV, newV string) (api.PatchSpec, error) {
 	edits := myers.ComputeEdits(span.URIFromPath(fileName), oldV, newV)
-	diff := fmt.Sprint(gotextdiff.ToUnified(fileName+"@old", fileName+"@new", oldV, edits))
+	diff := fmt.Sprint(gotextdiff.ToUnified(fileName, fileName, oldV, edits))
 
 	patchSpec := api.PatchSpec{
 		File:      fileName,


### PR DESCRIPTION
When we generate patches for updated resources, we add `@old` and `@new` suffixes to the filename in the patches. This prevents us from successfully applying the patches when we replay the task list. This removes those suffixes from the generated patches.

We should also add tests for this, but I can do that in a follow-up PR if merging this helps unblock other work.