### PR TITLE
use semver library for `rpkg copy` default revision

### DIFF
--- a/internal/cmdrpkgcopy/command_test.go
+++ b/internal/cmdrpkgcopy/command_test.go
@@ -1,0 +1,59 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmdrpkgcopy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNextRevisionNumber(t *testing.T) {
+	testcases := map[string]struct {
+		input    string
+		expected string
+		err      string
+	}{
+		"invalid": {
+			input: "alskdfj",
+			err:   "invalid revision format alskdfj; explicit --revision flag is required",
+		},
+		"no dots": {
+			input:    "v4",
+			expected: "v5",
+		},
+		"one dot": {
+			input:    "v3.1",
+			expected: "v3.2",
+		},
+		"two dots": {
+			input:    "v1.2.3",
+			expected: "v1.2.4",
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			output, err := nextRevisionNumber(tc.input)
+			if tc.err != "" {
+				require.Error(t, err)
+				require.Equal(t, tc.err, err.Error())
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expected, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/kpt/issues/3200

The logic to compute the "latest" tag in porch and the logic to check if upstream updates are available uses the `semver` library. This PR aligns `rpkg copy` to use the same library and support the same semver formats when computing the default next revision number. 

