### PR TITLE
docs: fix broken links in porch guides

### DIFF
--- a/site/guides/porch-installation.md
+++ b/site/guides/porch-installation.md
@@ -91,7 +91,7 @@ packagerevisionresources                       porch.kpt.dev/v1alpha1           
 packagerevisions                               porch.kpt.dev/v1alpha1                 true         PackageRevision
 ```
 
-You can start [using Porch](./porch-user-guide.md).
+You can start [using Porch](guides/porch-user-guide.md).
 
 ## Run Custom Build of Porch
 
@@ -138,7 +138,7 @@ As above, you can verify that Porch is running by querying the `api-resources`:
 kubectl api-resources | grep porch
 ```
 
-And start [using Porch](./porch-user-guide.md) if the Porch resources are
+And start [using Porch](guides/porch-user-guide.md) if the Porch resources are
 available.
 
 ### Workload Identity
@@ -190,5 +190,5 @@ As above, you can verify that Porch is running by querying the `api-resources`:
 kubectl api-resources | grep porch
 ```
 
-And start [using Porch](./porch-user-guide.md) if the Porch resources are
+And start [using Porch](guides/porch-user-guide.md) if the Porch resources are
 available.

--- a/site/guides/porch-user-guide.md
+++ b/site/guides/porch-user-guide.md
@@ -3,7 +3,7 @@
 This document is focused on using Porch via the `kpt` CLI.
 
 Installation of Porch, including prerequisites, is covered in a
-[dedicated document](./porch-installation.md).
+[dedicated document](guides/porch-installation.md).
 
 ## Prerequisites
 
@@ -15,7 +15,7 @@ To use Porch, you will need:
 
 Make sure that your `kubectl` context is set up for `kubectl` to interact with the
 correct Kubernetes instance (see
-[installation instructions](./porch-installation.md) or
+[installation instructions](guides/porch-installation.md) or
 the [running-locally](https://github.com/GoogleContainerTools/kpt/blob/main/porch/docs/running-locally.md) guide for details).
 
 To check whether `kubectl` is configured with your Porch cluster (or local instance), run:
@@ -69,7 +69,7 @@ To use Porch with an OCI repository
 ([Artifact Registry](https://console.cloud.google.com/artifacts) or
 [Google Container Registry](https://cloud.google.com/container-registry)), first
 make sure to:
-* Enable [workload identity](./porch-installation.md#workload-identity) for Porch
+* Enable [workload identity](guides/porch-installation.md#workload-identity) for Porch
 * Assign appropriate roles to the Porch workload identity service account
   (`iam.gke.io/gcp-service-account=porch-server@$(GCP_PROJECT_ID).iam.gserviceaccount.com`)
   to have appropriate level of access to your OCI repository.


### PR DESCRIPTION
This pull request fixes several broken links in the Porch guides.