### PR TITLE
feat: add newline to cli output when creating new packages

### DIFF
--- a/internal/cmdrpkgclone/command.go
+++ b/internal/cmdrpkgclone/command.go
@@ -196,7 +196,7 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 		return errors.E(op, err)
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "%s created", pr.Name)
+	fmt.Fprintf(cmd.OutOrStdout(), "%s created\n", pr.Name)
 	return nil
 }
 

--- a/internal/cmdrpkgcopy/command.go
+++ b/internal/cmdrpkgcopy/command.go
@@ -112,7 +112,7 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 	if err := r.client.Create(r.ctx, pr); err != nil {
 		return errors.E(op, err)
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "%s created", pr.Name)
+	fmt.Fprintf(cmd.OutOrStdout(), "%s created\n", pr.Name)
 	return nil
 }
 

--- a/internal/cmdrpkginit/command.go
+++ b/internal/cmdrpkginit/command.go
@@ -126,6 +126,6 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 		return errors.E(op, err)
 	}
 
-	fmt.Fprintf(cmd.OutOrStdout(), "%s created", pr.Name)
+	fmt.Fprintf(cmd.OutOrStdout(), "%s created\n", pr.Name)
 	return nil
 }


### PR DESCRIPTION
This pull request adds a newline character to output of `rpkg init`, `rpkg copy`, and `rpkg clone` commands.