### PR TITLE
Update docs to clarify that GCP/GKE is not required

### DIFF
--- a/site/guides/porch-installation.md
+++ b/site/guides/porch-installation.md
@@ -6,6 +6,11 @@ building Porch from sources.
 
 ## Prerequisites
 
+Note: Porch should run on any kubernetes cluster and should work on any cloud.
+We have just started by documenting one known-good configuration: GCP and GKE.
+We would welcome comparable installation instructions or feedback from people
+that try it out on other clouds / configurations.
+
 To run one of the [released versions](https://github.com/GoogleContainerTools/kpt/releases)
 of Porch on GKE, you will need:
 

--- a/site/guides/porch-ui-installation.md
+++ b/site/guides/porch-ui-installation.md
@@ -3,15 +3,15 @@
 The easiest way to access the Configuration as Data UI is running by a docker
 container on your local machine where you'll be able to access the UI with your
 browser. Running the container locally simplifies the overall setup by allowing
-the UI to use your local kubeconfig and Google credentials to access the GKE
+the UI to use your local kubeconfig and Google credentials to access the kubernetes
 cluster with Porch installed. This guide will show you how to do this.
 
 ## Prerequisites
 
 To access the Configuration as Data UI with a docker container, you will need:
 
-*   [Porch](guides/porch-installation.md) installed on a GKE cluster
-*   [kubectl](https://kubernetes.io/docs/tasks/tools/) targeting the GKE cluster
+*   [Porch](guides/porch-installation.md) installed on a kubernetes cluster
+*   [kubectl](https://kubernetes.io/docs/tasks/tools/) targeting the kubernetes cluster
     with Porch installed
 *   [git](https://git-scm.com/)
 *   [docker](https://docs.docker.com/get-docker/)
@@ -40,6 +40,9 @@ credentials, and the UI will be exposed over port 7007.
 ```sh
 docker run -v ~/.kube/config:/root/.kube/config -v ~/.config/gcloud:/root/.config/gcloud -p 7007:7007 kpt-backstage-plugins
 ```
+
+(Note: these instructions assume GKE and workload identity, to simplify authentication configuration, but we would welcome
+contributions or feedback from people that have set this up in other clouds)
 
 And now access the Configuration as Data UI by opening your browser to
 http://localhost:7007/config-as-data.


### PR DESCRIPTION
We have to start somewhere, and so we've documented GKE/GCP
configuration, but this should work on any kubernetes cluster and any
cloud.
