### PR TITLE
update kpt installation instructions and homebrew for kpt v1.0.0-beta.18 release

### DIFF
--- a/Formula/kpt.rb
+++ b/Formula/kpt.rb
@@ -15,8 +15,8 @@
 class Kpt < Formula
   desc "Toolkit to manage,and apply Kubernetes Resource config data files"
   homepage "https://googlecontainertools.github.io/kpt"
-  url "https://github.com/GoogleContainerTools/kpt/archive/v1.0.0-beta.17.tar.gz"
-  sha256 "18d97bd9a0fcfc486f4e31b8007cfe2e0b5d666f75eed342d4cb0afe2c7c0aba"
+  url "https://github.com/GoogleContainerTools/kpt/archive/v1.0.0-beta.18.tar.gz"
+  sha256 "2f8ee9778c07400c83b1dd9b5d4605df414b3cc4e5c00dcd0a9a5f0f87586e3d"
 
   depends_on "go" => :build
 

--- a/site/installation/kpt-cli.md
+++ b/site/installation/kpt-cli.md
@@ -93,7 +93,7 @@ Use one of the kpt docker images.
 ### `kpt`
 
 ```shell
-$ docker run gcr.io/kpt-dev/kpt:v1.0.0-beta.17 version
+$ docker run gcr.io/kpt-dev/kpt:v1.0.0-beta.18 version
 ```
 
 ### `kpt-gcloud`
@@ -101,7 +101,7 @@ $ docker run gcr.io/kpt-dev/kpt:v1.0.0-beta.17 version
 An image which includes kpt based upon the Google [cloud-sdk] alpine image.
 
 ```shell
-$ docker run gcr.io/kpt-dev/kpt-gcloud:v1.0.0-beta.17 version
+$ docker run gcr.io/kpt-dev/kpt-gcloud:v1.0.0-beta.18 version
 ```
 
 ## Source
@@ -124,8 +124,8 @@ $ kpt version
   https://console.cloud.google.com/gcr/images/kpt-dev/GLOBAL/kpt-gcloud?gcrImageListsize=30
 [cloud-sdk]: https://github.com/GoogleCloudPlatform/cloud-sdk-docker
 [linux]:
-  https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.17/kpt_linux_amd64
+  https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.18/kpt_linux_amd64
 [darwin]:
-  https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.17/kpt_darwin_amd64
+  https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.18/kpt_darwin_amd64
 [migration guide]: /installation/migration
 [bash-completion]: https://github.com/scop/bash-completion#installation


### PR DESCRIPTION
update installation doc to use 1.0.0-beta.18 release

update homebrew to use 1.0.0-beta.18 release