### PR TITLE
Add office hours link on contact us page

### DIFF
--- a/site/contact/README.md
+++ b/site/contact/README.md
@@ -14,5 +14,6 @@ We'd love to hear from you!
 
 - Join our [Slack channel](https://kubernetes.slack.com/channels/kpt)
 - Join our [email list](https://groups.google.com/forum/?oldui=1#!forum/kpt-users)
+- Join our [office hours](https://calendar.google.com/event?action=TEMPLATE&tmeid=MGk2NWhrdmkyMjgxOGc3ZWtobzFrZnB0NnBfMjAyMjA3MjhUMTcwMDAwWiBzdW5pbGFyb3JhQGdvb2dsZS5jb20&tmsrc=sunilarora%40google.com&scp=ALL)
 - Follow us on [Twitter](https://twitter.com/kptdev)
 - Subscribe to our [Youtube channel](https://www.youtube.com/channel/UCE6EvJ37y6Z8Xu_cDykhlnw)


### PR DESCRIPTION
We are introducing kpt office hours, so adding a link to the meeting to our contact-us page.