### PR TITLE
fix: preserve annotation comments

### DIFF
--- a/internal/util/addmergecomment/addmergecomment.go
+++ b/internal/util/addmergecomment/addmergecomment.go
@@ -71,7 +71,6 @@ func Process(paths ...string) error {
 // One known caveat is that upstream meta change can cause downstream origin mismatch. This potentially causes the 3-way merge
 // to fail in pkg update step.
 func addUpstreamAnnotation(object *kyaml.RNode, mergeComment string) error {
-	annotations := object.GetAnnotations()
 	group, _ := resid.ParseGroupVersion(object.GetApiVersion())
 	var name, namespace string
 	if strings.Contains(mergeComment, merge.MergeCommentPrefix) {
@@ -90,8 +89,8 @@ func addUpstreamAnnotation(object *kyaml.RNode, mergeComment string) error {
 	} else if object.GetNamespace() == resid.TotallyNotANamespace {
 		namespace = unknownNamespace
 	}
-	annotations[upstreamIdentifier] = fmt.Sprintf(upstreamIdentifierFmt, group, object.GetKind(), namespace, name)
-	return object.SetAnnotations(annotations)
+	upstreamIdentifierValue := fmt.Sprintf(upstreamIdentifierFmt, group, object.GetKind(), namespace, name)
+	return object.PipeE(kyaml.SetAnnotation(upstreamIdentifier, upstreamIdentifierValue))
 }
 
 // Filter implements kyaml.Filter

--- a/internal/util/addmergecomment/addmergecomment_test.go
+++ b/internal/util/addmergecomment/addmergecomment_test.go
@@ -47,7 +47,7 @@ metadata: # kpt-merge: my-space/nginx-deployment
   name: nginx-deployment
   namespace: my-space
   annotations:
-    internal.kpt.dev/upstream-identifier: apps|Deployment|my-space|nginx-deployment
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|my-space|nginx-deployment'
 spec:
   replicas: 3
  `,
@@ -70,7 +70,7 @@ metadata: # kpt-merge: default/nginx-deployment
   name: nginx-deployment
   namespace: default
   annotations:
-    internal.kpt.dev/upstream-identifier: apps|Deployment|default|nginx-deployment
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|default|nginx-deployment'
 spec:
   replicas: 3
  `,
@@ -91,7 +91,7 @@ kind: Deployment
 metadata: # kpt-merge: /nginx-deployment
   name: nginx-deployment
   annotations:
-    internal.kpt.dev/upstream-identifier: apps|Deployment|default|nginx-deployment
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|default|nginx-deployment'
 spec:
   replicas: 3
  `,
@@ -112,7 +112,7 @@ kind: Deployment
 metadata: # kpt-merge: my-space/nginx-deployment
   name: nginx-deployment-new
   annotations:
-    internal.kpt.dev/upstream-identifier: apps|Deployment|my-space|nginx-deployment
+    internal.kpt.dev/upstream-identifier: 'apps|Deployment|my-space|nginx-deployment'
 spec:
   replicas: 3
  `,
@@ -143,6 +143,35 @@ spec:
   path: /spec
   value:
     group: kubeflow.org
+ `,
+		},
+		{
+			name: "Preserve label comments and orders during upstream-id label editing",
+			input: `
+apiVersion: v1
+kind: Namespace
+metadata: # kpt-merge: /some-app
+  name: some-app # kpt-set: ${some-app}
+  annotations:
+    a-custom: value1
+    b-custom: value2
+    ncp/static_snat_ip: 122.122.122.122 # kpt-set: ${gateway-snat-ip}
+
+spec:
+  replicas: 3 # kpt-set: ${other}
+ `,
+			expected: `
+apiVersion: v1
+kind: Namespace
+metadata: # kpt-merge: /some-app
+  name: some-app # kpt-set: ${some-app}
+  annotations:
+    a-custom: value1
+    b-custom: value2
+    ncp/static_snat_ip: 122.122.122.122 # kpt-set: ${gateway-snat-ip}
+    internal.kpt.dev/upstream-identifier: '|Namespace|default|some-app'
+spec:
+  replicas: 3 # kpt-set: ${other}
  `,
 		},
 	}


### PR DESCRIPTION
Fix https://github.com/GoogleContainerTools/kpt/issues/3405
Comments are dropped when calling `rnode.SetAnnotations`. This PR adds back the comments after adding the upstream-identifier, and also sort the order.

From the example in #3405, before adding the upstream annotation we have
``` yaml
kind: Namespace
metadata: # kpt-merge: /some-app
  name: some-app # kpt-set: ${some-app}
  labels:
  annotations:
    ncp/static_snat_ip: 122.122.122.122 # kpt-set: ${gateway-snat-ip}
    config.kubernetes.io/index: '0'
    config.kubernetes.io/path: 'namespace.yaml'
    internal.config.kubernetes.io/index: '0'
    internal.config.kubernetes.io/path: 'namespace.yaml'
    internal.config.kubernetes.io/seqindent: 'compact'
    internal.config.kubernetes.io/annotations-migration-resource-id: '0'
```
After adding upstream annotation
```yaml
apiVersion: v1
kind: Namespace
metadata: # kpt-merge: /some-app
  name: some-app # kpt-set: ${some-app}
  labels:
  annotations:
    ncp/static_snat_ip: 122.122.122.122 # kpt-set: ${gateway-snat-ip}
    config.kubernetes.io/index: "0"
    config.kubernetes.io/path: namespace.yaml
    internal.config.kubernetes.io/index: "0"
    internal.config.kubernetes.io/path: namespace.yaml
    internal.config.kubernetes.io/seqindent: compact
    internal.config.kubernetes.io/annotations-migration-resource-id: "0"
    internal.kpt.dev/upstream-identifier: '|Namespace|default|some-app'
``` 

if not sort annotations, the output can be annoying to users in git diff.  
```yaml
apiVersion: v1
kind: Namespace
metadata: # kpt-merge: /some-app
  name: some-app # kpt-set: ${some-app}
  labels:
  annotations:
    config.kubernetes.io/index: "0"
    config.kubernetes.io/path: namespace.yaml
    internal.config.kubernetes.io/annotations-migration-resource-id: "0"
    internal.config.kubernetes.io/index: "0"
    internal.config.kubernetes.io/path: namespace.yaml
    internal.config.kubernetes.io/seqindent: compact
    internal.kpt.dev/upstream-identifier: '|Namespace|default|some-app'
    ncp/static_snat_ip: 122.122.122.122 # kpt-set: ${gateway-snat-ip}
```