### PR TITLE
WIP: fix porch logic for determining root package

### DIFF
--- a/internal/pkg/pkg.go
+++ b/internal/pkg/pkg.go
@@ -195,7 +195,7 @@ type Pkg struct {
 // Use ReadKptfile or ReadPipeline on the return value to read meta resources from filesystem.
 func New(fs filesys.FileSystem, path string) (*Pkg, error) {
 	if !filepath.IsAbs(path) {
-		return nil, fmt.Errorf("need absolute path")
+		return nil, fmt.Errorf("provided path %s must be absolute", path)
 	}
 	absPath := filepath.Clean(path)
 	pkg := &Pkg{

--- a/porch/pkg/engine/render.go
+++ b/porch/pkg/engine/render.go
@@ -92,7 +92,7 @@ func writeResources(fs filesys.FileSystem, resources repository.PackageResources
 		if base == "Kptfile" {
 			// Found Kptfile. Check if the current directory is ancestor of the current
 			// topmost package directory. If so, use it instead.
-			if packageDir == "" || strings.HasPrefix(packageDir, dir+"/") {
+			if packageDir == "" || dir == "/" || strings.HasPrefix(packageDir, dir+"/") {
 				packageDir = dir
 			}
 		}


### PR DESCRIPTION
This seems to fix one issue with the ghost package described in https://github.com/GoogleContainerTools/kpt/issues/3419. Seems like a small string parsing issue with the sub-package logic. 

Before this change:

```
$ kpt alpha rpkg clone https://github.com/natasha41575/kpt-samples.git/ghost@ghost/v1 --repository=deployment --revision=v0 -ndefault ghost-clone-6
Error: Internal error occurred: fn.render: pkg ghost-app:
        pkg.read: need absolute path
```

One thing that is odd is that the above failure seems flaky - not really sure what that's about. In my experimentation, it will sometimes (though rarely) succeed, but usually throw this `need absolute path` error. 

After this change:

```
$ kpt alpha rpkg clone https://github.com/natasha41575/kpt-samples.git/ghost@ghost/v1 --repository=deployment --revision=v0 -ndefault ghost-clone-7
Error: Internal error occurred: fn.render: pkg /:
        pkg.render:
        pipeline.run: func eval "gcr.io/kpt-fn/set-namespace:v0.3.4" failed: rpc error: code = NotFound desc = function "gcr.io/kpt-fn/set-namespace:v0.3.4" not found
```

This failure is also odd - it's only the set-namespace function that it can't find. It's able to find and run all the other functions in the ghost package and subpackages:

```
I0729 16:10:34.897747 2648751 package_tree.go:143] found package "ghost/Kptfile" with Kptfile hash "b80d0bbba28eb6d8a28e806c878527c3b9985569"
I0729 16:10:34.962150 2648751 render.go:59] Package "ghost-app": 
I0729 16:10:34.964711 2648751 render.go:59] [RUNNING] "gcr.io/kpt-fn/set-labels:v0.1.5"
I0729 16:10:34.964749 2648751 render.go:59] 
I0729 16:10:36.192896 2648751 render.go:59] [PASS] "gcr.io/kpt-fn/set-labels:v0.1.5" in 1.2s
I0729 16:10:36.195568 2648751 render.go:59] [RUNNING] "gcr.io/kpt-fn/apply-replacements:v0.1.1"
I0729 16:10:36.195620 2648751 render.go:59] 
I0729 16:10:36.242093 2648751 render.go:59] [PASS] "gcr.io/kpt-fn/apply-replacements:v0.1.1" in 0s
I0729 16:10:36.242757 2648751 render.go:59] [RUNNING] "gcr.io/kpt-fn/starlark:v0.4.3"
I0729 16:10:36.242785 2648751 render.go:59] 
I0729 16:10:36.282144 2648751 render.go:59] [PASS] "gcr.io/kpt-fn/starlark:v0.4.3" in 0s
I0729 16:10:36.282208 2648751 render.go:59] 
I0729 16:10:36.284385 2648751 render.go:59] Package "mariadb": 
I0729 16:10:36.286165 2648751 render.go:59] [RUNNING] "gcr.io/kpt-fn/set-labels:v0.1.5"
I0729 16:10:36.286197 2648751 render.go:59] 
I0729 16:10:37.470136 2648751 render.go:59] [PASS] "gcr.io/kpt-fn/set-labels:v0.1.5" in 1.1s
I0729 16:10:37.471023 2648751 render.go:59] 
I0729 16:10:37.471531 2648751 render.go:59] Package "/": 
I0729 16:10:37.472819 2648751 render.go:59] [RUNNING] "gcr.io/kpt-fn/set-namespace:v0.3.4"
I0729 16:10:37.472958 2648751 render.go:59] 
I0729 16:10:37.546721 2648751 render.go:59] [FAIL] "gcr.io/kpt-fn/set-namespace:v0.3.4" in 0s
```

It is possible that the other functions are built into porch and it's just a network issue on my end. 

After changing `set-namespace` version in the ghost package to 0.4.1 (the version that's built into porch), cloning with this PR's build of porch succeeds consistently: 

```
$ kpt alpha rpkg clone https://github.com/natasha41575/kpt-samples.git/ghost@ghost/v2 --repository=deployment --revision=v0 -ndefault ghost-clone-9
deployment-8643b347e81d3662790ea1e96ae92cabc0ca2869 created
```


