### PR TITLE
add set-namespace v0.3.4 to porch dockerfile

### DIFF
--- a/porch/func/Dockerfile
+++ b/porch/func/Dockerfile
@@ -20,6 +20,7 @@ FROM gcr.io/kpt-fn/set-annotations:v0.1.4 as set-annotations
 FROM gcr.io/kpt-fn/set-image:v0.1.0 as set-image
 FROM gcr.io/kpt-fn/set-labels:v0.1.5 as set-labels
 FROM gcr.io/kpt-fn/set-namespace:v0.2.0 as set-namespace
+FROM gcr.io/kpt-fn/set-namespace:v0.3.4 as set-namespace-v3
 FROM gcr.io/kpt-fn/set-project-id:v0.2.0 as set-project-id
 FROM gcr.io/kpt-fn/starlark:v0.3.0 as starlark
 FROM gcr.io/kpt-fn/upsert-resource:v0.2.0 as upsert-resource
@@ -52,6 +53,7 @@ COPY --from=set-annotations        /usr/local/bin/function /functions/set-annota
 COPY --from=set-image              /usr/local/bin/function /functions/set-image
 COPY --from=set-labels             /usr/local/bin/function /functions/set-labels
 COPY --from=set-namespace          /usr/local/bin/function /functions/set-namespace
+COPY --from=set-namespace-v3       /usr/local/bin/function /functions/set-namespace-v3
 COPY --from=set-project-id         /usr/local/bin/function /functions/set-project-id
 COPY --from=starlark               /usr/local/bin/star     /functions/starlark
 COPY --from=upsert-resource        /usr/local/bin/function /functions/upsert-resource

--- a/porch/func/config.yaml
+++ b/porch/func/config.yaml
@@ -21,6 +21,10 @@ functions:
     images:
       - gcr.io/kpt-fn/set-namespace@sha256:7adc23986f97572d75af9aec6a7f74d60f7b9976227f43a75486633e7c539e6f
       - gcr.io/kpt-fn/set-namespace:v0.2.0
+  - function: set-namespace-v3
+    images:
+      - gcr.io/kpt-fn/set-namespace@sha256:0ec0fb2380be42142a87a7c9815f0d30415e2da07468591dd9345c7c81d6c93e
+      - gcr.io/kpt-fn/set-namespace:v0.3.4
   - function: upsert-resource
     images:
       - gcr.io/kpt-fn/upsert-resource@sha256:77196bdb9e33e4259d530ee1996a05c40bbefe39b80d52dcb66c32f7b85a62f1


### PR DESCRIPTION
cc @mengqiy 

I'm trying to make set-namespace v0.3.4 easily available to porch. Not sure if this is the right place, lmk if there's another file that needs to be updated as well. 

Last thing to do before closing https://github.com/GoogleContainerTools/kpt/issues/3419

Marking this as a draft until I try it out