### PR TITLE
porch should ignore tags that are not associated with any package

### DIFF
--- a/porch/pkg/git/git.go
+++ b/porch/pkg/git/git.go
@@ -192,7 +192,8 @@ func (r *gitRepository) ListPackageRevisions(ctx context.Context, filter reposit
 		case isTagInLocalRepo(ref.Name()):
 			tagged, err := r.loadTaggedPackages(ctx, ref)
 			if err != nil {
-				return nil, fmt.Errorf("failed to load packages from tag %q: %w", name, err)
+				// this tag is not associated with any package (e.g. could be a release tag)
+				continue
 			}
 			for _, p := range tagged {
 				if filter.Matches(p) {
@@ -547,7 +548,9 @@ func (r *gitRepository) loadTaggedPackages(ctx context.Context, tag *plumbing.Re
 
 	if slash < 0 {
 		// tag=<version>
-		return r.discoverFinalizedPackages(ctx, tag)
+		// could be a release tag or something else, we ignore these types of tags
+		return nil, nil
+
 	}
 
 	// tag=<package path>/version

--- a/porch/test/e2e/e2e_test.go
+++ b/porch/test/e2e/e2e_test.go
@@ -40,6 +40,7 @@ import (
 
 const (
 	testBlueprintsRepo = "https://github.com/platkrm/test-blueprints.git"
+	kptRepo            = "https://github.com/GoogleContainerTools/kpt.git"
 )
 
 func TestE2E(t *testing.T) {
@@ -144,9 +145,16 @@ func (t *PorchSuite) TestGitRepository(ctx context.Context) {
 	}
 }
 
+func (t *PorchSuite) TestGitRepositoryWithReleaseTags(ctx context.Context) {
+	t.registerGitRepositoryF(ctx, kptRepo, "kpt-repo", "package-examples")
+
+	var list porchapi.PackageRevisionList
+	t.ListF(ctx, &list, client.InNamespace(t.namespace))
+}
+
 func (t *PorchSuite) TestCloneFromUpstream(ctx context.Context) {
 	// Register Upstream Repository
-	t.registerGitRepositoryF(ctx, testBlueprintsRepo, "test-blueprints")
+	t.registerGitRepositoryF(ctx, testBlueprintsRepo, "test-blueprints", "")
 
 	var list porchapi.PackageRevisionList
 	t.ListE(ctx, &list, client.InNamespace(t.namespace))
@@ -353,7 +361,7 @@ func (t *PorchSuite) TestCloneIntoDeploymentRepository(ctx context.Context) {
 	t.registerMainGitRepositoryF(ctx, downstreamRepository, withDeployment())
 
 	// Register the upstream repository
-	t.registerGitRepositoryF(ctx, testBlueprintsRepo, "test-blueprints")
+	t.registerGitRepositoryF(ctx, testBlueprintsRepo, "test-blueprints", "")
 
 	var upstreamPackages porchapi.PackageRevisionList
 	t.ListE(ctx, &upstreamPackages, client.InNamespace(t.namespace))
@@ -557,7 +565,7 @@ func (t *PorchSuite) TestFunctionRepository(ctx context.Context) {
 }
 
 func (t *PorchSuite) TestPublicGitRepository(ctx context.Context) {
-	t.registerGitRepositoryF(ctx, testBlueprintsRepo, "demo-blueprints")
+	t.registerGitRepositoryF(ctx, testBlueprintsRepo, "demo-blueprints", "")
 
 	var list porchapi.PackageRevisionList
 	t.ListE(ctx, &list, client.InNamespace(t.namespace))
@@ -838,7 +846,7 @@ func (t *PorchSuite) TestPackageUpdate(ctx context.Context) {
 		gitRepository = "package-update"
 	)
 
-	t.registerGitRepositoryF(ctx, testBlueprintsRepo, "test-blueprints")
+	t.registerGitRepositoryF(ctx, testBlueprintsRepo, "test-blueprints", "")
 
 	var list porchapi.PackageRevisionList
 	t.ListE(ctx, &list, client.InNamespace(t.namespace))
@@ -1455,7 +1463,7 @@ func (t *PorchSuite) TestRepositoryError(ctx context.Context) {
 	}
 }
 
-func (t *PorchSuite) registerGitRepositoryF(ctx context.Context, repo, name string) {
+func (t *PorchSuite) registerGitRepositoryF(ctx context.Context, repo, name, directory string) {
 	t.CreateF(ctx, &configapi.Repository{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Repository",
@@ -1469,8 +1477,9 @@ func (t *PorchSuite) registerGitRepositoryF(ctx context.Context, repo, name stri
 			Type:    configapi.RepositoryTypeGit,
 			Content: configapi.RepositoryContentPackage,
 			Git: &configapi.GitRepository{
-				Repo:   repo,
-				Branch: "main",
+				Repo:      repo,
+				Branch:    "main",
+				Directory: directory,
 			},
 		},
 	})

--- a/porch/test/e2e/update_test.go
+++ b/porch/test/e2e/update_test.go
@@ -28,7 +28,7 @@ func (t *PorchSuite) TestPackageUpdateRecloneAndReplay(ctx context.Context) {
 		gitRepository = "package-update"
 	)
 
-	t.registerGitRepositoryF(ctx, testBlueprintsRepo, "test-blueprints")
+	t.registerGitRepositoryF(ctx, testBlueprintsRepo, "test-blueprints", "")
 
 	var list porchapi.PackageRevisionList
 	t.ListE(ctx, &list, client.InNamespace(t.namespace))


### PR DESCRIPTION
Proposed fix for https://github.com/GoogleContainerTools/kpt/issues/3407

Basically ignore tags that don't have a package name in front of the version, and ignore tags that throw errors. As we see in the kpt repo, a tag like `v0.33.0` is a release tag and not associated with any package. In the kustomize repo, we have release tags like `kustomize/v1.2.3` that look like package revision tags, but aren't. If users have repos with similar release tagging schemas, porch should not throw an error when it encounters those tags.

An alternative would be to change the porch tagging scheme, making it have a unique `porch` prefix or something. 