### PR TITLE
`kpt alpha rpkg update --discover`: option to find downstream packages that can be updated from an upstream package

### DIFF
--- a/e2e/testdata/porch/rpkg-update/config.yaml
+++ b/e2e/testdata/porch/rpkg-update/config.yaml
@@ -89,8 +89,8 @@ commands:
       - --namespace=rpkg-update
       - --discover=downstream
     stdout: |
-      PACKAGE REVISION                              DOWNSTREAM PACKAGE                            DOWNSTREAM UPDATE
-      git-894137a40c0792e88a9b844491a95a466b085ca1  git-542e4d9fd8ca2ee94edf43aadb3ec31dc2fbd3a0  v0->v2
+      PACKAGE REVISION                               DOWNSTREAM PACKAGE                             DOWNSTREAM UPDATE
+      git-894137a40c0792e88a9b844491a95a466b085ca1   git-542e4d9fd8ca2ee94edf43aadb3ec31dc2fbd3a0   v0->v2
   - args:
       - alpha
       - rpkg

--- a/e2e/testdata/porch/rpkg-update/config.yaml
+++ b/e2e/testdata/porch/rpkg-update/config.yaml
@@ -89,8 +89,8 @@ commands:
       - --namespace=rpkg-update
       - --discover=downstream
     stdout: |
-      UPSTREAM PACKAGE                              UPSTREAM REVISION   DOWNSTREAM PACKAGE                            DOWNSTREAM REVISION
-      git-894137a40c0792e88a9b844491a95a466b085ca1  v2                  git-542e4d9fd8ca2ee94edf43aadb3ec31dc2fbd3a0  v1
+      PACKAGE REVISION                              DOWNSTREAM PACKAGE                            DOWNSTREAM UPDATE
+      git-894137a40c0792e88a9b844491a95a466b085ca1  git-542e4d9fd8ca2ee94edf43aadb3ec31dc2fbd3a0  v0->v2
   - args:
       - alpha
       - rpkg
@@ -104,7 +104,7 @@ commands:
       - rpkg
       - update
       - --namespace=rpkg-update
-      - --discover
+      - --discover=upstream
     stdout: |
       PACKAGE REVISION                               UPSTREAM REPOSITORY   UPSTREAM UPDATES
       git-f1fbc2b72ee70b2f34e64c2630031d0560e6cf48                         No update available

--- a/e2e/testdata/porch/rpkg-update/config.yaml
+++ b/e2e/testdata/porch/rpkg-update/config.yaml
@@ -66,7 +66,7 @@ commands:
       - rpkg
       - update
       - --namespace=rpkg-update
-      - --discover
+      - --discover=upstream
       - git-542e4d9fd8ca2ee94edf43aadb3ec31dc2fbd3a0
     stdout: |
       PACKAGE REVISION                               UPSTREAM REPOSITORY   UPSTREAM UPDATES
@@ -76,12 +76,21 @@ commands:
       - rpkg
       - update
       - --namespace=rpkg-update
-      - --discover
+      - --discover=upstream
     stdout: |
       PACKAGE REVISION                               UPSTREAM REPOSITORY   UPSTREAM UPDATES
       git-f1fbc2b72ee70b2f34e64c2630031d0560e6cf48                         No update available
       git-894137a40c0792e88a9b844491a95a466b085ca1                         No update available
       git-542e4d9fd8ca2ee94edf43aadb3ec31dc2fbd3a0   git                   v2
+  - args:
+      - alpha
+      - rpkg
+      - update
+      - --namespace=rpkg-update
+      - --discover=downstream
+    stdout: |
+      UPSTREAM PACKAGE                              UPSTREAM REVISION   DOWNSTREAM PACKAGE                            DOWNSTREAM REVISION
+      git-894137a40c0792e88a9b844491a95a466b085ca1  v2                  git-542e4d9fd8ca2ee94edf43aadb3ec31dc2fbd3a0  v1
   - args:
       - alpha
       - rpkg

--- a/internal/cmdrpkgupdate/command.go
+++ b/internal/cmdrpkgupdate/command.go
@@ -105,22 +105,18 @@ func (r *runner) preRunE(cmd *cobra.Command, args []string) error {
 func (r *runner) runE(cmd *cobra.Command, args []string) error {
 	const op errors.Op = command + ".runE"
 
-	var err error
 	if r.discover == "" {
 		pr := r.findPackageRevision(args[0])
 		if pr == nil {
 			return errors.E(op, fmt.Errorf("could not find package revision %s", args[0]))
 		}
 		if err := r.doUpdate(pr); err != nil {
-			return err
+			return errors.E(op, err)
 		}
 		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%s updated\n", pr.Name); err != nil {
-			return err
+			return errors.E(op, err)
 		}
-	} else {
-		err = r.discoverUpdates(cmd, args)
-	}
-	if err != nil {
+	} else if err := r.discoverUpdates(cmd, args); err != nil {
 		return errors.E(op, err)
 	}
 	return nil

--- a/internal/cmdrpkgupdate/command.go
+++ b/internal/cmdrpkgupdate/command.go
@@ -89,10 +89,8 @@ func (r *runner) preRunE(cmd *cobra.Command, args []string) error {
 		if r.revision == "" {
 			return errors.E(op, fmt.Errorf("revision is required"))
 		}
-	} else {
-		if r.discover != upstream && r.discover != downstream {
-			return errors.E(op, fmt.Errorf("argument for 'discover' must be one of 'upstream' or 'downstream'"))
-		}
+	} else if r.discover != upstream && r.discover != downstream {
+		return errors.E(op, fmt.Errorf("argument for 'discover' must be one of 'upstream' or 'downstream'"))
 	}
 
 	packageRevisionList := porchapi.PackageRevisionList{}

--- a/internal/cmdrpkgupdate/command.go
+++ b/internal/cmdrpkgupdate/command.go
@@ -28,6 +28,9 @@ import (
 
 const (
 	command = "cmdrpkgupdate"
+
+	upstream   = "upstream"
+	downstream = "downstream"
 )
 
 func NewCommand(ctx context.Context, rcg *genericclioptions.ConfigFlags) *cobra.Command {
@@ -46,8 +49,10 @@ func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner 
 		Hidden:  porch.HidePorchCommands,
 	}
 	r.Command.Flags().StringVar(&r.revision, "revision", "", "Revision of the upstream package to update to.")
-	r.Command.Flags().BoolVar(&r.discover, "discover", false,
-		"If set, search for available updates instead of performing an update. If no arguments given, look at all package revisions.")
+	r.Command.Flags().StringVar(&r.discover, "discover", "",
+		`If set, search for available updates instead of performing an update. 
+Setting this to 'upstream' will discover upstream updates of downstream packages.
+Setting this to 'downstream' will discover downstream package revisions of upstream packages that need to be updated.`)
 	return r
 }
 
@@ -58,7 +63,7 @@ type runner struct {
 	Command *cobra.Command
 
 	revision string // Target package revision
-	discover bool   // If set, discover updates rather than do updates
+	discover string // If set, discover updates rather than do updates
 
 	// there are multiple places where we need access to all package revisions, so
 	// we store it in the runner
@@ -73,7 +78,7 @@ func (r *runner) preRunE(cmd *cobra.Command, args []string) error {
 	}
 	r.client = c
 
-	if !r.discover {
+	if r.discover == "" {
 		if len(args) < 1 {
 			return errors.E(op, fmt.Errorf("SOURCE_PACKAGE is a required positional argument"))
 		}
@@ -83,6 +88,10 @@ func (r *runner) preRunE(cmd *cobra.Command, args []string) error {
 		// TODO: This should use the latest available revision if one isn't specified.
 		if r.revision == "" {
 			return errors.E(op, fmt.Errorf("revision is required"))
+		}
+	} else {
+		if r.discover != upstream && r.discover != downstream {
+			return errors.E(op, fmt.Errorf("argument for 'discover' must be one of 'upstream' or 'downstream'"))
 		}
 	}
 
@@ -99,15 +108,19 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 	const op errors.Op = command + ".runE"
 
 	var err error
-	if r.discover {
-		err = r.discoverUpdates(cmd, args)
-	} else {
+	if r.discover == "" {
 		pr := r.findPackageRevision(args[0])
 		if pr == nil {
 			return errors.E(op, fmt.Errorf("could not find package revision %s", args[0]))
 		}
-		err = r.doUpdate(pr)
-		fmt.Fprintf(cmd.OutOrStdout(), "%s updated\n", pr.Name)
+		if err := r.doUpdate(pr); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "%s updated\n", pr.Name); err != nil {
+			return err
+		}
+	} else {
+		err = r.discoverUpdates(cmd, args)
 	}
 	if err != nil {
 		return errors.E(op, err)

--- a/internal/cmdrpkgupdate/discover.go
+++ b/internal/cmdrpkgupdate/discover.go
@@ -181,7 +181,14 @@ func printdownstreamUpdates(downstreamUpdatesMap map[string][]porchapi.PackageRe
 		upstreamPkgRevName := split[0]
 		upstreamPkgRevNum := split[1]
 		for _, downstreamPkgRev := range downstreamPkgRevs {
-			downstreamUpdates = append(downstreamUpdates, []string{upstreamPkgRevName, upstreamPkgRevNum, downstreamPkgRev.Name, downstreamPkgRev.Spec.Revision})
+			// figure out which upstream revision the downstream revision is based on
+			lastIndex := strings.LastIndex(downstreamPkgRev.Status.UpstreamLock.Git.Ref, "v")
+			if lastIndex < 0 {
+				// this ref isn't formatted the way that porch expects
+				continue
+			}
+			downstreamRev := downstreamPkgRev.Status.UpstreamLock.Git.Ref[lastIndex:]
+			downstreamUpdates = append(downstreamUpdates, []string{upstreamPkgRevName, upstreamPkgRevNum, downstreamPkgRev.Name, downstreamRev})
 		}
 	}
 
@@ -206,7 +213,7 @@ func printdownstreamUpdates(downstreamUpdatesMap map[string][]porchapi.PackageRe
 			return err
 		}
 	} else {
-		if _, err := fmt.Fprintln(w, "UPSTREAM PACKAGE\tUPSTREAM REVISION\tdownstream PACKAGE\tdownstream REVISION"); err != nil {
+		if _, err := fmt.Fprintln(w, "UPSTREAM PACKAGE\tUPSTREAM REVISION\tDOWNSTREAM PACKAGE\tDOWNSTREAM REVISION"); err != nil {
 			return err
 		}
 		for _, pkgRev := range pkgRevsToPrint {

--- a/internal/cmdrpkgupdate/discover.go
+++ b/internal/cmdrpkgupdate/discover.go
@@ -29,7 +29,7 @@ import (
 func (r *runner) discoverUpdates(cmd *cobra.Command, args []string) error {
 	var prs []porchapi.PackageRevision
 	var errs []string
-	if len(args) == 0 {
+	if len(args) == 0 || r.discover == downstream {
 		prs = r.prs
 	} else {
 		for i := range args {
@@ -50,31 +50,48 @@ func (r *runner) discoverUpdates(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	var updates [][]string
+	var upstreamUpdates [][]string
+	downstreamUpdatesMap := make(map[string][]porchapi.PackageRevision) // map from the upstream package revision to a list of its downstream package revisions
+
 	for _, pr := range prs {
 		availableUpdates, upstreamName := r.availableUpdates(pr.Status.UpstreamLock, repositories)
-		if len(availableUpdates) == 0 {
-			updates = append(updates, []string{pr.Name, upstreamName, "No update available"})
-		} else {
-			updates = append(updates, []string{pr.Name, upstreamName, strings.Join(availableUpdates, ", ")})
+
+		switch r.discover {
+		case upstream:
+			if len(availableUpdates) == 0 {
+				upstreamUpdates = append(upstreamUpdates, []string{pr.Name, upstreamName, "No update available"})
+			} else {
+				var revisions []string
+				for i := range availableUpdates {
+					revisions = append(revisions, availableUpdates[i].Spec.Revision)
+				}
+				upstreamUpdates = append(upstreamUpdates, []string{pr.Name, upstreamName, strings.Join(revisions, ", ")})
+			}
+		case downstream:
+			for _, update := range availableUpdates {
+				key := update.Name + ":" + update.Spec.Revision
+				downstreamUpdatesMap[key] = append(downstreamUpdatesMap[key], pr)
+			}
+		default:
+			// this should never happen, because we validate in preRunE
+			return fmt.Errorf("invalid argument %q for --discover", r.discover)
 		}
 	}
 
-	w := printers.GetNewTabWriter(cmd.OutOrStdout())
-	if _, err := fmt.Fprintln(w, "PACKAGE REVISION\tUPSTREAM REPOSITORY\tUPSTREAM UPDATES"); err != nil {
-		return err
-	}
-	for _, pkgRev := range updates {
-		if _, err := fmt.Fprintln(w, strings.Join(pkgRev, "\t")); err != nil {
-			return err
-		}
+	switch r.discover {
+	case upstream:
+		return printupstreamUpdates(upstreamUpdates, cmd)
+	case downstream:
+		return printdownstreamUpdates(downstreamUpdatesMap, args, cmd)
+	default:
+		// this should never happen, because we validate in preRunE
+		return fmt.Errorf("invalid argument %q for --discover", r.discover)
 	}
 
-	return w.Flush()
 }
 
-func (r *runner) availableUpdates(upstreamLock *porchapi.UpstreamLock, repositories *configapi.RepositoryList) ([]string, string) {
-	var availableUpdates []string
+func (r *runner) availableUpdates(upstreamLock *porchapi.UpstreamLock, repositories *configapi.RepositoryList) ([]porchapi.PackageRevision, string) {
+	var availableUpdates []porchapi.PackageRevision
 	var upstream string
 
 	if upstreamLock == nil || upstreamLock.Git == nil {
@@ -96,7 +113,7 @@ func (r *runner) availableUpdates(upstreamLock *porchapi.UpstreamLock, repositor
 	}
 
 	// find a repo that matches the upstreamLock
-	var revisions []string
+	var revisions []porchapi.PackageRevision
 	for _, repo := range repositories.Items {
 		if repo.Spec.Type != configapi.RepositoryTypeGit {
 			// we are not currently supporting non-git repos for updates
@@ -112,7 +129,7 @@ func (r *runner) availableUpdates(upstreamLock *porchapi.UpstreamLock, repositor
 	}
 
 	for _, upstreamRevision := range revisions {
-		switch cmp := semver.Compare(upstreamRevision, currentUpstreamRevision); {
+		switch cmp := semver.Compare(upstreamRevision.Spec.Revision, currentUpstreamRevision); {
 		case cmp > 0: // upstreamRevision > currentUpstreamRevision
 			availableUpdates = append(availableUpdates, upstreamRevision)
 		case cmp == 0, cmp < 0: // upstreamRevision <= currentUpstreamRevision, do nothing
@@ -130,18 +147,74 @@ func (r *runner) getRepositories() (*configapi.RepositoryList, error) {
 }
 
 // fetches all package revision numbers for packages with the name upstreamPackageName from the repo
-func (r *runner) getUpstreamRevisions(repo configapi.Repository, upstreamPackageName string) []string {
-	var result []string
+func (r *runner) getUpstreamRevisions(repo configapi.Repository, upstreamPackageName string) []porchapi.PackageRevision {
+	var result []porchapi.PackageRevision
 	for _, pkgRev := range r.prs {
 		if pkgRev.Spec.Lifecycle != porchapi.PackageRevisionLifecyclePublished {
 			// only consider published packages
 			continue
 		}
-		if pkgRev.Spec.RepositoryName != repo.Name ||
-			pkgRev.Spec.PackageName != upstreamPackageName {
-			continue
+		if pkgRev.Spec.RepositoryName == repo.Name && pkgRev.Spec.PackageName == upstreamPackageName {
+			result = append(result, pkgRev)
 		}
-		result = append(result, pkgRev.Spec.Revision)
 	}
 	return result
+}
+
+func printupstreamUpdates(upstreamUpdates [][]string, cmd *cobra.Command) error {
+	w := printers.GetNewTabWriter(cmd.OutOrStdout())
+	if _, err := fmt.Fprintln(w, "PACKAGE REVISION\tUPSTREAM REPOSITORY\tUPSTREAM UPDATES"); err != nil {
+		return err
+	}
+	for _, pkgRev := range upstreamUpdates {
+		if _, err := fmt.Fprintln(w, strings.Join(pkgRev, "\t")); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}
+
+func printdownstreamUpdates(downstreamUpdatesMap map[string][]porchapi.PackageRevision, args []string, cmd *cobra.Command) error {
+	var downstreamUpdates [][]string
+	for upstreamPkgRev, downstreamPkgRevs := range downstreamUpdatesMap {
+		split := strings.Split(upstreamPkgRev, ":")
+		upstreamPkgRevName := split[0]
+		upstreamPkgRevNum := split[1]
+		for _, downstreamPkgRev := range downstreamPkgRevs {
+			downstreamUpdates = append(downstreamUpdates, []string{upstreamPkgRevName, upstreamPkgRevNum, downstreamPkgRev.Name, downstreamPkgRev.Spec.Revision})
+		}
+	}
+
+	w := printers.GetNewTabWriter(cmd.OutOrStdout())
+	var pkgRevsToPrint [][]string
+	if len(args) != 0 {
+		for _, arg := range args {
+			for _, pkgRev := range downstreamUpdates {
+				// filter out irrelevant packages based on provided args
+				if arg != pkgRev[0] {
+					continue
+				}
+				pkgRevsToPrint = append(pkgRevsToPrint, pkgRev)
+			}
+		}
+	} else {
+		pkgRevsToPrint = downstreamUpdates
+	}
+
+	if len(pkgRevsToPrint) == 0 {
+		if _, err := fmt.Fprintln(w, "All downstream packages are up to date."); err != nil {
+			return err
+		}
+	} else {
+		if _, err := fmt.Fprintln(w, "UPSTREAM PACKAGE\tUPSTREAM REVISION\tdownstream PACKAGE\tdownstream REVISION"); err != nil {
+			return err
+		}
+		for _, pkgRev := range pkgRevsToPrint {
+			if _, err := fmt.Fprintln(w, strings.Join(pkgRev, "\t")); err != nil {
+				return err
+			}
+		}
+	}
+
+	return w.Flush()
 }


### PR DESCRIPTION
Related to https://github.com/GoogleContainerTools/kpt/issues/3202

Trying to tackle the second bullet point - finding out which downstream packages need an update based on the provided upstream package. 

This PR does the following:

What is currently supported by `kpt alpha rpkg update --discover` will change to `kpt alpha rpkg update --discover=upstream`:
```
$ kpt alpha rpkg update --discover=upstream
PACKAGE REVISION                                            UPSTREAM REPOSITORY   UPSTREAM UPDATES
kpt-samples-47e4436a7490df604f57e75a9d995c2ca7ba0a88                              No update available
kpt-samples-6b14817885cbbaa1144d5b19df3378144cc24551                              No update available
test-deployments-2f36052b298673c231e8debcdd1a4553200b45c7   kpt-samples           v1, v2
test-deployments-bfcd0186c8528d13068e6d71b73329bac504f30b   kpt-samples           v2
test-deployments-f21b3faa487feec5cd231c3aa8698bbd8c2dd88d   kpt-samples           v2
```

This PR adds another option `--discover=downstream` to tackle the reverse question. If a package revision has multiple downstream packages that need to be updated, those entries in the output table will be grouped together (like the middle two in the following output):
```
$ kpt alpha rpkg update --discover=downstream
PACKAGE REVISION                                       DOWNSTREAM PACKAGE                                          DOWNSTREAM UPDATE
kpt-samples-dc223acc4eeba1e3a41a90e9756b00872a51855d   test-deployments-2f36052b298673c231e8debcdd1a4553200b45c7   v0->v2
kpt-samples-b2d61a19750d212c61a1c64b0a1cf1ce0efddc28   test-deployments-bfcd0186c8528d13068e6d71b73329bac504f30b   v1->v2
kpt-samples-b2d61a19750d212c61a1c64b0a1cf1ce0efddc28   test-deployments-f21b3faa487feec5cd231c3aa8698bbd8c2dd88d   v1->v2
kpt-samples-ec01f2365a60ce92d9217225dc447da8e1e722c1   test-deployments-2f36052b298673c231e8debcdd1a4553200b45c7   v0->v1
```

You can optionally provide package revisions as arguments if you only want to look at specific ones:
```
$ kpt alpha rpkg update --discover=downstream kpt-samples-b2d61a19750d212c61a1c64b0a1cf1ce0efddc28
PACKAGE REVISION                                       DOWNSTREAM PACKAGE                                          DOWNSTREAM UPDATE
kpt-samples-b2d61a19750d212c61a1c64b0a1cf1ce0efddc28   test-deployments-bfcd0186c8528d13068e6d71b73329bac504f30b   v1->v2
kpt-samples-b2d61a19750d212c61a1c64b0a1cf1ce0efddc28   test-deployments-f21b3faa487feec5cd231c3aa8698bbd8c2dd88d   v1->v2
```

If there is nothing to output, we just print that all downstream packages are up to date:
```
$ kpt alpha rpkg update --discover=downstream kpt-samples-414c1509c368a46650e4a1098487096ed5c05d81
All downstream packages are up to date.
```