### PR TITLE
Add missing license headers

### DIFF
--- a/dogfood/sitev2/main.go
+++ b/dogfood/sitev2/main.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/scripts/update-license.sh
+++ b/scripts/update-license.sh
@@ -26,4 +26,7 @@ go run github.com/justinsb/addlicense@v1.0.1 \
   --ignore "**/.expected/results.yaml" \
   --ignore "**/testdata/**" \
   --ignore "**/generated/**" \
+  --ignore "package-examples/cert-manager-basic/**" \
+  --ignore "package-examples/ghost/**" \
+  --ignore "package-examples/ingress-nginx/**" \
   . 2>&1 | ( grep -v "skipping: " || true )


### PR DESCRIPTION
We have some files that are missing the license headers. This causes unexpected changes when running `make all`. This PR excludes the `cert-manager`, `ghost` and `ingress-nginx` packages and updates the one remaining file that was missing the license.