### PR TITLE
cli: ensure we hide most klog flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,6 @@ package main
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"os"
 
@@ -48,22 +47,15 @@ func main() {
 // runMain does the initial setup in order to run kpt. The return value from
 // this function will be the exit code when kpt terminates.
 func runMain() int {
-	var logFlags flag.FlagSet
 	var err error
 
 	ctx := context.Background()
 
-	cmd := run.GetMain(ctx)
-
 	// Enable commandline flags for klog.
 	// logging will help in collecting debugging information from users
-	// Note(droot): There are too many flags exposed that makes the command
-	// usage verbose but couldn't find a way to make it less verbose.
-	klog.InitFlags(&logFlags)
-	// By default klog v1 logs to stderr, switch that off
-	_ = logFlags.Set("logtostderr", "false")
-	_ = logFlags.Set("alsologtostderr", "true")
-	cmd.Flags().AddGoFlagSet(&logFlags)
+	klog.InitFlags(nil)
+
+	cmd := run.GetMain(ctx)
 
 	err = cli.RunNoErrOutput(cmd)
 	if err != nil {

--- a/run/run.go
+++ b/run/run.go
@@ -17,6 +17,7 @@ package run
 import (
 	"bytes"
 	"context"
+	"flag"
 	"fmt"
 	"os"
 	"os/exec"
@@ -54,6 +55,8 @@ func GetMain(ctx context.Context) *cobra.Command {
 			return cmd.Usage()
 		},
 	}
+
+	cmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 
 	cmd.PersistentFlags().BoolVar(&printer.TruncateOutput, "truncate-output", true,
 		"Enable the truncation for output")
@@ -171,8 +174,12 @@ func hideFlags(cmd *cobra.Command) {
 		"log_dir",
 		"log_file",
 		"log_file_max_size",
+		"logtostderr",
+		"one_output",
 		"skip_headers",
 		"skip_log_headers",
+		"stack-trace",
+		"stderrthreshold",
 		"vmodule",
 
 		// Flags related to apiserver


### PR DESCRIPTION
We already had the logic to hide flags, we just needed to change the
order of initialization a bit.
