### PR TITLE
release: Generate SLSA signatures on GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: kpt-release
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
     steps:
       - name: Set up Go
         uses: actions/setup-go@v2
@@ -48,8 +50,29 @@ jobs:
           ./scripts/create-licenses.sh
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
+        id: run-goreleaser
         with:
           version: latest
           args: release --skip-validate -f release/tag/goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Generate SLSA subjects for provenance
+        id: hash
+        env:
+          ARTIFACTS: "${{ steps.run-goreleaser.outputs.artifacts }}"
+        run: |
+          set -euo pipefail
+
+          checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
+          echo "::set-output name=hashes::$(cat $checksum_file | base64 -w0)"
+  
+  provenance:
+    needs: [build]
+    permissions:
+      actions: read # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.0
+    with:
+      base64-subjects: "${{ needs.build.outputs.hashes }}"
+      upload-assets: true # upload to a new release

--- a/site/installation/kpt-cli.md
+++ b/site/installation/kpt-cli.md
@@ -11,6 +11,14 @@ Download pre-compiled binaries:
 - [MacOS (amd64)][darwin-amd64]
 - [MacOS (arm64)][darwin-arm64]
 
+Optionally verify the [SLSA3 signatures](slsa.dev) generated using the OpenSSF's [slsa-framework/slsa-github-generator](https://github.com/slsa-framework/slsa-github-generator) during the release process. To verify a release binary:
+1. Install the verification tool from [slsa-framework/slsa-verifier#installation](https://github.com/slsa-framework/slsa-verifier#installation).
+2. Download the signature file `attestation.intoto.jsonl` from the [GitHub releases page](https://github.com/GoogleContainerTools/jib/releases/latest).
+3. Run the verifier:
+```shell
+slsa-verifier -artifact-path kpt-<os>-<arch> -provenance attestation.intoto.jsonl -source github.com/GoogleContainerTools/kpt -tag <the-tag>
+```
+
 On Linux and MacOS, make it executable:
 
 ```shell


### PR DESCRIPTION
Signed-off-by: Asra Ali <asraa@google.com>

Hi,

I'm reaching out on behalf of the [Open Source Security Foundation (openssf.org)](https://openssf.org/). We work on improving the security of critical open source projects like yours.

Together with [GitHub](https://github.blog/2022-04-07-slsa-3-compliance-with-github-actions/), we designed a free, easy-to-use method of code signing. It will help your users verify that your release binaries were built from your repository’s [workflow](https://github.com/GoogleContainerTools/kpt/blob/master/.github/workflows/release.yml) and not altered by anyone. It’s just a few lines of code, but it will make your project more secure against third-party tampering and attacks like [Codecov](https://about.codecov.io/apr-2021-post-mortem/) and [CTX](https://sockpuppets.medium.com/how-i-hacked-ctx-and-phpass-modules-656638c6ec5e).

We have also integrated with [jib](https://github.com/GoogleContainerTools/jib).

This PR shows how to add this seamless code signing to your workflow. You don’t have to be a cryptography expert or learn complicated tools and [verification](https://github.com/slsa-framework/slsa-verifier/blob/main/README.md#verification-of-provenance) is simple for your users.

You can read more on the [SLSA blog](https://slsa.dev/blog/2022/06/slsa-github-workflows) or on the documentation of the workflow [here](https://github.com/slsa-framework/slsa-github-generator/blob/main/internal/builders/generic/README.md). Please reach out if you have any questions!