### PR TITLE
Add governance and update community page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Conduct].
 Join following groups/channels to discuss ideas with other kpt contributors.
 
 1. For developers join our [email list](https://groups.google.com/forum/?oldui=1#!forum/kpt-dev)
-1. If you'd like to be invited to all public meetings join [email list](https://groups.google.com/forum/?oldui=1#!forum/kpt-contribx)
+1. If you'd like to be invited to all public meetings join [email list](https://groups.google.com/forum/?oldui=1#!forum/kpt-contribx). Pleae note, our meetings are open to anyone and you do not need an agenda to come. You will likely be asked at most for an introduction. For your first meeting, we would suggest you either start with Office Hours or a SIG meeting.
 1. Join our [Slack channel](https://kubernetes.slack.com/channels/kpt)
 
 ## Style Guides

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # How to Contribute
 
-We'd love to accept your patches and contributions to this project. There are
+We'd love to accept your patches and contributions to this project. To learn more about the project structure and organization, please refer to Project [Governance](governance.md) information. There are
 just a few small guidelines you need to follow.
 
 ## Contributor License Agreement
@@ -43,7 +43,8 @@ Conduct].
 
 Join following groups/channels to discuss ideas with other kpt contributors.
 
-1. Join our [email list](https://groups.google.com/forum/?oldui=1#!forum/kpt-dev)
+1. For developers join our [email list](https://groups.google.com/forum/?oldui=1#!forum/kpt-dev)
+1. If you'd like to be invited to all public meetings join [email list](https://groups.google.com/forum/?oldui=1#!forum/kpt-contribx)
 1. Join our [Slack channel](https://kubernetes.slack.com/channels/kpt)
 
 ## Style Guides
@@ -59,6 +60,24 @@ The kpt toolchain has several components such as `kpt CLI`, `package orchestrato
 `function catalog`, `function SDKs`, `Backstage UI plugin` and `config sync`. Each
 component has their own development process.
 Refer to the pointers below to learn more:
+
+## Attend Meetings
+* All [SIGs](governance.md) have a regular scheduled meeting for feature/roadmap management and planning. For example if you are interested in discussing the roadmap for Config Sync you should attend the **Kpt SIG Config Sync** meeting
+* Sub-projects are focused on more tactical items and other sub-project lifecycle items. Sub-projects generally have standups associated with them.
+* Working Groups are nimble. Focused a lot on experimentation. Attend if you'd like to see demos and discuss future looking user experiences.
+* We regularly have an office hours where we invite the entire community to attend.
+* Meeting notes will be kept for all meetings. Recordings are optional.
+* Demos will be recorded and linked in meeting notes.
+
+### Meeting Notes
+Links to meeting notes. Some may require access to mailing lists above. If in doubt join [kpt-contribx](https://groups.google.com/forum/?oldui=1#!forum/kpt-contribx)
+
+* [Kpt Office Hours](https://docs.google.com/document/d/1I5CJDk9xkDj1vvvwvZNgvaNusE2TanX0Iiy9G1oitz0/view)
+* [App Wow Working Group](https://docs.google.com/document/d/1pHsmYjHr9XMwJ_fdJtPiodd8WSg5ilCLIrP_8KE-yKE/view)
+
+Coming soon
+* SIG Config as Data
+* SIG Config Sync
 
 ### kpt CLI
 

--- a/governance.md
+++ b/governance.md
@@ -1,0 +1,58 @@
+# Governance
+
+The Kpt governance model is modeled after [Kubernetes](https://github.com/kubernetes/community/blob/master/governance.md). In particular, we leverage the same hierarchy of steering committee, SIGs, subprojects, working groups that Kubernetes does to facilitiate engagement with the greater ecosystem. We plan to refine this over time as the number of contributors grow. As an example, we don't plan to record all sig meetings at the start but may over time as it becomes valuable for interested parties who miss the meetings. If something is not defined here, it is expected that we will inherit the Kubernetes equivalent.
+
+# Committees and Groups
+
+## Kpt Steering Committee
+The Kpt Steering Committee is the governing body for the Kpt project
+Please reach out to us on slack or attend one of the SIG meetings to bring up anything you'd like to discuss. We actively partcipate in the SIGs as well as Office Hours
+ | Name | Profile |
+ | ---- | ------- |
+ | Chris Sosa | **[@selfmanagingresource](https://github.com/selfmanagingresource)** |
+ | Brian Grant | **[@bgrant0607](https://github.com/bgrant0607)** |
+ | Justin Santa Barbara | **[@justinsb](https://github.com/justinsb)** |
+ | John Belamaric | **[@johnbelamaric](https://github.com/johnbelamaric)** |
+    
+
+## SIG - Config As Data
+Covers leveraging [Config as Data](https://cloud.google.com/blog/products/containers-kubernetes/understanding-configuration-as-data-in-kubernetes) to customize and automate configuration at scale. This is the largest SIG in Kpt that spans most of its surface area including incubation for apply config as data to new use cases.
+### Chairs
+ * Brian Grant ( **[@bgrant0607](https://github.com/bgrant0607)**)
+ * Chris Sosa (**[@selfmanagingresource](https://github.com/selfmanagingresource)**)
+
+### Sub-Projects
+
+#### Kpt-Core
+Everything not covered by another sub-project including porch, fn render, etc
+
+##### Tech Leads
+
+ * Sunil Arora ( **[@droot](https://github.com/droot)**)
+ * Morten Torkildsen (**[@mortent](https://github.com/mortent)**)
+
+#### Kpt SDK
+Owns the SDK that enables our Config as Data experience
+
+##### Tech Leads
+  * Yuwen Ma ( **[@yuwenma](https://github.com/yuwenma)**)
+
+### Working-Groups
+
+#### App Wow
+Focused on making it easy to leverage Config as Data with application workloads
+
+##### Lead
+ * Chris Sosa (**[@selfmanagingresource](https://github.com/selfmanagingresource)**)
+
+
+## SIG - Config Sync
+Focused on making it easy to automate deployments through GitOps. Owns the APIs and tools that are part of the [Config Sync repository](https://kpt.dev/gitops/configsync/)
+
+### Chairs
+ * Mike Borozdin ( **[@mikebz](https://github.com/mikebz)**)
+ * Janet Kuo (**[@janetkuo](https://github.com/janetkuo)**)
+
+
+
+


### PR DESCRIPTION
This changes adds the governance page for Kpt and updates the community page to reflect that. In addition, I've included the meeting notes and additional mailing lists to join that have been created organically along the way