### PR TITLE
Fix controller configuration

### DIFF
--- a/porch/controllers/config/crd/bases/config.porch.kpt.dev_remoterootsyncsets.yaml
+++ b/porch/controllers/config/crd/bases/config.porch.kpt.dev_remoterootsyncsets.yaml
@@ -19,9 +19,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
-  name: remoterootsyncsets.config.cloud.google.com
+  name: remoterootsyncsets.config.porch.kpt.dev
 spec:
-  group: config.cloud.google.com
+  group: config.porch.kpt.dev
   names:
     kind: RemoteRootSyncSet
     listKind: RemoteRootSyncSetList

--- a/porch/controllers/config/crd/bases/config.porch.kpt.dev_rootsyncsets.yaml
+++ b/porch/controllers/config/crd/bases/config.porch.kpt.dev_rootsyncsets.yaml
@@ -19,24 +19,20 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
-  name: workloadidentitybindings.porch.kpt.dev
+  name: rootsyncsets.config.porch.kpt.dev
 spec:
-  group: porch.kpt.dev
+  group: config.porch.kpt.dev
   names:
-    kind: WorkloadIdentityBinding
-    listKind: WorkloadIdentityBindingList
-    plural: workloadidentitybindings
-    singular: workloadidentitybinding
+    kind: RootSyncSet
+    listKind: RootSyncSetList
+    plural: rootsyncsets
+    singular: rootsyncset
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .status.conditions[?(@.type=='Ready')].reason
-      name: Ready
-      type: string
-    name: v1alpha1
+  - name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: WorkloadIdentityBinding
+        description: RootSyncSet is the Schema for the rootsyncsets API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -51,37 +47,66 @@ spec:
           metadata:
             type: object
           spec:
-            description: WorkloadIdentityBindingSpec defines the desired state of
-              RemoteRootSync
+            description: RootSyncSetSpec defines the desired state of RootSyncSet
             properties:
-              resourceRef:
+              clusterRefs:
+                items:
+                  properties:
+                    apiVersion:
+                      type: string
+                    kind:
+                      type: string
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                  required:
+                  - namespace
+                  type: object
+                type: array
+              template:
                 properties:
-                  apiVersion:
-                    type: string
-                  external:
-                    type: string
-                  kind:
-                    type: string
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                type: object
-              serviceAccountRef:
-                properties:
-                  apiVersion:
-                    type: string
-                  kind:
-                    type: string
-                  name:
-                    type: string
-                  namespace:
-                    type: string
+                  spec:
+                    properties:
+                      git:
+                        properties:
+                          auth:
+                            type: string
+                          branch:
+                            type: string
+                          dir:
+                            type: string
+                          gcpServiceAccountEmail:
+                            type: string
+                          noSSLVerify:
+                            type: boolean
+                          period:
+                            type: string
+                          proxy:
+                            type: string
+                          repo:
+                            type: string
+                          revision:
+                            type: string
+                          secretRef:
+                            description: SecretReference contains the reference to
+                              the secret used to connect to Git source of truth.
+                            properties:
+                              name:
+                                description: Name represents the secret name.
+                                type: string
+                            type: object
+                        required:
+                        - auth
+                        - repo
+                        type: object
+                      sourceFormat:
+                        type: string
+                    type: object
                 type: object
             type: object
           status:
-            description: WorkloadIdentityBindingStatus defines the observed state
-              of WorkloadIdentityBinding
+            description: RootSyncSetStatus defines the observed state of RootSyncSet
             properties:
               conditions:
                 description: Conditions describes the reconciliation state of the

--- a/porch/controllers/config/crd/bases/config.porch.kpt.dev_workloadidentitybindings.yaml
+++ b/porch/controllers/config/crd/bases/config.porch.kpt.dev_workloadidentitybindings.yaml
@@ -19,20 +19,24 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
-  name: rootsyncsets.config.cloud.google.com
+  name: workloadidentitybindings.config.porch.kpt.dev
 spec:
-  group: config.cloud.google.com
+  group: config.porch.kpt.dev
   names:
-    kind: RootSyncSet
-    listKind: RootSyncSetList
-    plural: rootsyncsets
-    singular: rootsyncset
+    kind: WorkloadIdentityBinding
+    listKind: WorkloadIdentityBindingList
+    plural: workloadidentitybindings
+    singular: workloadidentitybinding
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].reason
+      name: Ready
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: RootSyncSet is the Schema for the rootsyncsets API
+        description: WorkloadIdentityBinding
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation
@@ -47,66 +51,37 @@ spec:
           metadata:
             type: object
           spec:
-            description: RootSyncSetSpec defines the desired state of RootSyncSet
+            description: WorkloadIdentityBindingSpec defines the desired state of
+              RemoteRootSync
             properties:
-              clusterRefs:
-                items:
-                  properties:
-                    apiVersion:
-                      type: string
-                    kind:
-                      type: string
-                    name:
-                      type: string
-                    namespace:
-                      type: string
-                  required:
-                  - namespace
-                  type: object
-                type: array
-              template:
+              resourceRef:
                 properties:
-                  spec:
-                    properties:
-                      git:
-                        properties:
-                          auth:
-                            type: string
-                          branch:
-                            type: string
-                          dir:
-                            type: string
-                          gcpServiceAccountEmail:
-                            type: string
-                          noSSLVerify:
-                            type: boolean
-                          period:
-                            type: string
-                          proxy:
-                            type: string
-                          repo:
-                            type: string
-                          revision:
-                            type: string
-                          secretRef:
-                            description: SecretReference contains the reference to
-                              the secret used to connect to Git source of truth.
-                            properties:
-                              name:
-                                description: Name represents the secret name.
-                                type: string
-                            type: object
-                        required:
-                        - auth
-                        - repo
-                        type: object
-                      sourceFormat:
-                        type: string
-                    type: object
+                  apiVersion:
+                    type: string
+                  external:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                type: object
+              serviceAccountRef:
+                properties:
+                  apiVersion:
+                    type: string
+                  kind:
+                    type: string
+                  name:
+                    type: string
+                  namespace:
+                    type: string
                 type: object
             type: object
           status:
-            description: RootSyncSetStatus defines the observed state of RootSyncSet
+            description: WorkloadIdentityBindingStatus defines the observed state
+              of WorkloadIdentityBinding
             properties:
               conditions:
                 description: Conditions describes the reconciliation state of the

--- a/porch/controllers/config/rbac/role.yaml
+++ b/porch/controllers/config/rbac/role.yaml
@@ -17,7 +17,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   creationTimestamp: null
-  name: configmanagement-operator
+  name: porch-controllers
 rules:
 - apiGroups:
   - ""
@@ -27,9 +27,9 @@ rules:
   - create
   - patch
 - apiGroups:
-  - config.cloud.google.com
+  - config.porch.kpt.dev
   resources:
-  - remoterootsyncs
+  - remoterootsyncsets
   verbs:
   - create
   - delete
@@ -39,21 +39,21 @@ rules:
   - update
   - watch
 - apiGroups:
-  - config.cloud.google.com
+  - config.porch.kpt.dev
   resources:
-  - remoterootsyncs/finalizers
+  - remoterootsyncsets/finalizers
   verbs:
   - update
 - apiGroups:
-  - config.cloud.google.com
+  - config.porch.kpt.dev
   resources:
-  - remoterootsyncs/status
+  - remoterootsyncsets/status
   verbs:
   - get
   - patch
   - update
 - apiGroups:
-  - config.cloud.google.com
+  - config.porch.kpt.dev
   resources:
   - rootsyncsets
   verbs:
@@ -65,15 +65,41 @@ rules:
   - update
   - watch
 - apiGroups:
-  - config.cloud.google.com
+  - config.porch.kpt.dev
   resources:
   - rootsyncsets/finalizers
   verbs:
   - update
 - apiGroups:
-  - config.cloud.google.com
+  - config.porch.kpt.dev
   resources:
   - rootsyncsets/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - config.porch.kpt.dev
+  resources:
+  - workloadidentitybindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - config.porch.kpt.dev
+  resources:
+  - workloadidentitybindings/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - config.porch.kpt.dev
+  resources:
+  - workloadidentitybindings/status
   verbs:
   - get
   - patch
@@ -90,29 +116,3 @@ rules:
   - patch
   - update
   - watch
-- apiGroups:
-  - porch.kpt.dev
-  resources:
-  - workloadidentitybindings
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-- apiGroups:
-  - porch.kpt.dev
-  resources:
-  - workloadidentitybindings/finalizers
-  verbs:
-  - update
-- apiGroups:
-  - porch.kpt.dev
-  resources:
-  - workloadidentitybindings/status
-  verbs:
-  - get
-  - patch
-  - update

--- a/porch/controllers/main.go
+++ b/porch/controllers/main.go
@@ -14,7 +14,7 @@
 
 package main
 
-//go:generate go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.8.0 rbac:roleName=configmanagement-operator webhook paths="./..."
+//go:generate go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.8.0 rbac:roleName=porch-controllers webhook paths="./..."
 
 //go:generate go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.8.0 crd paths="./..." output:crd:artifacts:config=config/crd/bases
 
@@ -88,7 +88,7 @@ func run(ctx context.Context) error {
 		Port:                       9443,
 		HealthProbeBindAddress:     ":8081",
 		LeaderElection:             false,
-		LeaderElectionID:           "porch-operators.config.cloud.google.com",
+		LeaderElectionID:           "porch-operators.config.porch.kpt.dev",
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
 	}
 

--- a/porch/controllers/remoterootsync/api/v1alpha1/groupversion_info.go
+++ b/porch/controllers/remoterootsync/api/v1alpha1/groupversion_info.go
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package v1alpha1 contains API Schema definitions for the config.cloud.google.com v1alpha1 API group
+// Package v1alpha1 contains API Schema definitions for the config.porch.kpt.dev v1alpha1 API group
 // +kubebuilder:object:generate=true
-// +groupName=config.cloud.google.com
+// +groupName=config.porch.kpt.dev
 package v1alpha1
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "config.cloud.google.com", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "config.porch.kpt.dev", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/porch/controllers/remoterootsync/config/samples/apply-to-gke.yaml
+++ b/porch/controllers/remoterootsync/config/samples/apply-to-gke.yaml
@@ -26,7 +26,7 @@ spec:
 
 ---
 
-apiVersion: config.cloud.google.com/v1alpha1
+apiVersion: config.porch.kpt.dev/v1alpha1
 kind: RemoteRootSyncSet
 metadata:
   name: example-1

--- a/porch/controllers/remoterootsync/config/samples/hack-self-apply.yaml
+++ b/porch/controllers/remoterootsync/config/samples/hack-self-apply.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-apiVersion: config.cloud.google.com/v1alpha1
+apiVersion: config.porch.kpt.dev/v1alpha1
 kind: RemoteRootSyncSet
 metadata:
   name: loopback-apply

--- a/porch/controllers/remoterootsync/pkg/controllers/remoterootsyncset/remoterootsync_controller.go
+++ b/porch/controllers/remoterootsync/pkg/controllers/remoterootsyncset/remoterootsync_controller.go
@@ -62,9 +62,9 @@ type RemoteRootSyncSetReconciler struct {
 	localRESTConfig *rest.Config
 }
 
-//+kubebuilder:rbac:groups=config.cloud.google.com,resources=remoterootsyncs,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=config.cloud.google.com,resources=remoterootsyncs/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=config.cloud.google.com,resources=remoterootsyncs/finalizers,verbs=update
+//+kubebuilder:rbac:groups=config.porch.kpt.dev,resources=remoterootsyncsets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=config.porch.kpt.dev,resources=remoterootsyncsets/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=config.porch.kpt.dev,resources=remoterootsyncsets/finalizers,verbs=update
 
 // Reconcile implements the main kubernetes reconciliation loop.
 func (r *RemoteRootSyncSetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -72,7 +72,7 @@ func (r *RemoteRootSyncSetReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	if err := r.Get(ctx, req.NamespacedName, &subject); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	myFinalizerName := "config.cloud.google.com/finalizer"
+	myFinalizerName := "config.porch.kpt.dev/finalizer"
 	if subject.ObjectMeta.DeletionTimestamp.IsZero() {
 		// The object is not being deleted, so if it does not have our finalizer,
 		// then lets add the finalizer and update the object. This is equivalent

--- a/porch/controllers/rootsyncset/api/v1alpha1/groupversion_info.go
+++ b/porch/controllers/rootsyncset/api/v1alpha1/groupversion_info.go
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package v1alpha1 contains API Schema definitions for the config.cloud.google.com v1alpha1 API group
+// Package v1alpha1 contains API Schema definitions for the config.porch.kpt.dev v1alpha1 API group
 //+kubebuilder:object:generate=true
-//+groupName=config.cloud.google.com
+//+groupName=config.porch.kpt.dev
 package v1alpha1
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "config.cloud.google.com", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "config.porch.kpt.dev", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/porch/controllers/rootsyncset/pkg/controllers/rootsyncset/controller.go
+++ b/porch/controllers/rootsyncset/pkg/controllers/rootsyncset/controller.go
@@ -55,9 +55,9 @@ type RootSyncSetReconciler struct {
 	WorkloadIdentityHelper
 }
 
-//+kubebuilder:rbac:groups=config.cloud.google.com,resources=rootsyncsets,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=config.cloud.google.com,resources=rootsyncsets/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=config.cloud.google.com,resources=rootsyncsets/finalizers,verbs=update
+//+kubebuilder:rbac:groups=config.porch.kpt.dev,resources=rootsyncsets,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=config.porch.kpt.dev,resources=rootsyncsets/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=config.porch.kpt.dev,resources=rootsyncsets/finalizers,verbs=update
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -74,7 +74,7 @@ func (r *RootSyncSetReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	if err := r.Get(ctx, req.NamespacedName, &rootsyncset); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	myFinalizerName := "config.cloud.google.com/finalizer"
+	myFinalizerName := "config.porch.kpt.dev/finalizer"
 	if rootsyncset.ObjectMeta.DeletionTimestamp.IsZero() {
 		// The object is not being deleted, so if it does not have our finalizer,
 		// then lets add the finalizer and update the object. This is equivalent

--- a/porch/controllers/workloadidentitybinding/api/v1alpha1/groupversion_info.go
+++ b/porch/controllers/workloadidentitybinding/api/v1alpha1/groupversion_info.go
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package v1alpha1 contains API Schema definitions for the porch.kpt.dev v1alpha1 API group
+// Package v1alpha1 contains API Schema definitions for the config.porch.kpt.dev v1alpha1 API group
 // +kubebuilder:object:generate=true
-// +groupName=porch.kpt.dev
+// +groupName=config.porch.kpt.dev
 package v1alpha1
 
 import (
@@ -26,7 +26,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "porch.kpt.dev", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "config.porch.kpt.dev", Version: "v1alpha1"}
 
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}

--- a/porch/controllers/workloadidentitybinding/config/samples/simple.yaml
+++ b/porch/controllers/workloadidentitybinding/config/samples/simple.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: porch.kpt.dev/v1alpha1
+apiVersion: config.porch.kpt.dev/v1alpha1
 kind: WorkloadIdentityBinding
 metadata:
   name: cnrm-controller-manager-example-project-id

--- a/porch/controllers/workloadidentitybinding/pkg/controllers/workloadidentitybinding/controller.go
+++ b/porch/controllers/workloadidentitybinding/pkg/controllers/workloadidentitybinding/controller.go
@@ -40,9 +40,9 @@ type WorkloadIdentityBindingReconciler struct {
 	restMapper    meta.RESTMapper
 }
 
-//+kubebuilder:rbac:groups=porch.kpt.dev,resources=workloadidentitybindings,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=porch.kpt.dev,resources=workloadidentitybindings/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=porch.kpt.dev,resources=workloadidentitybindings/finalizers,verbs=update
+//+kubebuilder:rbac:groups=config.porch.kpt.dev,resources=workloadidentitybindings,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=config.porch.kpt.dev,resources=workloadidentitybindings/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=config.porch.kpt.dev,resources=workloadidentitybindings/finalizers,verbs=update
 
 // Reconcile implements the main kubernetes reconciliation loop.
 func (r *WorkloadIdentityBindingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -50,7 +50,7 @@ func (r *WorkloadIdentityBindingReconciler) Reconcile(ctx context.Context, req c
 	if err := r.Get(ctx, req.NamespacedName, &subject); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	// myFinalizerName := "config.cloud.google.com/finalizer"
+	// myFinalizerName := "config.porch.kpt.dev/finalizer"
 	// if subject.ObjectMeta.DeletionTimestamp.IsZero() {
 	// 	// The object is not being deleted, so if it does not have our finalizer,
 	// 	// then lets add the finalizer and update the object. This is equivalent

--- a/porch/deployments/porch/9-controllers.yaml
+++ b/porch/deployments/porch/9-controllers.yaml
@@ -49,21 +49,49 @@ spec:
           value: "1"
 
 ---
-
+# TODO: Part of this is currently copied from porch/controller/config/rbac/role.yaml
+# We should find a better solution.
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: porch-controllers
 rules:
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
 - apiGroups: ["config.porch.kpt.dev"]
   resources: ["repositories"]
   verbs: ["get", "list", "watch", "create", "update", "patch"]
-- apiGroups: ["config.cloud.google.com"]
+- apiGroups: ["config.porch.kpt.dev"]
   resources: ["remoterootsyncsets"]
   verbs: ["get", "list", "watch", "create", "update", "patch"]
-- apiGroups: ["config.cloud.google.com"]
+- apiGroups: ["config.porch.kpt.dev"]
   resources: ["remoterootsyncsets/status"]
   verbs: ["get", "list", "watch", "create", "update", "patch"]
+- apiGroups: ["config.porch.kpt.dev"]
+  resources: ["remoterootsyncsets/finalizers"]
+  verbs: ["update"]
+- apiGroups: ["config.porch.kpt.dev"]
+  resources: ["rootsyncsets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]
+- apiGroups: ["config.porch.kpt.dev"]
+  resources: ["rootsyncsets/status"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]
+- apiGroups: ["config.porch.kpt.dev"]
+  resources: ["rootsyncsets/finalizers"]
+  verbs: ["update"]
+- apiGroups: ["config.porch.kpt.dev"]
+  resources: ["workloadidentitybindings"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]
+- apiGroups: ["config.porch.kpt.dev"]
+  resources: ["workloadidentitybindings/status"]
+  verbs: ["get", "list", "watch", "create", "update", "patch"]
+- apiGroups: ["config.porch.kpt.dev"]
+  resources: ["workloadidentitybindings/finalizers"]
+  verbs: ["update"]
 
 ---
 

--- a/porch/scripts/create-deployment-blueprint.sh
+++ b/porch/scripts/create-deployment-blueprint.sh
@@ -168,10 +168,15 @@ function customize-sa {
 
 function main() {
   # RemoteRootSync controller
-  cp "${PORCH_DIR}/controllers/config/crd/bases/config.cloud.google.com_remoterootsyncsets.yaml" \
+  cp "${PORCH_DIR}/controllers/config/crd/bases/config.porch.kpt.dev_remoterootsyncsets.yaml" \
      "${DESTINATION}/0-remoterootsyncsets.yaml"
-  cp "${PORCH_DIR}/controllers/config/rbac/role.yaml" \
-     "${DESTINATION}/0-remoterootsync-role.yaml"
+  # WorkloadIdentityBinding controller
+  cp "${PORCH_DIR}/controllers/config/crd/bases/config.porch.kpt.dev_workloadidentitybindings.yaml" \
+     "${DESTINATION}/0-workloadidentitybindings.yaml"
+  # RootSyncSet controller
+  cp "${PORCH_DIR}/controllers/config/crd/bases/config.porch.kpt.dev_rootsyncsets.yaml" \
+     "${DESTINATION}/0-rootsyncsets.yaml"
+
   # Repository CRD
   cp "./api/porchconfig/v1alpha1/config.porch.kpt.dev_repositories.yaml" \
      "${DESTINATION}/0-repositories.yaml"


### PR DESCRIPTION
* Updated the `porch/scripts/create-deployment-blueprint.sh` script to include the CRDs for the WorkloadIdentityBindings and the RootSyncSet controllers.
* Changed the group for the WorkloadIdentityBindings CRD from `porch.kpt.dev` to `config.cloud.google.com` to avoid using the same group for the CRD and the types for the aggregated apiserver.

Longer term, we need to decide:
* Which group should we be using for kpt/porch types?
* We probably need to be able to enable/disable certain of the controllers.
