### PR TITLE
WorkloadIdentityBinding: needs RBAC permissions to read namespaces

### DIFF
--- a/porch/controllers/config/rbac/role.yaml
+++ b/porch/controllers/config/rbac/role.yaml
@@ -27,6 +27,14 @@ rules:
   - create
   - patch
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - config.porch.kpt.dev
   resources:
   - remoterootsyncsets

--- a/porch/controllers/workloadidentitybinding/pkg/controllers/workloadidentitybinding/controller.go
+++ b/porch/controllers/workloadidentitybinding/pkg/controllers/workloadidentitybinding/controller.go
@@ -44,6 +44,9 @@ type WorkloadIdentityBindingReconciler struct {
 //+kubebuilder:rbac:groups=config.porch.kpt.dev,resources=workloadidentitybindings/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=config.porch.kpt.dev,resources=workloadidentitybindings/finalizers,verbs=update
 
+// Needs to read namespace to get project-id annotation
+//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
+
 // Reconcile implements the main kubernetes reconciliation loop.
 func (r *WorkloadIdentityBindingReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var subject api.WorkloadIdentityBinding
@@ -121,7 +124,6 @@ func updateStatus(subject *api.WorkloadIdentityBinding, results *applyset.ApplyR
 }
 
 func (r *WorkloadIdentityBindingReconciler) applyToClusterRef(ctx context.Context, subject *api.WorkloadIdentityBinding) (*applyset.ApplyResults, error) {
-
 	ns := &corev1.Namespace{}
 	if err := r.Get(ctx, types.NamespacedName{Name: subject.GetNamespace()}, ns); err != nil {
 		return nil, fmt.Errorf("error getting namespace %q: %w", subject.GetNamespace(), err)


### PR DESCRIPTION
We need to get the project-id annotation from the namespace.
