### PR TITLE
Add workaround for bug in goreleaser to enable signing of kpt release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
+          # Workaround for https://github.com/goreleaser/goreleaser-action/issues/368
+          # checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
+          checksum_file=$(cat dist/artifacts.json | jq -r '.[] | select (.type=="Checksum") | .path')
+
           echo "::set-output name=hashes::$(cat $checksum_file | base64 -w0)"
   
   provenance:


### PR DESCRIPTION
Workaround for https://github.com/goreleaser/goreleaser-action/issues/368