### PR TITLE
Update path to generated artifacts for signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
 
           # Workaround for https://github.com/goreleaser/goreleaser-action/issues/368
           # checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
-          checksum_file=$(cat dist/artifacts.json | jq -r '.[] | select (.type=="Checksum") | .path')
+          checksum_file=$(cat _output/artifacts.json | jq -r '.[] | select (.type=="Checksum") | .path')
 
           echo "::set-output name=hashes::$(cat $checksum_file | base64 -w0)"
   


### PR DESCRIPTION
Trying the same workaround as in https://github.com/grpc-ecosystem/grpc-gateway/pull/2864
