### PR TITLE
fix: Fix broken releases due to improper configs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,24 +50,18 @@ jobs:
           ./scripts/create-licenses.sh
       - name: Setup release environment
         id: setup-release-env
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |-
-          echo 'GITHUB_TOKEN=${{secrets.GORELEASER_ACCESS_TOKEN}}' > .release-env
+          echo 'GITHUB_TOKEN=${{secrets.GITHUB_TOKEN}}' > .release-env
       - name: Run GoReleaser within Docker
         id: run-goreleaser
         run: |
           make release
       - name: Generate SLSA subjects for provenance
         id: hash
-        env:
-          ARTIFACTS: "${{ steps.run-goreleaser.outputs.artifacts }}"
         run: |
           set -euo pipefail
 
-          # Workaround for https://github.com/goreleaser/goreleaser-action/issues/368
-          # checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
-          checksum_file=$(cat _output/artifacts.json | jq -r '.[] | select (.type=="Checksum") | .path')
+          checksum_file=$(cat dist/artifacts.json | jq -r '.[] | select (.type=="Checksum") | .path')
 
           echo "::set-output name=hashes::$(cat $checksum_file | base64 -w0)"
   

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GOLANG_VERSION         := 1.18.3
 GORELEASER_CONFIG      = release/tag/goreleaser.yaml
 GORELEASER_IMAGE       := ghcr.io/goreleaser/goreleaser-cross:v$(GOLANG_VERSION)
 
-.PHONY: docs license fix vet fmt lint test build tidy
+.PHONY: docs license fix vet fmt lint test build tidy release
 
 GOBIN := $(shell go env GOPATH)/bin
 GIT_COMMIT := $(shell git rev-parse --short HEAD)


### PR DESCRIPTION
Add release as a phony to our Makefile and remove unnecessary steps in
the release workflow. Certain elements from the previous iteration of
the workflow should also be removed since GoReleaser is now being run
within a container and not as a native GitHub action, so they are not
compatible.