### PR TITLE
Fix RootSyncSet permissions

### DIFF
--- a/porch/controllers/rootsyncset/config/samples/README.md
+++ b/porch/controllers/rootsyncset/config/samples/README.md
@@ -1,0 +1,40 @@
+# Simple example
+
+This example adds a RootSync with name `simple` to two GKE clusters
+created with Config Connector.
+
+## Setup
+Create clusters with Config Connector using the following two manifests:
+```
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  name: gke-one
+  namespace: config-control
+spec:
+  location: us-central1
+  initialNodeCount: 1
+  workloadIdentityConfig:
+    workloadPool: ${PROJECT-ID}.svc.id.goog
+```
+
+```
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  name: gke-two
+  namespace: config-control
+spec:
+  location: us-central1
+  initialNodeCount: 1
+  workloadIdentityConfig:
+    workloadPool: ${PROJECT-ID}.svc.id.goog
+```
+
+Install Config Management through the Google Cloud console to make sure
+Config Sync is available in the cluster.
+
+Apply the `simple.yaml` manifest:
+```
+k apply -f simple.yaml
+```

--- a/porch/controllers/rootsyncset/config/samples/simple.yaml
+++ b/porch/controllers/rootsyncset/config/samples/simple.yaml
@@ -1,0 +1,37 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: config.porch.kpt.dev/v1alpha1
+kind: RootSyncSet
+metadata:
+  name: simple
+  namespace: default
+spec:
+  clusterRefs:
+  - apiVersion: container.cnrm.cloud.google.com/v1beta1
+    kind: ContainerCluster
+    name: gke-one
+    namespace: config-control
+  - apiVersion: container.cnrm.cloud.google.com/v1beta1
+    kind: ContainerCluster
+    name: gke-two
+    namespace: config-control
+  template:
+    spec:
+      sourceFormat: unstructured
+      git:
+        repo: https://github.com/mortent/csmr-examples.git
+        branch: main
+        dir: "multirepo/root"
+        auth: none

--- a/porch/deployments/porch/9-controllers.yaml
+++ b/porch/deployments/porch/9-controllers.yaml
@@ -92,6 +92,21 @@ rules:
 - apiGroups: ["config.porch.kpt.dev"]
   resources: ["workloadidentitybindings/finalizers"]
   verbs: ["update"]
+- apiGroups: ["configcontroller.cnrm.cloud.google.com"]
+  resources: ["configcontrollerinstances"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["container.cnrm.cloud.google.com"]
+  resources: ["containerclusters"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["core.cnrm.cloud.google.com"]
+  resources: ["configconnectorcontexts"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: ["hub.gke.io"]
+  resources: ["memberships"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["serviceaccounts/token"]
+  verbs: ["create"]
 
 ---
 


### PR DESCRIPTION
Updates the rbac permissions to the RootSyncSet controller to include the config connector and hub resources types needed. This also adds an example of how to use the RootSyncSet controller.
