### PR TITLE
fix: Upate release to use docker login in DinD

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Run GoReleaser within Docker
         id: run-goreleaser
         run: |
-          make release
+          make release-ci
       - name: Generate SLSA subjects for provenance
         id: hash
         run: |


### PR DESCRIPTION
DinD does not carry over the docker credentials from host. This PR copies over the docker credentials file from the host to the runner container.
goreleaser-cross provides a helper function to run docker login within the container, however, this does not play nicely with GitHub actions hence why we use the helper GH action to run the login from host first.