### PR TITLE
statically link compiled binaries for release

### DIFF
--- a/release/tag/goreleaser.yaml
+++ b/release/tag/goreleaser.yaml
@@ -61,6 +61,8 @@ builds:
     env:
       - CC=aarch64-linux-gnu-gcc
       - CXX=aarch64-linux-gnu-g++
+    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}} -linkmode external -extldflags "-static"
+
 dockers:
   - ids:
       - linux-amd64

--- a/release/tag/goreleaser.yaml
+++ b/release/tag/goreleaser.yaml
@@ -31,7 +31,7 @@ builds:
     env:
       - CC=o64-clang
       - CXX=o64-clang++
-    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}}
+    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}} -linkmode external -extldflags "-static"
 
   - id: darwin-arm64
     goos:
@@ -41,7 +41,7 @@ builds:
     env:
       - CC=oa64-clang
       - CXX=oa64-clang++
-    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}}
+    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}} -linkmode external -extldflags "-static"
 
   - id: linux-amd64
     goos:
@@ -51,7 +51,7 @@ builds:
     env:
       - CC=x86_64-linux-gnu-gcc
       - CXX=x86_64-linux-gnu-g++
-    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}}
+    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}} -linkmode external -extldflags "-static"
 
   - id: linux-arm64
     goos:


### PR DESCRIPTION
Fix https://github.com/GoogleContainerTools/kpt/issues/3524
Fix https://github.com/GoogleContainerTools/kpt/issues/3528
FIx https://github.com/GoogleContainerTools/kpt/issues/3511

Ref: https://github.com/goreleaser/goreleaser/pull/226/files

This seemed to fix the issue for me on my locally built container images.