### PR TITLE
rpkg get: clean up namespace handling

### DIFF
--- a/internal/cmdrpkgget/command.go
+++ b/internal/cmdrpkgget/command.go
@@ -22,15 +22,17 @@ import (
 	"github.com/GoogleContainerTools/kpt/internal/docs/generated/rpkgdocs"
 	"github.com/GoogleContainerTools/kpt/internal/errors"
 	"github.com/GoogleContainerTools/kpt/internal/util/porch"
-	api "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/cmd/get"
 )
 
@@ -44,7 +46,7 @@ func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner 
 		cfg:        rcg,
 		printFlags: get.NewGetPrintFlags(),
 	}
-	c := &cobra.Command{
+	cmd := &cobra.Command{
 		Use:        "get",
 		Aliases:    []string{"list"},
 		SuggestFor: []string{},
@@ -55,12 +57,16 @@ func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner 
 		RunE:       r.runE,
 		Hidden:     porch.HidePorchCommands,
 	}
-	r.Command = c
+	r.Command = cmd
 
 	// Create flags
-	c.Flags().StringVar(&r.name, "name", "", "Name of the packages to get. Any package whose name contains this value will be included in the results.")
-	c.Flags().StringVar(&r.revision, "revision", "", "Revision of the packages to get. Any package whose revision matches this value will be included in the results.")
-	r.printFlags.AddFlags(c)
+	cmd.Flags().StringVar(&r.packageName, "name", "", "Name of the packages to get. Any package whose name contains this value will be included in the results.")
+	cmd.Flags().StringVar(&r.revision, "revision", "", "Revision of the packages to get. Any package whose revision matches this value will be included in the results.")
+
+	cmd.Flags().BoolVarP(&r.AllNamespaces, "all-namespaces", "A", r.AllNamespaces,
+		"If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
+
+	r.printFlags.AddFlags(cmd)
 	return r
 }
 
@@ -74,14 +80,29 @@ type runner struct {
 	Command *cobra.Command
 
 	// Flags
-	name       string
-	revision   string
-	printFlags *get.PrintFlags
+	packageName   string
+	revision      string
+	printFlags    *get.PrintFlags
+	AllNamespaces bool
 
 	requestTable bool
 }
 
 func (r *runner) preRunE(cmd *cobra.Command, args []string) error {
+	if *r.cfg.Namespace == "" {
+		// Get the namespace from kubeconfig
+		namespace, _, err := r.cfg.ToRawKubeConfigLoader().Namespace()
+		if err != nil {
+			return fmt.Errorf("error getting namespace: %w", err)
+		}
+		r.cfg.Namespace = &namespace
+	}
+
+	// Print the namespace if we're spanning namespaces
+	if r.AllNamespaces {
+		r.printFlags.HumanReadableFlags.WithNamespace = true
+	}
+
 	outputOption := cmd.Flags().Lookup("output").Value.String()
 	if strings.Contains(outputOption, "custom-columns") || outputOption == "yaml" || strings.Contains(outputOption, "json") {
 		r.requestTable = false
@@ -96,14 +117,43 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 
 	var objs []runtime.Object
 	b := resource.NewBuilder(r.cfg).
-		Unstructured().
-		NamespaceParam(*r.cfg.Namespace).DefaultNamespace()
+		NamespaceParam(*r.cfg.Namespace).AllNamespaces(r.AllNamespaces)
 
+	if r.requestTable {
+		scheme := runtime.NewScheme()
+		// Accept PartialObjectMetadata and Table
+		if err := metav1.AddMetaToScheme(scheme); err != nil {
+			return fmt.Errorf("error building runtime.Scheme: %w", err)
+		}
+		b = b.WithScheme(scheme, schema.GroupVersion{Version: "v1"})
+	} else {
+		// We want to print the server version, not whatever version we happen to have compiled in
+		b = b.Unstructured()
+	}
+
+	useSelectors := true
 	if len(args) > 0 {
 		b = b.ResourceNames("packagerevisions", args...)
+		// We can't pass selectors here, get an error "Error: selectors and the all flag cannot be used when passing resource/name arguments"
+		// TODO: cli-utils bug?  I think there is a metadata.name field selector (used for single object watch)
+		useSelectors = false
 	} else {
-		b = b.SelectAllParam(true).
-			ResourceTypes("packagerevisions")
+		b = b.ResourceTypes("packagerevisions")
+	}
+
+	if useSelectors {
+		fieldSelector := fields.Everything()
+		if r.revision != "" {
+			fieldSelector = fields.OneTermEqualSelector("spec.revision", r.revision)
+		}
+		if r.packageName != "" {
+			fieldSelector = fields.OneTermEqualSelector("spec.packageName", r.packageName)
+		}
+		if s := fieldSelector.String(); s != "" {
+			b = b.FieldSelectorParam(s)
+		} else {
+			b = b.SelectAllParam(true)
+		}
 	}
 
 	b = b.ContinueOnError().
@@ -129,16 +179,39 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 		return errors.E(op, err)
 	}
 
+	// Decode json objects in tables (likely PartialObjectMetadata)
+	for _, i := range infos {
+		if table, ok := i.Object.(*metav1.Table); ok {
+			for i := range table.Rows {
+				row := &table.Rows[i]
+				if row.Object.Object == nil && row.Object.Raw != nil {
+					u := &unstructured.Unstructured{}
+					if err := u.UnmarshalJSON(row.Object.Raw); err != nil {
+						klog.Warningf("error parsing raw object: %v", err)
+					}
+					row.Object.Object = u
+				}
+			}
+		}
+	}
+
+	// Apply any filters we couldn't pass down as field selectors
 	for _, i := range infos {
 		switch obj := i.Object.(type) {
 		case *unstructured.Unstructured:
-			o, err := r.tranformAndMatch(obj)
+			match, err := r.packageRevisionMatches(obj)
 			if err != nil {
 				return errors.E(op, err)
 			}
-			if o != nil {
-				objs = append(objs, o)
+			if match {
+				objs = append(objs, obj)
 			}
+		case *metav1.Table:
+			// Technically we should have applied this as a field-selector, so this might not be necessary
+			if err := r.filterTableRows(obj); err != nil {
+				return err
+			}
+			objs = append(objs, obj)
 		default:
 			return errors.E(op, fmt.Sprintf("Unrecognized response %T", obj))
 		}
@@ -147,10 +220,6 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 	printer, err := r.printFlags.ToPrinter()
 	if err != nil {
 		return errors.E(op, err)
-	}
-
-	if r.requestTable {
-		printer = &get.TablePrinter{Delegate: printer}
 	}
 
 	w := printers.GetNewTabWriter(cmd.OutOrStdout())
@@ -166,37 +235,22 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-var tableGVK = metav1.SchemeGroupVersion.WithKind("Table")
-var packageRevisionGVK = api.SchemeGroupVersion.WithKind("PackageRevision")
-
-func (r *runner) tranformAndMatch(obj *unstructured.Unstructured) (runtime.Object, error) {
-	switch gvk := obj.GroupVersionKind(); gvk {
-	case tableGVK:
-		return r.matchTable(obj)
-	case packageRevisionGVK:
-		return r.matchPackageRevision(obj)
-	default:
-		fmt.Fprintf(r.Command.OutOrStderr(), "Unrecognized response type %s", gvk)
-		return obj, nil // unrecognized, attempt to print
-	}
-}
-
-func (r *runner) matchPackageRevision(o *unstructured.Unstructured) (runtime.Object, error) {
+func (r *runner) packageRevisionMatches(o *unstructured.Unstructured) (bool, error) {
 	packageName, _, err := unstructured.NestedString(o.Object, "spec", "packageName")
 	if err != nil {
-		return nil, err
+		return false, err
 	}
 	revision, _, err := unstructured.NestedString(o.Object, "spec", "revision")
 	if err != nil {
-		return nil, err
+		return false, err
 	}
-	if !strings.Contains(packageName, r.name) {
-		return nil, nil
+	if r.packageName != "" && r.packageName != packageName {
+		return false, nil
 	}
 	if r.revision != "" && r.revision != revision {
-		return nil, nil
+		return false, nil
 	}
-	return o, nil
+	return true, nil
 }
 
 func findColumn(cols []metav1.TableColumnDefinition, name string) int {
@@ -216,31 +270,22 @@ func getStringCell(cells []interface{}, col int) (string, bool) {
 	return s, ok
 }
 
-func (r *runner) matchTable(u *unstructured.Unstructured) (runtime.Object, error) {
-	table := &metav1.Table{}
-	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, table); err != nil {
-		return nil, err
-	}
-
+func (r *runner) filterTableRows(table *metav1.Table) error {
 	filtered := make([]metav1.TableRow, 0, len(table.Rows))
-	nameCol := findColumn(table.ColumnDefinitions, "Package")
+	packageNameCol := findColumn(table.ColumnDefinitions, "Package")
 	revisionCol := findColumn(table.ColumnDefinitions, "Revision")
 
 	for i := range table.Rows {
 		row := &table.Rows[i]
-		if row.Object.Object != nil {
-			fmt.Fprintf(r.Command.OutOrStderr(), "Found non-nil Object in table: %s",
-				row.Object.Object.GetObjectKind().GroupVersionKind())
-		} else {
-			if name, ok := getStringCell(row.Cells, nameCol); ok {
-				if !strings.Contains(name, r.name) {
-					continue
-				}
+
+		if packageName, ok := getStringCell(row.Cells, packageNameCol); ok {
+			if r.packageName != "" && r.packageName != packageName {
+				continue
 			}
-			if revision, ok := getStringCell(row.Cells, revisionCol); ok {
-				if r.revision != "" && r.revision != revision {
-					continue
-				}
+		}
+		if revision, ok := getStringCell(row.Cells, revisionCol); ok {
+			if r.revision != "" && r.revision != revision {
+				continue
 			}
 		}
 
@@ -248,5 +293,5 @@ func (r *runner) matchTable(u *unstructured.Unstructured) (runtime.Object, error
 		filtered = append(filtered, *row)
 	}
 	table.Rows = filtered
-	return table, nil
+	return nil
 }


### PR DESCRIPTION
If we don't specify a namespace, we should only get the current namespace.

If we specify --all-namespaces or -A, we should print the namespace.
