### PR TITLE
Isolate git servers for tests

### DIFF
--- a/e2e/testdata/porch/rpkg-clone/config.yaml
+++ b/e2e/testdata/porch/rpkg-clone/config.yaml
@@ -5,7 +5,7 @@ commands:
       - register
       - --namespace=rpkg-clone
       - --name=git
-      - http://git-server.test-git-namespace.svc.cluster.local:8080
+      - http://git-server.test-git-namespace.svc.cluster.local:8080/rpkg-clone
   - args:
       - alpha
       - rpkg

--- a/e2e/testdata/porch/rpkg-copy/config.yaml
+++ b/e2e/testdata/porch/rpkg-copy/config.yaml
@@ -5,7 +5,7 @@ commands:
       - register
       - --namespace=rpkg-copy
       - --name=git
-      - http://git-server.test-git-namespace.svc.cluster.local:8080
+      - http://git-server.test-git-namespace.svc.cluster.local:8080/rpkg-copy
   - args:
       - alpha
       - rpkg

--- a/e2e/testdata/porch/rpkg-init-deploy/config.yaml
+++ b/e2e/testdata/porch/rpkg-init-deploy/config.yaml
@@ -6,7 +6,7 @@ commands:
       - --namespace=rpkg-init-deploy
       - --name=git
       - --deployment
-      - http://git-server.test-git-namespace.svc.cluster.local:8080
+      - http://git-server.test-git-namespace.svc.cluster.local:8080/rpkg-init-deploy
   - args:
       - alpha
       - repo
@@ -76,4 +76,4 @@ commands:
       - --namespace=rpkg-init-deploy
     stdout: |
       NAME   TYPE   CONTENT   DEPLOYMENT   READY   ADDRESS
-      git    git    Package   true         True    http://git-server.test-git-namespace.svc.cluster.local:8080
+      git    git    Package   true         True    http://git-server.test-git-namespace.svc.cluster.local:8080/rpkg-init-deploy

--- a/e2e/testdata/porch/rpkg-init/config.yaml
+++ b/e2e/testdata/porch/rpkg-init/config.yaml
@@ -5,7 +5,7 @@ commands:
       - register
       - --namespace=rpkg-init
       - --name=git
-      - http://git-server.test-git-namespace.svc.cluster.local:8080
+      - http://git-server.test-git-namespace.svc.cluster.local:8080/rpkg-init
   - args:
       - alpha
       - repo
@@ -13,8 +13,8 @@ commands:
       - --namespace=rpkg-init
       - --output=custom-columns=NAME:.metadata.name,ADDRESS:.spec.git.repo,BRANCH:.spec.git.branch,DIR:.spec.git.directory
     stdout: |
-      NAME   ADDRESS                                                       BRANCH   DIR
-      git    http://git-server.test-git-namespace.svc.cluster.local:8080   main     /
+      NAME   ADDRESS                                                                 BRANCH   DIR
+      git    http://git-server.test-git-namespace.svc.cluster.local:8080/rpkg-init   main     /
   - args:
       - alpha
       - rpkg

--- a/e2e/testdata/porch/rpkg-lifecycle/config.yaml
+++ b/e2e/testdata/porch/rpkg-lifecycle/config.yaml
@@ -5,7 +5,7 @@ commands:
       - register
       - --namespace=rpkg-lifecycle
       - --name=git
-      - http://git-server.test-git-namespace.svc.cluster.local:8080
+      - http://git-server.test-git-namespace.svc.cluster.local:8080/rpkg-lifecycle
   - args:
       - alpha
       - rpkg

--- a/e2e/testdata/porch/rpkg-push/config.yaml
+++ b/e2e/testdata/porch/rpkg-push/config.yaml
@@ -5,7 +5,7 @@ commands:
       - register
       - --namespace=rpkg-push
       - --name=git
-      - http://git-server.test-git-namespace.svc.cluster.local:8080
+      - http://git-server.test-git-namespace.svc.cluster.local:8080/rpkg-push
   - args:
       - alpha
       - rpkg

--- a/e2e/testdata/porch/rpkg-update/config.yaml
+++ b/e2e/testdata/porch/rpkg-update/config.yaml
@@ -5,7 +5,7 @@ commands:
       - register
       - --namespace=rpkg-update
       - --name=git
-      - http://git-server.test-git-namespace.svc.cluster.local:8080
+      - http://git-server.test-git-namespace.svc.cluster.local:8080/rpkg-update
   - args:
       - alpha
       - rpkg

--- a/porch/pkg/git/repo.go
+++ b/porch/pkg/git/repo.go
@@ -1,0 +1,60 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+import gogit "github.com/go-git/go-git/v5"
+
+// Repo manages a single git repository
+type Repo struct {
+	gogit *gogit.Repository
+
+	// Basic auth
+	username string
+	password string
+}
+
+// NewRepo constructs an instance of Repo
+func NewRepo(gogit *gogit.Repository, options ...GitRepoOption) (*Repo, error) {
+	r := &Repo{
+		gogit: gogit,
+	}
+	for _, option := range options {
+		if err := option.apply(r); err != nil {
+			return nil, err
+		}
+	}
+	return r, nil
+}
+
+// GitRepoOption is implemented by configuration settings for git repository.
+type GitRepoOption interface {
+	apply(*Repo) error
+}
+
+type optionBasicAuth struct {
+	username, password string
+}
+
+func (o *optionBasicAuth) apply(s *Repo) error {
+	s.username, s.password = o.username, o.password
+	return nil
+}
+
+func WithBasicAuth(username, password string) GitRepoOption {
+	return &optionBasicAuth{
+		username: username,
+		password: password,
+	}
+}

--- a/porch/pkg/git/repos.go
+++ b/porch/pkg/git/repos.go
@@ -1,0 +1,215 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package git
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sync"
+	"time"
+
+	gogit "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+)
+
+type Repos interface {
+	FindRepo(ctx context.Context, id string) (*Repo, error)
+}
+
+// StaticRepos holds multiple registered git repositories
+type StaticRepos struct {
+	mutex sync.Mutex
+	repos map[string]*Repo
+}
+
+// NewRepos constructs an instance of Repos
+func NewStaticRepos() *StaticRepos {
+	return &StaticRepos{
+		repos: make(map[string]*Repo),
+	}
+}
+
+// FindRepo returns a repo registered under the specified id, or nil if none is registered.
+func (r *StaticRepos) FindRepo(ctx context.Context, id string) (*Repo, error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	return r.repos[id], nil
+}
+
+// Add registers a git repository under the specified id
+func (r *StaticRepos) Add(id string, repo *Repo) error {
+	if !isRepoIDAllowed(id) {
+		return fmt.Errorf("invalid name %q", id)
+	}
+
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if _, found := r.repos[id]; found {
+		return fmt.Errorf("repo %q already exists", id)
+	}
+	r.repos[id] = repo
+	return nil
+}
+
+func NewDynamicRepos(baseDir string, gitRepoOptions []GitRepoOption) *DynamicRepos {
+	return &DynamicRepos{
+		baseDir:        baseDir,
+		repos:          make(map[string]*dynamicRepo),
+		gitRepoOptions: gitRepoOptions,
+	}
+}
+
+type DynamicRepos struct {
+	mutex          sync.Mutex
+	repos          map[string]*dynamicRepo
+	baseDir        string
+	gitRepoOptions []GitRepoOption
+}
+
+type dynamicRepo struct {
+	mutex          sync.Mutex
+	repo           *Repo
+	dir            string
+	gitRepoOptions []GitRepoOption
+}
+
+func isRepoIDAllowed(s string) bool {
+	if len(s) == 0 {
+		return false
+	}
+	for _, r := range s {
+		if r >= 'a' && r <= 'z' {
+			// OK
+		} else if r >= '0' && r <= '9' {
+			// OK
+		} else {
+			switch r {
+			case '-':
+				// OK
+			default:
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func (r *DynamicRepos) FindRepo(ctx context.Context, id string) (*Repo, error) {
+	dir := filepath.Join(r.baseDir, id)
+	if !isRepoIDAllowed(id) {
+		return nil, fmt.Errorf("invalid name %q", id)
+	}
+
+	r.mutex.Lock()
+	repo := r.repos[id]
+	if repo == nil {
+		repo = &dynamicRepo{
+			dir:            dir,
+			gitRepoOptions: r.gitRepoOptions,
+		}
+		r.repos[id] = repo
+	}
+	r.mutex.Unlock()
+
+	return repo.open()
+}
+
+func (r *dynamicRepo) open() (*Repo, error) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+
+	if r.repo == nil {
+		var gogitRepo *gogit.Repository
+		var err error
+
+		if gogitRepo, err = gogit.PlainOpen(r.dir); err != nil {
+			if err != gogit.ErrRepositoryNotExists {
+				return nil, fmt.Errorf("failed to open git repository %q: %w", r.dir, err)
+			}
+			isBare := true
+			gogitRepo, err = gogit.PlainInit(r.dir, isBare)
+			if err != nil {
+				return nil, fmt.Errorf("failed to initialize git repository %q: %w", r.dir, err)
+			}
+			if err := CreateEmptyCommit(gogitRepo); err != nil {
+				return nil, err
+			}
+
+			// Delete go-git default branch
+			_ = gogitRepo.Storer.RemoveReference(plumbing.Master)
+		}
+		repo, err := NewRepo(gogitRepo, r.gitRepoOptions...)
+		if err != nil {
+			return nil, err
+		}
+		r.repo = repo
+	}
+
+	return r.repo, nil
+}
+
+func CreateEmptyCommit(repo *gogit.Repository) error {
+	store := repo.Storer
+	// Create first commit using empty tree.
+	emptyTree := object.Tree{}
+	encodedTree := store.NewEncodedObject()
+	if err := emptyTree.Encode(encodedTree); err != nil {
+		return fmt.Errorf("failed to encode initial empty commit tree: %w", err)
+	}
+
+	treeHash, err := store.SetEncodedObject(encodedTree)
+	if err != nil {
+		return fmt.Errorf("failed to create initial empty commit tree: %w", err)
+	}
+
+	sig := object.Signature{
+		Name:  "Git Server",
+		Email: "git-server@kpt.dev",
+		When:  time.Now(),
+	}
+
+	commit := object.Commit{
+		Author:       sig,
+		Committer:    sig,
+		Message:      "Empty Commit",
+		TreeHash:     treeHash,
+		ParentHashes: []plumbing.Hash{}, // No parents
+	}
+
+	encodedCommit := store.NewEncodedObject()
+	if err := commit.Encode(encodedCommit); err != nil {
+		return fmt.Errorf("failed to encode initial empty commit: %w", err)
+	}
+
+	commitHash, err := store.SetEncodedObject(encodedCommit)
+	if err != nil {
+		return fmt.Errorf("failed to create initial empty commit: %w", err)
+	}
+
+	main := plumbing.NewHashReference(plumbing.ReferenceName("refs/heads/main"), commitHash)
+	if err := repo.Storer.SetReference(main); err != nil {
+		return fmt.Errorf("failed to set refs/heads/main to commit sha %s: %w", commitHash, err)
+	}
+
+	head := plumbing.NewSymbolicReference(plumbing.HEAD, "refs/heads/main")
+	if err := repo.Storer.SetReference(head); err != nil {
+		return fmt.Errorf("failed to set HEAD to refs/heads/main: %w", err)
+	}
+
+	return nil
+}

--- a/porch/pkg/git/testing_repo.go
+++ b/porch/pkg/git/testing_repo.go
@@ -124,7 +124,19 @@ func ServeGitRepository(t *testing.T, tarfile, tempdir string) (*gogit.Repositor
 func ServeExistingRepository(t *testing.T, git *gogit.Repository) string {
 	t.Helper()
 
-	server, err := NewGitServer(git)
+	repo, err := NewRepo(git)
+	if err != nil {
+		t.Fatalf("NewRepo failed: %v", err)
+	}
+
+	key := "default"
+
+	repos := NewStaticRepos()
+	if err := repos.Add(key, repo); err != nil {
+		t.Fatalf("repos.Add failed: %v", err)
+	}
+
+	server, err := NewGitServer(repos)
 	if err != nil {
 		t.Fatalf("NewGitServer() failed: %v", err)
 	}
@@ -152,7 +164,7 @@ func ServeExistingRepository(t *testing.T, git *gogit.Repository) string {
 	if !ok {
 		t.Fatalf("Git Server failed to start")
 	}
-	return "http://" + address.String()
+	return "http://" + address.String() + "/" + key
 }
 
 func extractTar(t *testing.T, tarfile string, dir string) {

--- a/porch/test/e2e/e2e_test.go
+++ b/porch/test/e2e/e2e_test.go
@@ -74,14 +74,21 @@ func Run(suite interface{}, t *testing.T) {
 
 type PorchSuite struct {
 	TestSuite
-	config GitConfig
+
+	gitConfig GitConfig
 }
 
 var _ Initializer = &PorchSuite{}
 
 func (p *PorchSuite) Initialize(ctx context.Context) {
 	p.TestSuite.Initialize(ctx)
-	p.config = p.CreateGitRepo()
+	p.gitConfig = p.CreateGitRepo()
+}
+
+func (p *PorchSuite) GitConfig(repoID string) GitConfig {
+	config := p.gitConfig
+	config.Repo = config.Repo + "/" + repoID
+	return config
 }
 
 func (t *PorchSuite) TestGitRepository(ctx context.Context) {
@@ -1497,7 +1504,8 @@ func (t *PorchSuite) registerGitRepositoryF(ctx context.Context, repo, name, dir
 type repositoryOption func(*configapi.Repository)
 
 func (t *PorchSuite) registerMainGitRepositoryF(ctx context.Context, name string, opts ...repositoryOption) {
-	config := t.config
+	repoID := t.namespace + "-" + name
+	config := t.GitConfig(repoID)
 
 	var secret string
 	// Create auth secret if necessary

--- a/porch/test/git/main.go
+++ b/porch/test/git/main.go
@@ -22,12 +22,8 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"time"
 
 	"github.com/GoogleContainerTools/kpt/porch/pkg/git"
-	gogit "github.com/go-git/go-git/v5"
-	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/plumbing/object"
 	"k8s.io/klog/v2"
 )
 
@@ -46,44 +42,27 @@ func main() {
 }
 
 func run(dirs []string) error {
-	var dir string
+	var baseDir string
 
 	switch len(dirs) {
 	case 0:
 		var err error
-		dir, err = os.MkdirTemp("", "repo-*")
+		baseDir, err = os.MkdirTemp("", "repo-*")
 		if err != nil {
 			return fmt.Errorf("failed to create temporary directory for git repository: %w", err)
 		}
 
 	case 1:
-		dir = dirs[0]
+		baseDir = dirs[0]
 
 	default:
-		return fmt.Errorf("can server only one git repository, not %d", len(dirs))
+		return fmt.Errorf("can serve only one git repository, not %d", len(dirs))
 	}
 
-	var repo *gogit.Repository
-	var err error
+	var gitRepoOptions []git.GitRepoOption
+	repos := git.NewDynamicRepos(baseDir, gitRepoOptions)
 
-	if repo, err = gogit.PlainOpen(dir); err != nil {
-		if err != gogit.ErrRepositoryNotExists {
-			return fmt.Errorf("failed to open git repository %q: %w", dir, err)
-		}
-		isBare := true
-		repo, err = gogit.PlainInit(dir, isBare)
-		if err != nil {
-			return fmt.Errorf("failed to initialize git repository %q: %w", dir, err)
-		}
-		if err := createEmptyCommit(repo); err != nil {
-			return err
-		}
-
-		// Delete go-git default branch
-		_ = repo.Storer.RemoveReference(plumbing.Master)
-	}
-
-	server, err := git.NewGitServer(repo)
+	server, err := git.NewGitServer(repos)
 	if err != nil {
 		return fmt.Errorf("filed to initialize git server: %w", err)
 	}
@@ -106,57 +85,6 @@ func run(dirs []string) error {
 	signal.Notify(wait, os.Interrupt)
 
 	<-wait
-
-	return nil
-}
-
-func createEmptyCommit(repo *gogit.Repository) error {
-	store := repo.Storer
-	// Create first commit using empty tree.
-	emptyTree := object.Tree{}
-	encodedTree := store.NewEncodedObject()
-	if err := emptyTree.Encode(encodedTree); err != nil {
-		return fmt.Errorf("failed to encode initial empty commit tree: %w", err)
-	}
-
-	treeHash, err := store.SetEncodedObject(encodedTree)
-	if err != nil {
-		return fmt.Errorf("failed to create initial empty commit tree: %w", err)
-	}
-
-	sig := object.Signature{
-		Name:  "Git Server",
-		Email: "git-server@kpt.dev",
-		When:  time.Now(),
-	}
-
-	commit := object.Commit{
-		Author:       sig,
-		Committer:    sig,
-		Message:      "Empty Commit",
-		TreeHash:     treeHash,
-		ParentHashes: []plumbing.Hash{}, // No parents
-	}
-
-	encodedCommit := store.NewEncodedObject()
-	if err := commit.Encode(encodedCommit); err != nil {
-		return fmt.Errorf("failed to encode initial empty commit: %w", err)
-	}
-
-	commitHash, err := store.SetEncodedObject(encodedCommit)
-	if err != nil {
-		return fmt.Errorf("failed to create initial empty commit: %w", err)
-	}
-
-	main := plumbing.NewHashReference(plumbing.ReferenceName("refs/heads/main"), commitHash)
-	if err := repo.Storer.SetReference(main); err != nil {
-		return fmt.Errorf("failed to set refs/heads/main to commit sha %s: %w", commitHash, err)
-	}
-
-	head := plumbing.NewSymbolicReference(plumbing.HEAD, "refs/heads/main")
-	if err := repo.Storer.SetReference(head); err != nil {
-		return fmt.Errorf("failed to set HEAD to refs/heads/main: %w", err)
-	}
 
 	return nil
 }


### PR DESCRIPTION
To avoid packages being discovered from different tests, we run each
in their own git repository.  We use the first component of the path
as the repo key.
