### PR TITLE
Fix null pointer deref in diff if no Upstream

### DIFF
--- a/internal/util/diff/diff.go
+++ b/internal/util/diff/diff.go
@@ -125,7 +125,7 @@ func (c *Command) Run(ctx context.Context) error {
 
 	// Return early if upstream is not set
 	if kptFile.Upstream == nil || kptFile.Upstream.Git == nil {
-		return errors.Errorf("no upstream set")
+		return errors.Errorf("package missing upstream in Kptfile at '%s'", c.Path)
 	}
 
 	// Create a staging directory to store all compared packages

--- a/internal/util/diff/diff.go
+++ b/internal/util/diff/diff.go
@@ -123,6 +123,11 @@ func (c *Command) Run(ctx context.Context) error {
 		return errors.Errorf("package missing Kptfile at '%s': %v", c.Path, err)
 	}
 
+	// Return early if upstream is not set
+	if kptFile.Upstream == nil || kptFile.Upstream.Git == nil {
+		return errors.Errorf("no upstream set")
+	}
+
 	// Create a staging directory to store all compared packages
 	stagingDirectory, err := os.MkdirTemp("", "kpt-")
 	if err != nil {


### PR DESCRIPTION
Running `kpt pkg diff` without an upstream set panics because we attempt
to dereference `kptFile.Upstream` without checking to see if it is nil. 

This commit adds a check and returns early if necessary.
