### PR TITLE
Use merge commits on approval

### DIFF
--- a/porch/pkg/git/draft.go
+++ b/porch/pkg/git/draft.go
@@ -27,7 +27,6 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/plumbing/object"
 	"github.com/go-git/go-git/v5/plumbing/transport"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/klog/v2"
@@ -246,54 +245,12 @@ func (r *gitRepository) commitPackageToMain(ctx context.Context, d *gitPackageDr
 		return zero, zero, nil, fmt.Errorf("failed to resolve main branch to commit: %w", err)
 	}
 	packagePath := d.path
-	packageRevision := d.revision
-
-	// Fetch the commits belonging to this package revision.
-	commits, err := r.loadPackageCommits(d.commit, packagePath, packageRevision)
-	if err != nil {
-		return zero, zero, nil, fmt.Errorf("failed to load commits for package %s: %w", packagePath, err)
-	}
-	reverseCommitSlice(commits)
 
 	// TODO: Check for out-of-band update of the package in main branch
 	// (compare package tree in target branch and common base)
-	var ch *commitHelper
-	if len(commits) == 0 {
-		// If we can't find any commits, the draft might have been created outside of porch. We
-		// just add the changes to the main branch in a single commit.
-		ch, err = newCommitHelper(repo, r.userInfoProvider, headCommit.Hash, packagePath, d.tree)
-		if err != nil {
-			return zero, zero, nil, fmt.Errorf("failed to initialize commit of package %s to %s", packagePath, localRef)
-		}
-	} else {
-		// If we have commits, we reproduce the same commits on the main branch to keep
-		// the history from the draft.
-		ch, err = newCommitHelper(repo, r.userInfoProvider, headCommit.Hash, packagePath, plumbing.ZeroHash)
-		if err != nil {
-			return zero, zero, nil, fmt.Errorf("failed to initialize commit of package %s to %s", packagePath, localRef)
-		}
-
-		for _, commit := range commits {
-			// Look up the tree for the package in the commit.
-			t, err := commit.Tree()
-			if err != nil {
-				return zero, zero, nil, fmt.Errorf("cannot resolve commit's (%s) tree (%s) to tree object: %w", t.Hash, commit.TreeHash, err)
-			}
-			te, err := t.FindEntry(packagePath)
-			if err != nil {
-				return zero, zero, nil, err
-			}
-
-			err = ch.storeTree(packagePath, te.Hash)
-			if err != nil {
-				return zero, zero, nil, err
-			}
-
-			_, _, err = ch.commit(ctx, commit.Message, packagePath)
-			if err != nil {
-				return zero, zero, nil, fmt.Errorf("failed to commit package %s to %s", packagePath, localRef)
-			}
-		}
+	ch, err := newCommitHelper(repo, r.userInfoProvider, headCommit.Hash, packagePath, d.tree)
+	if err != nil {
+		return zero, zero, nil, fmt.Errorf("failed to initialize commit of package %s to %s", packagePath, localRef)
 	}
 
 	// Add a commit without changes to mark that the package revision is approved. The gitAnnotation is
@@ -305,58 +262,10 @@ func (r *gitRepository) commitPackageToMain(ctx context.Context, d *gitPackageDr
 	if err != nil {
 		return zero, zero, nil, fmt.Errorf("failed annotation commit message for package %s: %v", packagePath, err)
 	}
-	commitHash, newPackageTreeHash, err = ch.commit(ctx, message, packagePath)
+	commitHash, newPackageTreeHash, err = ch.commit(ctx, message, packagePath, d.commit)
 	if err != nil {
 		return zero, zero, nil, fmt.Errorf("failed to commit package %s to %s", packagePath, localRef)
 	}
 
 	return commitHash, newPackageTreeHash, localTarget, nil
-}
-
-// TODO: This is an almost direct copy of
-// https://github.com/GoogleContainerTools/kpt/blob/3c3288af0c4c4a7e07ffeb6fe473d32afd81137b/porch/pkg/git/git.go#L860.
-// Fix it when we can use generics.
-func reverseCommitSlice(s []*object.Commit) {
-	first := 0
-	last := len(s) - 1
-	for first < last {
-		s[first], s[last] = s[last], s[first]
-		first++
-		last--
-	}
-}
-
-// loadPackageCommits looks through the commit log starting at the provided
-// commitHash and fetches all commits with a matching packagePath and revision.
-func (r *gitRepository) loadPackageCommits(commitHash plumbing.Hash, packagePath, revision string) ([]*object.Commit, error) {
-	var logOptions = git.LogOptions{
-		From:  commitHash,
-		Order: git.LogOrderCommitterTime,
-	}
-
-	commits, err := r.repo.Log(&logOptions)
-	if err != nil {
-		return nil, fmt.Errorf("error walking commits: %w", err)
-	}
-
-	var packageRevCommits []*object.Commit
-
-	visitCommit := func(commit *object.Commit) error {
-		gitAnnotations, err := ExtractGitAnnotations(commit)
-		if err != nil {
-			return err
-		}
-
-		for _, gitAnnotation := range gitAnnotations {
-			if gitAnnotation.PackagePath == packagePath && gitAnnotation.Revision == revision {
-				packageRevCommits = append(packageRevCommits, commit)
-			}
-		}
-		return nil
-	}
-
-	if err := commits.ForEach(visitCommit); err != nil {
-		return nil, fmt.Errorf("error visiting commits: %w", err)
-	}
-	return packageRevCommits, nil
 }

--- a/porch/pkg/git/git.go
+++ b/porch/pkg/git/git.go
@@ -785,7 +785,7 @@ func (r *gitRepository) createBranch(ctx context.Context, branch BranchName) err
 		Message:  commitMessage,
 		TreeHash: treeHash,
 	}
-	commitHash, err := storeCommit(r.repo.Storer, plumbing.ZeroHash, commit)
+	commitHash, err := storeCommit(r.repo.Storer, commit)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This changes the way we handle existing commits on approval of packagerevisions from recreating the commits to doing a merge commit. This simplifies the code and also makes sure that the original author and timestamps for each package commit is preserved.

This functionality is already covered by the existing test: https://github.com/GoogleContainerTools/kpt/blob/main/porch/pkg/git/git_test.go#L681