### PR TITLE
Changes release URL from jib to kpt

### DIFF
--- a/site/installation/kpt-cli.md
+++ b/site/installation/kpt-cli.md
@@ -13,7 +13,7 @@ Download pre-compiled binaries:
 
 Optionally verify the [SLSA3 signatures](slsa.dev) generated using the OpenSSF's [slsa-framework/slsa-github-generator](https://github.com/slsa-framework/slsa-github-generator) during the release process. To verify a release binary:
 1. Install the verification tool from [slsa-framework/slsa-verifier#installation](https://github.com/slsa-framework/slsa-verifier#installation).
-2. Download the signature file `attestation.intoto.jsonl` from the [GitHub releases page](https://github.com/GoogleContainerTools/jib/releases/latest).
+2. Download the signature file `attestation.intoto.jsonl` from the [GitHub releases page](https://github.com/GoogleContainerTools/kpt/releases).
 3. Run the verifier:
 ```shell
 slsa-verifier -artifact-path kpt-<os>-<arch> -provenance attestation.intoto.jsonl -source github.com/GoogleContainerTools/kpt -tag <the-tag>


### PR DESCRIPTION
The current attestation file gives the following error: FAILED: SLSA verification failed: source used to generate the binary does not match provenance: expected source 'GoogleContainerTools/kpt', got 'GoogleContainerTools/jib' so I changed this file to point to the kpt release page.
