### PR TITLE
Only run e2e tests if E2E env var is set

### DIFF
--- a/porch/Makefile
+++ b/porch/Makefile
@@ -138,7 +138,7 @@ tidy:
 
 .PHONY: test
 test:
-	@for f in $(MODULES); do (cd $$f; echo "Testing $$f"; go test --count=1 ./...) || exit 1; done
+	@for f in $(MODULES); do (cd $$f; echo "Testing $$f"; E2E=1 go test --count=1 ./...) || exit 1; done
 
 .PHONY: vet
 vet:

--- a/porch/test/e2e/e2e_test.go
+++ b/porch/test/e2e/e2e_test.go
@@ -46,6 +46,11 @@ const (
 )
 
 func TestE2E(t *testing.T) {
+	e2e := os.Getenv("E2E")
+	if e2e == "" {
+		t.Skip("set E2E to run this test")
+	}
+
 	Run(&PorchSuite{}, t)
 }
 


### PR DESCRIPTION
This allows us to run `go test ./...` without running integration tests.

Suggested by:
https://peter.bourgon.org/blog/2021/04/02/dont-use-build-tags-for-integration-tests.html