### PR TITLE
Refactor controller initialization logic

### DIFF
--- a/porch/controllers/remoterootsyncsets/pkg/controllers/remoterootsyncset/remoterootsync_controller.go
+++ b/porch/controllers/remoterootsyncsets/pkg/controllers/remoterootsyncset/remoterootsync_controller.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
 	memory "k8s.io/client-go/discovery/cached"
 	"k8s.io/client-go/dynamic"
@@ -53,7 +52,6 @@ var (
 // RemoteRootSyncSetReconciler reconciles RemoteRootSyncSet objects
 type RemoteRootSyncSetReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
 
 	ociStorage *kptoci.Storage
 
@@ -363,6 +361,12 @@ func isWhitespace(s string) bool {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *RemoteRootSyncSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := api.AddToScheme(mgr.GetScheme()); err != nil {
+		return err
+	}
+
+	r.Client = mgr.GetClient()
+
 	if err := ctrl.NewControllerManagedBy(mgr).
 		For(&api.RemoteRootSyncSet{}).
 		Complete(r); err != nil {

--- a/porch/controllers/rootsyncsets/pkg/controllers/rootsyncset/controller.go
+++ b/porch/controllers/rootsyncsets/pkg/controllers/rootsyncset/controller.go
@@ -49,7 +49,6 @@ var (
 // RootSyncSetReconciler reconciles a RootSyncSet object
 type RootSyncSetReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
 
 	WorkloadIdentityHelper
 }
@@ -166,6 +165,12 @@ func BuildObjectsToApply(rootsyncset *v1alpha1.RootSyncSet) (schema.GroupVersion
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *RootSyncSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := v1alpha1.AddToScheme(mgr.GetScheme()); err != nil {
+		return err
+	}
+
+	r.Client = mgr.GetClient()
+
 	if err := r.WorkloadIdentityHelper.Init(mgr.GetConfig()); err != nil {
 		return err
 	}


### PR DESCRIPTION
By moving more logic to the SetupWithManager function, we can create
something that is looking more like traditional discovery.
