### PR TITLE
Exclude the tools/licensescan/modules folder the license make target

### DIFF
--- a/scripts/update-license.sh
+++ b/scripts/update-license.sh
@@ -29,4 +29,5 @@ go run github.com/justinsb/addlicense@v1.0.1 \
   --ignore "package-examples/cert-manager-basic/**" \
   --ignore "package-examples/ghost/**" \
   --ignore "package-examples/ingress-nginx/**" \
+  --ignore "tools/licensescan/modules/**" \
   . 2>&1 | ( grep -v "skipping: " || true )

--- a/tools/licensescan/main.go
+++ b/tools/licensescan/main.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (


### PR DESCRIPTION
Otherwise running `make license` updates adds the license header to files in the `tools/licensescan/modules` folder.
