### PR TITLE
fix: add escape character to dot

### DIFF
--- a/internal/util/parse/parse.go
+++ b/internal/util/parse/parse.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/kustomize/kyaml/errors"
 )
 
-const gitSuffixRegexp = ".git($|/)"
+const gitSuffixRegexp = "\\.git($|/)"
 
 type Target struct {
 	kptfilev1.Git


### PR DESCRIPTION
Using Kpt for Devops on Azure was not possible due to Kpt matching `OrgName/Namespace/_git/RepoName` with `.git` regex, where dot should have been escaped to prevent this from happening.