### PR TITLE
Added license info alpha command

### DIFF
--- a/commands/alpha/alphacmd.go
+++ b/commands/alpha/alphacmd.go
@@ -17,6 +17,7 @@ package alpha
 import (
 	"context"
 
+	"github.com/GoogleContainerTools/kpt/commands/alpha/license"
 	"github.com/GoogleContainerTools/kpt/commands/alpha/live"
 	"github.com/GoogleContainerTools/kpt/commands/alpha/repo"
 	"github.com/GoogleContainerTools/kpt/commands/alpha/rpkg"
@@ -52,6 +53,7 @@ func GetCommand(ctx context.Context, name, version string) *cobra.Command {
 		sync.NewCommand(ctx, version),
 		wasm.NewCommand(ctx, version),
 		live.GetCommand(ctx, "", version),
+		license.NewCommand(ctx, version),
 	)
 
 	return alpha

--- a/commands/alpha/license/command.go
+++ b/commands/alpha/license/command.go
@@ -1,0 +1,46 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package license
+
+import (
+	"context"
+
+	"github.com/GoogleContainerTools/kpt/commands/alpha/license/info"
+	"github.com/spf13/cobra"
+)
+
+func NewCommand(ctx context.Context, version string) *cobra.Command {
+	licenseCmd := &cobra.Command{
+		Use:   "license",
+		Short: "[Alpha] " + "Displays open source licenses.",
+		Long:  "[Alpha] " + "Displays open source licenses.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			h, err := cmd.Flags().GetBool("help")
+			if err != nil {
+				return err
+			}
+			if h {
+				return cmd.Help()
+			}
+			return cmd.Usage()
+		},
+	}
+
+	licenseCmd.AddCommand(
+		info.NewCommand(ctx),
+	)
+
+	return licenseCmd
+}

--- a/commands/alpha/license/info/info.go
+++ b/commands/alpha/license/info/info.go
@@ -1,0 +1,51 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package info
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+
+	"github.com/GoogleContainerTools/kpt/licenses"
+	"github.com/spf13/cobra"
+)
+
+func newRunner(ctx context.Context) *runner {
+	r := &runner{
+		ctx: ctx,
+	}
+	c := &cobra.Command{
+		Use:   "info",
+		Short: "Displays licenses for the OSS libraries used by kpt CLI.",
+		RunE:  r.runE,
+	}
+	r.Command = c
+	return r
+}
+
+func NewCommand(ctx context.Context) *cobra.Command {
+	return newRunner(ctx).Command
+}
+
+type runner struct {
+	ctx     context.Context
+	Command *cobra.Command
+}
+
+func (r *runner) runE(cmd *cobra.Command, args []string) error {
+	fmt.Println(licenses.AllOSSLicense)
+	return nil
+}

--- a/commands/alpha/license/info/info.go
+++ b/commands/alpha/license/info/info.go
@@ -16,7 +16,6 @@ package info
 
 import (
 	"context"
-	_ "embed"
 	"fmt"
 
 	"github.com/GoogleContainerTools/kpt/licenses"

--- a/licenses/licenses.go
+++ b/licenses/licenses.go
@@ -1,0 +1,8 @@
+package licenses
+
+import _ "embed"
+
+var (
+	//go:embed kpt.txt
+	AllOSSLicense string
+)

--- a/licenses/licenses.go
+++ b/licenses/licenses.go
@@ -1,5 +1,7 @@
 package licenses
 
+// blank import is required as per
+// https://pkg.go.dev/embed#hdr-Strings_and_Bytes
 import _ "embed"
 
 var (


### PR DESCRIPTION
license info command displays the OSS licenses of all the libraries that kpt depends on.

The PR embeds `licenses/kpt.txt` file in the kpt binary.

```sh
$ kpt alpha license info | less
===============================================================================
= cloud.google.com/go/compute =


                                 Apache License
                           Version 2.0, January 2004
                        http://www.apache.org/licenses/

   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION

   1. Definitions.

      "License" shall mean the terms and conditions for use, reproduction,
      and distribution as defined by Sections 1 through 9 of this do
...
....

```

Note: This will help in producing the license compliance evidence for internal review required by `gcloud`. Eventually it should eliminate the need for bundling this license with the release (simplifying the release process), but that can be done as a second step.
