### PR TITLE
fix: Build static MacOS releases

### DIFF
--- a/release/tag/goreleaser.yaml
+++ b/release/tag/goreleaser.yaml
@@ -31,7 +31,7 @@ builds:
     env:
       - CC=o64-clang
       - CXX=o64-clang++
-    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}} -linkmode external -extldflags "-static"
+    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}}
 
   - id: darwin-arm64
     goos:
@@ -41,7 +41,7 @@ builds:
     env:
       - CC=oa64-clang
       - CXX=oa64-clang++
-    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}} -linkmode external -extldflags "-static"
+    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}}
 
   - id: linux-amd64
     goos:


### PR DESCRIPTION
It is strongly recommened to build statically linked binaries for MacOS in the community. Switching to dynamic builds for MacOS given this guidance, and the failure in building static binaries.