### PR TITLE
Keep the repository an impelementation detail of the engine

### DIFF
--- a/porch/pkg/engine/edit_test.go
+++ b/porch/pkg/engine/edit_test.go
@@ -116,8 +116,8 @@ func (f *fakeCaD) ObjectCache() cache.ObjectCache {
 	return f.cache.ObjectCache()
 }
 
-func (f *fakeCaD) OpenRepository(context.Context, *configapi.Repository) (repository.Repository, error) {
-	return f.repository, nil
+func (f *fakeCaD) ListPackageRevisions(ctx context.Context, _ *configapi.Repository, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error) {
+	return f.repository.ListPackageRevisions(ctx, filter)
 }
 
 func (f *fakeCaD) CreatePackageRevision(context.Context, *configapi.Repository, *v1alpha1.PackageRevision) (repository.PackageRevision, error) {
@@ -138,6 +138,10 @@ func (f *fakeCaD) DeletePackageRevision(context.Context, *configapi.Repository, 
 
 func (f *fakeCaD) ListFunctions(context.Context, *configapi.Repository) ([]repository.Function, error) {
 	return []repository.Function{}, nil
+}
+
+func (f *fakeCaD) ListPackages(ctx context.Context, _ *configapi.Repository, filter repository.ListPackageFilter) ([]repository.Package, error) {
+	return f.repository.ListPackages(ctx, filter)
 }
 
 func (f *fakeCaD) CreatePackage(context.Context, *configapi.Repository, *v1alpha1.Package) (repository.Package, error) {

--- a/porch/pkg/engine/package.go
+++ b/porch/pkg/engine/package.go
@@ -38,12 +38,7 @@ func (p *PackageFetcher) FetchRevision(ctx context.Context, packageRef *api.Pack
 		return nil, fmt.Errorf("cannot find repository %s/%s: %w", namespace, repositoryName, err)
 	}
 
-	open, err := p.cad.OpenRepository(ctx, &resolved)
-	if err != nil {
-		return nil, err
-	}
-
-	revisions, err := open.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{KubeObjectName: packageRef.Name})
+	revisions, err := p.cad.ListPackageRevisions(ctx, &resolved, repository.ListPackageRevisionFilter{KubeObjectName: packageRef.Name})
 	if err != nil {
 		return nil, err
 	}

--- a/porch/pkg/registry/porch/package.go
+++ b/porch/pkg/registry/porch/package.go
@@ -25,6 +25,7 @@ import (
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/klog/v2"
@@ -124,7 +125,7 @@ func (r *packages) Create(ctx context.Context, runtimeObject runtime.Object, cre
 		return nil, apierrors.NewBadRequest("spec.repository is required")
 	}
 
-	repositoryObj, err := r.packageCommon.getRepositoryObj(ctx, ns, repositoryName)
+	repositoryObj, err := r.packageCommon.getRepositoryObj(ctx, types.NamespacedName{Name: repositoryName, Namespace: ns})
 	if err != nil {
 		return nil, err
 	}

--- a/porch/pkg/registry/porch/packagerevision.go
+++ b/porch/pkg/registry/porch/packagerevision.go
@@ -26,6 +26,7 @@ import (
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/klog/v2"
@@ -127,7 +128,7 @@ func (r *packageRevisions) Create(ctx context.Context, runtimeObject runtime.Obj
 		return nil, apierrors.NewBadRequest("spec.repositoryName is required")
 	}
 
-	repositoryObj, err := r.packageCommon.getRepositoryObj(ctx, ns, repositoryName)
+	repositoryObj, err := r.packageCommon.getRepositoryObj(ctx, types.NamespacedName{Name: repositoryName, Namespace: ns})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This removes the `OpenRepository` function from the `CaDEngine` interface. Instead of passing the repository to callers, we add the `ListPackageRevisions` and `ListPackages` functions to the interface and move callers to use those instead of the repository.
