### PR TITLE
Populate package-path metadata into package context

### DIFF
--- a/porch/pkg/engine/builtin.go
+++ b/porch/pkg/engine/builtin.go
@@ -33,17 +33,13 @@ type builtinEvalMutation struct {
 	runner   fn.FunctionRunner
 }
 
-func newBuiltinFunctionMutation(function string) (mutation, error) {
-	var runner fn.FunctionRunner
-	switch function {
-	case fnruntime.FuncGenPkgContext:
-		runner = &builtins.PackageContextGenerator{}
-	default:
-		return nil, fmt.Errorf("unrecognized built-in function %q", function)
+func newPackageContextGeneratorMutation(packageConfig *builtins.PackageConfig) (mutation, error) {
+	runner := &builtins.PackageContextGenerator{
+		PackageConfig: packageConfig,
 	}
 
 	return &builtinEvalMutation{
-		function: function,
+		function: fnruntime.FuncGenPkgContext,
 		runner:   runner,
 	}, nil
 }

--- a/porch/pkg/engine/builtin_test.go
+++ b/porch/pkg/engine/builtin_test.go
@@ -20,21 +20,13 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/GoogleContainerTools/kpt/internal/fnruntime"
+	"github.com/GoogleContainerTools/kpt/internal/builtins"
 	"github.com/google/go-cmp/cmp"
 )
 
 const (
 	updateGoldenFiles = "UPDATE_GOLDEN_FILES"
 )
-
-func TestUnknownBuiltinFunctionMutation(t *testing.T) {
-	const doesNotExist = "function-does-not-exist"
-	m, err := newBuiltinFunctionMutation(doesNotExist)
-	if err == nil || m != nil {
-		t.Errorf("creating builtin function runner for an unknown function %q unexpectedly succeeded", doesNotExist)
-	}
-}
 
 func TestPackageContext(t *testing.T) {
 	testdata, err := filepath.Abs(filepath.Join(".", "testdata", "context"))
@@ -44,7 +36,10 @@ func TestPackageContext(t *testing.T) {
 
 	input := readPackage(t, filepath.Join(testdata, "input"))
 
-	m, err := newBuiltinFunctionMutation(fnruntime.FuncGenPkgContext)
+	packageConfig := &builtins.PackageConfig{
+		PackagePath: "parent1/parent1.2/parent1.2.3/me",
+	}
+	m, err := newPackageContextGeneratorMutation(packageConfig)
 	if err != nil {
 		t.Fatalf("Failed to get builtin function mutation: %v", err)
 	}

--- a/porch/pkg/engine/testdata/context/expected/package-context.yaml
+++ b/porch/pkg/engine/testdata/context/expected/package-context.yaml
@@ -6,3 +6,4 @@ metadata:
     config.kubernetes.io/local-config: "true"
 data:
   name: input
+  package-path: parent1/parent1.2/parent1.2.3/me


### PR DESCRIPTION
We construct a path based on the hierarchy of parent packages.  This
is useful for packages/package functions that want to construct values
meaningful beyond just their package - for example domain names, GCP
project IDs, bucket names, descriptions etc.
