### PR TITLE
[WIP] Immediate poll of repo and enable race detector

### DIFF
--- a/porch/Makefile
+++ b/porch/Makefile
@@ -135,7 +135,7 @@ tidy:
 
 .PHONY: test
 test:
-	@for f in $(MODULES); do (cd $$f; echo "Testing $$f"; E2E=1 go test --count=1 ./...) || exit 1; done
+	@for f in $(MODULES); do (cd $$f; echo "Testing $$f"; E2E=1 go test --race --count=1 ./...) || exit 1; done
 
 .PHONY: vet
 vet:

--- a/porch/pkg/cache/repository.go
+++ b/porch/pkg/cache/repository.go
@@ -282,8 +282,11 @@ func (r *cachedRepository) Close() error {
 
 // pollForever will continue polling until signal channel is closed or ctx is done.
 func (r *cachedRepository) pollForever(ctx context.Context) {
-	ticker := time.NewTicker(1 * time.Minute)
+	// Poll immediately so we don't have to wait for the ticker to trigger the first
+	// sync of the repo.
+	r.pollOnce(ctx)
 
+	ticker := time.NewTicker(1 * time.Minute)
 	for {
 		select {
 		case <-ticker.C:


### PR DESCRIPTION
This updates the polling loop for the repositories so it will run during tests. This leads to concurrency problems as demonstrated when enabling the race detector.
