### PR TITLE
porch: restrict `clone` and `init` to only create the first package revision

### DIFF
--- a/commands/alpha/rpkg/clone/command.go
+++ b/commands/alpha/rpkg/clone/command.go
@@ -208,7 +208,9 @@ func (r *runner) packageAlreadyExists(packageName string) error {
 	// only the first package revision can be created from init or clone, so
 	// we need to check that the package doesn't already exist.
 	packageRevisionList := porchapi.PackageRevisionList{}
-	if err := r.client.List(r.ctx, &packageRevisionList, &client.ListOptions{}); err != nil {
+	if err := r.client.List(r.ctx, &packageRevisionList, &client.ListOptions{
+		Namespace: *r.cfg.Namespace,
+	}); err != nil {
 		return err
 	}
 	for _, pr := range packageRevisionList.Items {

--- a/commands/alpha/rpkg/clone/command.go
+++ b/commands/alpha/rpkg/clone/command.go
@@ -121,7 +121,7 @@ func (r *runner) preRunE(cmd *cobra.Command, args []string) error {
 	}
 	if pkgExists {
 		return fmt.Errorf("`clone` cannot create a new revision for package %q that already exists in repo %q; make subsequent revisions using `copy`",
-			r.target, r.repository)
+			target, r.repository)
 	}
 
 	switch {

--- a/commands/alpha/rpkg/init/command.go
+++ b/commands/alpha/rpkg/init/command.go
@@ -133,7 +133,9 @@ func (r *runner) packageAlreadyExists(packageName string) error {
 	// only the first package revision can be created from init or clone, so
 	// we need to check that the package doesn't already exist.
 	packageRevisionList := porchapi.PackageRevisionList{}
-	if err := r.client.List(r.ctx, &packageRevisionList, &client.ListOptions{}); err != nil {
+	if err := r.client.List(r.ctx, &packageRevisionList, &client.ListOptions{
+		Namespace: *r.cfg.Namespace,
+	}); err != nil {
 		return err
 	}
 	for _, pr := range packageRevisionList.Items {

--- a/commands/alpha/rpkg/util/common.go
+++ b/commands/alpha/rpkg/util/common.go
@@ -1,0 +1,39 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	"context"
+
+	porchapi "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func PackageAlreadyExists(ctx context.Context, c client.Client, repository, packageName, namespace string) (bool, error) {
+	// only the first package revision can be created from init or clone, so
+	// we need to check that the package doesn't already exist.
+	packageRevisionList := porchapi.PackageRevisionList{}
+	if err := c.List(ctx, &packageRevisionList, &client.ListOptions{
+		Namespace: namespace,
+	}); err != nil {
+		return false, err
+	}
+	for _, pr := range packageRevisionList.Items {
+		if pr.Spec.RepositoryName == repository && pr.Spec.PackageName == packageName {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/e2e/testdata/porch/rpkg-clone/config.yaml
+++ b/e2e/testdata/porch/rpkg-clone/config.yaml
@@ -18,6 +18,17 @@ commands:
     stdout: "git-317a42f437be4e9695da4f043ff2c727f6001156 created\n"
   - args:
       - alpha
+      - rpkg
+      - clone
+      - --namespace=rpkg-clone
+      - https://github.com/platkrm/test-blueprints.git/basens@basens/v1
+      - --repository=git
+      - --revision=v1
+      - basens-clone
+    stderr: "error: `clone` cannot create a new revision for package \"basens-clone\" that already exists in repo \"git\"; make subsequent revisions using `copy`\n"
+    exitCode: 1
+  - args:
+      - alpha
       - repo
       - register
       - https://github.com/platkrm/test-blueprints.git

--- a/e2e/testdata/porch/rpkg-init/config.yaml
+++ b/e2e/testdata/porch/rpkg-init/config.yaml
@@ -68,3 +68,13 @@ commands:
           name: kptfile.kpt.dev
       kind: ResourceList
     yaml: true
+  - args:
+      - alpha
+      - rpkg
+      - init
+      - --namespace=rpkg-init
+      - --repository=git
+      - --revision=v1
+      - init-package
+    stderr: "error: `init` cannot create a new revision for package \"init-package\" that already exists in repo \"git\"; make subsequent revisions using `copy`\n"
+    exitCode: 1

--- a/porch/api/porch/types_packagerevisions.go
+++ b/porch/api/porch/types_packagerevisions.go
@@ -226,7 +226,7 @@ type SecretRef struct {
 	Name string `json:"name"`
 }
 
-// OciPackage describes a repository compatible with the Open Coutainer Registry standard.
+// OciPackage describes a repository compatible with the Open Container Registry standard.
 type OciPackage struct {
 	// Image is the address of an OCI image.
 	Image string `json:"image"`

--- a/porch/pkg/engine/engine.go
+++ b/porch/pkg/engine/engine.go
@@ -270,6 +270,16 @@ func (cad *cadEngine) CreatePackageRevision(ctx context.Context, repositoryObj *
 	if err != nil {
 		return nil, err
 	}
+
+	sameOrigin, err := cad.ensureSameOrigin(ctx, obj, repo)
+	if err != nil {
+		return nil, fmt.Errorf("error ensuring same origin: %w", err)
+	}
+
+	if !sameOrigin {
+		return nil, fmt.Errorf("cannot create revision of %s with a different origin than other package revisions in the same package", obj.Spec.PackageName)
+	}
+
 	draft, err := repo.CreatePackageRevision(ctx, obj)
 	if err != nil {
 		return nil, err
@@ -302,6 +312,55 @@ func (cad *cadEngine) CreatePackageRevision(ctx context.Context, repositoryObj *
 		repoPackageRevision: repoPkgRev,
 		packageRevisionMeta: pkgRevMeta,
 	}, nil
+}
+
+func (cad *cadEngine) ensureSameOrigin(ctx context.Context, obj *api.PackageRevision, r repository.Repository) (bool, error) {
+	revs, err := r.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{
+		Package: obj.Spec.PackageName})
+	if err != nil {
+		return false, fmt.Errorf("error listing package revisions: %w", err)
+	}
+	if len(revs) == 0 {
+		// no prior package revisions, no need to check anything else
+		return true, nil
+	}
+
+	tasks := obj.Spec.Tasks
+	if len(tasks) == 0 || (tasks[0].Type != api.TaskTypeInit && tasks[0].Type != api.TaskTypeClone) {
+		// If there are no tasks, or the first task is not init or clone, then this revision was not
+		// created from another package revision. That means we expect it to be the first revision
+		// for this package.
+		return false, nil
+
+	}
+
+	firstObjTask := tasks[0]
+	// iterate over existing package revisions, and look for one with a matching init or clone task
+	for _, rev := range revs {
+		p, err := rev.GetPackageRevision(ctx)
+		if err != nil {
+			return false, err
+		}
+		revTasks := p.Spec.Tasks
+		if len(revTasks) == 0 {
+			// not a match
+			continue
+		}
+		firstRevTask := revTasks[0]
+		if firstRevTask.Type != firstObjTask.Type {
+			// not a match
+			continue
+		}
+		if firstObjTask.Type == api.TaskTypeClone {
+			// we want to make sure everything is equal except for the git upstream ref,
+			// so we make the git upstream refs equal before calling reflect.DeepEqual
+			firstRevTask.Clone.Upstream.Git.Ref = firstObjTask.Clone.Upstream.Git.Ref
+			if reflect.DeepEqual(firstRevTask, firstObjTask) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
 }
 
 func (cad *cadEngine) applyTasks(ctx context.Context, draft repository.PackageDraft, repositoryObj *configapi.Repository, obj *api.PackageRevision, packageConfig *builtins.PackageConfig) error {

--- a/porch/test/e2e/update_test.go
+++ b/porch/test/e2e/update_test.go
@@ -33,7 +33,6 @@ func (t *PorchSuite) TestPackageUpdateRecloneAndReplay(ctx context.Context) {
 	var list porchapi.PackageRevisionList
 	t.ListE(ctx, &list, client.InNamespace(t.namespace))
 
-	basensV1 := MustFindPackageRevision(t.T, &list, repository.PackageRevisionKey{Repository: "test-blueprints", Package: "basens", Revision: "v1"})
 	basensV2 := MustFindPackageRevision(t.T, &list, repository.PackageRevisionKey{Repository: "test-blueprints", Package: "basens", Revision: "v2"})
 	t.Logf("basensV2 = %v", basensV2)
 
@@ -50,7 +49,7 @@ func (t *PorchSuite) TestPackageUpdateRecloneAndReplay(ctx context.Context) {
 			Namespace: t.namespace,
 		},
 		Spec: porchapi.PackageRevisionSpec{
-			PackageName:    "testns",
+			PackageName:    "testRecloneAndReplay",
 			Revision:       "v1",
 			RepositoryName: gitRepository,
 			Tasks: []porchapi.Task{

--- a/porch/test/e2e/update_test.go
+++ b/porch/test/e2e/update_test.go
@@ -58,8 +58,10 @@ func (t *PorchSuite) TestPackageUpdateRecloneAndReplay(ctx context.Context) {
 					Type: porchapi.TaskTypeClone,
 					Clone: &porchapi.PackageCloneTaskSpec{
 						Upstream: porchapi.UpstreamPackage{
-							UpstreamRef: &porchapi.PackageRevisionRef{
-								Name: basensV1.Name,
+							Git: &porchapi.GitPackage{
+								Repo:      testBlueprintsRepo,
+								Ref:       "v1",
+								Directory: "basens",
 							},
 						},
 					},


### PR DESCRIPTION
Partially implements https://github.com/GoogleContainerTools/kpt/issues/3467#issuecomment-1236430901

Only the first package revision can be made by `init` or `clone`. Subsequent package revisions should be created with `edit`/`copy`.

This adds the check on both the CLI and server side. 