### PR TITLE
Don't skip the Porch e2e test in the GA workflow

### DIFF
--- a/.github/workflows/porch-e2e.yml
+++ b/.github/workflows/porch-e2e.yml
@@ -95,7 +95,7 @@ jobs:
             fi
           done
       - name: e2e test
-        run: go test -v .
+        run: E2E=1 go test -v .
         working-directory: ./porch/test/e2e
       - name: Porch CLI e2e test
         run: make test-porch


### PR DESCRIPTION
We need to set the env variable for the e2e tests to actually run and not get skipped.
