### PR TITLE
leveraging `pkg get` for easy function scaffolding

### DIFF
--- a/internal/util/parse/parse.go
+++ b/internal/util/parse/parse.go
@@ -29,6 +29,8 @@ import (
 )
 
 const gitSuffixRegexp = "\\.git($|/)"
+const FnScaffoldingPackage = "fn"
+const FnScaffoldingURL = "https://github.com/GoogleContainerTools/kpt-functions-sdk.git/go/get-started@master"
 
 type Target struct {
 	kptfilev1.Git
@@ -41,6 +43,9 @@ func GitParseArgs(ctx context.Context, args []string) (Target, error) {
 		return g, nil
 	}
 
+	if args[0] == FnScaffoldingPackage {
+		args[0] = FnScaffoldingURL
+	}
 	// Simple parsing if contains .git{$|/)
 	if HasGitSuffix(args[0]) {
 		return targetFromPkgURL(ctx, args[0], args[1])


### PR DESCRIPTION
Rather than developing a new set of commands for KRM function scaffolding, I'd like to make it easy and use this to give users another example on what kind of cool things they can do with `kpt pkg get`: get a KRM fn scaffolding package to get started.   

This PR adds a command shortcut:
`kpt pkg get fn <DIR>`, which is equivalent to `kpt pkg get  https://github.com/GoogleContainerTools/kpt-functions-sdk.git/go/get-started@master  <DIR>`.
[The get-started package](https://github.com/GoogleContainerTools/kpt-functions-sdk/tree/master/go/get-started) contains (or will contain), main method with some coding guidance, go dependencies, test infra and fn building options(Dockerfile, ko, and maybe some others).

I'd like to know if you like this approach, and what else a fn scaffolding package should contain.  
    