### PR TITLE
licensecan: Fix go.mod so we can `go run`

### DIFF
--- a/tools/licensescan/go.mod
+++ b/tools/licensescan/go.mod
@@ -1,4 +1,4 @@
-module licensescan
+module github.com/GoogleContainerTools/kpt/tools/licensescan
 
 go 1.18
 

--- a/tools/licensescan/main.go
+++ b/tools/licensescan/main.go
@@ -78,6 +78,7 @@ func buildLicenseScanCommand() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&opts.Binary, "binary", opts.Binary, "binary to analyze")
+	cmd.MarkFlagRequired("binary")
 
 	cmd.Flags().BoolVar(&opts.IncludeLicenses, "print", opts.IncludeLicenses, "include license text")
 


### PR DESCRIPTION
Also mark the --binary flag as required (to avoid a cryptic error
message).
