### PR TITLE
fix non-US-ascii characters

### DIFF
--- a/pkg/live/inventoryrg.go
+++ b/pkg/live/inventoryrg.go
@@ -689,7 +689,7 @@ spec:
                             last transition
                           type: string
                         reason:
-                          description: one-word CamelCase reason for the condition’s
+                          description: one-word CamelCase reason for the condition's
                             last transition
                           type: string
                         status:
@@ -909,7 +909,7 @@ spec:
                               about last transition
                             type: string
                           reason:
-                            description: one-word CamelCase reason for the condition’s
+                            description: one-word CamelCase reason for the condition's
                               last transition
                             type: string
                           status:


### PR DESCRIPTION
We ran into an issue where applying the resourcegroup.kpt.dev CRD through an old-fashioned system towards our cluster, that the contents of the description weren't fully in US-ASCII format.

This commit fixes that.