### PR TITLE
Upgrade GitHub Actions versions to avoid deprecated Node 12 runtime

### DIFF
--- a/.github/workflows/checkDocSync.yml
+++ b/.github/workflows/checkDocSync.yml
@@ -20,6 +20,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: |
           ./.github/hooks/pre-commit

--- a/.github/workflows/checkLicenses.yml
+++ b/.github/workflows/checkLicenses.yml
@@ -20,15 +20,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Go 1.18
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - run: |
           ./scripts/create-licenses.sh
       # Upload the licenses list so it's available if needed
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: Licenses
           path: LICENSES.txt

--- a/.github/workflows/checkSite.yml
+++ b/.github/workflows/checkSite.yml
@@ -24,7 +24,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 # disabling href checker https://github.com/GoogleContainerTools/kpt/issues/3157
 # Re-enable it by replacing it with robust mechanism
 #      - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
 #          repository: etefera/href-checker
 #          ref: docsify
 #          path: href-checker
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Lint site content

--- a/.github/workflows/e2eEnvironment.yml
+++ b/.github/workflows/e2eEnvironment.yml
@@ -32,10 +32,10 @@ jobs:
         version: ["1.19", "1.20", "1.21", "1.22", "1.23", "1.24"]
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       # Pinned to Commit to ensure action is consistent: https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
       # If you upgrade this version confirm the changes match your expectations
       - name: Install KinD

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -24,15 +24,15 @@ jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
         with:
           node-version: '16'
       - name: Generate Site
         run: make site-run-server
       - name: Generate sitemap
         run: make site-map
-      - uses: FirebaseExtended/action-hosting-deploy@276388dd6c2cde23455b30293105cc866c22282d # v0
+      - uses: FirebaseExtended/action-hosting-deploy@4d0d0023f1d92b9b7d16dda64b3d7abd2c98974b # v0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_KPT_DEV }}"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -46,7 +46,7 @@ jobs:
           which podman
           podman version
       - name: Set up Go 1.18
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
         id: go
@@ -68,7 +68,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Set up Go 1.18
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
         id: go

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -31,7 +31,7 @@ jobs:
         version: ["1.21.12"]
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - uses: actions/checkout@master

--- a/.github/workflows/porch-e2e.yml
+++ b/.github/workflows/porch-e2e.yml
@@ -54,11 +54,11 @@ jobs:
 
     steps:
       - name: Set up Go 1.18
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - name: Checkout Porch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Build kpt
         run: go install .
       - name: Build Docker Images

--- a/.github/workflows/porch.yml
+++ b/.github/workflows/porch.yml
@@ -30,11 +30,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.18
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - name: Run Porch Unit Tests
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Verify format / headers etc
         run: scripts/verify-fix-all.sh
         working-directory: ./porch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,11 +26,11 @@ jobs:
       hashes: ${{ steps.hash.outputs.hashes }}
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.18
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Build, Test, Lint
@@ -40,7 +40,7 @@ jobs:
           make all
           make test-docker
       - name: Login to GCR
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: gcr.io
           username: _json_key

--- a/.github/workflows/verifyContent.yml
+++ b/.github/workflows/verifyContent.yml
@@ -28,10 +28,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: 1.18
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: |
           make build
       - name: Get dependencies


### PR DESCRIPTION
Ref warning in https://github.com/GoogleContainerTools/kpt/actions/runs/3252439509/attempts/1
