### PR TITLE
docs: update porch ui installation guide

### DIFF
--- a/site/guides/porch-ui-installation.md
+++ b/site/guides/porch-ui-installation.md
@@ -1,24 +1,20 @@
 # Accessing the Configuration as Data UI
 
-The easiest way to access the Configuration as Data UI is running by a docker
-container on your local machine where you'll be able to access the UI with your
-browser. Running the container locally simplifies the overall setup by allowing
-the UI to use your local kubeconfig and Google credentials to access the kubernetes
-cluster with Porch installed. This guide will show you how to do this.
+You can access the Configuration as Data UI UI either by running the UI on a
+cluster or integrating the UI into an existing Backstage installation.
 
 ## Prerequisites
 
-To access the Configuration as Data UI with a docker container, you will need:
+To access the Configuration as Data UI, you will need:
 
-*   [Porch](guides/porch-installation.md) installed on a kubernetes cluster
-*   [kubectl](https://kubernetes.io/docs/tasks/tools/) targeting the kubernetes cluster
-    with Porch installed
-*   [git](https://git-scm.com/)
-*   [docker](https://docs.docker.com/get-docker/)
+- [Porch](guides/porch-installation.md) installed on a Kubernetes cluster
+- [kubectl](https://kubernetes.io/docs/tasks/tools/) targeting the Kubernetes
+  cluster with Porch installed
+- [kpt CLI](https://kpt.dev/installation/kpt-cli) installed
 
 ## Running on a GKE cluster
 
-This setup assumes that you have a GKE cluster up and running with porch installed, and that
+This setup assumes that you have a GKE cluster up and running with Porch installed, and that
 your current kube context is set to that GKE cluster. We would welcome contributions or feedback
 from people that have set this up in other clouds outside of GKE.
 
@@ -136,38 +132,6 @@ kubectl port-forward --namespace=backstage svc/backstage 7007
 
 Open the plugin by browsing to `localhost:7007/config-as-data`. On the plugin, you will need to sign in to your
 Google account so that the plugin can access your GKE cluster.
-
-## Running locally in a container
-
-This setup is intended for those developing the plugin. These instructions assume GKE and workload identity,
-to simplify authentication configuration, but we would welcome contributions or feedback from people that have set
-this up in other clouds.
-
-First, clone the
-[kpt-backstage-plugins](https://github.com/GoogleContainerTools/kpt-backstage-plugins)
-repository.
-
-```sh
-git clone https://github.com/GoogleContainerTools/kpt-backstage-plugins.git
-cd kpt-backstage-plugins
-```
-
-Next, build the kpt-backstage-plugins image.
-
-```sh
-docker build --target backstage-app-local --tag kpt-backstage-plugins .
-```
-
-And create a new container using the kpt-backstage-plugins image. The two
-attached volumnes allows the UI to connect to your GKE using your local Google
-credentials, and the UI will be exposed over port 7007.
-
-```sh
-docker run -v ~/.kube/config:/root/.kube/config -v ~/.config/gcloud:/root/.config/gcloud -p 7007:7007 kpt-backstage-plugins
-```
-
-And now access the Configuration as Data UI by opening your browser to
-http://localhost:7007/config-as-data.
 
 ## Running in Backstage
 


### PR DESCRIPTION
This pull request updates the Porch UI Installation Guide, removing how to run the UI in a standalone Docker container as this is now deprecated.