### PR TITLE
Watch for PackageRevisions

### DIFF
--- a/porch/pkg/apiserver/apiserver.go
+++ b/porch/pkg/apiserver/apiserver.go
@@ -216,10 +216,13 @@ func (c completedConfig) New() (*PorchServer, error) {
 	referenceResolver := porch.NewReferenceResolver(coreClient)
 	userInfoProvider := &porch.ApiserverUserInfoProvider{}
 
+	watcherMgr := engine.NewWatcherManager()
+
 	cache := cache.NewCache(c.ExtraConfig.CacheDirectory, cache.CacheOptions{
 		CredentialResolver: credentialResolver,
 		UserInfoProvider:   userInfoProvider,
 		MetadataStore:      metadataStore,
+		ObjectNotifier:     watcherMgr,
 	})
 
 	runnerOptionsResolver := func(namespace string) fnruntime.RunnerOptions {
@@ -247,6 +250,7 @@ func (c completedConfig) New() (*PorchServer, error) {
 		engine.WithReferenceResolver(referenceResolver),
 		engine.WithUserInfoProvider(userInfoProvider),
 		engine.WithMetadataStore(metadataStore),
+		engine.WithWatcherManager(watcherMgr),
 	)
 	if err != nil {
 		return nil, err

--- a/porch/pkg/cache/cache_test.go
+++ b/porch/pkg/cache/cache_test.go
@@ -23,9 +23,10 @@ import (
 
 	api "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
 	"github.com/GoogleContainerTools/kpt/porch/api/porchconfig/v1alpha1"
+	fakecache "github.com/GoogleContainerTools/kpt/porch/pkg/cache/fake"
 	"github.com/GoogleContainerTools/kpt/porch/pkg/git"
 	"github.com/GoogleContainerTools/kpt/porch/pkg/meta"
-	"github.com/GoogleContainerTools/kpt/porch/pkg/meta/fake"
+	fakemeta "github.com/GoogleContainerTools/kpt/porch/pkg/meta/fake"
 	"github.com/GoogleContainerTools/kpt/porch/pkg/repository"
 	gogit "github.com/go-git/go-git/v5"
 	"github.com/google/go-cmp/cmp"
@@ -134,7 +135,8 @@ func openRepositoryFromArchive(t *testing.T, ctx context.Context, testPath, name
 	metadataStore := createMetadataStoreFromArchive(t, "", "")
 
 	cache := NewCache(t.TempDir(), CacheOptions{
-		MetadataStore: metadataStore,
+		MetadataStore:  metadataStore,
+		ObjectNotifier: &fakecache.ObjectNotifier{},
 	})
 	cachedGit, err := cache.OpenRepository(ctx, &v1alpha1.Repository{
 		TypeMeta: metav1.TypeMeta{
@@ -170,7 +172,7 @@ func createMetadataStoreFromArchive(t *testing.T, testPath, name string) meta.Me
 		t.Fatalf("Error reading metadata file found for repository %s", name)
 	}
 	if os.IsNotExist(err) {
-		return &fake.MemoryMetadataStore{
+		return &fakemeta.MemoryMetadataStore{
 			Metas: []meta.PackageRevisionMeta{},
 		}
 	}
@@ -180,7 +182,7 @@ func createMetadataStoreFromArchive(t *testing.T, testPath, name string) meta.Me
 		t.Fatalf("Error unmarshalling metadata file for repository %s", name)
 	}
 
-	return &fake.MemoryMetadataStore{
+	return &fakemeta.MemoryMetadataStore{
 		Metas: metas,
 	}
 }

--- a/porch/pkg/cache/fake/objectnotifier.go
+++ b/porch/pkg/cache/fake/objectnotifier.go
@@ -1,0 +1,26 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fake
+
+import (
+	"github.com/GoogleContainerTools/kpt/porch/pkg/meta"
+	"github.com/GoogleContainerTools/kpt/porch/pkg/repository"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+type ObjectNotifier struct{}
+
+func (o *ObjectNotifier) NotifyPackageRevisionChange(watch.EventType, repository.PackageRevision, meta.PackageRevisionMeta) {
+}

--- a/porch/pkg/engine/options.go
+++ b/porch/pkg/engine/options.go
@@ -127,3 +127,10 @@ func WithMetadataStore(metadataStore meta.MetadataStore) EngineOption {
 		return nil
 	})
 }
+
+func WithWatcherManager(watcherManager *watcherManager) EngineOption {
+	return EngineOptionFunc(func(engine *cadEngine) error {
+		engine.watcherManager = watcherManager
+		return nil
+	})
+}

--- a/porch/pkg/registry/porch/packagecommon.go
+++ b/porch/pkg/registry/porch/packagecommon.go
@@ -21,7 +21,6 @@ import (
 	unversionedapi "github.com/GoogleContainerTools/kpt/porch/api/porch"
 	api "github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
 	configapi "github.com/GoogleContainerTools/kpt/porch/api/porchconfig/v1alpha1"
-	"github.com/GoogleContainerTools/kpt/porch/pkg/cache"
 	"github.com/GoogleContainerTools/kpt/porch/pkg/engine"
 	"github.com/GoogleContainerTools/kpt/porch/pkg/repository"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -129,7 +128,7 @@ func (r *packageCommon) listPackages(ctx context.Context, filter packageFilter, 
 	return nil
 }
 
-func (r *packageCommon) watchPackages(ctx context.Context, filter packageRevisionFilter, callback cache.ObjectWatcher) error {
+func (r *packageCommon) watchPackages(ctx context.Context, filter packageRevisionFilter, callback engine.ObjectWatcher) error {
 	if err := r.cad.ObjectCache().WatchPackageRevisions(ctx, filter.ListPackageRevisionFilter, callback); err != nil {
 		return err
 	}

--- a/porch/pkg/registry/porch/packagerevision.go
+++ b/porch/pkg/registry/porch/packagerevision.go
@@ -46,6 +46,7 @@ var _ rest.Scoper = &packageRevisions{}
 var _ rest.Creater = &packageRevisions{}
 var _ rest.Updater = &packageRevisions{}
 var _ rest.GracefulDeleter = &packageRevisions{}
+var _ rest.Watcher = &packageRevisions{}
 
 func (r *packageRevisions) New() runtime.Object {
 	return &api.PackageRevision{}

--- a/porch/pkg/registry/porch/packagerevisionresources.go
+++ b/porch/pkg/registry/porch/packagerevisionresources.go
@@ -45,7 +45,6 @@ var _ rest.Lister = &packageRevisionResources{}
 var _ rest.Getter = &packageRevisionResources{}
 var _ rest.Scoper = &packageRevisionResources{}
 var _ rest.Updater = &packageRevisionResources{}
-var _ rest.Watcher = &packageRevisionResources{}
 
 func (r *packageRevisionResources) New() runtime.Object {
 	return &api.PackageRevisionResources{}


### PR DESCRIPTION
This moves the watch from PackageRevisionResources to PackageRevisions. It also makes sure to send watch notifications on both updates coming from polling the repository (git/oci) and create/update/delete through the API.

