### PR TITLE
build: slsa fix in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,8 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.1
     with:
+      compile-generator: true # Workaround for https://github.com/slsa-framework/slsa-github-generator/issues/1163
       base64-subjects: "${{ needs.build.outputs.hashes }}"
       upload-assets: true # upload to a new release


### PR DESCRIPTION
Latest release of `kpt CLI` failed due to `FAILED: SLSA verification failed: could not find a matching valid signature entry`. This PR fixes the issue.

slsa gh runner has this issue: https://github.com/slsa-framework/slsa-github-generator/issues/1163