### PR TITLE
update `kpt alpha rpkg` command help docs

### DIFF
--- a/commands/alpha/rpkg/clone/command.go
+++ b/commands/alpha/rpkg/clone/command.go
@@ -68,7 +68,7 @@ func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner 
 	c.Flags().StringVar(&r.directory, "directory", "", "Directory within the repository where the upstream package is located.")
 	c.Flags().StringVar(&r.ref, "ref", "", "Branch in the repository where the upstream package is located.")
 	c.Flags().StringVar(&r.repository, "repository", "", "Repository to which package will be cloned (downstream repository).")
-	c.Flags().StringVar(&r.workspace, "workspace", "v1", "WorkspaceName of the downstream package.")
+	c.Flags().StringVar(&r.workspace, "workspace", "v1", "Workspace name of the downstream package.")
 
 	return r
 }

--- a/commands/alpha/rpkg/copy/command.go
+++ b/commands/alpha/rpkg/copy/command.go
@@ -52,7 +52,7 @@ func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner 
 		RunE:    r.runE,
 		Hidden:  porch.HidePorchCommands,
 	}
-	r.Command.Flags().StringVar(&r.workspace, "workspace", "", "WorkspaceName of the copy of the package.")
+	r.Command.Flags().StringVar(&r.workspace, "workspace", "", "Workspace name of the copy of the package.")
 	return r
 }
 

--- a/commands/alpha/rpkg/init/command.go
+++ b/commands/alpha/rpkg/init/command.go
@@ -57,7 +57,7 @@ func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner 
 	c.Flags().StringSliceVar(&r.Keywords, "keywords", []string{}, "list of keywords for the package.")
 	c.Flags().StringVar(&r.Site, "site", "", "link to page with information about the package.")
 	c.Flags().StringVar(&r.repository, "repository", "", "Repository to which package will be cloned (downstream repository).")
-	c.Flags().StringVar(&r.workspace, "workspace", "", "WorkspaceName of the downstream package.")
+	c.Flags().StringVar(&r.workspace, "workspace", "", "Workspace name of the downstream package.")
 
 	return r
 }

--- a/internal/docs/generated/rpkgdocs/docs.go
+++ b/internal/docs/generated/rpkgdocs/docs.go
@@ -59,8 +59,8 @@ Flags:
     Repository to which package revision will be cloned
     (downstream repository).
   
-  --revision
-    Revision for the new package.
+  --workspace
+    Workspace for the new package. The default value is v1.
   
   --strategy
     Update strategy that should be used when updating the new
@@ -89,14 +89,12 @@ Args:
 
 Flags:
 
-  --revision
-    Revision for the new package. If this is not specified, the default
-    revision will be ` + "`" + `latest + 1` + "`" + `. The default can only be used if the
-    latest package revision is of the format ` + "`" + `^v[0-9]+$` + "`" + `.
+  --workspace
+    Workspace for the new package revision.
 `
 var CopyExamples = `
   # create a new package from package blueprint-b47eadc99f3c525571d3834cc61b974453bc6be2
-  $ kpt alpha rpkg copy blueprint-b47eadc99f3c525571d3834cc61b974453bc6be2 --revision=v10 --namespace=default
+  $ kpt alpha rpkg copy blueprint-b47eadc99f3c525571d3834cc61b974453bc6be2 --workspace=v10 --namespace=default
 `
 
 var DelShort = `Delete a package revision.`
@@ -160,21 +158,21 @@ Flags:
   --repository
     Repository in which the new package will be created.
   
-  --revision
-    Revision of the new package. The default value if v1.
+  --workspace
+    Workspace of the new package.
   
   --description
-    short description of the package
+    Short description of the package
   
   --keywords
-    list of keywords for the package
+    List of keywords for the package
   
   --site
-    link to page with information about the package
+    Link to page with information about the package
 `
 var InitExamples = `
   # create a new package named foo in the repository blueprint.
-  $ kpt alpha rpkg init foo --namespace=default --repository=blueprint
+  $ kpt alpha rpkg init foo --namespace=default --repository=blueprint --workspace=v1
 `
 
 var ProposeShort = `Propose that a package revision should be published.`

--- a/site/reference/cli/alpha/rpkg/clone/README.md
+++ b/site/reference/cli/alpha/rpkg/clone/README.md
@@ -59,8 +59,8 @@ TARGET_PACKAGE_NAME:
   Repository to which package revision will be cloned
   (downstream repository).
 
---revision
-  Revision for the new package.
+--workspace
+  Workspace for the new package. The default value is v1.
 
 --strategy
   Update strategy that should be used when updating the new

--- a/site/reference/cli/alpha/rpkg/copy/README.md
+++ b/site/reference/cli/alpha/rpkg/copy/README.md
@@ -12,7 +12,7 @@ description: >
 
 `copy` creates a new package revision from an existing one. The new
 revision will be identical to the existing one but with a different
-revision.
+workspace.
 
 ### Synopsis
 
@@ -33,10 +33,8 @@ SOURCE_PACKAGE_REV_NAME:
 #### Flags
 
 ```
---revision
-  Revision for the new package. If this is not specified, the default
-  revision will be `latest + 1`. The default can only be used if the
-  latest package revision is of the format `^v[0-9]+$`.
+--workspace
+  Workspace for the new package revision.
 ```
 
 <!--mdtogo-->
@@ -47,7 +45,7 @@ SOURCE_PACKAGE_REV_NAME:
 
 ```shell
 # create a new package from package blueprint-b47eadc99f3c525571d3834cc61b974453bc6be2
-$ kpt alpha rpkg copy blueprint-b47eadc99f3c525571d3834cc61b974453bc6be2 --revision=v10 --namespace=default
+$ kpt alpha rpkg copy blueprint-b47eadc99f3c525571d3834cc61b974453bc6be2 --workspace=v10 --namespace=default
 ```
 
 <!--mdtogo-->

--- a/site/reference/cli/alpha/rpkg/init/README.md
+++ b/site/reference/cli/alpha/rpkg/init/README.md
@@ -34,17 +34,17 @@ PACKAGE_NAME:
 --repository
   Repository in which the new package will be created.
 
---revision
-  Revision of the new package. The default value if v1.
+--workspace
+  Workspace of the new package.
 
 --description
-  short description of the package
+  Short description of the package
 
 --keywords
-  list of keywords for the package
+  List of keywords for the package
 
 --site
-  link to page with information about the package
+  Link to page with information about the package
 ```
 
 <!--mdtogo-->
@@ -55,7 +55,7 @@ PACKAGE_NAME:
 
 ```shell
 # create a new package named foo in the repository blueprint.
-$ kpt alpha rpkg init foo --namespace=default --repository=blueprint
+$ kpt alpha rpkg init foo --namespace=default --repository=blueprint --workspace=v1
 ```
 
 <!--mdtogo-->


### PR DESCRIPTION
This pull request updates the long help documentation for the `rpkg init`, `rpkg clone`, and `rpkg copy` commands to bring the documentation up to date with the latest release.