### PR TITLE
add validations to `kpt alpha rpkg init` command

### DIFF
--- a/commands/alpha/rpkg/clone/command.go
+++ b/commands/alpha/rpkg/clone/command.go
@@ -113,7 +113,7 @@ func (r *runner) preRunE(cmd *cobra.Command, args []string) error {
 	}
 
 	if r.workspace == "" {
-		return errors.E(op, fmt.Errorf("--workspace is required to specify downstream workspaceName"))
+		return errors.E(op, fmt.Errorf("--workspace is required to specify downstream workspace name"))
 	}
 
 	source := args[0]

--- a/commands/alpha/rpkg/copy/command.go
+++ b/commands/alpha/rpkg/copy/command.go
@@ -124,7 +124,7 @@ func (r *runner) getPackageRevisionSpec() (*porchapi.PackageRevisionSpec, error)
 	}
 
 	if r.workspace == "" {
-		return nil, fmt.Errorf("--workspace is required to specify downstream workspaceName")
+		return nil, fmt.Errorf("--workspace is required to specify workspace name")
 	}
 
 	spec := &porchapi.PackageRevisionSpec{

--- a/commands/alpha/rpkg/init/command.go
+++ b/commands/alpha/rpkg/init/command.go
@@ -56,8 +56,8 @@ func newRunner(ctx context.Context, rcg *genericclioptions.ConfigFlags) *runner 
 	c.Flags().StringVar(&r.Description, "description", "sample description", "short description of the package.")
 	c.Flags().StringSliceVar(&r.Keywords, "keywords", []string{}, "list of keywords for the package.")
 	c.Flags().StringVar(&r.Site, "site", "", "link to page with information about the package.")
-	c.Flags().StringVar(&r.repository, "repository", "", "Repository to which package will be cloned (downstream repository).")
-	c.Flags().StringVar(&r.workspace, "workspace", "", "Workspace name of the downstream package.")
+	c.Flags().StringVar(&r.repository, "repository", "", "Repository to which package will be created.")
+	c.Flags().StringVar(&r.workspace, "workspace", "", "Workspace name of the package.")
 
 	return r
 }
@@ -88,6 +88,14 @@ func (r *runner) preRunE(cmd *cobra.Command, args []string) error {
 
 	if len(args) < 1 {
 		return errors.E(op, "PACKAGE_NAME is a required positional argument")
+	}
+
+	if r.repository == "" {
+		return errors.E(op, fmt.Errorf("--repository is required to specify target repository"))
+	}
+
+	if r.workspace == "" {
+		return errors.E(op, fmt.Errorf("--workspace is required to specify workspace name"))
 	}
 
 	r.name = args[0]


### PR DESCRIPTION
This pull request adds two validations to the `kpt alpha rpkg init` command ensuring that the --repository and --workspace flags are present when the cli command is executed.