### PR TITLE
Fix bugs in RootSyncSet controller

### DIFF
--- a/porch/controllers/rootsyncsets/api/v1alpha1/rootsyncset_types.go
+++ b/porch/controllers/rootsyncsets/api/v1alpha1/rootsyncset_types.go
@@ -63,6 +63,8 @@ type SecretReference struct {
 
 // RootSyncSetStatus defines the observed state of RootSyncSet
 type RootSyncSetStatus struct {
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
+
 	// Conditions describes the reconciliation state of the object.
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 

--- a/porch/controllers/rootsyncsets/config/rbac/role.yaml
+++ b/porch/controllers/rootsyncsets/config/rbac/role.yaml
@@ -58,6 +58,7 @@ rules:
   verbs:
   - get
   - list
+  - watch
 - apiGroups:
   - container.cnrm.cloud.google.com
   resources:


### PR DESCRIPTION
Fixes some issues in the RootSyncSet:
 * Properly remove watchers.
 * Add ObservedGeneration to the RootSyncSet type so it is possible for clients to determine if the statuses are stale.

