### PR TITLE
Update the RootSyncSet CRD with changes in the go structs

### DIFF
--- a/porch/controllers/config/crd/bases/config.porch.kpt.dev_rootsyncsets.yaml
+++ b/porch/controllers/config/crd/bases/config.porch.kpt.dev_rootsyncsets.yaml
@@ -191,6 +191,9 @@ spec:
                   - type
                   type: object
                 type: array
+              observedGeneration:
+                format: int64
+                type: integer
             type: object
         type: object
     served: true


### PR DESCRIPTION
I accidentally left this change out when I split out https://github.com/GoogleContainerTools/kpt/pull/3651
