### PR TITLE
Finalizers and OwnerRefs for PackageRevision

### DIFF
--- a/porch/pkg/engine/fake/packagerevision.go
+++ b/porch/pkg/engine/fake/packagerevision.go
@@ -20,12 +20,14 @@ import (
 	kptfile "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
 	"github.com/GoogleContainerTools/kpt/porch/pkg/repository"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // Implementation of the repository.PackageRevision interface for testing.
 type PackageRevision struct {
 	Name               string
 	Namespace          string
+	Uid                types.UID
 	PackageRevisionKey repository.PackageRevisionKey
 	PackageLifecycle   v1alpha1.PackageRevisionLifecycle
 	PackageRevision    *v1alpha1.PackageRevision
@@ -39,6 +41,10 @@ func (pr *PackageRevision) KubeObjectName() string {
 
 func (pr *PackageRevision) KubeObjectNamespace() string {
 	return pr.Namespace
+}
+
+func (pr *PackageRevision) UID() types.UID {
+	return pr.Uid
 }
 
 func (pr *PackageRevision) Key() repository.PackageRevisionKey {

--- a/porch/pkg/git/package.go
+++ b/porch/pkg/git/package.go
@@ -72,6 +72,10 @@ func (p *gitPackageRevision) KubeObjectNamespace() string {
 	return p.repo.namespace
 }
 
+func (p *gitPackageRevision) UID() types.UID {
+	return p.uid()
+}
+
 func (p *gitPackageRevision) Key() repository.PackageRevisionKey {
 	return repository.PackageRevisionKey{
 		Repository:    p.repo.name,

--- a/porch/pkg/meta/fake/memorystore.go
+++ b/porch/pkg/meta/fake/memorystore.go
@@ -48,7 +48,7 @@ func (m *MemoryMetadataStore) List(ctx context.Context, repo *configapi.Reposito
 	return m.Metas, nil
 }
 
-func (m *MemoryMetadataStore) Create(ctx context.Context, pkgRevMeta meta.PackageRevisionMeta, repo *configapi.Repository) (meta.PackageRevisionMeta, error) {
+func (m *MemoryMetadataStore) Create(ctx context.Context, pkgRevMeta meta.PackageRevisionMeta, repoName string, pkgRevUID types.UID) (meta.PackageRevisionMeta, error) {
 	for _, m := range m.Metas {
 		if m.Name == pkgRevMeta.Name && m.Namespace == pkgRevMeta.Namespace {
 			return m, apierrors.NewAlreadyExists(
@@ -78,7 +78,7 @@ func (m *MemoryMetadataStore) Update(ctx context.Context, pkgRevMeta meta.Packag
 	return pkgRevMeta, nil
 }
 
-func (m *MemoryMetadataStore) Delete(ctx context.Context, namespacedName types.NamespacedName) (meta.PackageRevisionMeta, error) {
+func (m *MemoryMetadataStore) Delete(ctx context.Context, namespacedName types.NamespacedName, _ bool) (meta.PackageRevisionMeta, error) {
 	var metas []meta.PackageRevisionMeta
 	found := false
 	var deletedMeta meta.PackageRevisionMeta

--- a/porch/pkg/oci/oci.go
+++ b/porch/pkg/oci/oci.go
@@ -392,6 +392,10 @@ func (p *ociPackageRevision) KubeObjectNamespace() string {
 	return p.parent.namespace
 }
 
+func (p *ociPackageRevision) UID() types.UID {
+	return p.uid
+}
+
 func (p *ociPackageRevision) Key() repository.PackageRevisionKey {
 	return repository.PackageRevisionKey{
 		Repository:    p.parent.name,

--- a/porch/pkg/registry/porch/watch.go
+++ b/porch/pkg/registry/porch/watch.go
@@ -95,7 +95,7 @@ func (w *watcher) ResultChan() <-chan watch.Event {
 func (w *watcher) listAndWatch(ctx context.Context, r *packageRevisions, filter packageRevisionFilter, selector labels.Selector) {
 	if err := w.listAndWatchInner(ctx, r, filter, selector); err != nil {
 		// TODO: We need to populate the object on this error
-		klog.Warningf("sending error to watch stream")
+		klog.Warningf("sending error to watch stream: %v", err)
 		ev := watch.Event{
 			Type: watch.Error,
 		}

--- a/porch/pkg/repository/repository.go
+++ b/porch/pkg/repository/repository.go
@@ -21,6 +21,7 @@ import (
 	kptfile "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
 	"github.com/go-git/go-git/v5/plumbing/transport"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // TODO: 	"sigs.k8s.io/kustomize/kyaml/filesys" FileSystem?
@@ -55,7 +56,12 @@ type PackageRevision interface {
 	// More "readable" values are returned by Key()
 	KubeObjectName() string
 
+	// KubeObjectNamespace returns the namespace in which the PackageRevision
+	// belongs.
 	KubeObjectNamespace() string
+
+	// UID returns a unique identifier for the PackageRevision.
+	UID() types.UID
 
 	// Key returns the "primary key" of the package.
 	Key() PackageRevisionKey


### PR DESCRIPTION
This adds support for Finalizers and OwnerReferences for the PackageRevision type. It does this by reusing these fields from the internal PackageRev type to the PackageRevision type from the aggregated APIServer.

There are a few caveats to finalizers for PackageRevisions. Since these can be removed out-of-band from the APIServer, either by deletion of the Repository from Porch or removal of the PackageRevision directly from git/oci. In these cases, there isn't any way for us to honor the finalizers, so the resource will be deleted directly.
