### PR TITLE
docs: update local-config annotation documentation

### DIFF
--- a/site/reference/annotations/local-config/README.md
+++ b/site/reference/annotations/local-config/README.md
@@ -24,8 +24,8 @@ YAML boolean (invalid annotation), not a string.
 
 ### Behavior
 
-Resources with the `local-config` annotation set to `true` will not be applied
-to the cluster when using `kpt live apply`.
+Resources with the `local-config` annotation set to any value except `false`
+will not be applied to the cluster when using `kpt live apply`.
 
 ### Example
 


### PR DESCRIPTION
This pull request updates the `local-config` annotation documentation to indicate that any local-config resources except where the annotation value is set to false will not be applied to the cluster with kpt live apply. 