### PR TITLE
Add stubs for compiling without wasmtime / without cgo

### DIFF
--- a/internal/fnruntime/wasmtime.go
+++ b/internal/fnruntime/wasmtime.go
@@ -1,3 +1,6 @@
+//go:build cgo
+// +build cgo
+
 // Copyright 2022 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");

--- a/internal/fnruntime/wasmtime_unsupported.go
+++ b/internal/fnruntime/wasmtime_unsupported.go
@@ -1,0 +1,37 @@
+//go:build !cgo
+// +build !cgo
+
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fnruntime
+
+// Stub functions for running without wasmtime support compiled in.
+// wasmtime requires cgo, which is not always a viable option.
+
+import (
+	"fmt"
+	"io"
+)
+
+type WasmtimeFn struct {
+}
+
+func NewWasmtimeFn(loader WasmLoader) (*WasmtimeFn, error) {
+	return nil, fmt.Errorf("wasmtime support is not compiled into binary (check cgo settings)")
+}
+
+func (f *WasmtimeFn) Run(r io.Reader, w io.Writer) error {
+	return fmt.Errorf("wasmtime support is not compiled into binary (check cgo settings)")
+}


### PR DESCRIPTION
This allows us to compile kpt without cgo support; wasm support is in
alpha and we have to opt in to wasm support and the wasmtime runner
anyway.

We can likely add an exec-based runner here instead in future (though
we already have the nodejs one).
