### PR TITLE
licensetool: embed license DB, update for more modules

### DIFF
--- a/tools/licensescan/modules/bitbucket.org/creachadair/stringset/v0.0.8.yaml
+++ b/tools/licensescan/modules/bitbucket.org/creachadair/stringset/v0.0.8.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/bitbucket.org/creachadair/stringset@v0.0.8
+license: BSD-3-Clause

--- a/tools/licensescan/modules/cloud.google.com/go/bigtable/v1.16.0.yaml
+++ b/tools/licensescan/modules/cloud.google.com/go/bigtable/v1.16.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/cloud.google.com/go/bigtable@v1.16.0
+license: Apache-2.0

--- a/tools/licensescan/modules/cloud.google.com/go/iam/v0.3.0.yaml
+++ b/tools/licensescan/modules/cloud.google.com/go/iam/v0.3.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/cloud.google.com/go/iam@v0.3.0
+license: Apache-2.0

--- a/tools/licensescan/modules/cloud.google.com/go/v0.102.1.yaml
+++ b/tools/licensescan/modules/cloud.google.com/go/v0.102.1.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/cloud.google.com/go@v0.102.1
+license: Apache-2.0

--- a/tools/licensescan/modules/github.com/Azure/go-autorest/autorest/adal/v0.9.20.yaml
+++ b/tools/licensescan/modules/github.com/Azure/go-autorest/autorest/adal/v0.9.20.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/Azure/go-autorest/autorest/adal@v0.9.20
+license: Apache-2.0

--- a/tools/licensescan/modules/github.com/Azure/go-autorest/autorest/v0.11.27.yaml
+++ b/tools/licensescan/modules/github.com/Azure/go-autorest/autorest/v0.11.27.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/Azure/go-autorest/autorest@v0.11.27
+license: Apache-2.0

--- a/tools/licensescan/modules/github.com/GoogleCloudPlatform/declarative-resource-client-library/v1.26.1.yaml
+++ b/tools/licensescan/modules/github.com/GoogleCloudPlatform/declarative-resource-client-library/v1.26.1.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/GoogleCloudPlatform/declarative-resource-client-library@v1.26.1
+license: Apache-2.0

--- a/tools/licensescan/modules/github.com/GoogleContainerTools/kpt/porch/api/v0.0.0-20221028161857-aa271f292cc0.yaml
+++ b/tools/licensescan/modules/github.com/GoogleContainerTools/kpt/porch/api/v0.0.0-20221028161857-aa271f292cc0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/GoogleContainerTools/kpt/porch/api@v0.0.0-20221028161857-aa271f292cc0
+license: Apache-2.0

--- a/tools/licensescan/modules/github.com/GoogleContainerTools/kpt/v1.0.0-beta.23.0.20221117142901-c67b11f2e138.yaml
+++ b/tools/licensescan/modules/github.com/GoogleContainerTools/kpt/v1.0.0-beta.23.0.20221117142901-c67b11f2e138.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/GoogleContainerTools/kpt@v1.0.0-beta.23.0.20221117142901-c67b11f2e138
+license: Apache-2.0

--- a/tools/licensescan/modules/github.com/MakeNowJust/heredoc/v1.0.0.yaml
+++ b/tools/licensescan/modules/github.com/MakeNowJust/heredoc/v1.0.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/MakeNowJust/heredoc@v1.0.0
+license: MIT

--- a/tools/licensescan/modules/github.com/apparentlymart/go-cidr/v1.1.0.yaml
+++ b/tools/licensescan/modules/github.com/apparentlymart/go-cidr/v1.1.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/apparentlymart/go-cidr@v1.1.0
+license: MIT

--- a/tools/licensescan/modules/github.com/apparentlymart/go-textseg/v13/v13.0.0.yaml
+++ b/tools/licensescan/modules/github.com/apparentlymart/go-textseg/v13/v13.0.0.yaml
@@ -1,0 +1,4 @@
+# https://pkg.go.dev/github.com/apparentlymart/go-textseg/v13@v13.0.0
+license: Apache-2.0,MIT,Unicode-DFS-2016
+licenseURLs:
+- https://raw.githubusercontent.com/apparentlymart/go-textseg/master/LICENSE

--- a/tools/licensescan/modules/github.com/cenkalti/backoff/v2.2.1+incompatible.yaml
+++ b/tools/licensescan/modules/github.com/cenkalti/backoff/v2.2.1+incompatible.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/cenkalti/backoff@v2.2.1+incompatible
+license: MIT

--- a/tools/licensescan/modules/github.com/chai2010/gettext-go/v1.0.2.yaml
+++ b/tools/licensescan/modules/github.com/chai2010/gettext-go/v1.0.2.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/chai2010/gettext-go@v1.0.2
+license: BSD-3-Clause

--- a/tools/licensescan/modules/github.com/emicklei/go-restful/v3/v3.8.0.yaml
+++ b/tools/licensescan/modules/github.com/emicklei/go-restful/v3/v3.8.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/emicklei/go-restful/v3@v3.8.0
+license: MIT

--- a/tools/licensescan/modules/github.com/evanphx/json-patch/v5/v5.6.0.yaml
+++ b/tools/licensescan/modules/github.com/evanphx/json-patch/v5/v5.6.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/evanphx/json-patch/v5@v5.6.0
+license: BSD-3-Clause

--- a/tools/licensescan/modules/github.com/fatih/color/v1.13.0.yaml
+++ b/tools/licensescan/modules/github.com/fatih/color/v1.13.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/fatih/color@v1.13.0
+license: MIT

--- a/tools/licensescan/modules/github.com/golang-jwt/jwt/v4/v4.2.0.yaml
+++ b/tools/licensescan/modules/github.com/golang-jwt/jwt/v4/v4.2.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/golang-jwt/jwt/v4@v4.2.0
+license: MIT

--- a/tools/licensescan/modules/github.com/golang/glog/v1.0.0.yaml
+++ b/tools/licensescan/modules/github.com/golang/glog/v1.0.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/golang/glog@v1.0.0
+license: Apache-2.0

--- a/tools/licensescan/modules/github.com/golang/groupcache/v0.0.0-20210331224755-41bb18bfe9da.yaml
+++ b/tools/licensescan/modules/github.com/golang/groupcache/v0.0.0-20210331224755-41bb18bfe9da.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/golang/groupcache@v0.0.0-20210331224755-41bb18bfe9da
+license: Apache-2.0

--- a/tools/licensescan/modules/github.com/google/btree/v1.1.2.yaml
+++ b/tools/licensescan/modules/github.com/google/btree/v1.1.2.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/google/btree@v1.1.2
+license: Apache-2.0

--- a/tools/licensescan/modules/github.com/google/go-cmp/v0.5.9.yaml
+++ b/tools/licensescan/modules/github.com/google/go-cmp/v0.5.9.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/google/go-cmp@v0.5.9
+license: BSD-3-Clause

--- a/tools/licensescan/modules/github.com/google/go-cpy/v0.0.0-20211218193943-a9c933c06932.yaml
+++ b/tools/licensescan/modules/github.com/google/go-cpy/v0.0.0-20211218193943-a9c933c06932.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/google/go-cpy@v0.0.0-20211218193943-a9c933c06932
+license: BSD-3-Clause

--- a/tools/licensescan/modules/github.com/googleapis/enterprise-certificate-proxy/v0.1.0.yaml
+++ b/tools/licensescan/modules/github.com/googleapis/enterprise-certificate-proxy/v0.1.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/googleapis/enterprise-certificate-proxy@v0.1.0
+license: Apache-2.0

--- a/tools/licensescan/modules/github.com/googleapis/gax-go/v2/v2.4.0.yaml
+++ b/tools/licensescan/modules/github.com/googleapis/gax-go/v2/v2.4.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/googleapis/gax-go/v2@v2.4.0
+license: BSD-3-Clause

--- a/tools/licensescan/modules/github.com/googleapis/gnostic/v0.5.5.yaml
+++ b/tools/licensescan/modules/github.com/googleapis/gnostic/v0.5.5.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/googleapis/gnostic@v0.5.5
+license: Apache-2.0

--- a/tools/licensescan/modules/github.com/grpc-ecosystem/go-grpc-middleware/v1.3.0.yaml
+++ b/tools/licensescan/modules/github.com/grpc-ecosystem/go-grpc-middleware/v1.3.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/grpc-ecosystem/go-grpc-middleware@v1.3.0
+license: Apache-2.0

--- a/tools/licensescan/modules/github.com/hashicorp/go-checkpoint/v0.5.0.yaml
+++ b/tools/licensescan/modules/github.com/hashicorp/go-checkpoint/v0.5.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/hashicorp/go-checkpoint@v0.5.0
+license: MPL-2.0

--- a/tools/licensescan/modules/github.com/hashicorp/go-cty/v1.4.1-0.20200414143053-d3edf31b6320.yaml
+++ b/tools/licensescan/modules/github.com/hashicorp/go-cty/v1.4.1-0.20200414143053-d3edf31b6320.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/hashicorp/go-cty@v1.4.1-0.20200414143053-d3edf31b6320
+license: MIT

--- a/tools/licensescan/modules/github.com/hashicorp/go-hclog/v1.2.1.yaml
+++ b/tools/licensescan/modules/github.com/hashicorp/go-hclog/v1.2.1.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/hashicorp/go-hclog@v1.2.1
+license: MIT

--- a/tools/licensescan/modules/github.com/hashicorp/go-multierror/v1.1.1.yaml
+++ b/tools/licensescan/modules/github.com/hashicorp/go-multierror/v1.1.1.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/hashicorp/go-multierror@v1.1.1
+license: MPL-2.0

--- a/tools/licensescan/modules/github.com/hashicorp/go-plugin/v1.4.4.yaml
+++ b/tools/licensescan/modules/github.com/hashicorp/go-plugin/v1.4.4.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/hashicorp/go-plugin@v1.4.4
+license: MPL-2.0

--- a/tools/licensescan/modules/github.com/hashicorp/go-uuid/v1.0.3.yaml
+++ b/tools/licensescan/modules/github.com/hashicorp/go-uuid/v1.0.3.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/hashicorp/go-uuid@v1.0.3
+license: MPL-2.0

--- a/tools/licensescan/modules/github.com/hashicorp/go-version/v1.6.0.yaml
+++ b/tools/licensescan/modules/github.com/hashicorp/go-version/v1.6.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/hashicorp/go-version@v1.6.0
+license: MPL-2.0

--- a/tools/licensescan/modules/github.com/hashicorp/hc-install/v0.4.0.yaml
+++ b/tools/licensescan/modules/github.com/hashicorp/hc-install/v0.4.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/hashicorp/hc-install@v0.4.0
+license: MPL-2.0

--- a/tools/licensescan/modules/github.com/hashicorp/hcl/v2/v2.13.0.yaml
+++ b/tools/licensescan/modules/github.com/hashicorp/hcl/v2/v2.13.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/hashicorp/hcl/v2@v2.13.0
+license: MPL-2.0

--- a/tools/licensescan/modules/github.com/hashicorp/terraform-exec/v0.17.2.yaml
+++ b/tools/licensescan/modules/github.com/hashicorp/terraform-exec/v0.17.2.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/hashicorp/terraform-exec@v0.17.2
+license: MPL-2.0

--- a/tools/licensescan/modules/github.com/hashicorp/terraform-json/v0.14.0.yaml
+++ b/tools/licensescan/modules/github.com/hashicorp/terraform-json/v0.14.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/hashicorp/terraform-json@v0.14.0
+license: MPL-2.0

--- a/tools/licensescan/modules/github.com/hashicorp/terraform-plugin-go/v0.10.0.yaml
+++ b/tools/licensescan/modules/github.com/hashicorp/terraform-plugin-go/v0.10.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/hashicorp/terraform-plugin-go@v0.10.0
+license: MPL-2.0

--- a/tools/licensescan/modules/github.com/hashicorp/terraform-plugin-log/v0.4.1.yaml
+++ b/tools/licensescan/modules/github.com/hashicorp/terraform-plugin-log/v0.4.1.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/hashicorp/terraform-plugin-log@v0.4.1
+license: MPL-2.0

--- a/tools/licensescan/modules/github.com/hashicorp/terraform-plugin-sdk/v2/v2.18.0.yaml
+++ b/tools/licensescan/modules/github.com/hashicorp/terraform-plugin-sdk/v2/v2.18.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/hashicorp/terraform-plugin-sdk/v2@v2.18.0
+license: MPL-2.0

--- a/tools/licensescan/modules/github.com/hashicorp/terraform-provider-google-beta/(devel).yaml
+++ b/tools/licensescan/modules/github.com/hashicorp/terraform-provider-google-beta/(devel).yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/hashicorp/terraform-provider-google-beta@(devel)
+license: MPL-2.0

--- a/tools/licensescan/modules/github.com/hashicorp/terraform-registry-address/v0.0.0-20220623143253-7d51757b572c.yaml
+++ b/tools/licensescan/modules/github.com/hashicorp/terraform-registry-address/v0.0.0-20220623143253-7d51757b572c.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/hashicorp/terraform-registry-address@v0.0.0-20220623143253-7d51757b572c
+license: MPL-2.0

--- a/tools/licensescan/modules/github.com/hashicorp/terraform-svchost/v0.0.0-20200729002733-f050f53b9734.yaml
+++ b/tools/licensescan/modules/github.com/hashicorp/terraform-svchost/v0.0.0-20200729002733-f050f53b9734.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/hashicorp/terraform-svchost@v0.0.0-20200729002733-f050f53b9734
+license: MPL-2.0

--- a/tools/licensescan/modules/github.com/mattn/go-colorable/v0.1.12.yaml
+++ b/tools/licensescan/modules/github.com/mattn/go-colorable/v0.1.12.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/mattn/go-colorable@v0.1.12
+license: MIT

--- a/tools/licensescan/modules/github.com/mattn/go-isatty/v0.0.14.yaml
+++ b/tools/licensescan/modules/github.com/mattn/go-isatty/v0.0.14.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/mattn/go-isatty@v0.0.14
+license: MIT

--- a/tools/licensescan/modules/github.com/mitchellh/copystructure/v1.2.0.yaml
+++ b/tools/licensescan/modules/github.com/mitchellh/copystructure/v1.2.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/mitchellh/copystructure@v1.2.0
+license: MIT

--- a/tools/licensescan/modules/github.com/mitchellh/go-testing-interface/v1.14.1.yaml
+++ b/tools/licensescan/modules/github.com/mitchellh/go-testing-interface/v1.14.1.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/mitchellh/go-testing-interface@v1.14.1
+license: MIT

--- a/tools/licensescan/modules/github.com/mitchellh/hashstructure/v1.1.0.yaml
+++ b/tools/licensescan/modules/github.com/mitchellh/hashstructure/v1.1.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/mitchellh/hashstructure@v1.1.0
+license: MIT

--- a/tools/licensescan/modules/github.com/mitchellh/mapstructure/v1.5.0.yaml
+++ b/tools/licensescan/modules/github.com/mitchellh/mapstructure/v1.5.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/mitchellh/mapstructure@v1.5.0
+license: MIT

--- a/tools/licensescan/modules/github.com/mitchellh/reflectwalk/v1.0.2.yaml
+++ b/tools/licensescan/modules/github.com/mitchellh/reflectwalk/v1.0.2.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/mitchellh/reflectwalk@v1.0.2
+license: MIT

--- a/tools/licensescan/modules/github.com/nasa9084/go-openapi/v0.0.0-20200604141640-2875b7376353.yaml
+++ b/tools/licensescan/modules/github.com/nasa9084/go-openapi/v0.0.0-20200604141640-2875b7376353.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/nasa9084/go-openapi@v0.0.0-20200604141640-2875b7376353
+license: MIT

--- a/tools/licensescan/modules/github.com/sirupsen/logrus/v1.8.1.yaml
+++ b/tools/licensescan/modules/github.com/sirupsen/logrus/v1.8.1.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/sirupsen/logrus@v1.8.1
+license: MIT

--- a/tools/licensescan/modules/github.com/spf13/cobra/v1.2.1.yaml
+++ b/tools/licensescan/modules/github.com/spf13/cobra/v1.2.1.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/spf13/cobra@v1.2.1
+license: Apache-2.0

--- a/tools/licensescan/modules/github.com/spyzhov/ajson/v0.7.1.yaml
+++ b/tools/licensescan/modules/github.com/spyzhov/ajson/v0.7.1.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/spyzhov/ajson@v0.7.1
+license: MIT

--- a/tools/licensescan/modules/github.com/terraform-providers/terraform-provider-google-beta/v1.20.0.yaml
+++ b/tools/licensescan/modules/github.com/terraform-providers/terraform-provider-google-beta/v1.20.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/terraform-providers/terraform-provider-google-beta@v1.20.0
+license: MPL-2.0

--- a/tools/licensescan/modules/github.com/vmihailenco/msgpack/v4/v4.3.12.yaml
+++ b/tools/licensescan/modules/github.com/vmihailenco/msgpack/v4/v4.3.12.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/vmihailenco/msgpack/v4@v4.3.12
+license: BSD-2-Clause

--- a/tools/licensescan/modules/github.com/vmihailenco/tagparser/v0.1.1.yaml
+++ b/tools/licensescan/modules/github.com/vmihailenco/tagparser/v0.1.1.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/vmihailenco/tagparser@v0.1.1
+license: BSD-2-Clause

--- a/tools/licensescan/modules/github.com/zclconf/go-cty/v1.10.0.yaml
+++ b/tools/licensescan/modules/github.com/zclconf/go-cty/v1.10.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/zclconf/go-cty@v1.10.0
+license: MIT

--- a/tools/licensescan/modules/go.opencensus.io/v0.23.0.yaml
+++ b/tools/licensescan/modules/go.opencensus.io/v0.23.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/go.opencensus.io@v0.23.0
+license: Apache-2.0

--- a/tools/licensescan/modules/golang.org/x/crypto/v0.0.0-20220315160706-3147a52a75dd.yaml
+++ b/tools/licensescan/modules/golang.org/x/crypto/v0.0.0-20220315160706-3147a52a75dd.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/golang.org/x/crypto@v0.0.0-20220315160706-3147a52a75dd
+license: BSD-3-Clause

--- a/tools/licensescan/modules/golang.org/x/crypto/v0.0.0-20220517005047-85d78b3ac167.yaml
+++ b/tools/licensescan/modules/golang.org/x/crypto/v0.0.0-20220517005047-85d78b3ac167.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/golang.org/x/crypto@v0.0.0-20220517005047-85d78b3ac167
+license: BSD-3-Clause

--- a/tools/licensescan/modules/golang.org/x/oauth2/v0.0.0-20220622183110-fd043fe589d2.yaml
+++ b/tools/licensescan/modules/golang.org/x/oauth2/v0.0.0-20220622183110-fd043fe589d2.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/golang.org/x/oauth2@v0.0.0-20220622183110-fd043fe589d2
+license: BSD-3-Clause

--- a/tools/licensescan/modules/golang.org/x/sync/v0.0.0-20220722155255-886fb9371eb4.yaml
+++ b/tools/licensescan/modules/golang.org/x/sync/v0.0.0-20220722155255-886fb9371eb4.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/golang.org/x/sync@v0.0.0-20220722155255-886fb9371eb4
+license: BSD-3-Clause

--- a/tools/licensescan/modules/golang.org/x/time/v0.0.0-20210723032227-1f47c861a9ac.yaml
+++ b/tools/licensescan/modules/golang.org/x/time/v0.0.0-20210723032227-1f47c861a9ac.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/golang.org/x/time@v0.0.0-20210723032227-1f47c861a9ac
+license: BSD-3-Clause

--- a/tools/licensescan/modules/golang.org/x/time/v0.0.0-20220609170525-579cf78fd858.yaml
+++ b/tools/licensescan/modules/golang.org/x/time/v0.0.0-20220609170525-579cf78fd858.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/golang.org/x/time@v0.0.0-20220609170525-579cf78fd858
+license: BSD-3-Clause

--- a/tools/licensescan/modules/golang.org/x/xerrors/v0.0.0-20220609144429-65e65417b02f.yaml
+++ b/tools/licensescan/modules/golang.org/x/xerrors/v0.0.0-20220609144429-65e65417b02f.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/golang.org/x/xerrors@v0.0.0-20220609144429-65e65417b02f
+license: BSD-3-Clause

--- a/tools/licensescan/modules/google.golang.org/api/v0.92.0.yaml
+++ b/tools/licensescan/modules/google.golang.org/api/v0.92.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/google.golang.org/api@v0.92.0
+license: BSD-3-Clause

--- a/tools/licensescan/modules/google.golang.org/genproto/v0.0.0-20220725144611-272f38e5d71b.yaml
+++ b/tools/licensescan/modules/google.golang.org/genproto/v0.0.0-20220725144611-272f38e5d71b.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/google.golang.org/genproto@v0.0.0-20220725144611-272f38e5d71b
+license: Apache-2.0

--- a/tools/licensescan/modules/google.golang.org/grpc/v1.48.0.yaml
+++ b/tools/licensescan/modules/google.golang.org/grpc/v1.48.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/google.golang.org/grpc@v1.48.0
+license: Apache-2.0

--- a/tools/licensescan/modules/k8s.io/api/v0.23.0.yaml
+++ b/tools/licensescan/modules/k8s.io/api/v0.23.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/k8s.io/api@v0.23.0
+license: Apache-2.0

--- a/tools/licensescan/modules/k8s.io/api/v0.25.3.yaml
+++ b/tools/licensescan/modules/k8s.io/api/v0.25.3.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/k8s.io/api@v0.25.3
+license: Apache-2.0

--- a/tools/licensescan/modules/k8s.io/apiextensions-apiserver/v0.23.0.yaml
+++ b/tools/licensescan/modules/k8s.io/apiextensions-apiserver/v0.23.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/k8s.io/apiextensions-apiserver@v0.23.0
+license: Apache-2.0

--- a/tools/licensescan/modules/k8s.io/apiextensions-apiserver/v0.24.0.yaml
+++ b/tools/licensescan/modules/k8s.io/apiextensions-apiserver/v0.24.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/k8s.io/apiextensions-apiserver@v0.24.0
+license: Apache-2.0

--- a/tools/licensescan/modules/k8s.io/apimachinery/v0.23.0.yaml
+++ b/tools/licensescan/modules/k8s.io/apimachinery/v0.23.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/k8s.io/apimachinery@v0.23.0
+license: Apache-2.0

--- a/tools/licensescan/modules/k8s.io/apimachinery/v0.25.3.yaml
+++ b/tools/licensescan/modules/k8s.io/apimachinery/v0.25.3.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/k8s.io/apimachinery@v0.25.3
+license: Apache-2.0

--- a/tools/licensescan/modules/k8s.io/cli-runtime/v0.25.3.yaml
+++ b/tools/licensescan/modules/k8s.io/cli-runtime/v0.25.3.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/k8s.io/cli-runtime@v0.25.3
+license: Apache-2.0

--- a/tools/licensescan/modules/k8s.io/client-go/v0.23.0.yaml
+++ b/tools/licensescan/modules/k8s.io/client-go/v0.23.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/k8s.io/client-go@v0.23.0
+license: Apache-2.0

--- a/tools/licensescan/modules/k8s.io/client-go/v0.25.3.yaml
+++ b/tools/licensescan/modules/k8s.io/client-go/v0.25.3.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/k8s.io/client-go@v0.25.3
+license: Apache-2.0

--- a/tools/licensescan/modules/k8s.io/component-base/v0.25.3.yaml
+++ b/tools/licensescan/modules/k8s.io/component-base/v0.25.3.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/k8s.io/component-base@v0.25.3
+license: Apache-2.0

--- a/tools/licensescan/modules/k8s.io/klog/v2/v2.70.1.yaml
+++ b/tools/licensescan/modules/k8s.io/klog/v2/v2.70.1.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/k8s.io/klog/v2@v2.70.1
+license: Apache-2.0

--- a/tools/licensescan/modules/k8s.io/kube-openapi/v0.0.0-20211115234752-e816edb12b65.yaml
+++ b/tools/licensescan/modules/k8s.io/kube-openapi/v0.0.0-20211115234752-e816edb12b65.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/k8s.io/kube-openapi@v0.0.0-20211115234752-e816edb12b65
+license: Apache-2.0

--- a/tools/licensescan/modules/k8s.io/kube-openapi/v0.0.0-20220803162953-67bda5d908f1.yaml
+++ b/tools/licensescan/modules/k8s.io/kube-openapi/v0.0.0-20220803162953-67bda5d908f1.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/k8s.io/kube-openapi@v0.0.0-20220803162953-67bda5d908f1
+license: Apache-2.0

--- a/tools/licensescan/modules/k8s.io/kubectl/v0.25.3.yaml
+++ b/tools/licensescan/modules/k8s.io/kubectl/v0.25.3.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/k8s.io/kubectl@v0.25.3
+license: Apache-2.0

--- a/tools/licensescan/modules/k8s.io/utils/v0.0.0-20220823124924-e9cbc92d1a73.yaml
+++ b/tools/licensescan/modules/k8s.io/utils/v0.0.0-20220823124924-e9cbc92d1a73.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/k8s.io/utils@v0.0.0-20220823124924-e9cbc92d1a73
+license: Apache-2.0

--- a/tools/licensescan/modules/sigs.k8s.io/cli-utils/v0.34.0.yaml
+++ b/tools/licensescan/modules/sigs.k8s.io/cli-utils/v0.34.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/sigs.k8s.io/cli-utils@v0.34.0
+license: Apache-2.0

--- a/tools/licensescan/modules/sigs.k8s.io/controller-runtime/v0.13.0.yaml
+++ b/tools/licensescan/modules/sigs.k8s.io/controller-runtime/v0.13.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.13.0
+license: Apache-2.0

--- a/tools/licensescan/modules/sigs.k8s.io/json/v0.0.0-20211020170558-c049b76a60c6.yaml
+++ b/tools/licensescan/modules/sigs.k8s.io/json/v0.0.0-20211020170558-c049b76a60c6.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/sigs.k8s.io/json@v0.0.0-20211020170558-c049b76a60c6
+license: Apache-2.0, BSD-3-Clause

--- a/tools/licensescan/modules/sigs.k8s.io/json/v0.0.0-20220713155537-f223a00ba0e2.yaml
+++ b/tools/licensescan/modules/sigs.k8s.io/json/v0.0.0-20220713155537-f223a00ba0e2.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/sigs.k8s.io/json@v0.0.0-20220713155537-f223a00ba0e2
+license: Apache-2.0, BSD-3-Clause

--- a/tools/licensescan/modules/sigs.k8s.io/structured-merge-diff/v4/v4.2.0.yaml
+++ b/tools/licensescan/modules/sigs.k8s.io/structured-merge-diff/v4/v4.2.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/sigs.k8s.io/structured-merge-diff/v4@v4.2.0
+license: Apache-2.0

--- a/tools/licensescan/modules/sigs.k8s.io/structured-merge-diff/v4/v4.2.3.yaml
+++ b/tools/licensescan/modules/sigs.k8s.io/structured-merge-diff/v4/v4.2.3.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/sigs.k8s.io/structured-merge-diff/v4@v4.2.3
+license: Apache-2.0


### PR DESCRIPTION
We now embed some licenses using `go:embed`, so we don't need to set up a `modules` DB in every project.  A local modules folder is still checked first, and TODO files are still written locally to a local modules folder.

Also add a bunch more module license information from different places I've been running the tool.

