### PR TITLE
Provide version to RESTMapper in WorkloadIdentityBinding controller

### DIFF
--- a/porch/controllers/workloadidentitybindings/pkg/controllers/workloadidentitybinding/controller.go
+++ b/porch/controllers/workloadidentitybindings/pkg/controllers/workloadidentitybinding/controller.go
@@ -350,7 +350,7 @@ func (r *WorkloadIdentityBindingReconciler) updateServiceAccount(ctx context.Con
 		return err
 	}
 
-	mapping, err := r.restMapper.RESTMapping(corev1.SchemeGroupVersion.WithKind("ServiceAccount").GroupKind())
+	mapping, err := r.restMapper.RESTMapping(corev1.SchemeGroupVersion.WithKind("ServiceAccount").GroupKind(), corev1.SchemeGroupVersion.Version)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This fixes an issue with the WorkloadIdentityBinding controller. The new implementation of the RESTMapper interface that was added in https://github.com/GoogleContainerTools/kpt/pull/3567 differs from the regular implementation in that it requires that the version is provided when calling the `RESTMapping` function. This updates the controller to provide the version when use that function.

We should consider fixing the behavior in the RESTMapper implementation, as this differs from the regular implementation.
