### PR TITLE
Increase the timeout for the Porch e2e tests

### DIFF
--- a/.github/workflows/porch-e2e.yml
+++ b/.github/workflows/porch-e2e.yml
@@ -95,7 +95,7 @@ jobs:
             fi
           done
       - name: e2e test
-        run: E2E=1 go test -v .
+        run: E2E=1 go test -v -timeout 20m .
         working-directory: ./porch/test/e2e
       - name: Porch CLI e2e test
         run: make test-porch


### PR DESCRIPTION
We have seen a few examples of the Porch e2e tests failing because of the timeout: https://github.com/GoogleContainerTools/kpt/actions/runs/3509099343/jobs/5879171769
