### PR TITLE
rollouts: update package to target matcher to be optional

### DIFF
--- a/rollouts/api/v1alpha1/rollout_types.go
+++ b/rollouts/api/v1alpha1/rollout_types.go
@@ -37,7 +37,10 @@ type RolloutSpec struct {
 	Targets ClusterTargetSelector `json:"targets,omitempty"`
 
 	// PackageToTargetMatcher specifies the clusters that will receive a specific package.
-	PackageToTargetMatcher PackageToClusterMatcher `json:"packageToTargetMatcher"`
+	// +nullable
+	// +optional
+	PackageToTargetMatcher *PackageToClusterMatcher `json:"packageToTargetMatcher,omitempty"`
+
 	// Strategy specifies the rollout strategy to use for this rollout.
 	Strategy RolloutStrategy `json:"strategy"`
 }

--- a/rollouts/api/v1alpha1/zz_generated.deepcopy.go
+++ b/rollouts/api/v1alpha1/zz_generated.deepcopy.go
@@ -338,7 +338,11 @@ func (in *RolloutSpec) DeepCopyInto(out *RolloutSpec) {
 	*out = *in
 	out.Packages = in.Packages
 	in.Targets.DeepCopyInto(&out.Targets)
-	out.PackageToTargetMatcher = in.PackageToTargetMatcher
+	if in.PackageToTargetMatcher != nil {
+		in, out := &in.PackageToTargetMatcher, &out.PackageToTargetMatcher
+		*out = new(PackageToClusterMatcher)
+		**out = **in
+	}
 	in.Strategy.DeepCopyInto(&out.Strategy)
 }
 

--- a/rollouts/config/crd/bases/gitops.kpt.dev_rollouts.yaml
+++ b/rollouts/config/crd/bases/gitops.kpt.dev_rollouts.yaml
@@ -41,6 +41,7 @@ spec:
               packageToTargetMatcher:
                 description: PackageToTargetMatcher specifies the clusters that will
                   receive a specific package.
+                nullable: true
                 properties:
                   matchExpression:
                     type: string
@@ -177,7 +178,6 @@ spec:
                     x-kubernetes-map-type: atomic
                 type: object
             required:
-            - packageToTargetMatcher
             - packages
             - strategy
             type: object

--- a/rollouts/config/samples/gitops_rollout_kpt_samples.yaml
+++ b/rollouts/config/samples/gitops_rollout_kpt_samples.yaml
@@ -30,8 +30,5 @@ spec:
     selector:
       matchExpressions:
         - {key: location/island, operator: In, values: [oahu, maui]}
-  packageToTargetMatcher:
-    type: CEL
-    matchExpression: 'true'
   strategy:
     type: AllAtOnce

--- a/rollouts/config/samples/gitops_rollout_oahu.yaml
+++ b/rollouts/config/samples/gitops_rollout_oahu.yaml
@@ -26,9 +26,6 @@ spec:
         repo: oahu
         directory: namespaces
         revision: main
-  packageToTargetMatcher:
-    type: CEL
-    matchExpression: 'true'
   targets:
     selector:
       matchLabels:


### PR DESCRIPTION
This pull request updates the packageToTargetMatcher field in the rollouts custom resource definition to be optional since not all rollouts will need to specify advanced package to cluster matching logic.