### PR TITLE
rollouts: allow the root directory of a repository to be synced

### DIFF
--- a/rollouts/api/v1alpha1/rollout_types.go
+++ b/rollouts/api/v1alpha1/rollout_types.go
@@ -75,7 +75,7 @@ type GitHubSource struct {
 type GitHubSelector struct {
 	Org       string          `json:"org"`
 	Repo      string          `json:"repo"`
-	Directory string          `json:"directory"`
+	Directory string          `json:"directory,omitempty"`
 	Revision  string          `json:"revision"`
 	SecretRef SecretReference `json:"secretRef,omitempty"`
 }

--- a/rollouts/config/crd/bases/gitops.kpt.dev_rollouts.yaml
+++ b/rollouts/config/crd/bases/gitops.kpt.dev_rollouts.yaml
@@ -79,7 +79,6 @@ spec:
                                 type: string
                             type: object
                         required:
-                        - directory
                         - org
                         - repo
                         - revision

--- a/rollouts/config/samples/gitops_rollout_oahu.yaml
+++ b/rollouts/config/samples/gitops_rollout_oahu.yaml
@@ -24,7 +24,7 @@ spec:
       selector:
         org: droot
         repo: oahu
-        directory: namespaces
+        directory: "/"
         revision: main
   packageToTargetMatcher:
     type: CEL

--- a/rollouts/controllers/rollout_controller.go
+++ b/rollouts/controllers/rollout_controller.go
@@ -406,6 +406,10 @@ func toRootSyncSpec(dpkg *packagediscovery.DiscoveredPackage) *gitopsv1alpha1.Ro
 }
 
 func pkgID(dpkg *packagediscovery.DiscoveredPackage) string {
+	if dpkg.Directory == "" || dpkg.Directory == "." || dpkg.Directory == "/" {
+		return fmt.Sprintf("%s-%s", dpkg.Org, dpkg.Repo)
+	}
+
 	return fmt.Sprintf("%s-%s-%s", dpkg.Org, dpkg.Repo, dpkg.Directory)
 }
 


### PR DESCRIPTION
This pull request updates the rollouts proof of concept to allow the root directory a repository to be synced.