### PR TITLE
rollouts: implement progressive strategy

### DIFF
--- a/rollouts/config/samples/container_cluster_catalina.yaml
+++ b/rollouts/config/samples/container_cluster_catalina.yaml
@@ -1,0 +1,29 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  name: catalina-dev
+  namespace: config-control
+  labels:
+    env: dev
+    location/island: catalina
+    location/state: california
+spec:
+  description: Catalina dev autopilot cluster
+  enableAutopilot: true
+  location: us-central1
+  releaseChannel:
+    channel: REGULAR

--- a/rollouts/config/samples/container_cluster_kauai.yaml
+++ b/rollouts/config/samples/container_cluster_kauai.yaml
@@ -1,0 +1,29 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: container.cnrm.cloud.google.com/v1beta1
+kind: ContainerCluster
+metadata:
+  name: kauai
+  namespace: config-control
+  labels:
+    env: dev
+    location/island: kauai
+    location/state: hawaii
+spec:
+  description: Kauai autopilot cluster
+  enableAutopilot: true
+  location: us-central1
+  releaseChannel:
+    channel: REGULAR

--- a/rollouts/controllers/rollout_controller.go
+++ b/rollouts/controllers/rollout_controller.go
@@ -382,14 +382,14 @@ func (r *RolloutReconciler) computeTargets(ctx context.Context,
 	return targets, nil
 }
 
-func (r *RolloutReconciler) rolloutTargets(ctx context.Context, rollout *gitopsv1alpha1.Rollout, wave *gitopsv1alpha1.Wave, targets *Targets, waveAlreadyInProgress bool) (bool, []gitopsv1alpha1.ClusterStatus, error) {
+func (r *RolloutReconciler) rolloutTargets(ctx context.Context, rollout *gitopsv1alpha1.Rollout, wave *gitopsv1alpha1.Wave, targets *Targets, previousWaveAlreadyInProgress bool) (bool, []gitopsv1alpha1.ClusterStatus, error) {
 	clusterStatuses := []gitopsv1alpha1.ClusterStatus{}
 
 	concurrentUpdates := 0
 	maxConcurrent := int(wave.MaxConcurrent)
 	waiting := "Waiting"
 
-	if waveAlreadyInProgress {
+	if previousWaveAlreadyInProgress {
 		maxConcurrent = 0
 		waiting = "Waiting (Upcoming Wave)"
 	}
@@ -499,9 +499,9 @@ func (r *RolloutReconciler) rolloutTargets(ctx context.Context, rollout *gitopsv
 		})
 	}
 
-	waveComplete := concurrentUpdates > 0
+	thisWaveInProgress := concurrentUpdates > 0
 
-	return waveComplete, clusterStatuses, nil
+	return thisWaveInProgress, clusterStatuses, nil
 }
 
 type Targets struct {

--- a/rollouts/controllers/rollout_controller.go
+++ b/rollouts/controllers/rollout_controller.go
@@ -192,9 +192,9 @@ func (r *RolloutReconciler) validateProgressiveRolloutStrategy(ctx context.Conte
 		return err
 	}
 
-	clustersMap := make(map[string]int)
+	clusterWaveMap := make(map[string]int)
 	for _, cluster := range allClusters.Items {
-		clustersMap[cluster.Name] = -1
+		clusterWaveMap[cluster.Name] = -1
 	}
 
 	for waveIdx, wave := range strategy.Spec.Waves {
@@ -208,7 +208,7 @@ func (r *RolloutReconciler) validateProgressiveRolloutStrategy(ctx context.Conte
 		}
 
 		for _, cluster := range waveClusters.Items {
-			currentClusterWave, found := clustersMap[cluster.Name]
+			currentClusterWave, found := clusterWaveMap[cluster.Name]
 			if !found {
 				// this should never happen
 				return fmt.Errorf("wave %d references cluster %s not selected by the rollout", waveIdx, cluster.Name)
@@ -218,12 +218,12 @@ func (r *RolloutReconciler) validateProgressiveRolloutStrategy(ctx context.Conte
 				return fmt.Errorf("a cluster cannot be selected by more than one wave - cluster %s is selected by waves %d and %d", cluster.Name, currentClusterWave, waveIdx)
 			}
 
-			clustersMap[cluster.Name] = waveIdx
+			clusterWaveMap[cluster.Name] = waveIdx
 		}
 	}
 
 	for _, cluster := range allClusters.Items {
-		wave, _ := clustersMap[cluster.Name]
+		wave, _ := clusterWaveMap[cluster.Name]
 		if wave == -1 {
 			return fmt.Errorf("waves should cover all clusters selected by the rollout - cluster %s is not covered by any waves", cluster.Name)
 		}


### PR DESCRIPTION
This pull request updates the rollouts proof of concept implementing the Progressive strategy. This strategy allows rollouts to be defined by waves where each wave targets a subset of clusters by use of a label selector and limits the number maximum number of concurrent updates, and proceeds to the next wave after the previous wave is completed. Validation is added to ensure each wave targets a unique set of clusters and all waves cover all clusters targeted by the overall rollout.

Follow-ups to the pull request will include improving the status to provide the user with information on which wave the rollout is on and the targets for each wave and updating the logic to give the user control when the next wave is progressed to.