### PR TITLE
rollouts: refine package to cluster matcher

### DIFF
--- a/rollouts/api/v1alpha1/rollout_types.go
+++ b/rollouts/api/v1alpha1/rollout_types.go
@@ -36,6 +36,7 @@ type RolloutSpec struct {
 
 	// PackageToTargetMatcher specifies the clusters that will receive a specific package.
 	PackageToTargetMatcher PackageToClusterMatcher `json:"packageToTargetMatcher"`
+
 	// Strategy specifies the rollout strategy to use for this rollout.
 	Strategy RolloutStrategy `json:"strategy"`
 }
@@ -84,12 +85,17 @@ type SecretReference struct {
 	Name string `json:"name,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=CEL
+// +kubebuilder:validation:Enum=allClusters;custom
 type MatcherType string
+
+const (
+	MatchAllClusters MatcherType = "allClusters"
+	CustomMatcher    MatcherType = "custom"
+)
 
 type PackageToClusterMatcher struct {
 	Type            MatcherType `json:"type"`
-	MatchExpression string      `json:"matchExpression"`
+	MatchExpression string      `json:"matchExpression,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=AllAtOnce;RollingUpdate;Progressive
@@ -123,8 +129,6 @@ type RolloutStrategy struct {
 
 // RolloutStatus defines the observed state of Rollout
 type RolloutStatus struct {
-	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
 	// Conditions describes the reconciliation state of the object.

--- a/rollouts/api/v1alpha1/rollout_types.go
+++ b/rollouts/api/v1alpha1/rollout_types.go
@@ -85,12 +85,12 @@ type SecretReference struct {
 	Name string `json:"name,omitempty"`
 }
 
-// +kubebuilder:validation:Enum=allClusters;custom
+// +kubebuilder:validation:Enum=AllClusters;Custom
 type MatcherType string
 
 const (
-	MatchAllClusters MatcherType = "allClusters"
-	CustomMatcher    MatcherType = "custom"
+	MatchAllClusters MatcherType = "AllClusters"
+	CustomMatcher    MatcherType = "Custom"
 )
 
 type PackageToClusterMatcher struct {

--- a/rollouts/config/crd/bases/gitops.kpt.dev_rollouts.yaml
+++ b/rollouts/config/crd/bases/gitops.kpt.dev_rollouts.yaml
@@ -60,8 +60,8 @@ spec:
                     type: string
                   type:
                     enum:
-                    - allClusters
-                    - custom
+                    - AllClusters
+                    - Custom
                     type: string
                 required:
                 - type

--- a/rollouts/config/crd/bases/gitops.kpt.dev_rollouts.yaml
+++ b/rollouts/config/crd/bases/gitops.kpt.dev_rollouts.yaml
@@ -60,10 +60,10 @@ spec:
                     type: string
                   type:
                     enum:
-                    - CEL
+                    - allClusters
+                    - custom
                     type: string
                 required:
-                - matchExpression
                 - type
                 type: object
               packages:
@@ -299,9 +299,6 @@ spec:
                   type: object
                 type: array
               observedGeneration:
-                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                  of cluster Important: Run "make" to regenerate code after modifying
-                  this file'
                 format: int64
                 type: integer
             type: object

--- a/rollouts/config/samples/gitops_rollout_cert_manager.yaml
+++ b/rollouts/config/samples/gitops_rollout_cert_manager.yaml
@@ -31,6 +31,6 @@ spec:
       matchExpressions:
         - {key: env, operator: In, values: [dev, staging]}
   packageToTargetMatcher:
-    type: allClusters
+    type: AllClusters
   strategy:
     type: AllAtOnce

--- a/rollouts/config/samples/gitops_rollout_cert_manager.yaml
+++ b/rollouts/config/samples/gitops_rollout_cert_manager.yaml
@@ -31,7 +31,6 @@ spec:
       matchExpressions:
         - {key: env, operator: In, values: [dev, staging]}
   packageToTargetMatcher:
-    type: CEL
-    matchExpression: 'true'
+    type: allClusters
   strategy:
     type: AllAtOnce

--- a/rollouts/config/samples/gitops_rollout_cert_manager_progressive.yaml
+++ b/rollouts/config/samples/gitops_rollout_cert_manager_progressive.yaml
@@ -31,8 +31,7 @@ spec:
       matchExpressions:
         - {key: env, operator: In, values: [dev, staging]}
   packageToTargetMatcher:
-    type: CEL
-    matchExpression: 'true'
+    type: allClusters
   strategy:
     type: Progressive
     progressive:

--- a/rollouts/config/samples/gitops_rollout_cert_manager_progressive.yaml
+++ b/rollouts/config/samples/gitops_rollout_cert_manager_progressive.yaml
@@ -31,7 +31,7 @@ spec:
       matchExpressions:
         - {key: env, operator: In, values: [dev, staging]}
   packageToTargetMatcher:
-    type: allClusters
+    type: AllClusters
   strategy:
     type: Progressive
     progressive:

--- a/rollouts/config/samples/gitops_rollout_kpt_samples.yaml
+++ b/rollouts/config/samples/gitops_rollout_kpt_samples.yaml
@@ -31,7 +31,6 @@ spec:
       matchExpressions:
         - {key: location/island, operator: In, values: [oahu, maui]}
   packageToTargetMatcher:
-    type: CEL
-    matchExpression: 'true'
+    type: allClusters
   strategy:
     type: AllAtOnce

--- a/rollouts/config/samples/gitops_rollout_kpt_samples.yaml
+++ b/rollouts/config/samples/gitops_rollout_kpt_samples.yaml
@@ -31,6 +31,6 @@ spec:
       matchExpressions:
         - {key: location/island, operator: In, values: [oahu, maui]}
   packageToTargetMatcher:
-    type: allClusters
+    type: AllClusters
   strategy:
     type: AllAtOnce

--- a/rollouts/config/samples/gitops_rollout_oahu.yaml
+++ b/rollouts/config/samples/gitops_rollout_oahu.yaml
@@ -27,8 +27,7 @@ spec:
         directory: "/"
         revision: main
   packageToTargetMatcher:
-    type: CEL
-    matchExpression: 'true'
+    type: allClusters
   targets:
     selector:
       matchLabels:

--- a/rollouts/config/samples/gitops_rollout_oahu.yaml
+++ b/rollouts/config/samples/gitops_rollout_oahu.yaml
@@ -27,7 +27,7 @@ spec:
         directory: "/"
         revision: main
   packageToTargetMatcher:
-    type: allClusters
+    type: AllClusters
   targets:
     selector:
       matchLabels:

--- a/rollouts/config/samples/gitops_rollout_repo_selector.yaml
+++ b/rollouts/config/samples/gitops_rollout_repo_selector.yaml
@@ -31,7 +31,7 @@ spec:
       matchExpressions:
         - {key: location/state, operator: In, values: [hawaii]}
   packageToTargetMatcher:
-    type: custom
+    type: Custom
     matchExpression: rolloutPackage.repo == cluster.labels['location/island'] + '-apps'
   strategy:
     type: AllAtOnce

--- a/rollouts/config/samples/gitops_rollout_repo_selector.yaml
+++ b/rollouts/config/samples/gitops_rollout_repo_selector.yaml
@@ -31,7 +31,7 @@ spec:
       matchExpressions:
         - {key: location/state, operator: In, values: [hawaii]}
   packageToTargetMatcher:
-    type: CEL
+    type: custom
     matchExpression: rolloutPackage.repo == cluster.labels['location/island'] + '-apps'
   strategy:
     type: AllAtOnce


### PR DESCRIPTION
This PR refines the packageToClusterMatcher field in the rollouts API. Now, there are two matcherTypes

If you want to broadcast a package to all the clusters, you can simply specify

```yaml

packageToTargetMatcher:
    type: AllClusters

```

If you have any custom matcher logic, you will have to specify as:

```yaml

packageToTargetMatcher:
    type: Custom
    matchingExpression: `your CEL expression goes here`

```

Also, we now throw an error if more than one package is targeted for a cluster. We need to think more if we want to support rolling out multiple packages to a cluster.