### PR TITLE
rollouts: added skeleton CLI

### DIFF
--- a/rollouts/cli/get/get.go
+++ b/rollouts/cli/get/get.go
@@ -1,0 +1,66 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package get
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoogleContainerTools/kpt/rollouts/rolloutsclient"
+	"github.com/spf13/cobra"
+)
+
+func NewCommand(ctx context.Context) *cobra.Command {
+	return newRunner(ctx).Command
+}
+
+func newRunner(ctx context.Context) *runner {
+	r := &runner{
+		ctx: ctx,
+	}
+	c := &cobra.Command{
+		Use:     "get",
+		Short:   "lists rollouts",
+		Long:    "lists rollouts",
+		Example: "lists rollouts",
+		RunE:    r.runE,
+	}
+	r.Command = c
+	return r
+}
+
+type runner struct {
+	ctx     context.Context
+	Command *cobra.Command
+}
+
+func (r *runner) runE(cmd *cobra.Command, args []string) error {
+	rlc, err := rolloutsclient.New()
+	if err != nil {
+		fmt.Printf("%s\n", err)
+		return err
+	}
+
+	rollouts, err := rlc.List(r.ctx, "")
+	if err != nil {
+		fmt.Printf("%s\n", err)
+		return err
+	}
+	for _, rollout := range rollouts.Items {
+		fmt.Printf("%s\n", rollout.Name)
+	}
+
+	return nil
+}

--- a/rollouts/cli/main.go
+++ b/rollouts/cli/main.go
@@ -1,0 +1,53 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/GoogleContainerTools/kpt/rollouts/cli/get"
+	"github.com/GoogleContainerTools/kpt/rollouts/cli/status"
+	"github.com/spf13/cobra"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+)
+
+func main() {
+	ctx := context.Background()
+
+	rolloutsCmd := &cobra.Command{
+		Use:   "cli",
+		Short: "cli ",
+		Long:  "cli",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			h, err := cmd.Flags().GetBool("help")
+			if err != nil {
+				return err
+			}
+			if h {
+				return cmd.Help()
+			}
+			return cmd.Usage()
+		},
+	}
+
+	rolloutsCmd.AddCommand(
+		get.NewCommand(ctx),
+		status.NewCommand(ctx),
+	)
+	if err := rolloutsCmd.Execute(); err != nil {
+		os.Exit(-1)
+	}
+}

--- a/rollouts/cli/status/status.go
+++ b/rollouts/cli/status/status.go
@@ -1,0 +1,74 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package status
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoogleContainerTools/kpt/rollouts/rolloutsclient"
+	"github.com/spf13/cobra"
+)
+
+func newRunner(ctx context.Context) *runner {
+	r := &runner{
+		ctx: ctx,
+	}
+	c := &cobra.Command{
+		Use:     "status",
+		Short:   "displays status of a rollout",
+		Long:    "displays status of a rollout",
+		Example: "displays status of a rollout",
+		RunE:    r.runE,
+	}
+	r.Command = c
+	return r
+}
+
+func NewCommand(ctx context.Context) *cobra.Command {
+	return newRunner(ctx).Command
+}
+
+type runner struct {
+	ctx     context.Context
+	Command *cobra.Command
+}
+
+func (r *runner) runE(cmd *cobra.Command, args []string) error {
+	rlc, err := rolloutsclient.New()
+	if err != nil {
+		fmt.Printf("%s\n", err)
+		return err
+	}
+
+	if len(args) == 0 {
+		fmt.Printf("must provide rollout name")
+		return nil
+	}
+
+	rollout, err := rlc.Get(r.ctx, args[0])
+	if err != nil {
+		fmt.Printf("%s\n", err)
+		return err
+	}
+
+	fmt.Printf("CLUSTER PACKAGE_ID PACKAGE_STATUS PACKAGE_SYNC_STATUS\n")
+	for _, cluster := range rollout.Status.ClusterStatuses {
+		pkgStatus := cluster.PackageStatus
+		fmt.Printf("%s %s %s %s\n", cluster.Name, pkgStatus.PackageID, pkgStatus.Status, pkgStatus.SyncStatus)
+	}
+
+	return nil
+}

--- a/rollouts/rolloutsclient/client.go
+++ b/rollouts/rolloutsclient/client.go
@@ -1,0 +1,92 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rolloutsclient
+
+import (
+	"context"
+	"fmt"
+
+	rolloutsapi "github.com/GoogleContainerTools/kpt/rollouts/api/v1alpha1"
+	coreapi "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+// Client implments client for the rollouts API.
+type Client struct {
+	client client.Client
+}
+
+func New() (*Client, error) {
+	scheme, err := createScheme()
+	if err != nil {
+		return nil, err
+	}
+	cl, err := client.New(config.GetConfigOrDie(), client.Options{
+		Scheme: scheme,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &Client{client: cl}, nil
+}
+
+func createScheme() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+
+	for _, api := range (runtime.SchemeBuilder{
+		rolloutsapi.AddToScheme,
+		coreapi.AddToScheme,
+		metav1.AddMetaToScheme,
+	}) {
+		if err := api(scheme); err != nil {
+			return nil, err
+		}
+	}
+	return scheme, nil
+}
+
+func (rlc *Client) List(ctx context.Context, ns string) (*rolloutsapi.RolloutList, error) {
+	if ns == "" {
+		ns = "default"
+	}
+
+	rollouts := &rolloutsapi.RolloutList{}
+	if err := rlc.client.List(context.Background(), rollouts, client.InNamespace(ns)); err != nil {
+		return nil, err
+	}
+
+	return rollouts, nil
+}
+
+func (rlc *Client) Get(ctx context.Context, name string) (*rolloutsapi.Rollout, error) {
+	if name == "" {
+		return nil, fmt.Errorf("must provide rollout name")
+	}
+
+	key := types.NamespacedName{
+		Namespace: "default",
+		Name:      name,
+	}
+	rollout := &rolloutsapi.Rollout{}
+	if err := rlc.client.Get(context.Background(), key, rollout); err != nil {
+		return nil, err
+	}
+
+	return rollout, nil
+}


### PR DESCRIPTION
The [original attempt ](https://github.com/GoogleContainerTools/kpt/pull/3722) to add subcommand `rollouts` in kpt CLI is turning out to be difficult because rollouts component is on newer version of k8s libraries and also uses Go 1.19 and is becoming too disruptive.

So going with new plan where added a simple `cli` under rollouts component. It's structure is such that it can be easily added to `kpt` as a subcommand later, so this should be good from the POC's perspective.