### PR TITLE
rollouts: conditionally show wave status

### DIFF
--- a/rollouts/controllers/rollout_controller.go
+++ b/rollouts/controllers/rollout_controller.go
@@ -337,7 +337,9 @@ func (r *RolloutReconciler) updateStatus(ctx context.Context, rollout *gitopsv1a
 
 	rollout.Status.Overall = getOverallStatus(clusterStatuses)
 
-	rollout.Status.WaveStatuses = waveStatuses
+	if len(waveStatuses) > 1 {
+		rollout.Status.WaveStatuses = waveStatuses
+	}
 
 	rollout.Status.ClusterStatuses = clusterStatuses
 	rollout.Status.ObservedGeneration = rollout.Generation


### PR DESCRIPTION
This pull request updates the rollouts proof of concept to show wave status only if there is more than one wave (restoring logic accidentally reverted in #3728).