### PR TITLE
rollouts: add ready condition to remote root sync

### DIFF
--- a/rollouts/controllers/remoterootsync_controller.go
+++ b/rollouts/controllers/remoterootsync_controller.go
@@ -24,7 +24,6 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -211,7 +210,7 @@ func (r *RemoteRootSyncReconciler) updateStatus(ctx context.Context, rrs *gitops
 				Type:               "Ready",
 				Reason:             readyReason,
 				Status:             rssReady,
-				LastTransitionTime: v1.Now(),
+				LastTransitionTime: metav1.Now(),
 			},
 		}
 	}

--- a/rollouts/controllers/remoterootsync_controller.go
+++ b/rollouts/controllers/remoterootsync_controller.go
@@ -192,7 +192,7 @@ func (r *RemoteRootSyncReconciler) updateStatus(ctx context.Context, rrs *gitops
 
 	// Don't update if there are no changes.
 	syncStatusChanged := syncStatus != nil && rrs.Status.SyncStatus != *syncStatus
-	generationChanged := rrs.Generation == rrs.Status.ObservedGeneration
+	generationChanged := rrs.Generation != rrs.Status.ObservedGeneration
 	readyStatusChanged := len(rrs.Status.Conditions) == 0 || rrs.Status.Conditions[0].Type != "Ready" || rrs.Status.Conditions[0].Status != rssReady
 
 	if !generationChanged && !syncStatusChanged && !readyStatusChanged {


### PR DESCRIPTION
This pull request updates the rollouts proof of concept, adding a ready condition to the remote root sync status. This condition allows us to understand if the remote root sync has connectivity to the target cluster.