### PR TITLE
rollouts: add container cluster watch

### DIFF
--- a/rollouts/controllers/rollout_controller.go
+++ b/rollouts/controllers/rollout_controller.go
@@ -63,7 +63,7 @@ const (
 )
 
 var (
-	configConnectorContainerClusterGVK = schema.GroupVersionKind{
+	kccClusterGVK = schema.GroupVersionKind{
 		Group:   "container.cnrm.cloud.google.com",
 		Version: "v1beta1",
 		Kind:    "ContainerCluster",
@@ -709,7 +709,7 @@ func (r *RolloutReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	var containerCluster unstructured.Unstructured
-	containerCluster.SetGroupVersionKind(configConnectorContainerClusterGVK)
+	containerCluster.SetGroupVersionKind(kccClusterGVK)
 
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&gitopsv1alpha1.Rollout{}).

--- a/rollouts/controllers/rollout_controller.go
+++ b/rollouts/controllers/rollout_controller.go
@@ -738,7 +738,13 @@ func (r *RolloutReconciler) mapClusterUpdateToRequest(cluster client.Object) []r
 		rolloutDeploysToCluster := rolloutIncludesCluster(&rollout, cluster.GetName())
 		clusterInTargetSet := selector.Matches(labels.Set(cluster.GetLabels()))
 
-		if rolloutDeploysToCluster || clusterInTargetSet {
+		// Rollouts will be reconciled for cluster updates when
+		// 1) a cluster is added to the rollout target set (clusterInTargetSet will be true)
+		// 2) a cluster is removed from the rollout target saet (rolloutDeploysToCluster will be true)
+		// 3) an cluster in the rollout target set is being updated where the package matching logic may produce different results (both variables will be true)
+		reconcileRollout := rolloutDeploysToCluster || clusterInTargetSet
+
+		if reconcileRollout {
 			requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{Name: rollout.Name, Namespace: rollout.Namespace}})
 		}
 	}

--- a/rollouts/controllers/rollout_controller.go
+++ b/rollouts/controllers/rollout_controller.go
@@ -602,17 +602,13 @@ func (r *RolloutReconciler) listRemoteRootSyncs(ctx context.Context, rsdName, rs
 	return remoterootsyncs, nil
 }
 
-func (r *RolloutReconciler) listAllRollouts(ctx context.Context) ([]*gitopsv1alpha1.Rollout, error) {
-	var list gitopsv1alpha1.RolloutList
-	if err := r.List(ctx, &list); err != nil {
+func (r *RolloutReconciler) listAllRollouts(ctx context.Context) ([]gitopsv1alpha1.Rollout, error) {
+	var rolloutsList gitopsv1alpha1.RolloutList
+	if err := r.List(ctx, &rolloutsList); err != nil {
 		return nil, err
 	}
-	var rollouts []*gitopsv1alpha1.Rollout
-	for i := range list.Items {
-		item := &list.Items[i]
-		rollouts = append(rollouts, item)
-	}
-	return rollouts, nil
+
+	return rolloutsList.Items, nil
 }
 
 func isRRSSynced(rss *gitopsv1alpha1.RemoteRootSync) bool {
@@ -739,7 +735,7 @@ func (r *RolloutReconciler) mapClusterUpdateToRequest(cluster client.Object) []r
 			continue
 		}
 
-		rolloutDeploysToCluster := rolloutIncludesCluster(rollout, cluster.GetName())
+		rolloutDeploysToCluster := rolloutIncludesCluster(&rollout, cluster.GetName())
 		clusterInTargetSet := selector.Matches(labels.Set(cluster.GetLabels()))
 
 		if rolloutDeploysToCluster || clusterInTargetSet {

--- a/rollouts/controllers/rollout_controller.go
+++ b/rollouts/controllers/rollout_controller.go
@@ -704,8 +704,6 @@ func (r *RolloutReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 
 	var containerCluster gkeclusterapis.ContainerCluster
-	containerCluster.SetGroupVersionKind(kccClusterGVK)
-
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&gitopsv1alpha1.Rollout{}).
 		Owns(&gitopsv1alpha1.RemoteRootSync{}).

--- a/rollouts/controllers/rollout_controller.go
+++ b/rollouts/controllers/rollout_controller.go
@@ -28,7 +28,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -704,7 +703,7 @@ func (r *RolloutReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	var containerCluster unstructured.Unstructured
+	var containerCluster gkeclusterapis.ContainerCluster
 	containerCluster.SetGroupVersionKind(kccClusterGVK)
 
 	return ctrl.NewControllerManagedBy(mgr).


### PR DESCRIPTION
This pull request updates the rollouts proof of concept, adding a watch for container cluster resources. This watch allows the reconciliation of rollouts when the target cluster list changes (for instance, a cluster being added or removed from the list).