### PR TITLE
rollouts: delete remote root sync when no longer needed

### DIFF
--- a/rollouts/controllers/rollout_controller.go
+++ b/rollouts/controllers/rollout_controller.go
@@ -286,8 +286,7 @@ func (r *RolloutReconciler) reconcileRollout(ctx context.Context, rollout *gitop
 	packageClusterMatcherClient := packageclustermatcher.NewPackageClusterMatcher(targetClusters.Items, discoveredPackages)
 	allClusterPackages, err := packageClusterMatcherClient.GetClusterPackages(rollout.Spec.PackageToTargetMatcher)
 	if err != nil {
-		logger.Error(err, "get cluster packages failed")
-		return client.IgnoreNotFound(err)
+		return err
 	}
 
 	targets, err := r.computeTargets(ctx, rollout, allClusterPackages)

--- a/rollouts/controllers/rollout_controller.go
+++ b/rollouts/controllers/rollout_controller.go
@@ -310,9 +310,10 @@ func (r *RolloutReconciler) reconcileRollout(ctx context.Context, rollout *gitop
 		pauseAfterWaveName = rollout.Spec.Strategy.Progressive.PauseAfterWave.WaveName
 	}
 
-	for _, waveTargets := range allWaveTargets {
-		wave := waveTargets.Wave
-		waveTargets := waveTargets.Targets
+	for i := range allWaveTargets {
+		thisWaveTargets := allWaveTargets[i]
+		waveTargets := thisWaveTargets.Targets
+		wave := thisWaveTargets.Wave
 
 		thisWaveInProgress, clusterStatuses, err := r.rolloutTargets(ctx, rollout, wave, waveTargets, pauseFutureWaves)
 		if err != nil {


### PR DESCRIPTION
This pull request updates the rollouts proof of concept allowing the rollouts controller to remove RemoteRootSync resources which are no longer required for the rollout (for instance, when a cluster is removed from the rollout's target set). The RemoteRootSync resource will be removed in the same wave it was added in by the rollout.