### PR TITLE
Add vulncheck targets to makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,3 +205,8 @@ release-ci:
 		$(GORELEASER_IMAGE) \
 		-f "$(GORELEASER_CONFIG)" release \
 		--skip-validate
+
+.PHONY: vulncheck
+vulncheck: build
+	# Scan the source
+	GOFLAGS= go run golang.org/x/vuln/cmd/govulncheck@latest ./...

--- a/porch/Makefile
+++ b/porch/Makefile
@@ -268,3 +268,8 @@ run-in-kind:
 	kubectl rollout status deployment function-runner --namespace porch-system
 	kubectl rollout status deployment porch-controllers --namespace porch-system
 	kubectl rollout status deployment porch-server --namespace porch-system
+
+.PHONY: vulncheck
+vulncheck: build
+	# Scan the source
+	GOFLAGS= go run golang.org/x/vuln/cmd/govulncheck@latest ./...


### PR DESCRIPTION
This lets us easily get an idea of any potential library updates
needed to fix known security issues.
