### PR TITLE
packagevariant controller should unpropose deletion when needed

### DIFF
--- a/porch/controllers/packagevariants/pkg/controllers/packagevariant/packagevariant_controller.go
+++ b/porch/controllers/packagevariants/pkg/controllers/packagevariant/packagevariant_controller.go
@@ -237,6 +237,14 @@ func (r *PackageVariantReconciler) findAndUpdateExistingRevisions(ctx context.Co
 	var err error
 	for i, downstream := range downstreams {
 		if r.isUpToDate(pv, downstream) {
+			if downstream.Spec.Lifecycle == porchapi.PackageRevisionLifecycleDeletionProposed {
+				// We proposed this package revision for deletion in the past, but now it
+				// matches our target, so we no longer want it to be deleted.
+				downstream.Spec.Lifecycle = porchapi.PackageRevisionLifecyclePublished
+				if err := r.Client.Update(ctx, downstream); err != nil {
+					klog.Errorf("error updating package revision lifecycle: %v", err)
+				}
+			}
 			continue
 		}
 		if porchapi.LifecycleIsPublished(downstream.Spec.Lifecycle) {


### PR DESCRIPTION
Ran into this scenario when playing around with the packagevariant controller:

- I create a PackageVariant with a target downstream package `foo`. The PackageVariant controller creates the target draft package revision, and I publish it, resulting in `foo v1`. 
- I update the PackageVariant's target downstream package name to something else, like `bar`. The PackageVariant controller creates a new target draft package revision `bar`. It also sees that it owns a package revision `foo v1` that no longer matches its target, so proposes `foo v1` for deletion. This is working great so far.
- I update the PackageVariant's target downstream package name back to `foo`. The PackageVariant controller deletes its package revision `bar`. The controller also sees that there is already a package revision `foo v1` that it owns that matches its target, so it does nothing -- meaning that `foo v1` stays proposed for deletion. This PR makes it so that in such a case, the target package revision's lifecycle gets changed back from DeletionProposed to Published.