### PR TITLE
docs: Remove reference to poll-period in apply reference doc

### DIFF
--- a/internal/docs/generated/livedocs/docs.go
+++ b/internal/docs/generated/livedocs/docs.go
@@ -65,10 +65,6 @@ Flags:
   
     The default value is ‘events’.
   
-  --poll-period:
-    The frequency with which the cluster will be polled to determine
-    the status of the applied resources. The default value is 2 seconds.
-  
   --prune-propagation-policy:
     The propagation policy that should be used when pruning resources. The
     default value here is 'Background'. The other options are 'Foreground' and 'Orphan'.

--- a/site/reference/cli/live/apply/README.md
+++ b/site/reference/cli/live/apply/README.md
@@ -78,10 +78,6 @@ PKG_PATH | -:
 
   The default value is ‘events’.
 
---poll-period:
-  The frequency with which the cluster will be polled to determine
-  the status of the applied resources. The default value is 2 seconds.
-
 --prune-propagation-policy:
   The propagation policy that should be used when pruning resources. The
   default value here is 'Background'. The other options are 'Foreground' and 'Orphan'.


### PR DESCRIPTION
This flag was removed when we switched to using watches a while back.

Fixes: #3548