### PR TITLE
improve wasm error message

### DIFF
--- a/internal/fnruntime/wasmtime.go
+++ b/internal/fnruntime/wasmtime.go
@@ -152,8 +152,12 @@ func (f *WasmtimeFn) Run(r io.Reader, w io.Writer) error {
 	resultStr := fmt.Sprintf("%s", result)
 	resultStr = resultStr[2 : len(resultStr)-1]
 	// Try to parse the output as yaml.
-	if _, err = yaml.Parse(resultStr); err != nil {
-		return errors.New(resultStr)
+	resourceListOutput, err := yaml.Parse(resultStr)
+	if err != nil {
+		return fmt.Errorf("error parsing output resource list %q: %w", resultStr, err)
+	}
+	if resourceListOutput.GetKind() != "ResourceList" {
+		return fmt.Errorf("invalid resource list output from wasm library; got %q", resultStr)
 	}
 	if _, err = w.Write([]byte(resultStr)); err != nil {
 		return fmt.Errorf("unable to write the output resource list: %w", err)


### PR DESCRIPTION
Fix https://github.com/GoogleContainerTools/kpt/issues/3763

It looks like there is a flaky function in our wasm fnruntime library. Specifically this line is looking problematic:

https://github.com/GoogleContainerTools/kpt/blob/5a7e65fa4bf03f7948ec1365d4a4a0c30a59b889/internal/fnruntime/wasmtime.go#L145

It's _supposed_ to populate `result` with the output ResourceList, but for me, maybe 1/20 times it is returning very odd-looking strings like `s(<nil>)` or  `s(float64=4.0474e-320`. This currently results in kyaml throwing its very unhelpful `Error: wrong Node Kind for  expected: MappingNode was ScalarNode: value: {s(float64=5.565e-320}` error. 

This PR doesn't fix the flake, but it is trying to at least improve the error message to make it more obvious where it came from. I filed a separate issue for addressing the flake: https://github.com/GoogleContainerTools/kpt/issues/3782