### PR TITLE
rollouts: update core logic to be agnostic of exact cluster type

### DIFF
--- a/rollouts/controllers/rollout_controller.go
+++ b/rollouts/controllers/rollout_controller.go
@@ -207,7 +207,7 @@ func (r *RolloutReconciler) validateProgressiveRolloutStrategy(ctx context.Conte
 	}
 
 	clusterWaveMap := make(map[string]string)
-	for _, cluster := range allClusters.Items {
+	for _, cluster := range allClusters {
 		clusterWaveMap[cluster.Name] = ""
 	}
 
@@ -224,11 +224,11 @@ func (r *RolloutReconciler) validateProgressiveRolloutStrategy(ctx context.Conte
 			return err
 		}
 
-		if len(waveClusters.Items) == 0 {
+		if len(waveClusters) == 0 {
 			return fmt.Errorf("wave %q does not target any clusters", wave.Name)
 		}
 
-		for _, cluster := range waveClusters.Items {
+		for _, cluster := range waveClusters {
 			currentClusterWave, found := clusterWaveMap[cluster.Name]
 			if !found {
 				// this should never happen
@@ -245,7 +245,7 @@ func (r *RolloutReconciler) validateProgressiveRolloutStrategy(ctx context.Conte
 		pauseWaveNameFound = pauseWaveNameFound || pauseAfterWaveName == wave.Name
 	}
 
-	for _, cluster := range allClusters.Items {
+	for _, cluster := range allClusters {
 		wave, _ := clusterWaveMap[cluster.Name]
 		if wave == "" {
 			return fmt.Errorf("waves should cover all clusters selected by the rollout - cluster %s is not covered by any waves", cluster.Name)
@@ -283,7 +283,7 @@ func (r *RolloutReconciler) reconcileRollout(ctx context.Context, rollout *gitop
 	}
 	logger.Info("discovered packages", "count", len(discoveredPackages), "packages", discoveredPackages)
 
-	packageClusterMatcherClient := packageclustermatcher.NewPackageClusterMatcher(targetClusters.Items, discoveredPackages)
+	packageClusterMatcherClient := packageclustermatcher.NewPackageClusterMatcher(targetClusters, discoveredPackages)
 	clusterPackages, err := packageClusterMatcherClient.GetClusterPackages(rollout.Spec.PackageToTargetMatcher)
 	if err != nil {
 		return err
@@ -442,7 +442,7 @@ func (r *RolloutReconciler) getWaveTargets(ctx context.Context, rollout *gitopsv
 			return nil, err
 		}
 
-		for _, cluster := range waveClusters.Items {
+		for _, cluster := range waveClusters {
 			clusterNameToWaveTarget[cluster.Name] = &thisWaveTarget
 		}
 
@@ -624,7 +624,7 @@ type Targets struct {
 }
 
 type clusterPackagePair struct {
-	cluster    *gkeclusterapis.ContainerCluster
+	cluster    *clusterstore.Cluster
 	packageRef *packagediscovery.DiscoveredPackage
 }
 

--- a/rollouts/pkg/packageclustermatcher/packageclustermatcher.go
+++ b/rollouts/pkg/packageclustermatcher/packageclustermatcher.go
@@ -17,8 +17,8 @@ package packageclustermatcher
 import (
 	"fmt"
 
-	gkeclusterapis "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/container/v1beta1"
 	gitopsv1alpha1 "github.com/GoogleContainerTools/kpt/rollouts/api/v1alpha1"
+	"github.com/GoogleContainerTools/kpt/rollouts/pkg/clusterstore"
 	"github.com/GoogleContainerTools/kpt/rollouts/pkg/packagediscovery"
 
 	"github.com/google/cel-go/cel"
@@ -26,16 +26,16 @@ import (
 )
 
 type PackageClusterMatcher struct {
-	clusters []gkeclusterapis.ContainerCluster
+	clusters []clusterstore.Cluster
 	packages []packagediscovery.DiscoveredPackage
 }
 
 type ClusterPackages struct {
-	Cluster  gkeclusterapis.ContainerCluster
+	Cluster  clusterstore.Cluster
 	Packages []packagediscovery.DiscoveredPackage
 }
 
-func NewPackageClusterMatcher(clusters []gkeclusterapis.ContainerCluster, packages []packagediscovery.DiscoveredPackage) *PackageClusterMatcher {
+func NewPackageClusterMatcher(clusters []clusterstore.Cluster, packages []packagediscovery.DiscoveredPackage) *PackageClusterMatcher {
 	return &PackageClusterMatcher{
 		clusters: clusters,
 		packages: packages,
@@ -56,8 +56,8 @@ func (m *PackageClusterMatcher) GetClusterPackages(matcher gitopsv1alpha1.Packag
 			matchedPackages = packages
 		case gitopsv1alpha1.CustomMatcher:
 			celCluster := map[string]interface{}{
-				"name":   cluster.ObjectMeta.Name,
-				"labels": cluster.ObjectMeta.Labels,
+				"name":   cluster.Name,
+				"labels": cluster.Labels,
 			}
 
 			for _, discoveredPackage := range packages {


### PR DESCRIPTION
This pull request updates the rollouts proof of concept, updating the core rollouts logic to be agnostic of the exact cluster type being updated.