### PR TITLE
rollouts: filter wave clusters in process

### DIFF
--- a/rollouts/controllers/rollout_controller.go
+++ b/rollouts/controllers/rollout_controller.go
@@ -219,7 +219,7 @@ func (r *RolloutReconciler) validateProgressiveRolloutStrategy(ctx context.Conte
 	}
 
 	for _, wave := range strategy.Spec.Waves {
-		waveClusters, err := r.store.ListClusters(ctx, rollout.Spec.Targets.Selector, wave.Targets.Selector)
+		waveClusters, err := filterClusters(allClusters, wave.Targets.Selector)
 		if err != nil {
 			return err
 		}
@@ -297,7 +297,7 @@ func (r *RolloutReconciler) reconcileRollout(ctx context.Context, rollout *gitop
 	allClusterStatuses := []gitopsv1alpha1.ClusterStatus{}
 	waveStatuses := []gitopsv1alpha1.WaveStatus{}
 
-	allWaveTargets, err := r.getWaveTargets(ctx, rollout, targets, strategy.Spec.Waves)
+	allWaveTargets, err := r.getWaveTargets(ctx, rollout, targets, targetClusters, strategy.Spec.Waves)
 	if err != nil {
 		return err
 	}
@@ -427,7 +427,7 @@ func (r *RolloutReconciler) computeTargets(ctx context.Context,
 	return targets, nil
 }
 
-func (r *RolloutReconciler) getWaveTargets(ctx context.Context, rollout *gitopsv1alpha1.Rollout, allTargets *Targets,
+func (r *RolloutReconciler) getWaveTargets(ctx context.Context, rollout *gitopsv1alpha1.Rollout, allTargets *Targets, allClusters []clusterstore.Cluster,
 	allWaves []gitopsv1alpha1.Wave) ([]WaveTarget, error) {
 	allWaveTargets := []WaveTarget{}
 
@@ -437,7 +437,7 @@ func (r *RolloutReconciler) getWaveTargets(ctx context.Context, rollout *gitopsv
 		wave := allWaves[i]
 		thisWaveTarget := WaveTarget{Wave: &wave, Targets: &Targets{}}
 
-		waveClusters, err := r.store.ListClusters(ctx, rollout.Spec.Targets.Selector, wave.Targets.Selector)
+		waveClusters, err := filterClusters(allClusters, wave.Targets.Selector)
 		if err != nil {
 			return nil, err
 		}
@@ -875,4 +875,22 @@ func rolloutIncludesCluster(rollout *gitopsv1alpha1.Rollout, clusterName string)
 	}
 
 	return false
+}
+
+func filterClusters(allClusters []clusterstore.Cluster, labelSelector *metav1.LabelSelector) ([]clusterstore.Cluster, error) {
+	clusters := []clusterstore.Cluster{}
+
+	for _, cluster := range allClusters {
+		clusterLabelSet := labels.Set(cluster.Labels)
+		selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+		if err != nil {
+			return nil, err
+		}
+
+		if selector.Matches(clusterLabelSet) {
+			clusters = append(clusters, cluster)
+		}
+	}
+
+	return clusters, nil
 }

--- a/rollouts/pkg/clusterstore/clusterstore.go
+++ b/rollouts/pkg/clusterstore/clusterstore.go
@@ -54,30 +54,10 @@ func (cs *ClusterStore) Init() error {
 	return nil
 }
 
-func (cs *ClusterStore) ListClusters(ctx context.Context, selectors ...*metav1.LabelSelector) ([]Cluster, error) {
-	gkeClusters, err := cs.listClusters(ctx, selectors[0])
+func (cs *ClusterStore) ListClusters(ctx context.Context, selector *metav1.LabelSelector) ([]Cluster, error) {
+	gkeClusters, err := cs.listClusters(ctx, selector)
 	if err != nil {
 		return nil, err
-	}
-
-	for _, selector := range selectors[1:] {
-		selectorClusters, err := cs.listClusters(ctx, selector)
-		if err != nil {
-			return nil, err
-		}
-
-		intersection := []gkeclusterapis.ContainerCluster{}
-
-		for _, cluster := range gkeClusters.Items {
-			for _, selectorCluster := range selectorClusters.Items {
-				if cluster.Name == selectorCluster.Name {
-					intersection = append(intersection, cluster)
-					break
-				}
-			}
-		}
-
-		gkeClusters.Items = intersection
 	}
 
 	sort.Slice(gkeClusters.Items, func(i, j int) bool {


### PR DESCRIPTION
This pull request updates the rollouts proof of concept to filter wave clusters in process, reducing the number of times the Kubernetes API Server needs to be called.