### PR TITLE
update release/docs for using beta.25 release

### DIFF
--- a/Formula/kpt.rb
+++ b/Formula/kpt.rb
@@ -15,8 +15,8 @@
 class Kpt < Formula
   desc "Toolkit to manage,and apply Kubernetes Resource config data files"
   homepage "https://googlecontainertools.github.io/kpt"
-  url "https://github.com/GoogleContainerTools/kpt/archive/v1.0.0-beta.24.tar.gz"
-  sha256 "84d7389316f6915aea6e017cfe0b9425f1676ba6c41c2538b123e2d494b681f6"
+  url "https://github.com/GoogleContainerTools/kpt/archive/v1.0.0-beta.25.tar.gz"
+  sha256 "ff493d1f8766d5a0fa9254a82d26c71d687af8dfe990c8b74822a45021334708"
 
   depends_on "go" => :build
 

--- a/site/installation/kpt-cli.md
+++ b/site/installation/kpt-cli.md
@@ -103,7 +103,7 @@ Use one of the kpt docker images.
 ### `kpt`
 
 ```shell
-$ docker run gcr.io/kpt-dev/kpt:v1.0.0-beta.24 version
+$ docker run gcr.io/kpt-dev/kpt:v1.0.0-beta.25 version
 ```
 
 ### `kpt-gcloud`
@@ -111,7 +111,7 @@ $ docker run gcr.io/kpt-dev/kpt:v1.0.0-beta.24 version
 An image which includes kpt based upon the Google [cloud-sdk] alpine image.
 
 ```shell
-$ docker run gcr.io/kpt-dev/kpt-gcloud:v1.0.0-beta.24 version
+$ docker run gcr.io/kpt-dev/kpt-gcloud:v1.0.0-beta.25 version
 ```
 
 ## Source
@@ -134,12 +134,12 @@ $ kpt version
   https://console.cloud.google.com/gcr/images/kpt-dev/GLOBAL/kpt-gcloud?gcrImageListsize=30
 [cloud-sdk]: https://github.com/GoogleCloudPlatform/cloud-sdk-docker
 [linux-amd64]:
-  https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.24/kpt_linux_amd64
+  https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.25/kpt_linux_amd64
 [linux-arm64]:
-  https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.24/kpt_linux_arm64
+  https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.25/kpt_linux_arm64
 [darwin-amd64]:
-  https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.24/kpt_darwin_amd64
+  https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.25/kpt_darwin_amd64
 [darwin-arm64]:
-  https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.24/kpt_darwin_arm64
+  https://github.com/GoogleContainerTools/kpt/releases/download/v1.0.0-beta.25/kpt_darwin_arm64
 [migration guide]: /installation/migration
 [bash-completion]: https://github.com/scop/bash-completion#installation


### PR DESCRIPTION
- Update installation docs to use `beta.25`
- Updated the homebrew formula to use `beta.25`