### PR TITLE
rollouts: grant rollouts controller read access to container clusters

### DIFF
--- a/rollouts/config/rbac/role.yaml
+++ b/rollouts/config/rbac/role.yaml
@@ -20,6 +20,14 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - container.cnrm.cloud.google.com
+  resources:
+  - containerclusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - gitops.kpt.dev
   resources:
   - progressiverolloutstrategies

--- a/rollouts/controllers/rollout_controller.go
+++ b/rollouts/controllers/rollout_controller.go
@@ -81,6 +81,7 @@ type RolloutReconciler struct {
 	packageDiscoveryCache map[types.NamespacedName]*packagediscovery.PackageDiscovery
 }
 
+//+kubebuilder:rbac:groups=container.cnrm.cloud.google.com,resources=containerclusters,verbs=get;list;watch
 //+kubebuilder:rbac:groups=gitops.kpt.dev,resources=rollouts,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=gitops.kpt.dev,resources=rollouts/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=gitops.kpt.dev,resources=rollouts/finalizers,verbs=update


### PR DESCRIPTION
This pull request updates the rollouts proof of concept allowing the rollouts controller get, list, and watch ContainerCluster resources. This is needed for when using the KCC source type for cluster discovery.