### PR TITLE
rollouts: update remote root sync controller logging

### DIFF
--- a/rollouts/pkg/clusterstore/containerclusterstore.go
+++ b/rollouts/pkg/clusterstore/containerclusterstore.go
@@ -23,7 +23,6 @@ import (
 
 	"golang.org/x/oauth2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	gkeclusterapis "github.com/GoogleCloudPlatform/k8s-config-connector/pkg/clients/generated/apis/container/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -117,7 +116,6 @@ func (cs *ContainerClusterStore) listClusters(ctx context.Context, selector *met
 }
 
 func (cs *ContainerClusterStore) getRESTConfig(ctx context.Context, cluster *gkeclusterapis.ContainerCluster) (*rest.Config, error) {
-	logger := log.FromContext(ctx)
 	restConfig := &rest.Config{}
 	clusterCaCertificate := cluster.Spec.MasterAuth.ClusterCaCertificate
 	if clusterCaCertificate == nil || *clusterCaCertificate == "" {
@@ -132,7 +130,6 @@ func (cs *ContainerClusterStore) getRESTConfig(ctx context.Context, cluster *gke
 		return nil, fmt.Errorf("cluster master endpoint field is empty")
 	}
 	restConfig.Host = "https://" + cluster.Status.Endpoint
-	logger.Info("Host endpoint is", "endpoint", restConfig.Host)
 	tokenSource, err := cs.getConfigConnectorContextTokenSource(ctx, cluster.GetNamespace())
 	if err != nil {
 		return nil, err

--- a/rollouts/pkg/tokenexchange/gcptokensource/gcptokensource.go
+++ b/rollouts/pkg/tokenexchange/gcptokensource/gcptokensource.go
@@ -54,6 +54,8 @@ func (ts *gcpTokenSource) Token() (*oauth2.Token, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	logger := klog.TODO()
+
 	// use the provided token source to make the request
 	c, err := iamv1.NewIamCredentialsClient(ctx, option.WithTokenSource(ts.tokenSource))
 	if err != nil {
@@ -68,7 +70,7 @@ func (ts *gcpTokenSource) Token() (*oauth2.Token, error) {
 		return nil, fmt.Errorf("token exchange for GCP serviceaccount %q failed: %w", ts.gcpServiceAccount, err)
 	}
 
-	klog.Infof("got GCP token for %v", ts.gcpServiceAccount)
+	logger.Info("Got GCP token", "gcpServiceAccount", ts.gcpServiceAccount)
 
 	expiry, err := ptypes.Timestamp(resp.ExpireTime)
 	if err != nil {


### PR DESCRIPTION
This pull request updates the logging in the remote root sync controller. Updates include ensuring all log messages start with a capital letter, there's no string formatting within the logging message, and the logr.Logger instance is used for logging, following the best practices listed in https://github.com/kubernetes/community/blob/HEAD/contributors/devel/sig-instrumentation/migration-to-structured-logging.md. Additionally, every logging entry will now be associated with the controller and remote root sync name, allowing us to filters logs to a single remote root sync object if needed.