### PR TITLE
wip: packagevariant controller: support namespacing target packages

### DIFF
--- a/porch/controllers/packagevariants/api/v1alpha1/packagevariant_types.go
+++ b/porch/controllers/packagevariants/api/v1alpha1/packagevariant_types.go
@@ -62,6 +62,7 @@ type PackageVariantSpec struct {
 
 	Labels      map[string]string `json:"labels,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`
+	Namespace   *Namespace        `json:"namespace,omitempty"`
 }
 
 type Upstream struct {
@@ -73,6 +74,17 @@ type Upstream struct {
 type Downstream struct {
 	Repo    string `json:"repo,omitempty"`
 	Package string `json:"package,omitempty"`
+}
+
+type Namespace struct {
+	// Create, if set to true, means that we will create a
+	// Namespace object in the target package revision if
+	// one does not already exist. Defaults to false.
+	Create bool `json:"create,omitempty"`
+
+	// Value is the identifies the namespace in which to deploy the
+	// package revision. This defaults to the name of the package.
+	Value string `json:"value,omitempty"`
 }
 
 // PackageVariantStatus defines the observed state of PackageVariant

--- a/porch/controllers/packagevariantsets/api/v1alpha1/packagevariantset_types.go
+++ b/porch/controllers/packagevariantsets/api/v1alpha1/packagevariantset_types.go
@@ -48,8 +48,9 @@ type PackageVariantSetSpec struct {
 	AdoptionPolicy pkgvarapi.AdoptionPolicy `json:"adoptionPolicy,omitempty"`
 	DeletionPolicy pkgvarapi.DeletionPolicy `json:"deletionPolicy,omitempty"`
 
-	Labels      map[string]string `json:"labels,omitempty"`
-	Annotations map[string]string `json:"annotations,omitempty"`
+	Labels      map[string]string    `json:"labels,omitempty"`
+	Annotations map[string]string    `json:"annotations,omitempty"`
+	Namespace   *pkgvarapi.Namespace `json:"namespace,omitempty"`
 }
 
 type Upstream struct {

--- a/porch/controllers/packagevariantsets/pkg/controllers/packagevariantset/packagevariantset_controller.go
+++ b/porch/controllers/packagevariantsets/pkg/controllers/packagevariantset/packagevariantset_controller.go
@@ -409,6 +409,7 @@ func (r *PackageVariantSetReconciler) ensurePackageVariants(ctx context.Context,
 			DeletionPolicy: pvs.Spec.DeletionPolicy,
 			Labels:         pvs.Spec.Labels,
 			Annotations:    pvs.Spec.Annotations,
+			Namespace:      pvs.Spec.Namespace,
 		}
 		hash, err := hashFromPackageVariantSpec(&pvSpec)
 		if err != nil {


### PR DESCRIPTION
Not yet ready for review.

Related issue: https://github.com/GoogleContainerTools/kpt/issues/3488

Adds the `set-namespace` function to target downstream packages using the [package-context pattern](https://catalog.kpt.dev/set-namespace/v0.4/set-namespace-kpt-package-context/). This should result in the target packages' resources ending up with the specified namespace set on them.