### PR TITLE
Improve wasm errors

### DIFF
--- a/internal/fnruntime/wasmtime.go
+++ b/internal/fnruntime/wasmtime.go
@@ -1,5 +1,4 @@
 //go:build cgo
-// +build cgo
 
 // Copyright 2022 Google LLC
 //
@@ -157,9 +156,9 @@ func (f *WasmtimeFn) Run(r io.Reader, w io.Writer) error {
 	if err != nil {
 		additionalErrorMessage, err2 := retrieveError(f, resourceList)
 		if err2 != nil {
-			additionalErrorMessage = fmt.Sprint("failed to retrieve more error information: %q", err2)
+			additionalErrorMessage = fmt.Sprint("failed to retrieve more error information: %w", err2)
 		}
-		return fmt.Errorf("error parsing output resource list %q: %w\n%s", resultStr, err, additionalErrorMessage)
+		return fmt.Errorf("parsing output resource list with content: %q\n%w\n%s", resultStr, err, additionalErrorMessage)
 	}
 	if resourceListOutput.GetKind() != "ResourceList" {
 		additionalErrorMessage, err2 := retrieveError(f, resourceList)

--- a/internal/fnruntime/wasmtime.go
+++ b/internal/fnruntime/wasmtime.go
@@ -146,6 +146,7 @@ func (f *WasmtimeFn) Run(r io.Reader, w io.Writer) error {
 	if err != nil {
 		return fmt.Errorf("unable to invoke %v: %v", jsEntrypointFunction, err)
 	}
+
 	// We expect `result` to be a *wasmexec.jsString (which is not exportable) with
 	// the following definition: type jsString struct { data string }. It will look
 	// like `&{realPayload}`
@@ -154,15 +155,31 @@ func (f *WasmtimeFn) Run(r io.Reader, w io.Writer) error {
 	// Try to parse the output as yaml.
 	resourceListOutput, err := yaml.Parse(resultStr)
 	if err != nil {
-		return fmt.Errorf("error parsing output resource list %q: %w", resultStr, err)
+		additionalErrorMessage, err2 := retrieveError(f, resourceList)
+		if err2 != nil {
+			additionalErrorMessage = fmt.Sprint("failed to retrieve more error information: %q", err2)
+		}
+		return fmt.Errorf("error parsing output resource list %q: %w\n%s", resultStr, err, additionalErrorMessage)
 	}
 	if resourceListOutput.GetKind() != "ResourceList" {
-		return fmt.Errorf("invalid resource list output from wasm library; got %q", resultStr)
+		additionalErrorMessage, err2 := retrieveError(f, resourceList)
+		if err2 != nil {
+			additionalErrorMessage = fmt.Sprint("failed to retrieve more error information: %w", err2)
+		}
+		return fmt.Errorf("invalid resource list output from wasm library; got %q\n%s", resultStr, additionalErrorMessage)
 	}
 	if _, err = w.Write([]byte(resultStr)); err != nil {
 		return fmt.Errorf("unable to write the output resource list: %w", err)
 	}
 	return f.loader.cleanup()
+}
+
+func retrieveError(f *WasmtimeFn, resourceList []byte) (string, error) {
+	errResult, err := f.gomod.Call(jsEntrypointFunction+"Errors", string(resourceList))
+	if err != nil {
+		return "", fmt.Errorf("unable to retrieve additional error message from function: %w", err)
+	}
+	return fmt.Sprintf("%s", errResult), nil
 }
 
 var _ wasmexec.Instance = &WasmtimeFn{}


### PR DESCRIPTION
Currently WASM compiled functions panic when attempting to return an error.
Also, the error returned is often not meaningful without retrieving the `resourceList.Results` and showing them to the user.

This change builds on this PR https://github.com/GoogleContainerTools/kpt-functions-catalog/pull/978 to benefit from the additional function, introduced to allow retrieving and showing `resourceList.Results` to the user.

Shortcomings:
1. This only applies to the wasmexec based fnruntime
2. No effort is made to match `resourceList.Results` entries to the entry introduced by the last function. In the PR I assume that entries with Severity "error" result in the function failing, and that all "error" entries are relevant