### PR TITLE
Make sure kpt release uses an existing version of the goreleaser image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-GOLANG_VERSION         := 1.19.6
+GOLANG_VERSION         := 1.19.5
 GORELEASER_CONFIG      = release/tag/goreleaser.yaml
 GORELEASER_IMAGE       := ghcr.io/goreleaser/goreleaser-cross:v$(GOLANG_VERSION)
 

--- a/porch/func/Dockerfile
+++ b/porch/func/Dockerfile
@@ -25,7 +25,7 @@ FROM gcr.io/kpt-fn/set-project-id:v0.2.0 as set-project-id
 FROM gcr.io/kpt-fn/starlark:v0.3.0 as starlark
 FROM gcr.io/kpt-fn/upsert-resource:v0.2.0 as upsert-resource
 
-FROM golang:1.19.6-alpine3.17 as builder
+FROM golang:1.19.5-alpine3.17 as builder
 WORKDIR /go/src/github.com/GoogleContainerTools/kpt
 
 RUN go install github.com/grpc-ecosystem/grpc-health-probe@v0.4.11

--- a/porch/func/Dockerfile-wrapperserver
+++ b/porch/func/Dockerfile-wrapperserver
@@ -1,4 +1,4 @@
-FROM golang:1.19.6-alpine3.17 as builder
+FROM golang:1.19.5-alpine3.17 as builder
 
 WORKDIR /go/src/github.com/GoogleContainerTools/kpt
 


### PR DESCRIPTION
Goreleaser haven't yet published a version of the goreleaser-cross image based on go1.19.6, so just switching to 1.19.5.
