### PR TITLE
rollouts: reconcile fleet rollouts periodically

### DIFF
--- a/rollouts/controllers/rollout_controller.go
+++ b/rollouts/controllers/rollout_controller.go
@@ -157,8 +157,8 @@ func (r *RolloutReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 	if rollout.Spec.Clusters.SourceType == gitopsv1alpha1.GCPFleet &&
-		rollout.Status.Overall == "Completed" {
-		// TODO (droot): The rollouts in completed state will not be reconciled
+		(rollout.Status.Overall == "Completed" || rollout.Status.Overall == "Stalled") {
+		// TODO (droot): The rollouts in completed/stalled state will not be reconciled
 		// whenever fleet memberships change, so scheduling a periodic reconcile
 		// until we fix https://github.com/GoogleContainerTools/kpt/issues/3835
 		// This can be safely removed once we start monitoring fleet changes.


### PR DESCRIPTION
This PR ensures the rollouts using `GCPFleet` as cluster source are reconciled periodically after completion. This is a hack until we add support for monitor fleet membership changes https://github.com/GoogleContainerTools/kpt/issues/3835.

