### PR TITLE
Rename the api group name to be healthcheck.config.k8s.io

### DIFF
--- a/healthcheck/api/v1alpha1/groupversion_info.go
+++ b/healthcheck/api/v1alpha1/groupversion_info.go
@@ -14,7 +14,7 @@
 
 // Package v1alpha1 contains API Schema definitions for the healthcheck v1alpha1 API group
 // +kubebuilder:object:generate=true
-// +groupName=healthcheck.cloud.google.com
+// +groupName=config.healthcheck.kpt.dev
 package v1alpha1
 
 import (
@@ -24,7 +24,7 @@ import (
 
 var (
 	// GroupVersion is group version used to register these objects
-	GroupVersion = schema.GroupVersion{Group: "healthcheck.cloud.google.com", Version: "v1alpha1"}
+	GroupVersion = schema.GroupVersion{Group: "config.healthcheck.kpt.dev", Version: "v1alpha1"}
 	// SchemeBuilder is used to add go types to the GroupVersionKind scheme
 	SchemeBuilder = &scheme.Builder{GroupVersion: GroupVersion}
 	// AddToScheme adds the types in this group-version to the given scheme.

--- a/healthcheck/api/v1alpha1/healthcheck_types.go
+++ b/healthcheck/api/v1alpha1/healthcheck_types.go
@@ -64,11 +64,11 @@ type HealthCheckCondition struct {
 
 const (
 	// LabelComponent indicates the component to which the health check belongs.
-	LabelComponent = "healthcheck.cloud.google.com/component"
+	LabelComponent = "config.healthcheck.kpt.dev/component"
 	// LabelServiceError should be set to true if the health check is service level.
 	// LabelServiceError should be set to false if the health check is user level.
-	// Example: healthcheck.cloud.google.io/serviceError: true
-	LabelServiceError = "healthcheck.cloud.google.com/serviceError"
+	// Example: config.healthcheck.kpt.dev/serviceError: true
+	LabelServiceError = "config.healthcheck.kpt.dev/serviceError"
 )
 
 // +kubebuilder:object:root=true

--- a/healthcheck/config/crd/config.healthcheck.kpt.dev_healthchecks.yaml
+++ b/healthcheck/config/crd/config.healthcheck.kpt.dev_healthchecks.yaml
@@ -19,9 +19,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.11.3
   creationTimestamp: null
-  name: healthchecks.healthcheck.cloud.google.com
+  name: healthchecks.config.healthcheck.kpt.dev
 spec:
-  group: healthcheck.cloud.google.com
+  group: config.healthcheck.kpt.dev
   names:
     kind: HealthCheck
     listKind: HealthCheckList


### PR DESCRIPTION

This PR renames the health check api group to be healthcheck.config.k8s.io, which is more OSS compared to the old one.

Fixes #3800