### PR TITLE
rollouts: support `repoSync` option

### DIFF
--- a/rollouts/api/v1alpha1/remoterootsync_types.go
+++ b/rollouts/api/v1alpha1/remoterootsync_types.go
@@ -25,11 +25,10 @@ import (
 
 // RemoteRootSyncSpec defines the desired state of RemoteRootSync
 type RemoteRootSyncSpec struct {
-	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-	// Important: Run "make" to regenerate code after modifying this file
-
-	ClusterRef ClusterRef    `json:"clusterRef,omitempty"`
-	Template   *RootSyncInfo `json:"template,omitempty"`
+	// ClusterReference contains the identify information need to refer a cluster.
+	ClusterRef ClusterRef       `json:"clusterRef,omitempty"`
+	Template   *RootSyncInfo    `json:"template,omitempty"`
+	Type       SyncTemplateType `json:"type,omitempty"`
 }
 
 type RootSyncInfo struct {

--- a/rollouts/config/crd/bases/gitops.kpt.dev_remoterootsyncs.yaml
+++ b/rollouts/config/crd/bases/gitops.kpt.dev_remoterootsyncs.yaml
@@ -111,6 +111,11 @@ spec:
                         type: string
                     type: object
                 type: object
+              type:
+                enum:
+                - RootSync
+                - RepoSync
+                type: string
             type: object
           status:
             description: RemoteRootSyncStatus defines the observed state of RemoteRootSync


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/kpt/issues/3838.

https://github.com/GoogleContainerTools/kpt/issues/3858 contains name changes to make the function of `RemoteRootSync` object more obvious.

This PR takes the approach of reusing the `RemoteRootSync` controller to also support RepoSync objects (and renames the controller to `RemoteSync`. 

Alternatives:
- Have a separate `RemoteRepoSync` controller. I played around with this option for a little bit but it was a lot of duplicated code. Seems better to have it all in one code path. I briefly looked into seeing of go generics + a common library could help with deduping with this option but I didn't immediately see a solution there that was better than reusing the controller. 