### PR TITLE
Fix the edit/copy of packagerevisions

### DIFF
--- a/porch/api/porch/v1alpha1/types_packagerevisions.go
+++ b/porch/api/porch/v1alpha1/types_packagerevisions.go
@@ -79,6 +79,25 @@ type PackageRevisionSpec struct {
 
 	Lifecycle PackageRevisionLifecycle `json:"lifecycle,omitempty"`
 
+	// The task slice holds zero or more tasks that describe the operations
+	// performed on the packagerevision. The are essentially a replayable history
+	// of the packagerevision,
+	//
+	// Packagerevisions that were not created in Porch may have an
+	// empty task list.
+	//
+	// Packagerevisions created and managed through Porch will always
+	// have either an Init, Edit, or a Clone task as the first entry in their
+	// task list. This represent packagerevisions created from scratch, based
+	// a copy of a different revision in the same package, or a packagerevision
+	// cloned from another package.
+	// Each change to the packagerevision will result in a correspondig
+	// task being added to the list of tasks. It will describe the operation
+	// performed and will have a corresponding entry (commit or layer) in git
+	// or oci.
+	// The task slice describes the history of the packagerevision, so it
+	// is an append only list (We might introduce some kind of compaction in the
+	// future to keep the number of tasks at a reasonable number).
 	Tasks []Task `json:"tasks,omitempty"`
 
 	ReadinessGates []ReadinessGate `json:"readinessGates,omitempty"`

--- a/porch/pkg/engine/edit_test.go
+++ b/porch/pkg/engine/edit_test.go
@@ -28,14 +28,23 @@ import (
 )
 
 func TestEdit(t *testing.T) {
-	packageName := "foo-1234567890"
+	pkg := "pkg"
+	packageName := "repo-1234567890"
+	repositoryName := "repo"
+	revision := "v1"
 	packageRevision := &fake.PackageRevision{
 		Name: packageName,
+		PackageRevisionKey: repository.PackageRevisionKey{
+			Package:    pkg,
+			Repository: repositoryName,
+			Revision:   revision,
+		},
+		PackageLifecycle: v1alpha1.PackageRevisionLifecyclePublished,
 		Resources: &v1alpha1.PackageRevisionResources{
 			Spec: v1alpha1.PackageRevisionResourcesSpec{
-				PackageName:    packageName,
-				Revision:       "v1",
-				RepositoryName: "foo",
+				PackageName:    pkg,
+				Revision:       revision,
+				RepositoryName: repositoryName,
 				Resources: map[string]string{
 					kptfile.KptFileName: strings.TrimSpace(`
 apiVersion: kpt.dev/v1
@@ -69,7 +78,10 @@ info:
 				},
 			},
 		},
+
 		namespace:         "test-namespace",
+		packageName:       pkg,
+		repositoryName:    repositoryName,
 		referenceResolver: &fakeReferenceResolver{},
 		repoOpener:        repoOpener,
 	}

--- a/porch/pkg/engine/engine_test.go
+++ b/porch/pkg/engine/engine_test.go
@@ -315,3 +315,451 @@ func TestSomething(t *testing.T) {
 		})
 	}
 }
+
+func TestEnsureSameOrigin(t *testing.T) {
+	testCases := map[string]struct {
+		obj           *api.PackageRevision
+		existingRevs  []repository.PackageRevision
+		repoRevs      []repository.PackageRevision
+		hasSameOrigin bool
+		expectedErr   error
+	}{
+		"init task, no existing packagerevisions": {
+			obj: &api.PackageRevision{
+				Spec: api.PackageRevisionSpec{
+					Tasks: []api.Task{
+						{
+							Type: api.TaskTypeInit,
+							Init: &api.PackageInitTaskSpec{},
+						},
+					},
+				},
+			},
+			existingRevs:  []repository.PackageRevision{},
+			hasSameOrigin: true,
+			expectedErr:   nil,
+		},
+		"init task, existing packagerevision with first init task": {
+			obj: &api.PackageRevision{
+				Spec: api.PackageRevisionSpec{
+					Tasks: []api.Task{
+						{
+							Type: api.TaskTypeInit,
+							Init: &api.PackageInitTaskSpec{},
+						},
+					},
+				},
+			},
+			existingRevs: toFakeRepoPkgRevSlice(
+				api.Task{
+					Type: api.TaskTypeInit,
+					Init: &api.PackageInitTaskSpec{},
+				},
+			),
+			hasSameOrigin: true,
+			expectedErr:   nil,
+		},
+		"init task, existing packagerevision with another first task": {
+			obj: &api.PackageRevision{
+				Spec: api.PackageRevisionSpec{
+					Tasks: []api.Task{
+						{
+							Type: api.TaskTypeInit,
+							Init: &api.PackageInitTaskSpec{},
+						},
+					},
+				},
+			},
+			existingRevs: toFakeRepoPkgRevSlice(
+				api.Task{
+					Type: api.TaskTypeClone,
+				},
+			),
+			hasSameOrigin: false,
+			expectedErr:   nil,
+		},
+		"clone task, no existing packagerevisions": {
+			obj: &api.PackageRevision{
+				Spec: api.PackageRevisionSpec{
+					Tasks: []api.Task{
+						{
+							Type:  api.TaskTypeClone,
+							Clone: &api.PackageCloneTaskSpec{},
+						},
+					},
+				},
+			},
+			existingRevs:  []repository.PackageRevision{},
+			hasSameOrigin: true,
+			expectedErr:   nil,
+		},
+		"clone task, existing packagerevision with different first task": {
+			obj: &api.PackageRevision{
+				Spec: api.PackageRevisionSpec{
+					Tasks: []api.Task{
+						{
+							Type:  api.TaskTypeClone,
+							Clone: &api.PackageCloneTaskSpec{},
+						},
+					},
+				},
+			},
+			existingRevs: toFakeRepoPkgRevSlice(
+				api.Task{
+					Type: api.TaskTypeInit,
+				},
+			),
+			hasSameOrigin: false,
+			expectedErr:   nil,
+		},
+		"clone task git, existing packagerevision with different source type": {
+			obj: &api.PackageRevision{
+				Spec: api.PackageRevisionSpec{
+					Tasks: []api.Task{
+						{
+							Type: api.TaskTypeClone,
+							Clone: &api.PackageCloneTaskSpec{
+								Upstream: api.UpstreamPackage{
+									Type: api.RepositoryTypeGit,
+									Git: &api.GitPackage{
+										Repo:      "https://github.com/GoogleContainerTools/kpt",
+										Ref:       "main",
+										Directory: "/",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			existingRevs: toFakeRepoPkgRevSlice(
+				api.Task{
+					Type: api.TaskTypeClone,
+					Clone: &api.PackageCloneTaskSpec{
+						Upstream: api.UpstreamPackage{
+							Type: api.RepositoryTypeOCI,
+						},
+					},
+				},
+			),
+			hasSameOrigin: false,
+			expectedErr:   nil,
+		},
+		"clone task git, existing packagerevision with different repo": {
+			obj: &api.PackageRevision{
+				Spec: api.PackageRevisionSpec{
+					Tasks: []api.Task{
+						{
+							Type: api.TaskTypeClone,
+							Clone: &api.PackageCloneTaskSpec{
+								Upstream: api.UpstreamPackage{
+									Type: api.RepositoryTypeGit,
+									Git: &api.GitPackage{
+										Repo:      "https://github.com/GoogleContainerTools/kpt",
+										Ref:       "main",
+										Directory: "/",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			existingRevs: toFakeRepoPkgRevSlice(
+				api.Task{
+					Type: api.TaskTypeClone,
+					Clone: &api.PackageCloneTaskSpec{
+						Upstream: api.UpstreamPackage{
+							Type: api.RepositoryTypeGit,
+							Git: &api.GitPackage{
+								Repo:      "https://github.com/GoogleContainerTools/somethingelse",
+								Ref:       "main",
+								Directory: "/",
+							},
+						},
+					},
+				},
+			),
+			hasSameOrigin: false,
+			expectedErr:   nil,
+		},
+		"clone task git, existing packagerevision with same repo": {
+			obj: &api.PackageRevision{
+				Spec: api.PackageRevisionSpec{
+					Tasks: []api.Task{
+						{
+							Type: api.TaskTypeClone,
+							Clone: &api.PackageCloneTaskSpec{
+								Upstream: api.UpstreamPackage{
+									Type: api.RepositoryTypeGit,
+									Git: &api.GitPackage{
+										Repo:      "https://github.com/GoogleContainerTools/kpt",
+										Ref:       "main",
+										Directory: "/",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			existingRevs: toFakeRepoPkgRevSlice(
+				api.Task{
+					Type: api.TaskTypeClone,
+					Clone: &api.PackageCloneTaskSpec{
+						Upstream: api.UpstreamPackage{
+							Type: api.RepositoryTypeGit,
+							Git: &api.GitPackage{
+								Repo:      "https://github.com/GoogleContainerTools/kpt",
+								Ref:       "main",
+								Directory: "/",
+							},
+						},
+					},
+				},
+			),
+			hasSameOrigin: true,
+			expectedErr:   nil,
+		},
+		"clone task oci, existing packagerevision with different image": {
+			obj: &api.PackageRevision{
+				Spec: api.PackageRevisionSpec{
+					Tasks: []api.Task{
+						{
+							Type: api.TaskTypeClone,
+							Clone: &api.PackageCloneTaskSpec{
+								Upstream: api.UpstreamPackage{
+									Type: api.RepositoryTypeOCI,
+									Oci: &api.OciPackage{
+										Image: "gcr.io/kpt-dev/image",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			existingRevs: toFakeRepoPkgRevSlice(
+				api.Task{
+					Type: api.TaskTypeClone,
+					Clone: &api.PackageCloneTaskSpec{
+						Upstream: api.UpstreamPackage{
+							Type: api.RepositoryTypeOCI,
+							Oci: &api.OciPackage{
+								Image: "gcr.io/kpt-dev/otherimage",
+							},
+						},
+					},
+				},
+			),
+			hasSameOrigin: false,
+			expectedErr:   nil,
+		},
+		"clone task oci, existing packagerevision with same image": {
+			obj: &api.PackageRevision{
+				Spec: api.PackageRevisionSpec{
+					Tasks: []api.Task{
+						{
+							Type: api.TaskTypeClone,
+							Clone: &api.PackageCloneTaskSpec{
+								Upstream: api.UpstreamPackage{
+									Type: api.RepositoryTypeOCI,
+									Oci: &api.OciPackage{
+										Image: "gcr.io/kpt-dev/image:foo",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			existingRevs: toFakeRepoPkgRevSlice(
+				api.Task{
+					Type: api.TaskTypeClone,
+					Clone: &api.PackageCloneTaskSpec{
+						Upstream: api.UpstreamPackage{
+							Type: api.RepositoryTypeOCI,
+							Oci: &api.OciPackage{
+								Image: "gcr.io/kpt-dev/image:bar",
+							},
+						},
+					},
+				},
+			),
+			hasSameOrigin: true,
+			expectedErr:   nil,
+		},
+		"clone task porch, existing packagerevision with different source type": {
+			obj: &api.PackageRevision{
+				Spec: api.PackageRevisionSpec{
+					Tasks: []api.Task{
+						{
+							Type: api.TaskTypeClone,
+							Clone: &api.PackageCloneTaskSpec{
+								Upstream: api.UpstreamPackage{
+									UpstreamRef: &api.PackageRevisionRef{
+										Name: "foo-12345",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			existingRevs: toFakeRepoPkgRevSlice(
+				api.Task{
+					Type: api.TaskTypeClone,
+					Clone: &api.PackageCloneTaskSpec{
+						Upstream: api.UpstreamPackage{
+							Type: api.RepositoryTypeOCI,
+							Oci: &api.OciPackage{
+								Image: "gcr.io/kpt-dev/image:bar",
+							},
+						},
+					},
+				},
+			),
+			hasSameOrigin: false,
+			expectedErr:   nil,
+		},
+		"clone task porch, existing packagerevision with upstream ref to different package": {
+			obj: &api.PackageRevision{
+				Spec: api.PackageRevisionSpec{
+					Tasks: []api.Task{
+						{
+							Type: api.TaskTypeClone,
+							Clone: &api.PackageCloneTaskSpec{
+								Upstream: api.UpstreamPackage{
+									UpstreamRef: &api.PackageRevisionRef{
+										Name: "foo-12345",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			existingRevs: toFakeRepoPkgRevSlice(
+				api.Task{
+					Type: api.TaskTypeClone,
+					Clone: &api.PackageCloneTaskSpec{
+						Upstream: api.UpstreamPackage{
+							UpstreamRef: &api.PackageRevisionRef{
+								Name: "bar-12345",
+							},
+						},
+					},
+				},
+			),
+			hasSameOrigin: false,
+			expectedErr:   nil,
+		},
+		"clone task porch, existing packagerevision with upstream ref to same package": {
+			obj: &api.PackageRevision{
+				Spec: api.PackageRevisionSpec{
+					Tasks: []api.Task{
+						{
+							Type: api.TaskTypeClone,
+							Clone: &api.PackageCloneTaskSpec{
+								Upstream: api.UpstreamPackage{
+									UpstreamRef: &api.PackageRevisionRef{
+										Name: "foo-12345",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			existingRevs: toFakeRepoPkgRevSlice(
+				api.Task{
+					Type: api.TaskTypeClone,
+					Clone: &api.PackageCloneTaskSpec{
+						Upstream: api.UpstreamPackage{
+							UpstreamRef: &api.PackageRevisionRef{
+								Name: "foo-67890",
+							},
+						},
+					},
+				},
+			),
+			repoRevs: []repository.PackageRevision{
+				&fake.PackageRevision{
+					Name: "foo-12345",
+					PackageRevisionKey: repository.PackageRevisionKey{
+						Repository: "foo",
+						Package:    "pkg",
+					},
+				},
+				&fake.PackageRevision{
+					Name: "foo-67890",
+					PackageRevisionKey: repository.PackageRevisionKey{
+						Repository: "foo",
+						Package:    "pkg",
+					},
+				},
+			},
+			hasSameOrigin: true,
+			expectedErr:   nil,
+		},
+		"edit task, existing packagerevision": {
+			obj: &api.PackageRevision{
+				Spec: api.PackageRevisionSpec{
+					Tasks: []api.Task{
+						{
+							Type: api.TaskTypeEdit,
+							Edit: &api.PackageEditTaskSpec{
+								Source: &api.PackageRevisionRef{
+									Name: "foo-12345",
+								},
+							},
+						},
+					},
+				},
+			},
+			existingRevs: toFakeRepoPkgRevSlice(
+				api.Task{
+					Type: api.TaskTypeInit,
+					Init: &api.PackageInitTaskSpec{},
+				},
+			),
+			hasSameOrigin: true,
+			expectedErr:   nil,
+		},
+	}
+
+	for tn := range testCases {
+		tc := testCases[tn]
+		t.Run(tn, func(t *testing.T) {
+			ctx := context.TODO()
+			repo := &fake.Repository{
+				PackageRevisions: tc.repoRevs,
+			}
+			sameOrigin, err := ensureSameOrigin(ctx, repo, tc.obj, tc.existingRevs)
+			if tc.expectedErr != nil {
+				if err == nil {
+					t.Error("expected error, but didn't get one")
+				}
+				if err != tc.expectedErr {
+					t.Errorf("expected error %v, but got %v", tc.expectedErr, err)
+				}
+			}
+
+			if sameOrigin != tc.hasSameOrigin {
+				t.Errorf("expected sameOrigin %t, but got %t", tc.hasSameOrigin, sameOrigin)
+			}
+		})
+	}
+}
+
+func toFakeRepoPkgRevSlice(task api.Task) []repository.PackageRevision {
+	return []repository.PackageRevision{
+		&fake.PackageRevision{
+			PackageRevision: &api.PackageRevision{
+				Spec: api.PackageRevisionSpec{
+					Tasks: []api.Task{task},
+				},
+			},
+		},
+	}
+}

--- a/porch/pkg/engine/fake/repository.go
+++ b/porch/pkg/engine/fake/repository.go
@@ -30,8 +30,23 @@ type Repository struct {
 
 var _ repository.Repository = &Repository{}
 
-func (r *Repository) ListPackageRevisions(context.Context, repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error) {
-	return r.PackageRevisions, nil
+func (r *Repository) ListPackageRevisions(_ context.Context, filter repository.ListPackageRevisionFilter) ([]repository.PackageRevision, error) {
+	var revs []repository.PackageRevision
+	for _, rev := range r.PackageRevisions {
+		if filter.KubeObjectName != "" && filter.KubeObjectName == rev.KubeObjectName() {
+			revs = append(revs, rev)
+		}
+		if filter.Package != "" && filter.Package == rev.Key().Package {
+			revs = append(revs, rev)
+		}
+		if filter.Revision != "" && filter.Revision == rev.Key().Revision {
+			revs = append(revs, rev)
+		}
+		if filter.WorkspaceName != "" && filter.WorkspaceName == rev.Key().WorkspaceName {
+			revs = append(revs, rev)
+		}
+	}
+	return revs, nil
 }
 
 func (r *Repository) CreatePackageRevision(_ context.Context, pr *v1alpha1.PackageRevision) (repository.PackageDraft, error) {


### PR DESCRIPTION
This PR adds proper support for the Edit/Copy task, which provides a way for creating new revisions of a package based on another one without using the replay strategy. This is needed for any package revisions that were not created through Porch and therefore doesn't have a task list we can use for replay.

The `kpt alpha rpkg edit` command will automatically choose the `edit/copy` strategy if the source revision doesn't have a task list. It also adds a flag that allows users to force the `edit/copy` strategy rather than the replay strategy.

It also updates the rules for the same origin policy to handle the edit task.