### PR TITLE
rollouts: fixed typo in default namespace for the advance command

### DIFF
--- a/commands/alpha/rollouts/advance/advance.go
+++ b/commands/alpha/rollouts/advance/advance.go
@@ -66,7 +66,7 @@ func (r *runner) runE(cmd *cobra.Command, args []string) error {
 	waveName := args[1]
 
 	// TODO(droot): plumb the namespace value from commandline flags
-	ns := "defaut"
+	ns := "default"
 	rollout, err := rlc.Get(r.ctx, ns, rolloutName)
 	if err != nil {
 		fmt.Printf("%s\n", err)


### PR DESCRIPTION
Found a typo in the `advance` command while testing e2e flow.

Note: e2e tests will help in catching these.