### PR TITLE
porch: fix issue with package names when repo dir is specified

### DIFF
--- a/porch/pkg/git/draft.go
+++ b/porch/pkg/git/draft.go
@@ -33,8 +33,8 @@ import (
 )
 
 type gitPackageDraft struct {
-	parent        *gitRepository
-	path          string
+	parent        *gitRepository // repo is repo containing the package
+	path          string         // the path to the package from the repo root
 	revision      string
 	workspaceName v1alpha1.WorkspaceName
 	updated       time.Time

--- a/porch/pkg/git/git_test.go
+++ b/porch/pkg/git/git_test.go
@@ -1131,7 +1131,7 @@ func (g GitSuite) TestNestedDirectories(t *testing.T) {
 	}{
 		{
 			directory: "sample",
-			packages:  []string{"sample/v1", "sample/v2", "sample/" + g.branch},
+			packages:  []string{"/v1", "/v2", "/" + g.branch},
 		},
 		{
 			directory: "nonexistent",
@@ -1140,11 +1140,11 @@ func (g GitSuite) TestNestedDirectories(t *testing.T) {
 		{
 			directory: "catalog/gcp",
 			packages: []string{
-				"catalog/gcp/cloud-sql/v1",
-				"catalog/gcp/spanner/v1",
-				"catalog/gcp/bucket/v2",
-				"catalog/gcp/bucket/v1",
-				"catalog/gcp/bucket/" + g.branch,
+				"cloud-sql/v1",
+				"spanner/v1",
+				"bucket/v2",
+				"bucket/v1",
+				"bucket/" + g.branch,
 			},
 		},
 	} {

--- a/porch/test/e2e/e2e_test.go
+++ b/porch/test/e2e/e2e_test.go
@@ -169,11 +169,17 @@ func (t *PorchSuite) TestGitRepository(ctx context.Context) {
 	}
 }
 
-func (t *PorchSuite) TestGitRepositoryWithReleaseTags(ctx context.Context) {
+func (t *PorchSuite) TestGitRepositoryWithReleaseTagsAndDirectory(ctx context.Context) {
 	t.registerGitRepositoryF(ctx, kptRepo, "kpt-repo", "package-examples")
 
 	var list porchapi.PackageRevisionList
 	t.ListF(ctx, &list, client.InNamespace(t.namespace))
+
+	for _, pr := range list.Items {
+		if strings.HasPrefix(pr.Spec.PackageName, "package-examples") {
+			t.Errorf("package name %q should not include repo directory %q as prefix", pr.Spec.PackageName, "package-examples")
+		}
+	}
 }
 
 func (t *PorchSuite) TestCloneFromUpstream(ctx context.Context) {


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/kpt/issues/3870.

If a repository is registered with a directory, porch should automatically put the package in the registered directory upon creation, and omit the directory name from the package name when fetching the package revision.

