### PR TITLE
rollouts: add namespace flag to CLI commands

### DIFF
--- a/commands/alpha/alphacmd.go
+++ b/commands/alpha/alphacmd.go
@@ -55,7 +55,7 @@ func GetCommand(ctx context.Context, name, version string) *cobra.Command {
 		wasm.NewCommand(ctx, version),
 		live.GetCommand(ctx, "", version),
 		license.NewCommand(ctx, version),
-		rollouts.NewCommand(ctx),
+		rollouts.NewCommand(ctx, version),
 	)
 
 	return alpha

--- a/commands/alpha/rollouts/rolloutscmd.go
+++ b/commands/alpha/rollouts/rolloutscmd.go
@@ -20,10 +20,11 @@ import (
 	"github.com/GoogleContainerTools/kpt/commands/alpha/rollouts/advance"
 	"github.com/GoogleContainerTools/kpt/commands/alpha/rollouts/get"
 	"github.com/GoogleContainerTools/kpt/commands/alpha/rollouts/status"
+	"github.com/GoogleContainerTools/kpt/commands/util"
 	"github.com/spf13/cobra"
 )
 
-func NewCommand(ctx context.Context) *cobra.Command {
+func NewCommand(ctx context.Context, version string) *cobra.Command {
 	rolloutsCmd := &cobra.Command{
 		Use:   "rollouts",
 		Short: "rollouts",
@@ -40,10 +41,12 @@ func NewCommand(ctx context.Context) *cobra.Command {
 		},
 	}
 
+	f := util.NewFactory(rolloutsCmd, version)
+
 	rolloutsCmd.AddCommand(
-		advance.NewCommand(ctx),
-		get.NewCommand(ctx),
-		status.NewCommand(ctx),
+		advance.NewCommand(ctx, f),
+		get.NewCommand(ctx, f),
+		status.NewCommand(ctx, f),
 	)
 	return rolloutsCmd
 }


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/kpt/issues/3814

Took a look at the `kpt live` code and used the same method of adding the namespace flag via `k8scmdutil.Factory`. This makes it so that the `rollouts` commands use the default value from `kubeconfig` and also supports `-n` or `--namespace` arg. 