### PR TITLE
Release both statically linked without wasm and dynamically linked with wasm

### DIFF
--- a/internal/fnruntime/wasmtime_unsupported.go
+++ b/internal/fnruntime/wasmtime_unsupported.go
@@ -25,13 +25,17 @@ import (
 	"io"
 )
 
+const (
+	msg = "wasmtime support is not complied into this binary. Binaries with wasmtime is avilable at github.com/GoogleContainerTools/kpt"
+)
+
 type WasmtimeFn struct {
 }
 
 func NewWasmtimeFn(loader WasmLoader) (*WasmtimeFn, error) {
-	return nil, fmt.Errorf("wasmtime support is not compiled into binary (check cgo settings)")
+	return nil, fmt.Errorf(msg)
 }
 
 func (f *WasmtimeFn) Run(r io.Reader, w io.Writer) error {
-	return fmt.Errorf("wasmtime support is not compiled into binary (check cgo settings)")
+	return fmt.Errorf(msg)
 }

--- a/release/tag/goreleaser.yaml
+++ b/release/tag/goreleaser.yaml
@@ -20,48 +20,96 @@
 # steps for each targetted OS and ARCH. This is because we need to specify the
 # platform specific C std library (libc) and cross-compiler to be used.
 env:
-  - CGO_ENABLED=1
+  - CGO_ENABLED=0
   - GO111MODULE=on
 builds:
   - id: darwin-amd64
+    env:
+      - CGO_ENABLED=0
+      - GO111MODULE=on
     goos:
       - darwin
     goarch:
       - amd64
-    env:
-      - CC=o64-clang
-      - CXX=o64-clang++
     ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}}
 
   - id: darwin-arm64
+    env:
+      - CGO_ENABLED=0
+      - GO111MODULE=on
     goos:
       - darwin
     goarch:
       - arm64
-    env:
-      - CC=oa64-clang
-      - CXX=oa64-clang++
     ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}}
 
   - id: linux-amd64
+    env:
+      - CGO_ENABLED=0
+      - GO111MODULE=on
     goos:
       - linux
     goarch:
       - amd64
-    env:
-      - CC=x86_64-linux-gnu-gcc
-      - CXX=x86_64-linux-gnu-g++
-    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}} -linkmode external -extldflags "-static -z noexecstack"
+    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}} -extldflags "-z noexecstack"
 
   - id: linux-arm64
+    env:
+      - CGO_ENABLED=0
+      - GO111MODULE=on
     goos:
       - linux
     goarch:
       - arm64
+    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}} -extldflags "-z noexecstack"
+
+  - id: darwin-amd64-wasm
     env:
+      - CGO_ENABLED=1
+      - GO111MODULE=on
+      - CC=o64-clang
+      - CXX=o64-clang++
+    goos:
+      - darwin
+    goarch:
+      - amd64
+    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}}
+
+  - id: darwin-arm64-wasm
+    env:
+      - CGO_ENABLED=1
+      - GO111MODULE=on
+      - CC=oa64-clang
+      - CXX=oa64-clang++
+    goos:
+      - darwin
+    goarch:
+      - arm64
+    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}}
+
+  - id: linux-amd64-wasm
+    env:
+      - CGO_ENABLED=1
+      - GO111MODULE=on
+      - CC=x86_64-linux-gnu-gcc
+      - CXX=x86_64-linux-gnu-g++
+    goos:
+      - linux
+    goarch:
+      - amd64
+    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}} -extldflags "-z noexecstack"
+
+  - id: linux-arm64-wasm
+    env:
+      - CGO_ENABLED=1
+      - GO111MODULE=on
       - CC=aarch64-linux-gnu-gcc
       - CXX=aarch64-linux-gnu-g++
-    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}} -linkmode external -extldflags "-static -z noexecstack"
+    goos:
+      - linux
+    goarch:
+      - arm64
+    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}} -extldflags "-z noexecstack"
 
 dockers:
   - ids:
@@ -85,6 +133,16 @@ archives:
       - LICENSES*
       - lib.zip*
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}-{{ .Version }}"
+  - id: archived-wasm
+    builds:
+      - darwin-amd64-wasm
+      - darwin-arm64-wasm
+      - linux-amd64-wasm
+      - linux-arm64-wasm
+    files:
+      - LICENSES*
+      - lib.zip*
+    name_template: "{{ .ProjectName }}_wasm_{{ .Os }}_{{ .Arch }}-{{ .Version }}"
   - id: bin-only
     format: binary
     builds:
@@ -93,6 +151,14 @@ archives:
       - linux-amd64
       - linux-arm64
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
+  - id: bin-only-wasm
+    format: binary
+    builds:
+      - darwin-amd64-wasm
+      - darwin-arm64-wasm
+      - linux-amd64-wasm
+      - linux-arm64-wasm
+    name_template: "{{ .ProjectName }}_wasm_{{ .Os }}_{{ .Arch }}"
 checksum:
   name_template: "checksums.txt"
 snapshot:


### PR DESCRIPTION
Fully functional statically linked binaries with WASM support doesn't seem to be possible, so for now we should just remove WASM support in the regular kpt releases. If there is sufficient demand, we can create dynamically linked binaries of kpt with WASM support for the most common Unix variants.
More details in https://github.com/GoogleContainerTools/kpt/issues/3892#issuecomment-1480545451

Fixes: https://github.com/GoogleContainerTools/kpt/issues/3892