### PR TITLE
rollouts: add unit test and fake client for simple reconcileRollouts case

### DIFF
--- a/rollouts/controllers/fakeclient.go
+++ b/rollouts/controllers/fakeclient.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2022.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	gitopsv1alpha1 "github.com/GoogleContainerTools/kpt/rollouts/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ client.Client = &fakeRolloutsClient{}
+
+type fakeRolloutsClient struct {
+	client.Client
+
+	remotesyncs []gitopsv1alpha1.RemoteSync
+	actions     []string
+}
+
+func (fc *fakeRolloutsClient) Create(ctx context.Context, obj client.Object, _ ...client.CreateOption) error {
+	fc.actions = append(fc.actions, fmt.Sprintf("creating object named %q", obj.GetName()))
+
+	if err := fc.Get(ctx, types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}, obj); err == nil {
+		// object already exists
+		return fmt.Errorf("object %q already exists", obj.GetName())
+	}
+	fc.remotesyncs = append(fc.remotesyncs, *obj.(*gitopsv1alpha1.RemoteSync))
+
+	return nil
+}
+
+func (fc *fakeRolloutsClient) Delete(_ context.Context, obj client.Object, _ ...client.DeleteOption) error {
+	fc.actions = append(fc.actions, fmt.Sprintf("deleting object named %q", obj.GetName()))
+
+	var newRemoteSyncs []gitopsv1alpha1.RemoteSync
+	for _, rs := range fc.remotesyncs {
+		if obj.GetName() == rs.GetName() && obj.GetNamespace() == rs.GetNamespace() {
+			continue
+		}
+		newRemoteSyncs = append(newRemoteSyncs, rs)
+	}
+	fc.remotesyncs = newRemoteSyncs
+
+	return nil
+}
+
+func (fc *fakeRolloutsClient) Update(_ context.Context, obj client.Object, _ ...client.UpdateOption) error {
+	fc.actions = append(fc.actions, fmt.Sprintf("updating object named %q", obj.GetName()))
+
+	for i, rs := range fc.remotesyncs {
+		if obj.GetName() == rs.GetName() && obj.GetNamespace() == rs.GetNamespace() {
+			continue
+		}
+		fc.remotesyncs[i] = *obj.(*gitopsv1alpha1.RemoteSync)
+	}
+
+	return nil
+}
+
+func (fc *fakeRolloutsClient) List(_ context.Context, obj client.ObjectList, _ ...client.ListOption) error {
+	fc.actions = append(fc.actions, fmt.Sprintf("listing objects"))
+
+	*obj.(*gitopsv1alpha1.RemoteSyncList) = gitopsv1alpha1.RemoteSyncList{Items: fc.remotesyncs}
+
+	return nil
+}
+
+func (fc *fakeRolloutsClient) Get(_ context.Context, namespacedname types.NamespacedName, obj client.Object, _ ...client.GetOption) error {
+	fc.actions = append(fc.actions, fmt.Sprintf("getting object of name %q", namespacedname.Name))
+
+	for _, rs := range fc.remotesyncs {
+		if rs.GetName() == namespacedname.Name && namespacedname.Namespace == rs.GetNamespace() {
+			*obj.(*gitopsv1alpha1.RemoteSync) = rs
+			return nil
+		}
+	}
+
+	return &errors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}
+}
+
+func (fc *fakeRolloutsClient) setSyncStatus(name string, namespace string, syncStatus string) error {
+	for i, rs := range fc.remotesyncs {
+		if rs.GetName() == name && namespace == rs.GetNamespace() {
+			rs.Status.SyncStatus = syncStatus
+			fc.remotesyncs[i] = rs
+			return nil
+		}
+	}
+	return &errors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}
+}

--- a/rollouts/controllers/rollout_controller.go
+++ b/rollouts/controllers/rollout_controller.go
@@ -172,7 +172,6 @@ func (r *RolloutReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	sortClusterStatuses(allClusterStatuses)
 	if err := r.updateStatus(ctx, &rollout, waveStatuses, allClusterStatuses); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -360,6 +359,8 @@ func (r *RolloutReconciler) reconcileRollout(ctx context.Context, rollout *gitop
 			afterPauseAfterWave = true
 		}
 	}
+
+	sortClusterStatuses(allClusterStatuses)
 
 	return allClusterStatuses, waveStatuses, nil
 }

--- a/rollouts/controllers/rollout_controller_test.go
+++ b/rollouts/controllers/rollout_controller_test.go
@@ -434,7 +434,7 @@ func TestReconcileRollout(t *testing.T) {
 			},
 		}
 
-		fc := &fakeRolloutsClient{}
+		fc := newFakeRemoteSyncClient()
 		reconciler := (&RolloutReconciler{Client: fc})
 
 		strategy, err := reconciler.getStrategy(context.Background(), rollout)
@@ -448,13 +448,14 @@ func TestReconcileRollout(t *testing.T) {
 			targetClusters,
 			[]packagediscovery.DiscoveredPackage{discoveredPackage},
 		)
+
 		require.NoError(t, err)
 		require.Equal(t, []string{
 			"listing objects",
-			"getting object of name \"github-0-dir-0\"",
-			"getting object of name \"github-0-dir-1\"",
+			"getting object named \"github-0-dir-0\"",
+			"getting object named \"github-0-dir-1\"",
 			"creating object named \"github-0-dir-0\"",
-			"getting object of name \"github-0-dir-0\"",
+			"getting object named \"github-0-dir-0\"",
 		}, fc.actions)
 		require.Equal(t, 1, len(fc.remotesyncs))
 		require.Equal(t, []gitopsv1alpha1.WaveStatus{
@@ -485,7 +486,7 @@ func TestReconcileRollout(t *testing.T) {
 
 		// reset actions and set sync status of remote sync to "synced"
 		fc.actions = nil
-		fc.setSyncStatus("github-0-dir-0", "", "Synced")
+		require.NoError(t, fc.setSyncStatus(types.NamespacedName{Name: "github-0-dir-0", Namespace: ""}, "Synced"))
 
 		// second call to reconcileRollout - the second cluster should now progress
 		_, waveStatus, err = reconciler.reconcileRollout(
@@ -499,10 +500,10 @@ func TestReconcileRollout(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, []string{
 			"listing objects",
-			"getting object of name \"github-0-dir-0\"",
-			"getting object of name \"github-0-dir-1\"",
+			"getting object named \"github-0-dir-0\"",
+			"getting object named \"github-0-dir-1\"",
 			"creating object named \"github-0-dir-1\"",
-			"getting object of name \"github-0-dir-1\"",
+			"getting object named \"github-0-dir-1\"",
 		}, fc.actions)
 		require.Equal(t, 2, len(fc.remotesyncs))
 		require.Equal(t, []gitopsv1alpha1.WaveStatus{

--- a/rollouts/go.mod
+++ b/rollouts/go.mod
@@ -14,8 +14,10 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/xanzy/go-gitlab v0.80.2
 	golang.org/x/oauth2 v0.3.0
+	golang.org/x/sync v0.1.0
 	google.golang.org/api v0.103.0
 	google.golang.org/genproto v0.0.0-20221201164419-0e50fba7f41c
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.25.3
 	k8s.io/apimachinery v0.25.4
 	k8s.io/client-go v0.25.3
@@ -89,7 +91,6 @@ require (
 	google.golang.org/grpc v1.50.1 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.25.3 // indirect
 	k8s.io/component-base v0.25.3 // indirect

--- a/rollouts/go.sum
+++ b/rollouts/go.sum
@@ -462,6 +462,8 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
This PR adds a unit test for a simple case for `reconcileRollouts`. To support the unit test, this PR adds a fake client and refactors a few things out of `reconcileRollout`. I'd like to add the remaining unit tests in a followup, so that the review here can focus on structure of the test, fake client code, and refactoring, and the followup PR can focus on code coverage.

I looked at using https://github.com/golang/mock for the fake client, but felt that this fake client is simple enough that another framework wasn't needed. Happy to revisit this idea though.

Related issue: https://github.com/GoogleContainerTools/kpt/issues/3856