### PR TITLE
allows rollouts controller to read secrets

### DIFF
--- a/rollouts/config/rbac/role.yaml
+++ b/rollouts/config/rbac/role.yaml
@@ -28,6 +28,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - container.cnrm.cloud.google.com
   resources:
   - containerclusters

--- a/rollouts/controllers/rollout_controller.go
+++ b/rollouts/controllers/rollout_controller.go
@@ -82,6 +82,7 @@ type RolloutReconciler struct {
 }
 
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=container.cnrm.cloud.google.com,resources=containerclusters,verbs=get;list;watch
 //+kubebuilder:rbac:groups=gitops.kpt.dev,resources=rollouts,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=gitops.kpt.dev,resources=rollouts/status,verbs=get;update;patch

--- a/rollouts/manifests/controller/controller.yaml
+++ b/rollouts/manifests/controller/controller.yaml
@@ -92,6 +92,22 @@ metadata:
   name: rollouts-manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - container.cnrm.cloud.google.com
   resources:
   - containerclusters
@@ -375,6 +391,7 @@ spec:
         command:
         - /manager
         image: gcr.io/kpt-dev/rollouts-controller:v0.0.2
+        imagePullPolicy: Always
         livenessProbe:
           httpGet:
             path: /healthz

--- a/rollouts/manifests/crds/crds.yaml
+++ b/rollouts/manifests/crds/crds.yaml
@@ -148,10 +148,19 @@ spec:
               clusterRef:
                 description: ClusterReference contains the identify information need to refer a cluster.
                 properties:
+                  apiVersion:
+                    type: string
+                  kind:
+                    type: string
                   name:
                     type: string
+                  namespace:
+                    type: string
                 required:
+                - apiVersion
+                - kind
                 - name
+                - namespace
                 type: object
               template:
                 properties:
@@ -321,10 +330,18 @@ spec:
                     required:
                     - projectIds
                     type: object
+                  kind:
+                    description: ClusterSourceKind contains configuration needed to discover kind clusters.
+                    properties:
+                      namespace:
+                        description: Namespace where configmaps corresponding to kind clusters live defaults to `kind-clusters`
+                        type: string
+                    type: object
                   sourceType:
                     enum:
                     - KCC
                     - GCPFleet
+                    - Kind
                     type: string
                 required:
                 - sourceType


### PR DESCRIPTION
Rollouts controller needs permissions to read secrets for discovering packages. This PR configures the cluster-role to enable that.

The PR also includes changes in the CRD for rollouts because we probably didn't run `make manifests` after our recent changes.