### PR TITLE
porch CLI: error instead of panic when the upstreamLock is not parseable

### DIFF
--- a/e2e/testdata/porch/rpkg-update/config.yaml
+++ b/e2e/testdata/porch/rpkg-update/config.yaml
@@ -111,3 +111,56 @@ commands:
       git-3f036055f7ba68706372cbe0c4b14d553794f7c4                         No update available
       git-7fcdd499f0790ac3bd8f805e3e5e00825641eb60                         No update available
       git-7ab0219ace10c1081a8b40a6b97d5da58bdb62e0   git                   No update available
+  - args:
+      - alpha
+      - rpkg
+      - push
+      - --namespace=rpkg-update
+      - git-7ab0219ace10c1081a8b40a6b97d5da58bdb62e0
+    stdin: |
+      apiVersion: config.kubernetes.io/v1
+      kind: ResourceList
+      items:
+      - apiVersion: kpt.dev/v1
+        kind: Kptfile
+        metadata:
+          name: basens-edit-clone
+          annotations:
+            config.kubernetes.io/index: '0'
+            config.kubernetes.io/local-config: "true"
+            config.kubernetes.io/path: Kptfile
+            internal.config.kubernetes.io/index: '0'
+            internal.config.kubernetes.io/path: 'Kptfile'
+        upstream:
+          type: git
+          git:
+            repo: http://git-server.test-git-namespace.svc.cluster.local:8080/rpkg-update
+            directory: base-ns
+            ref: basens/v1
+        upstreamLock:
+          type: git
+          git:
+            repo: http://git-server.test-git-namespace.svc.cluster.local:8080/rpkg-update
+            directory: base-ns
+            ref: invalid
+            commit: 8f3ee9e0d5724fbd0fbdcf81bef0d47d6d29cc64
+      - apiVersion: v1
+        data:
+          name: example
+        kind: ConfigMap
+        metadata:
+          annotations:
+            config.kubernetes.io/index: "0"
+            config.kubernetes.io/local-config: "true"
+            config.kubernetes.io/path: package-context.yaml
+            internal.config.kubernetes.io/index: "0"
+            internal.config.kubernetes.io/path: package-context.yaml
+          name: kptfile.kpt.dev
+  - args:
+      - alpha
+      - rpkg
+      - update
+      - --namespace=rpkg-update
+      - --discover=upstream
+    stderr: "Error: could not parse upstreamLock in Kptfile of package \"git-7ab0219ace10c1081a8b40a6b97d5da58bdb62e0\": malformed upstreamLock.Git.Ref \"invalid\" \n"
+    exitCode: 1


### PR DESCRIPTION
Throws an error instead of panicking in cases like https://github.com/GoogleContainerTools/kpt/issues/3933.

Sample output: 

```
$ kpt alpha rpkg update --discover=downstream
Error: could not parse upstreamLock in Kptfile of package "blueprints-8c50f85abaa5d22110b7c826bcb77f8f33d39dbb": malformed upstreamLock.Git.Ref "v2"
```

When using porch CLI, the upstreamLock.Git.Ref should be in the format of either `drafts/pkgname/workspace` or `pkgname/version`. So we theoretically shouldn't run into any cases where there is no `/` in upstreamLock.Git.Ref unless someone makes a change through something other than porch CLI. In these cases, we should throw an error that we are unable to parse the upstreamLock rather than panicking. 
