### PR TITLE
PackageVariantSet: Update status for all reconcile errors

### DIFF
--- a/porch/controllers/packagevariantsets/pkg/controllers/packagevariantset/packagevariantset_controller.go
+++ b/porch/controllers/packagevariantsets/pkg/controllers/packagevariantset/packagevariantset_controller.go
@@ -108,7 +108,8 @@ func (r *PackageVariantSetReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			setStalledConditionsToTrue(pvs, "NoMatchingTargets", err.Error())
 			return ctrl.Result{}, nil
 		}
-		return ctrl.Result{}, err
+		setStalledConditionsToTrue(pvs, "UnexpectedError", err.Error())
+		return ctrl.Result{}, nil
 	}
 
 	meta.SetStatusCondition(&pvs.Status.Conditions, metav1.Condition{
@@ -120,7 +121,8 @@ func (r *PackageVariantSetReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	err = r.ensurePackageVariants(ctx, pvs, repoList, upstreamPR, downstreams)
 	if err != nil {
-		return ctrl.Result{}, err
+		setStalledConditionsToTrue(pvs, "UnexpectedError", err.Error())
+		return ctrl.Result{}, nil
 	}
 
 	meta.SetStatusCondition(&pvs.Status.Conditions, metav1.Condition{


### PR DESCRIPTION
While testing, I noticed that errors were not always properly propagating to the PVS status. In particular, an error in an expression could only be found in the logs.