### PR TITLE
fix: cache directory name too long on windows

### DIFF
--- a/internal/gitutil/gitutil.go
+++ b/internal/gitutil/gitutil.go
@@ -27,6 +27,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strings"
 	"time"
 

--- a/internal/gitutil/gitutil.go
+++ b/internal/gitutil/gitutil.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/md5"
+	"encoding/base32"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -323,11 +324,14 @@ func (gur *GitUpstreamRepo) ResolveRef(ref string) (string, bool) {
 }
 
 // getRepoDir returns the cache directory name for a remote repo
-// This takes the md5 hash of the repo uri and then hex encodes it to make
-// sure it doesn't contain characters that isn't legal in directory names.
+// This takes the md5 hash of the repo uri and then base32 (or hex for Windows to shorten dir)
+// encodes it to make sure it doesn't contain characters that isn't legal in directory names.
 func (gur *GitUpstreamRepo) getRepoDir(uri string) string {
-	var hash = md5.Sum([]byte(uri))
-	return strings.ToLower(hex.EncodeToString(hash[:]))
+	if runtime.GOOS == "windows" {
+		var hash = md5.Sum([]byte(uri))
+		return strings.ToLower(hex.EncodeToString(hash[:]))	
+	}
+	return strings.ToLower(base32.StdEncoding.EncodeToString(md5.New().Sum([]byte(uri))))
 }
 
 // getRepoCacheDir

--- a/internal/gitutil/gitutil.go
+++ b/internal/gitutil/gitutil.go
@@ -19,7 +19,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/md5"
-	"encoding/base32"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -323,10 +323,11 @@ func (gur *GitUpstreamRepo) ResolveRef(ref string) (string, bool) {
 }
 
 // getRepoDir returns the cache directory name for a remote repo
-// This takes the md5 hash of the repo uri and then base32 encodes it to make
+// This takes the md5 hash of the repo uri and then hex encodes it to make
 // sure it doesn't contain characters that isn't legal in directory names.
 func (gur *GitUpstreamRepo) getRepoDir(uri string) string {
-	return strings.ToLower(base32.StdEncoding.EncodeToString(md5.New().Sum([]byte(uri))))
+	var hash = md5.Sum([]byte(uri))
+	return strings.ToLower(hex.EncodeToString(hash[:]))
 }
 
 // getRepoCacheDir


### PR DESCRIPTION
New implementation allows to use kpt on windows without getting "Name too long" since the previous implementation would generate very long directory names.