### PR TITLE
Fix incorrect error return

### DIFF
--- a/porch/controllers/packagevariants/pkg/controllers/packagevariant/packagevariant_controller.go
+++ b/porch/controllers/packagevariants/pkg/controllers/packagevariant/packagevariant_controller.go
@@ -949,7 +949,7 @@ func isPackageVariantFunc(fn *fn.SubObject, pvName string) (bool, error) {
 		return false, fmt.Errorf("could not retrieve field name: %w", err)
 	}
 	if !ok {
-		return false, fmt.Errorf("could not find field name in supplied func")
+		return false, nil
 	}
 
 	name := strings.Split(origname, ".")


### PR DESCRIPTION
The new pipeline editing feature of PackageVariant is failing if an existing function does not have a name specified. This is not an error condition, and so this fixes that.