### PR TITLE
update licensedb for new versions of deps

### DIFF
--- a/tools/licensescan/modules/cloud.google.com/go/compute/metadata/v0.2.3.yaml
+++ b/tools/licensescan/modules/cloud.google.com/go/compute/metadata/v0.2.3.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/cloud.google.com/go/compute/metadata@v0.2.3
+license: Apache-2.0

--- a/tools/licensescan/modules/github.com/containerd/stargz-snapshotter/estargz/v0.14.3.yaml
+++ b/tools/licensescan/modules/github.com/containerd/stargz-snapshotter/estargz/v0.14.3.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/containerd/stargz-snapshotter/estargz@v0.14.3
+license: Apache-2.0

--- a/tools/licensescan/modules/github.com/docker/cli/v23.0.1+incompatible.yaml
+++ b/tools/licensescan/modules/github.com/docker/cli/v23.0.1+incompatible.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/docker/cli@v23.0.1+incompatible
+license: Apache-2.0

--- a/tools/licensescan/modules/github.com/docker/distribution/v2.8.2+incompatible.yaml
+++ b/tools/licensescan/modules/github.com/docker/distribution/v2.8.2+incompatible.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/docker/distribution@v2.8.2+incompatible
+license: Apache-2.0

--- a/tools/licensescan/modules/github.com/docker/docker-credential-helpers/v0.7.0.yaml
+++ b/tools/licensescan/modules/github.com/docker/docker-credential-helpers/v0.7.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/docker/docker-credential-helpers@v0.7.0
+license: MIT

--- a/tools/licensescan/modules/github.com/docker/docker/v23.0.6+incompatible.yaml
+++ b/tools/licensescan/modules/github.com/docker/docker/v23.0.6+incompatible.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/docker/docker@v23.0.6+incompatible
+license: Apache-2.0

--- a/tools/licensescan/modules/github.com/go-openapi/jsonpointer/v0.19.6.yaml
+++ b/tools/licensescan/modules/github.com/go-openapi/jsonpointer/v0.19.6.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/go-openapi/jsonpointer@v0.19.6
+license: Apache-2.0

--- a/tools/licensescan/modules/github.com/go-openapi/jsonreference/v0.20.1.yaml
+++ b/tools/licensescan/modules/github.com/go-openapi/jsonreference/v0.20.1.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/go-openapi/jsonreference@v0.20.1
+license: Apache-2.0

--- a/tools/licensescan/modules/github.com/go-openapi/swag/v0.22.3.yaml
+++ b/tools/licensescan/modules/github.com/go-openapi/swag/v0.22.3.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/go-openapi/swag@v0.22.3
+license: Apache-2.0

--- a/tools/licensescan/modules/github.com/golang/protobuf/v1.5.3.yaml
+++ b/tools/licensescan/modules/github.com/golang/protobuf/v1.5.3.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/golang/protobuf@v1.5.3
+license: BSD-3-Clause

--- a/tools/licensescan/modules/github.com/google/go-containerregistry/v0.14.0.yaml
+++ b/tools/licensescan/modules/github.com/google/go-containerregistry/v0.14.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/google/go-containerregistry@v0.14.0
+license: Apache-2.0

--- a/tools/licensescan/modules/github.com/klauspost/compress/v1.16.0.yaml
+++ b/tools/licensescan/modules/github.com/klauspost/compress/v1.16.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/klauspost/compress@v1.16.0
+license: Apache-2.0, BSD-3-Clause, MIT

--- a/tools/licensescan/modules/github.com/opencontainers/image-spec/v1.1.0-rc2.yaml
+++ b/tools/licensescan/modules/github.com/opencontainers/image-spec/v1.1.0-rc2.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/github.com/opencontainers/image-spec@v1.1.0-rc2
+license: Apache-2.0

--- a/tools/licensescan/modules/golang.org/x/mod/v0.9.0.yaml
+++ b/tools/licensescan/modules/golang.org/x/mod/v0.9.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/golang.org/x/mod@v0.9.0
+license: BSD-3-Clause

--- a/tools/licensescan/modules/golang.org/x/net/v0.8.0.yaml
+++ b/tools/licensescan/modules/golang.org/x/net/v0.8.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/golang.org/x/net@v0.8.0
+license: BSD-3-Clause

--- a/tools/licensescan/modules/golang.org/x/oauth2/v0.6.0.yaml
+++ b/tools/licensescan/modules/golang.org/x/oauth2/v0.6.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/golang.org/x/oauth2@v0.6.0
+license: BSD-3-Clause

--- a/tools/licensescan/modules/golang.org/x/sys/v0.6.0.yaml
+++ b/tools/licensescan/modules/golang.org/x/sys/v0.6.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/golang.org/x/sys@v0.6.0
+license: BSD-3-Clause

--- a/tools/licensescan/modules/golang.org/x/term/v0.6.0.yaml
+++ b/tools/licensescan/modules/golang.org/x/term/v0.6.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/golang.org/x/term@v0.6.0
+license: BSD-3-Clause

--- a/tools/licensescan/modules/golang.org/x/text/v0.8.0.yaml
+++ b/tools/licensescan/modules/golang.org/x/text/v0.8.0.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/golang.org/x/text@v0.8.0
+license: BSD-3-Clause

--- a/tools/licensescan/modules/google.golang.org/protobuf/v1.29.1.yaml
+++ b/tools/licensescan/modules/google.golang.org/protobuf/v1.29.1.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/google.golang.org/protobuf@v1.29.1
+license: BSD-3-Clause

--- a/tools/licensescan/modules/k8s.io/klog/v2/v2.90.1.yaml
+++ b/tools/licensescan/modules/k8s.io/klog/v2/v2.90.1.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/k8s.io/klog/v2@v2.90.1
+license: Apache-2.0

--- a/tools/licensescan/modules/k8s.io/kube-openapi/v0.0.0-20230109183929-3758b55a6596.yaml
+++ b/tools/licensescan/modules/k8s.io/kube-openapi/v0.0.0-20230109183929-3758b55a6596.yaml
@@ -1,0 +1,2 @@
+# https://pkg.go.dev/k8s.io/kube-openapi@v0.0.0-20230109183929-3758b55a6596
+license: Apache-2.0


### PR DESCRIPTION
The PR updates the license info for newer versions of dependencies.

Note: checking what's going with some newlines.
