### PR TITLE
Make sure all access to deletionProposedCache is protected

### DIFF
--- a/porch/pkg/cache/repository.go
+++ b/porch/pkg/cache/repository.go
@@ -152,7 +152,7 @@ func (r *cachedRepository) getCachedPackages(ctx context.Context, forceRefresh b
 		if gitRepo, isGitRepo := r.repo.(git.GitRepository); isGitRepo {
 			// TODO: Figure out a way to do this without the cache layer
 			//  needing to know what type of repo we are working with.
-			if err := gitRepo.UpdateDeletionProposedCache(); err != nil {
+			if err := gitRepo.UpdateDeletionProposedCache(forceRefresh); err != nil {
 				return nil, nil, err
 			}
 		}


### PR DESCRIPTION
The deletionProposedCache is part of the gitRepository, but there were some places where it was accessed without holding the lock.
In general, we should split up the repository vs package objects into separate go packages so it is easier to enforce access to these objects only through the public functions that make sure any access happens while holding the locks.

Fixes: https://github.com/GoogleContainerTools/kpt/issues/3967