### PR TITLE
Fix issue with unprotected concurrent access to gitRepository state

### DIFF
--- a/porch/pkg/git/package.go
+++ b/porch/pkg/git/package.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"crypto/sha1"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -28,7 +27,6 @@ import (
 	kptfile "github.com/GoogleContainerTools/kpt/pkg/api/kptfile/v1"
 	"github.com/GoogleContainerTools/kpt/porch/api/porch/v1alpha1"
 	"github.com/GoogleContainerTools/kpt/porch/pkg/repository"
-	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -276,70 +274,11 @@ func (p *gitPackageRevision) GetLock() (kptfile.Upstream, kptfile.UpstreamLock, 
 }
 
 func (p *gitPackageRevision) Lifecycle() v1alpha1.PackageRevisionLifecycle {
-	switch ref := p.ref; {
-	case ref == nil:
-		return p.checkPublishedLifecycle()
-	case isDraftBranchNameInLocal(ref.Name()):
-		return v1alpha1.PackageRevisionLifecycleDraft
-	case isProposedBranchNameInLocal(ref.Name()):
-		return v1alpha1.PackageRevisionLifecycleProposed
-	default:
-		return p.checkPublishedLifecycle()
-	}
-
-}
-
-func (p *gitPackageRevision) checkPublishedLifecycle() v1alpha1.PackageRevisionLifecycle {
-	if p.repo.deletionProposedCache == nil {
-		if err := p.repo.UpdateDeletionProposedCache(); err != nil {
-			klog.Errorf("failed to update deletionProposed cache: %v", err)
-			return v1alpha1.PackageRevisionLifecyclePublished
-		}
-	}
-
-	branchName := createDeletionProposedName(p.path, p.revision)
-	if _, found := p.repo.deletionProposedCache[branchName]; found {
-		return v1alpha1.PackageRevisionLifecycleDeletionProposed
-	}
-
-	return v1alpha1.PackageRevisionLifecyclePublished
+	return p.repo.GetLifecycle(context.Background(), p)
 }
 
 func (p *gitPackageRevision) UpdateLifecycle(ctx context.Context, new v1alpha1.PackageRevisionLifecycle) error {
-	old := p.Lifecycle()
-	if !v1alpha1.LifecycleIsPublished(old) {
-		return fmt.Errorf("cannot update lifecycle for draft package revision")
-	}
-	refSpecs := newPushRefSpecBuilder()
-	deletionProposedBranch := createDeletionProposedName(p.path, p.revision)
-
-	if old == v1alpha1.PackageRevisionLifecyclePublished {
-		if new != v1alpha1.PackageRevisionLifecycleDeletionProposed {
-			return fmt.Errorf("invalid new lifecycle value: %q", new)
-		}
-
-		// Push the package revision into a deletionProposed branch.
-		p.repo.deletionProposedCache[deletionProposedBranch] = true
-		refSpecs.AddRefToPush(p.commit, deletionProposedBranch.RefInLocal())
-	}
-	if old == v1alpha1.PackageRevisionLifecycleDeletionProposed {
-		if new != v1alpha1.PackageRevisionLifecyclePublished {
-			return fmt.Errorf("invalid new lifecycle value: %q", new)
-		}
-
-		// Delete the deletionProposed branch
-		delete(p.repo.deletionProposedCache, deletionProposedBranch)
-		ref := plumbing.NewHashReference(deletionProposedBranch.RefInLocal(), p.commit)
-		refSpecs.AddRefToDelete(ref)
-	}
-
-	if err := p.repo.PushAndCleanup(ctx, refSpecs); err != nil {
-		if !errors.Is(err, git.NoErrAlreadyUpToDate) {
-			return err
-		}
-	}
-
-	return nil
+	return p.repo.UpdateLifecycle(ctx, p, new)
 }
 
 // TODO: Define a type `gitPackage` to implement the Repository.Package interface

--- a/porch/pkg/oci/mutate.go
+++ b/porch/pkg/oci/mutate.go
@@ -231,7 +231,16 @@ func (p *ociPackageDraft) Close(ctx context.Context) (repository.PackageRevision
 				revisions, err := r.ListPackageRevisions(ctx, repository.ListPackageRevisionFilter{
 					Package: p.packageName,
 				})
-				nextRevisionNumber, err := repository.NextRevisionNumber(revisions)
+				if err != nil {
+					return nil, err
+				}
+				var revs []string
+				for _, rev := range revisions {
+					if api.LifecycleIsPublished(rev.Lifecycle()) {
+						revs = append(revs, rev.Key().Revision)
+					}
+				}
+				nextRevisionNumber, err := repository.NextRevisionNumber(revs)
 				if err != nil {
 					return nil, err
 				}

--- a/porch/pkg/repository/util.go
+++ b/porch/pkg/repository/util.go
@@ -66,21 +66,14 @@ func toApiConditionStatus(s kptfile.ConditionStatus) api.ConditionStatus {
 	}
 }
 
-func NextRevisionNumber(revs []PackageRevision) (string, error) {
+func NextRevisionNumber(revs []string) (string, error) {
 	// Computes the next revision number as the latest revision number + 1.
 	// This function only understands strict versioning format, e.g. v1, v2, etc. It will
 	// ignore all revision numbers it finds that do not adhere to this format.
 	// If there are no published revisions (in the recognized format), the revision
 	// number returned here will be "v1".
 	latestRev := "v0"
-	for _, current := range revs {
-		// Check if the current package revision is more recent than the one seen so far.
-		// Only consider Published packages
-		if !v1alpha1.LifecycleIsPublished(current.Lifecycle()) {
-			continue
-		}
-
-		currentRev := current.Key().Revision
+	for _, currentRev := range revs {
 		if !semver.IsValid(currentRev) {
 			// ignore this revision
 			continue


### PR DESCRIPTION
This is a replacement for https://github.com/GoogleContainerTools/kpt/pull/3983. It moves the logic for fetching and updating the lifecycle of a PackageRevision from the `gitPackageRevision` object to the `gitRepository` object, as it involves manipulating the state of the `gitRepository`.

To make sure all access to the shared state is protected by the `gitRepository` mutex and no calls tries to take the lock twice, all calls from `gitRepository` will call versions of the functions that expects that the caller already has the lock, while calls from elsewhere call the versions of the functions that takes the lock.
