### PR TITLE
Docs: listed kubectl as a pre-requisite

### DIFF
--- a/porch/docs/running-locally.md
+++ b/porch/docs/running-locally.md
@@ -10,6 +10,7 @@ To run Porch locally, you will need:
 * [go 1.20](https://go.dev/dl/) or newer
 * [docker](https://docs.docker.com/get-docker/)
 * [git](https://git-scm.com/)
+* [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/)
 * `make`
 
 ## Getting Started


### PR DESCRIPTION
This PR updates the document to list kubectl as a pre-requisite that needs to be installed in addition to the other pre-requisites listed.

Fixes #3987