### PR TITLE
render: allows functions to access network during pipeline execution

### DIFF
--- a/commands/fn/render/cmdrender.go
+++ b/commands/fn/render/cmdrender.go
@@ -59,6 +59,8 @@ func NewRunner(ctx context.Context, parent string) *Runner {
 
 	c.Flags().BoolVar(&r.RunnerOptions.AllowExec, "allow-exec", r.RunnerOptions.AllowExec,
 		"allow binary executable to be run during pipeline execution.")
+	c.Flags().BoolVar(
+		&r.RunnerOptions.AllowNetwork, "allow-network", false, "allow functions to access network during pipeline execution.")
 	c.Flags().BoolVar(&r.RunnerOptions.AllowWasm, "allow-alpha-wasm", r.RunnerOptions.AllowWasm,
 		"allow wasm to be used during pipeline execution.")
 	cmdutil.FixDocs("kpt", parent, c)

--- a/e2e/testdata/fn-render/basicpipeline/.expected/config.yaml
+++ b/e2e/testdata/fn-render/basicpipeline/.expected/config.yaml
@@ -1,0 +1,15 @@
+# Copyright 2023 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+allowNetwork: true

--- a/internal/fnruntime/runner.go
+++ b/internal/fnruntime/runner.go
@@ -61,6 +61,12 @@ type RunnerOptions struct {
 	// privileged operation, so explicit permission is required.
 	AllowExec bool
 
+	// AllowNetwork specifies if containered functions are allowed
+	// to access network during pipeline execution. Accessing network is
+	// considered a privileged operation (and makes render operation non-hermetic),
+	// so explicit permission is desired.
+	AllowNetwork bool
+
 	// allowWasm determines if function wasm are allowed to be run during pipeline
 	// execution. Running wasm function is an alpha feature, so it needs to be
 	// enabled explicitly.
@@ -143,8 +149,14 @@ func NewRunner(
 					cfn := &ContainerFn{
 						Image:           f.Image,
 						ImagePullPolicy: opts.ImagePullPolicy,
-						Ctx:             ctx,
-						FnResult:        fnResult,
+						Perm: ContainerFnPermission{
+							AllowNetwork: opts.AllowNetwork,
+							// mounts are disabled for render operations (currently)
+							// but it may change in the future.
+							// AllowMount: true,
+						},
+						Ctx:      ctx,
+						FnResult: fnResult,
 					}
 					fltr.Run = cfn.Run
 				}

--- a/pkg/test/runner/config.go
+++ b/pkg/test/runner/config.go
@@ -81,6 +81,9 @@ type TestCaseConfig struct {
 	// AllowExec determines if `fn render` needs to be invoked with `--allow-exec` flag
 	AllowExec bool `json:"allowExec,omitempty" yaml:"allowExec,omitempty"`
 
+	// AllowExec determines if `fn render` needs to be invoked with `--allow-network` flag
+	AllowNetwork bool `json:"allowNetwork,omitempty" yaml:"allowNetwork,omitempty"`
+
 	// AllowWasm determines if `fn render` needs to be invoked with `--allow-alpha-wasm` flag
 	AllowWasm bool `json:"allowWasm,omitempty" yaml:"allowWasm,omitempty"`
 


### PR DESCRIPTION
With this PR, `kpt render` supports a commandline flag `--allow-network` that allows functions to access network during pipeline execution.

```sh

# an example
$ kpt fn render --allow-network

```

Note that the docs/help text will be added in the follow up PR because docs are merged post the `kpt` release.