### PR TITLE
docs: reference added for allow-network option in render

### DIFF
--- a/commands/fn/render/cmdrender.go
+++ b/commands/fn/render/cmdrender.go
@@ -59,8 +59,8 @@ func NewRunner(ctx context.Context, parent string) *Runner {
 
 	c.Flags().BoolVar(&r.RunnerOptions.AllowExec, "allow-exec", r.RunnerOptions.AllowExec,
 		"allow binary executable to be run during pipeline execution.")
-	c.Flags().BoolVar(
-		&r.RunnerOptions.AllowNetwork, "allow-network", false, "allow functions to access network during pipeline execution.")
+	c.Flags().BoolVar(&r.RunnerOptions.AllowNetwork, "allow-network", false,
+		"allow functions to access network during pipeline execution.")
 	c.Flags().BoolVar(&r.RunnerOptions.AllowWasm, "allow-alpha-wasm", r.RunnerOptions.AllowWasm,
 		"allow wasm to be used during pipeline execution.")
 	cmdutil.FixDocs("kpt", parent, c)

--- a/site/reference/cli/fn/render/README.md
+++ b/site/reference/cli/fn/render/README.md
@@ -50,6 +50,11 @@ PKG_PATH:
   can perform privileged operations on your system, so ensure that binaries
   referred in the pipeline are trusted and safe to execute.
 
+--allow-network:
+  Allow functions to access network during pipeline execution. If unspecified,
+  `false` will be the default. Note that this is applicable for container
+  based functions only.
+
 --image-pull-policy:
   If the image should be pulled before rendering the package(s). It can be set
   to one of always, ifNotPresent, never. If unspecified, always will be the
@@ -121,6 +126,11 @@ $ kpt fn render -o stdout \
 ```shell
 # Render my-package-dir with podman as runtime for functions
 $ KPT_FN_RUNTIME=podman kpt fn render my-package-dir
+```
+
+```shell
+# Render my-package-dir with network access enabled for functions
+$ kpt fn render --allow-network
 ```
 
 <!--mdtogo-->


### PR DESCRIPTION
Updated the reference for `fn render` to document `allow-network` commandline flag.