### PR TITLE
doc: add documentation on naming functions in a Kptfile

### DIFF
--- a/site/book/04-using-functions/01-declarative-function-execution.md
+++ b/site/book/04-using-functions/01-declarative-function-execution.md
@@ -213,6 +213,33 @@ pipeline:
         tier: mysql
 ```
 
+## Specifying function `name`
+
+Functions can optionally be named to e.g. express the combined effect
+of `function` and `functionConfig`.
+
+For example:
+
+```yaml
+# wordpress/mysql/Kptfile
+apiVersion: kpt.dev/v1
+kind: Kptfile
+metadata:
+  name: mysql
+pipeline:
+  mutators:
+    - name: set tier label
+      image: set-labels:v0.1
+      configMap:
+        tier: mysql
+```
+
+Specifying unique function names for all functions in a `Kptfile` is
+highly recommended, since package updates with `kpt pkg update` merges
+the `mutator` and `validator` function lists as associative list using
+the `name` field to identify functions. An unspecified `name` or
+duplicated names may result in unexpected package updates.
+
 ## Specifying `selectors`
 
 In some cases, you want to invoke the function only on a subset of resources based on a

--- a/site/book/04-using-functions/01-declarative-function-execution.md
+++ b/site/book/04-using-functions/01-declarative-function-execution.md
@@ -215,8 +215,8 @@ pipeline:
 
 ## Specifying function `name`
 
-Functions can optionally be named to e.g. express the combined effect
-of `function` and `functionConfig`.
+Functions can optionally be named using the `pipeline.mutators.name`
+or `pipeline.validators.name` field to identify a function.
 
 For example:
 
@@ -234,11 +234,11 @@ pipeline:
         tier: mysql
 ```
 
-Specifying unique function names for all functions in a `Kptfile` is
-highly recommended, since package updates with `kpt pkg update` merges
-the `mutator` and `validator` function lists as associative list using
-the `name` field to identify functions. An unspecified `name` or
-duplicated names may result in unexpected package updates.
+Unique function names for all functions in the Kptfile function
+pipeline is recommended.  If `name` is specified, `kpt pkg update`
+will merge each function pipeline list as an associative list, using
+`name` as the merge key. An unspecified `name` or duplicated names may
+result in unexpected merges.
 
 ## Specifying `selectors`
 


### PR DESCRIPTION
This PR documents/clarifies that using `name` on functions in a `Kptfile` is important when updating packages with `kpt pkg update`. The issue was discussed in Slack here: https://kubernetes.slack.com/archives/C0155NSPJSZ/p1689926397556699

The `name` field was not mentioned in the current version of the book, and since function lists are merged as associative lists, the effect of not specifying a `name` may result in unpredictable ordering of the function lists.

Specifically, the PR updates section 4.1 of the kpt book on "Declarative Function Execution"

A few considerations for reviewers:
- This document https://github.com/GoogleContainerTools/kpt/pull/2623/files deliberately avoids function names with spaces and resorts to names-with-hyphens instead. This PR use an example with spaces in names.
- The same document also describe cases where it is possible to do function identification based on the value of `image`. This PR does not describe this situation since there are multiple requirements for this to be possible. Also, I'm suspecting that this functionality may no longer be active since the example shown in the Slack thread should have merged the updated function list if it had used `image` as identifier.
