### PR TITLE
Update to golang 1.20.6

### DIFF
--- a/.github/workflows/checkLicenses.yml
+++ b/.github/workflows/checkLicenses.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go 1.20
         uses: actions/setup-go@v3
         with:
-          go-version: '>=1.20.5'
+          go-version: '>=1.20.6'
       - run: |
           ./scripts/create-licenses.sh
       # Upload the licenses list so it's available if needed

--- a/.github/workflows/e2eEnvironment.yml
+++ b/.github/workflows/e2eEnvironment.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '>=1.20.5'
+          go-version: '>=1.20.6'
       - uses: actions/checkout@v3
       # Pinned to Commit to ensure action is consistent: https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
       # If you upgrade this version confirm the changes match your expectations

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Go 1.20
         uses: actions/setup-go@v3
         with:
-          go-version: '>=1.20.5'
+          go-version: '>=1.20.6'
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
@@ -70,7 +70,7 @@ jobs:
       - name: Set up Go 1.20
         uses: actions/setup-go@v3
         with:
-          go-version: '>=1.20.5'
+          go-version: '>=1.20.6'
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
@@ -88,7 +88,7 @@ jobs:
 #      - name: Set up Go 1.20
 #        uses: actions/setup-go@v1
 #        with:
-#          go-version: '>=1.20.5'
+#          go-version: '>=1.20.6'
 #        id: go
 #      - name: Check out code into the Go module directory
 #        uses: actions/checkout@v3

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '>=1.20.5'
+          go-version: '>=1.20.6'
       - uses: actions/checkout@master
       # Pinned to Commit to ensure action is consistent: https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions
       # If you upgrade this version confirm the changes match your expectations

--- a/.github/workflows/porch-e2e.yml
+++ b/.github/workflows/porch-e2e.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Set up Go 1.20
         uses: actions/setup-go@v3
         with:
-          go-version: '>=1.20.5'
+          go-version: '>=1.20.6'
       - name: Checkout Porch
         uses: actions/checkout@v3
       - name: Build kpt

--- a/.github/workflows/porch.yml
+++ b/.github/workflows/porch.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go 1.20
         uses: actions/setup-go@v3
         with:
-          go-version: '>=1.20.5'
+          go-version: '>=1.20.6'
       - name: Run Porch Unit Tests
         uses: actions/checkout@v3
       - name: Verify format / headers etc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: '>=1.20.5'
+          go-version: '>=1.20.6'
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/verifyContent.yml
+++ b/.github/workflows/verifyContent.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: '>=1.20.5'
+          go-version: '>=1.20.6'
       - uses: actions/checkout@v3
       - run: |
           make build

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-GOLANG_VERSION         := 1.20.5
+GOLANG_VERSION         := 1.20.6
 GORELEASER_CONFIG      = release/tag/goreleaser.yaml
 GORELEASER_IMAGE       := ghcr.io/goreleaser/goreleaser-cross:v$(GOLANG_VERSION)
 

--- a/porch/build/Dockerfile.apiserver
+++ b/porch/build/Dockerfile.apiserver
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.20.5-bullseye as builder
+FROM golang:1.20.6-bullseye as builder
 
 WORKDIR /workspace/src
 RUN git clone https://github.com/kubernetes/kubernetes --branch v1.23.2 --depth=1

--- a/porch/build/Dockerfile.etcd
+++ b/porch/build/Dockerfile.etcd
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.20.5-bullseye as builder
+FROM golang:1.20.6-bullseye as builder
 
 WORKDIR /workspace
 ARG ETCD_VER=v3.5.1

--- a/porch/build/Dockerfile.porch
+++ b/porch/build/Dockerfile.porch
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM golang:1.20.5-bullseye as builder
+FROM golang:1.20.6-bullseye as builder
 
 WORKDIR /go/src/github.com/GoogleContainerTools/kpt
 

--- a/porch/controllers/Dockerfile
+++ b/porch/controllers/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.20-bullseye as builder
+FROM golang:1.20.6-bullseye as builder
 
 WORKDIR /workspace
 COPY go.mod go.sum ./

--- a/porch/examples/apps/hello-server/Dockerfile
+++ b/porch/examples/apps/hello-server/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.20.5-bullseye as builder
+FROM golang:1.20.6-bullseye as builder
 
 WORKDIR /src
 COPY go.mod go.sum ./

--- a/porch/func/Dockerfile
+++ b/porch/func/Dockerfile
@@ -25,7 +25,7 @@ FROM gcr.io/kpt-fn/set-project-id:v0.2.0 as set-project-id
 FROM gcr.io/kpt-fn/starlark:v0.3.0 as starlark
 FROM gcr.io/kpt-fn/upsert-resource:v0.2.0 as upsert-resource
 
-FROM golang:1.20.5-alpine3.18 as builder
+FROM golang:1.20.6-alpine3.18 as builder
 WORKDIR /go/src/github.com/GoogleContainerTools/kpt
 
 RUN go install github.com/grpc-ecosystem/grpc-health-probe@v0.4.11

--- a/porch/func/Dockerfile-wrapperserver
+++ b/porch/func/Dockerfile-wrapperserver
@@ -1,4 +1,4 @@
-FROM golang:1.20.5-alpine3.18 as builder
+FROM golang:1.20.6-alpine3.18 as builder
 
 WORKDIR /go/src/github.com/GoogleContainerTools/kpt
 

--- a/porch/test/Dockerfile
+++ b/porch/test/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-FROM golang:1.20.5-bullseye as builder
+FROM golang:1.20.6-bullseye as builder
 
 WORKDIR /go/src/github.com/GoogleContainerTools/kpt
 


### PR DESCRIPTION
Update to golang 1.20.6 due to CVE-2023-29406
