### PR TITLE
Fix release script by removing release targets that require CGO

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,10 +52,15 @@ jobs:
         id: setup-release-env
         run: |-
           echo 'GITHUB_TOKEN=${{secrets.GITHUB_TOKEN}}' > .release-env
-      - name: Run GoReleaser within Docker
+      - name: Run GoReleaser
         id: run-goreleaser
-        run: |
-          make release-ci
+        uses: goreleaser/goreleaser-action@v4
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --skip-validate -f release/tag/goreleaser.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate SLSA subjects for provenance
         id: hash
         run: |

--- a/release/tag/goreleaser.yaml
+++ b/release/tag/goreleaser.yaml
@@ -63,54 +63,6 @@ builds:
       - arm64
     ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}} -extldflags "-z noexecstack"
 
-  - id: darwin-amd64-wasm
-    env:
-      - CGO_ENABLED=1
-      - GO111MODULE=on
-      - CC=o64-clang
-      - CXX=o64-clang++
-    goos:
-      - darwin
-    goarch:
-      - amd64
-    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}}
-
-  - id: darwin-arm64-wasm
-    env:
-      - CGO_ENABLED=1
-      - GO111MODULE=on
-      - CC=oa64-clang
-      - CXX=oa64-clang++
-    goos:
-      - darwin
-    goarch:
-      - arm64
-    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}}
-
-  - id: linux-amd64-wasm
-    env:
-      - CGO_ENABLED=1
-      - GO111MODULE=on
-      - CC=x86_64-linux-gnu-gcc
-      - CXX=x86_64-linux-gnu-g++
-    goos:
-      - linux
-    goarch:
-      - amd64
-    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}} -extldflags "-z noexecstack"
-
-  - id: linux-arm64-wasm
-    env:
-      - CGO_ENABLED=1
-      - GO111MODULE=on
-      - CC=aarch64-linux-gnu-gcc
-      - CXX=aarch64-linux-gnu-g++
-    goos:
-      - linux
-    goarch:
-      - arm64
-    ldflags: -s -w -X github.com/GoogleContainerTools/kpt/run.version={{.Version}} -extldflags "-z noexecstack"
-
 dockers:
   - ids:
       - linux-amd64
@@ -133,16 +85,6 @@ archives:
       - LICENSES*
       - lib.zip*
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}-{{ .Version }}"
-  - id: archived-wasm
-    builds:
-      - darwin-amd64-wasm
-      - darwin-arm64-wasm
-      - linux-amd64-wasm
-      - linux-arm64-wasm
-    files:
-      - LICENSES*
-      - lib.zip*
-    name_template: "{{ .ProjectName }}_wasm_{{ .Os }}_{{ .Arch }}-{{ .Version }}"
   - id: bin-only
     format: binary
     builds:
@@ -151,14 +93,6 @@ archives:
       - linux-amd64
       - linux-arm64
     name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}"
-  - id: bin-only-wasm
-    format: binary
-    builds:
-      - darwin-amd64-wasm
-      - darwin-arm64-wasm
-      - linux-amd64-wasm
-      - linux-arm64-wasm
-    name_template: "{{ .ProjectName }}_wasm_{{ .Os }}_{{ .Arch }}"
 checksum:
   name_template: "checksums.txt"
 snapshot:


### PR DESCRIPTION
This fixes the release process by removing the release targets that require CGO, in practice these are the WASM targets. There are two reasons for this:
* The complexity of the kpt release process is much higher because of the need to compile with CGO, as we are using ghcr.io/goreleaser/goreleaser-cross and do builds within docker containers on Github Actions. This process is currently broken, and this is a fix that addresses the immediate issue and simplifies the process for the future.
* The ghcr.io/goreleaser/goreleaser-cross image tends to be a bit slow to pick up new Go versions, which makes it hard for us to quickly get out new versions of kpt when there are CVEs in go.

Both of these issues can be fixed, but it requires some effort to figure out how to do it right.
