### PR TITLE
Copy the labels map before editing

### DIFF
--- a/porch/pkg/cache/packagerevision.go
+++ b/porch/pkg/cache/packagerevision.go
@@ -40,10 +40,13 @@ func (c *cachedPackageRevision) GetPackageRevision(ctx context.Context) (*v1alph
 		return nil, err
 	}
 	if c.isLatestRevision {
-		if rev.Labels == nil {
-			rev.Labels = map[string]string{}
+		// copy the labels in case the cached object is being read by another go routine
+		labels := make(map[string]string, len(rev.Labels))
+		for k, v := range rev.Labels {
+			labels[k] = v
 		}
-		rev.Labels[v1alpha1.LatestPackageRevisionKey] = v1alpha1.LatestPackageRevisionValue
+		labels[v1alpha1.LatestPackageRevisionKey] = v1alpha1.LatestPackageRevisionValue
+		rev.Labels = labels
 	}
 	return rev, nil
 }

--- a/porch/pkg/engine/engine.go
+++ b/porch/pkg/engine/engine.go
@@ -113,10 +113,13 @@ func (p *PackageRevision) GetPackageRevision(ctx context.Context) (*api.PackageR
 	}
 	repoPkgRev.Labels = p.packageRevisionMeta.Labels
 	if isLatest {
-		if repoPkgRev.Labels == nil {
-			repoPkgRev.Labels = make(map[string]string)
+		// copy the labels in case the cached object is being read by another go routine
+		labels := make(map[string]string, len(repoPkgRev.Labels))
+		for k, v := range repoPkgRev.Labels {
+			labels[k] = v
 		}
-		repoPkgRev.Labels[api.LatestPackageRevisionKey] = api.LatestPackageRevisionValue
+		labels[api.LatestPackageRevisionKey] = api.LatestPackageRevisionValue
+		repoPkgRev.Labels = labels
 	}
 	repoPkgRev.Annotations = p.packageRevisionMeta.Annotations
 	repoPkgRev.Finalizers = p.packageRevisionMeta.Finalizers


### PR DESCRIPTION
Fixes #3958 

The logs showed a crash during rendering the metadata.Labels field. This was a crash that was completely outside the path of any of our code - meaning that extra locking won't help, because we can't change the API server code to grab a lock. The code was serving something up from a cache, so we must have been modifying the data in that cache at the same time.

I found a couple places that we tweak the Labels field, and these are areas of the code that were active in other runnable goroutines, so I am pretty sure they are the culprit. I have been running the new build for a few hours now, and no crashes. The released version was crashing ~1 per hour. Let's let it steep over the weekend.

/hold
