### PR TITLE
Fix: Throw error while rejecting a package which is not proposed/deletion-proposed

### DIFF
--- a/commands/alpha/rpkg/reject/command.go
+++ b/commands/alpha/rpkg/reject/command.go
@@ -123,7 +123,9 @@ func (r *runner) runE(_ *cobra.Command, args []string) error {
 				fmt.Fprintf(r.Command.OutOrStderr(), "%s no longer proposed for deletion\n", name)
 			}
 		default:
-			fmt.Fprintf(r.Command.ErrOrStderr(), "cannot reject %s with lifecycle '%s'\n", name, pr.Spec.Lifecycle)
+			msg := fmt.Sprintf("cannot reject %s with lifecycle '%s'", name, pr.Spec.Lifecycle)
+			messages = append(messages, msg)
+			fmt.Fprintln(r.Command.ErrOrStderr(), msg)
 		}
 	}
 

--- a/e2e/testdata/porch/rpkg-lifecycle/config.yaml
+++ b/e2e/testdata/porch/rpkg-lifecycle/config.yaml
@@ -158,6 +158,9 @@ commands:
       - --namespace=rpkg-lifecycle
     stderr: |
       cannot reject git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 with lifecycle 'Published'
+      Error: errors:
+        cannot reject git-017a8366a5e0d9b35ae6dc489d4d3f68046d6034 with lifecycle 'Published' 
+    exitCode: 1
   - args:
       - alpha
       - rpkg


### PR DESCRIPTION
Default case of switch should throw an error response while rejecting a package.