### PR TITLE
Use the correct form of `md5.Sum`.

### DIFF
--- a/internal/gitutil/gitutil.go
+++ b/internal/gitutil/gitutil.go
@@ -335,7 +335,8 @@ func (gur *GitUpstreamRepo) getRepoDir(uri string) string {
 		var hash = md5.Sum([]byte(uri))
 		return strings.ToLower(hex.EncodeToString(hash[:]))
 	}
-	return strings.ToLower(base32.StdEncoding.EncodeToString(md5.New().Sum([]byte(uri))))
+	sum := md5.Sum([]byte(uri))
+	return strings.ToLower(base32.StdEncoding.EncodeToString(sum[:]))
 }
 
 // getRepoCacheDir


### PR DESCRIPTION
`md5.New().Sum(foo)` appends the MD5 hash for nil to foo. See https://go.dev/play/p/vSW0U3Hq4qk (different algo but same issue).