### PR TITLE
Change the functions catalog link to https://catalog.kpt.dev/function…

### DIFF
--- a/documentation/config.toml
+++ b/documentation/config.toml
@@ -176,5 +176,5 @@ enable = false
 
 [[menu.main]]
 name = "Functions Catalog"
-url = "https://catalog.kpt.dev/"
+url = "https://catalog.kpt.dev/function-catalog/"
 weight = 40


### PR DESCRIPTION
…-catalog/

https://catalog.kpt.dev/ mimics the start page of the documentation, therefore confusing for the user to jump there.
