### PR TITLE
Fix homebrew releasing of kpt for MacOS

### DIFF
--- a/Formula/kpt.rb
+++ b/Formula/kpt.rb
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 class Kpt < Formula
-  desc "Toolkit to manage,and apply Kubernetes Resource config data files"
-  homepage "https://github.com/kptdev.github.io/kpt"
-  url "https://github.com/kptdev/kpt/archive/v1.0.0-beta.49.tar.gz"
-  sha256 "e8f5beb1b4538f0b5d5322cb1600b93728e4a90a975860873883507ee144a262"
+  desc "A toolchain for composing, customizing, and deploying Kubernetes packages at scale"
+  homepage "https://kpt.dev"
+  url "https://github.com/kptdev/kpt/archive/v1.0.0-beta.59.tar.gz"
+  sha256 "77f8693eea137a97c8e66178392fef6d5a7644aaf10a06091c57e0fcd9552340"
 
   depends_on "go" => :build
 

--- a/release/formula/main.go
+++ b/release/formula/main.go
@@ -107,8 +107,8 @@ const formulaTemplate = `# Copyright 2019 The kpt Authors
 # limitations under the License.
 
 class Kpt < Formula
-  desc "Toolkit to manage,and apply Kubernetes Resource config data files"
-  homepage "https://github.com/kptdev.github.io/kpt"
+  desc "A toolchain for composing, customizing, and deploying Kubernetes packages at scale"
+  homepage "https://kpt.dev"
   url "{{url}}"
   sha256 "{{sha256}}"
 


### PR DESCRIPTION
The [homebrew](https://brew.sh/) package manager is a package manager that for installing commonly used software on MacOS. Gitea, kind, and go are just three of the many packages available.

The homebrew kpt package currently installs V1.0.0-beta.49 of kpt.

```% which kpt
/opt/homebrew/bin/kpt
liam@MacBookPro kpt % brew info kpt
==> kptdev/kpt/kpt: stable 1.0.0-beta.49
Toolkit to manage,and apply Kubernetes Resource config data files
https://github.com/kptdev.github.io/kpt
Installed
/opt/homebrew/Cellar/kpt/1.0.0-beta.49 (6 files, 95.5MB) *
  Built from source on 2025-12-04 at 08:53:54
From: https://github.com/kptdev/kpt/blob/HEAD/Formula/kpt.rb
==> Dependencies
Build: go ✔
```

This PR updates the brew formula on kpt so that Homebrew will install the latest version of kpt.

Fixes #962 
