### PR TITLE
Enable Go CI workflow for release/formula Go code

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,8 @@ on:
       - "firebase/**"
       - "logo/**"
       - "package-examples/**"
-      - "release/**"
+      - "release/images/**"
+      - "release/tag/**"
       - "site/**"
       - "**.md"
   push:


### PR DESCRIPTION
### Description
Modified the GitHub Actions workflow to trigger Go CI verification for changes in the `release/formula/` directory. Previously, the entire `release/` directory was ignored, but now only `release/images/` and `release/tag/` are excluded from CI runs.

### Motivation
The release/formula/ directory contains Go code and unit tests. This code should be tested and validated through the CI pipeline to ensure it builds correctly. By removing the blanket exclusion of the entire `release/` directory, we can catch potential issues in the formula generation code early.

### Changes Made
- Updated `.github/workflows/go.yml` to replace the broad `release/**` exclusion with specific exclusions for `release/images/**` and `release/tag/**`
- This allows CI to run when files in `release/formula/` are modified while still ignoring non-code assets in other release subdirectories
