### PR TITLE
Docs: clarify Windows setup for documentation site

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -26,7 +26,14 @@ npm install
 Then run the site using `npm run serve`. To have the site run locally with a functioning local search, run
 `npm run serve:with-pagefind`.
 
+### Windows note (PowerShell/CMD)
+
+The site pulls some dependencies via Git submodules. If `npm install` succeeds but the site fails to build (for example, missing theme assets), initialize submodules and try again:
+
+```powershell
+git submodule update --init --recursive
+```
+
 ## License
 
 Licensed under the [Creative Commons Attribution 4.0 International license](LICENSE-documentation)
- 


### PR DESCRIPTION
## Title

Docs: clarify Windows setup for documentation site

## Description

### What changed
Added a short Windows (PowerShell/CMD) troubleshooting note in `README.md` explaining how to initialize Git submodules if the documentation site build fails due to missing theme or assets.

### Motivation
New contributors on Windows can successfully run `npm install`, but the documentation site may still fail to build if required Git submodules are not initialized. This was not documented in the README, leading to confusion and unnecessary setup friction.

### Fix
Documented the single command required to initialize submodules:

```bash
git submodule update --init --recursive
