### PR TITLE
Docs : Fix the incorrect example path in Chapter 2 of Book

### DIFF
--- a/documentation/content/en/book/02-concepts/_index.md
+++ b/documentation/content/en/book/02-concepts/_index.md
@@ -93,7 +93,7 @@ Just as directories can be nested, a package can contain another package, called
 Let's take a look at the wordpress package as an example:
 
 ```shell
-kpt pkg get https://github.com/kptdev/kpt/tree/package-examples/wordpress@v1.0.0-beta.59
+kpt pkg get https://github.com/kptdev/kpt/package-examples/wordpress@v1.0.0-beta.59
 ```
 
 View the package hierarchy using the `tree` command:


### PR DESCRIPTION
### What changed
Fixed an incorrect example path in the Chapter 2 of documentation.

### Motivation
The documented path does not exist in the repository, which causes copy-paste commands to fail for users following the guide.

### Scope
Docs-only change. No behavior changes.
