### PR TITLE
Removing kpt mailing list from issue_template & managed Docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -20,6 +20,3 @@ contact_links:
   - name: kpt Slack Channel
     url: https://kubernetes.slack.com/app_redirect?channel=kpt
     about: Discuss kpt topics with the kpt team on Slack
-  - name: kpt Mailing List
-    url: https://groups.google.com/forum/#!forum/kpt-users
-    about: Join the kpt mailing list

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -36,7 +36,7 @@ be spending time understanding the use-cases and need for this project. [Trackin
 
 ## Feedback channels:
 1. File a [new issue] on Github, but please search first. 
-1. kpt-users@googlegroups.com
+
 
 [new issue]: https://github.com/kptdev/kpt/issues/new/choose
 [The Kpt Book]: https://kpt.dev/book/


### PR DESCRIPTION

### Description
This pr ensures that there is no kpt mailing list in the issue template as we do not have a mailing list anymore.

### Motivation
The kpt mailing list is no longer active. Removing these references ensures users are not directed to a non-existent channel for support or feedback, preventing confusion and also managed the documentation and issue reporting flow.

### Fixes
Fixes #4359 