### PR TITLE
fix: add shell language specifier to fn doc Flags code block

### DIFF
--- a/documentation/content/en/reference/cli/fn/doc/_index.md
+++ b/documentation/content/en/reference/cli/fn/doc/_index.md
@@ -24,7 +24,7 @@ kpt fn doc --image=IMAGE
 
 #### Flags
 
-```
+```shell
 --image, i: (required flag)
   Container image of the function e.g. `ghcr.io/kptdev/krm-functions-catalog/set-namespace:latest`.
   For convenience, if full image path is not specified, `ghcr.io/kptdev/krm-functions-catalog/` is added as default prefix.


### PR DESCRIPTION
Docs: Fix Flags section rendering on fn doc page

## Description

The "Flags" section on the `kpt fn doc` reference page does not render correctly. The fenced code block for the Flags section was missing the `shell` language specifier, causing Hugo to interpret it as LaTeX math notation (`$$...$$`) instead of rendering it as a formatted code block.

Fixes #4372

## Motivation

All other fenced code blocks in the fn docs (including the Environment Variables section on the same page, and the Flags sections in `fn eval`, `fn render`, `fn source`) use ` ```shell `. The `fn doc` Flags block was the only one using bare ` ``` `, causing broken rendering on the documentation site.

The fix adds the `shell` language specifier to match the convention used everywhere else.
