### PR TITLE
Fix the kpt release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Generate SLSA subjects for provenance
         id: hash
+        working-directory: go/src/github.com/kptdev/kpt
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
The release jobs are failing on the kpt repo because the working-directory is not set on the "Generate SLSA subjects for provenance" step in the job.

This PR fixes that.

