### PR TITLE
docs: Fix installation link in README to use kpt.dev instead of GitHu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The best place to get started and learn about specific features of kpt is to vis
 
 ## Install kpt
 
-kpt installation instructions can be found on [kpt.dev/installation](https://kpt.dev/installation/)
+kpt installation instructions can be found on [kpt.dev/installation/kpt-cli](https://kpt.dev/installation/kpt-cli/)
 
 ## kpt components
 


### PR DESCRIPTION
## Summary
Fixed the installation link in README.md to point to the proper kpt.dev documentation page instead of a GitHub file path.

## Changes
- Updated installation link from `https://github.com/kptdev/kpt/blob/main/documentation/content/en/installation/kpt-cli.md` to `https://kpt.dev/installation/`

## Motivation
The previous link pointed to a raw GitHub file path, which is:
- Not user-friendly (shows markdown source instead of rendered documentation)
- Inconsistent with other documentation links in the README
- Harder to maintain (breaks if file path changes)

The new link points directly to the rendered documentation site, providing a better experience for users looking to install kpt.

## Type of Change
- [x] Documentation update
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
