### PR TITLE
Fix/docs todo link

### DIFF
--- a/documentation/content/en/guides/tenant-onboarding.md
+++ b/documentation/content/en/guides/tenant-onboarding.md
@@ -213,7 +213,8 @@ $ git commit -am "added tenant-a"
 $ git push origin onboarding-tenant-a
 
 # make a pull request for platform team to merge
-# TODO (link to an example PR will be great here)
+# Create a PR with the changes above. 
+# See example tenant packages at: https://github.com/kptdev/kpt/tree/main/package-examples/tenant
 ```
 
 ## Day 2 use-cases


### PR DESCRIPTION
## Summary

Improves the tenant onboarding documentation by replacing a TODO comment with a helpful reference to example tenant packages, making it easier for users to understand and create proper tenant onboarding pull requests.

## Problem

The tenant onboarding guide contained an unresolved TODO comment that left users without clear guidance on what their pull requests should look like:

```shell
# make a pull request for platform team to merge
# TODO 