### PR TITLE
Use golangci-lint v2, migrate config and adjust Makefile

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,54 +1,83 @@
-# Copyright 2019 Google Inc.  All Rights Reserved.
+# Copyright 2026 The kpt Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-run:
-  deadline: 5m
-
+version: "2"
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
+  default: none
   enable:
     - bodyclose
+    - copyloopvar
     - dogsled
     - dupl
     - errcheck
-# funlen triggers on test functions which it shouldn't
-#    - funlen
-    - copyloopvar
     - gochecknoinits
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
-#    - gosec
-    - gosimple
     - govet
     - ineffassign
     - lll
     - misspell
     - nakedret
-    - staticcheck
-    - stylecheck
     - revive
-    - typecheck
+    - staticcheck
     - unconvert
     - unparam
     - unused
     - whitespace
-
-issues:
-  exclude:
-     - Using the variable on range scope `tc` in function literal
-  exclude-dirs:
-    - thirdparty/
-
-linters-settings:
-  dupl:
-    threshold: 400
-  lll:
-    line-length: 170
-  gocyclo:
-    min-complexity: 30
-  golint:
-    min-confidence: 0.85
+#    - funlen # TODO: fix
+#    - gosec  # TODO: fix
+  settings:
+    dupl:
+      threshold: 400
+    gocyclo:
+      min-complexity: 30
+    lll:
+      line-length: 170
+    revive:
+      confidence: .85
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - path: (.+)\.go$
+        text: Using the variable on range scope `tc` in function literal
+      - path: (.+)_test\.go$
+        linters:
+          - gosec
+          - funlen
+      - path: (.+)/test(.+)/(.+)\.go$ # test, testutil packages
+        linters:
+          - gosec
+          - funlen
+    paths:
+      - thirdparty/
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - thirdparty/
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,11 @@
 # limitations under the License.
 
 GOLANG_VERSION    := 1.25.7
+GOLANGCI_LINT_VERSION := 2.11.3
+
 GORELEASER_CONFIG = release/tag/goreleaser.yaml
 GORELEASER_IMAGE  := ghcr.io/goreleaser/goreleaser-cross:v$(GOLANG_VERSION)
+
 YEAR_GEN          := $(shell date '+%Y')
 
 .PHONY: docs fix vet fmt lint test build tidy release release-ci
@@ -62,7 +65,7 @@ install-kind:
 
 .PHONY: install-golangci-lint
 install-golangci-lint:
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v$(GOLANGCI_LINT_VERSION)
 
 .PHONY: install-swagger
 install-swagger:
@@ -90,8 +93,8 @@ generate: install-mdtogo
 tidy:
 	go mod tidy
 
-lint: install-golangci-lint
-	$(GOBIN)/golangci-lint run ./...
+lint:
+	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v$(GOLANGCI_LINT_VERSION) run -v ./...
 
 test:
 	go test -cover ${LDFLAGS} ./...

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+SHELL := bash
+.SHELLFLAGS := -exc
+
 GOLANG_VERSION    := 1.25.7
-GOLANGCI_LINT_VERSION := 2.11.3
+GOLANGCI_LINT_VERSION := 2.11.4
 
 GORELEASER_CONFIG = release/tag/goreleaser.yaml
 GORELEASER_IMAGE  := ghcr.io/goreleaser/goreleaser-cross:v$(GOLANG_VERSION)
@@ -93,8 +96,13 @@ generate: install-mdtogo
 tidy:
 	go mod tidy
 
+# if the local version of golangci-lint matches the one we want, we can use that without overhead
 lint:
-	go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v$(GOLANGCI_LINT_VERSION) run -v ./...
+	@if [[ `command -v golangci-lint` && `golangci-lint version --short` == $(GOLANGCI_LINT_VERSION) ]]; then \
+		golangci-lint run -v ./...; \
+	else \
+		go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v$(GOLANGCI_LINT_VERSION) run -v ./...; \
+	fi
 
 test:
 	go test -cover ${LDFLAGS} ./...

--- a/commands/alpha/live/plan/command.go
+++ b/commands/alpha/live/plan/command.go
@@ -91,7 +91,7 @@ func (r *Runner) PreRunE(_ *cobra.Command, _ []string) error {
 }
 
 func (r *Runner) validateOutputFormat() error {
-	if !(r.output == "text" || r.output == "krm") {
+	if r.output != "text" && r.output != "krm" {
 		return fmt.Errorf("unknown output format %q. Must be either 'text' or 'krm'", r.output)
 	}
 	return nil

--- a/commands/live/migrate/migratecmd_test.go
+++ b/commands/live/migrate/migratecmd_test.go
@@ -207,12 +207,12 @@ func TestKptMigrate_migrateKptfileToRG(t *testing.T) {
 				t.Fatalf("unable to read ResourceGroup file")
 				return
 			}
-			assert.Equal(t, inventoryNamespace, rg.ObjectMeta.Namespace)
-			if len(rg.ObjectMeta.Name) == 0 {
+			assert.Equal(t, inventoryNamespace, rg.Namespace)
+			if len(rg.Name) == 0 {
 				t.Errorf("inventory name not set in Kptfile")
 			}
-			if rg.ObjectMeta.Labels[rgfilev1alpha1.RGInventoryIDLabel] != testInventoryID {
-				t.Errorf("inventory id not set correctly in ResourceGroup: %s", rg.ObjectMeta.Labels[rgfilev1alpha1.RGInventoryIDLabel])
+			if rg.Labels[rgfilev1alpha1.RGInventoryIDLabel] != testInventoryID {
+				t.Errorf("inventory id not set correctly in ResourceGroup: %s", rg.Labels[rgfilev1alpha1.RGInventoryIDLabel])
 			}
 		})
 	}

--- a/internal/fnruntime/fnerrors.go
+++ b/internal/fnruntime/fnerrors.go
@@ -54,7 +54,7 @@ func (fe *ExecError) String() string {
 		Separator: ", ",
 	}
 	b.WriteString(errLine.String())
-	b.WriteString(fmt.Sprintf("  Exit Code: %d\n", fe.ExitCode))
+	fmt.Fprintf(&b, "  Exit Code: %d\n", fe.ExitCode)
 	return b.String()
 }
 

--- a/internal/pkg/pkg.go
+++ b/internal/pkg/pkg.go
@@ -651,7 +651,7 @@ func filterResourceGroups(input []*yaml.RNode) (output []*yaml.RNode, err error)
 			return nil, fmt.Errorf("failed to read metadata for resource %w", err)
 		}
 		// Filter out any non-ResourceGroup files.
-		if !(meta.APIVersion == rgfilev1alpha1.ResourceGroupGVK().GroupVersion().String() && meta.Kind == rgfilev1alpha1.ResourceGroupGVK().Kind) {
+		if meta.APIVersion != rgfilev1alpha1.ResourceGroupGVK().GroupVersion().String() || meta.Kind != rgfilev1alpha1.ResourceGroupGVK().Kind {
 			continue
 		}
 

--- a/internal/testutil/pkgbuilder/builder.go
+++ b/internal/testutil/pkgbuilder/builder.go
@@ -546,17 +546,17 @@ func buildPkg(pkgPath string, pkg *pkg, pkgName string, reposInfo ReposInfo) err
 // buildRGFile creates a ResourceGroup inventory file.
 func buildRGFile(pkg *pkg) string {
 	tmp := rgfilev1alpha1.ResourceGroup{ResourceMeta: rgfilev1alpha1.DefaultMeta}
-	tmp.ObjectMeta.Name = pkg.RGFile.Name
-	tmp.ObjectMeta.Namespace = pkg.RGFile.Namespace
-	tmp.ObjectMeta.Annotations = pkg.RGFile.Annotations
-	tmp.ObjectMeta.Labels = pkg.RGFile.Labels
+	tmp.Name = pkg.RGFile.Name
+	tmp.Namespace = pkg.RGFile.Namespace
+	tmp.Annotations = pkg.RGFile.Annotations
+	tmp.Labels = pkg.RGFile.Labels
 
-	if tmp.ObjectMeta.Labels == nil {
-		tmp.ObjectMeta.Labels = make(map[string]string)
+	if tmp.Labels == nil {
+		tmp.Labels = make(map[string]string)
 	}
 
 	if pkg.RGFile.ID != "" {
-		tmp.ObjectMeta.Labels[rgfilev1alpha1.RGInventoryIDLabel] = pkg.RGFile.ID
+		tmp.Labels[rgfilev1alpha1.RGInventoryIDLabel] = pkg.RGFile.ID
 	}
 
 	b, err := yaml.MarshalWithOptions(tmp, &yaml.EncoderOptions{SeqIndent: yaml.WideSequenceStyle})
@@ -597,7 +597,7 @@ func buildKptfile(pkg *pkg, pkgName string, reposInfo ReposInfo) string {
 
 	kptfile := &kptfilev1.KptFile{}
 	kptfile.APIVersion, kptfile.Kind = kptfilev1.KptFileGVK().ToAPIVersionAndKind()
-	kptfile.ObjectMeta.Name = pkgName
+	kptfile.Name = pkgName
 	if pkg.Kptfile.Upstream != nil {
 		kptfile.Upstream = &kptfilev1.Upstream{
 			Type: "git",

--- a/internal/util/strings/strings.go
+++ b/internal/util/strings/strings.go
@@ -24,7 +24,7 @@ import (
 func JoinStringsWithQuotes(strs []string) string {
 	b := new(strings.Builder)
 	for i, s := range strs {
-		b.WriteString(fmt.Sprintf("%q", s))
+		fmt.Fprintf(b, "%q", s)
 		if i < (len(strs) - 1) {
 			b.WriteString(", ")
 		}

--- a/internal/util/strings/strings.go
+++ b/internal/util/strings/strings.go
@@ -15,7 +15,7 @@
 package strings
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 )
 
@@ -24,7 +24,7 @@ import (
 func JoinStringsWithQuotes(strs []string) string {
 	b := new(strings.Builder)
 	for i, s := range strs {
-		fmt.Fprintf(b, "%q", s)
+		b.WriteString(strconv.Quote(s))
 		if i < (len(strs) - 1) {
 			b.WriteString(", ")
 		}

--- a/internal/util/update/update.go
+++ b/internal/util/update/update.go
@@ -266,7 +266,7 @@ func (u Command) updateRootPackage(ctx context.Context, p *pkg.Pkg) error {
 	}
 
 	pr := printer.FromContextOrDie(ctx)
-	pr.PrintPackage(p, !(p == u.Pkg))
+	pr.PrintPackage(p, p != u.Pkg)
 
 	g := kf.Upstream.Git
 	updated := &git.RepoSpec{OrgRepo: g.Repo, Path: g.Directory, Ref: g.Ref}

--- a/pkg/api/kptfile/v1/validation.go
+++ b/pkg/api/kptfile/v1/validation.go
@@ -270,10 +270,10 @@ type ValidateError struct {
 
 func (e *ValidateError) Error() string {
 	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("Kptfile is invalid:\nField: `%s`\n", e.Field))
+	fmt.Fprintf(&sb, "Kptfile is invalid:\nField: `%s`\n", e.Field)
 	if e.Value != "" {
-		sb.WriteString(fmt.Sprintf("Value: %q\n", e.Value))
+		fmt.Fprintf(&sb, "Value: %q\n", e.Value)
 	}
-	sb.WriteString(fmt.Sprintf("Reason: %s\n", e.Reason))
+	fmt.Fprintf(&sb, "Reason: %s\n", e.Reason)
 	return sb.String()
 }

--- a/pkg/lib/errors/resolver/live.go
+++ b/pkg/lib/errors/resolver/live.go
@@ -139,7 +139,7 @@ func (*liveErrorResolver) Resolve(err error) (ResolvedResult, bool) {
 
 		msg.WriteString("\nDetails:\n")
 		for _, v := range inventoryInfoValidationError.Violations {
-			msg.WriteString(fmt.Sprintf("%s\n", v.Reason))
+			fmt.Fprintf(&msg, "%s\n", v.Reason)
 		}
 
 		return ResolvedResult{Message: msg.String()}, true
@@ -148,10 +148,10 @@ func (*liveErrorResolver) Resolve(err error) (ResolvedResult, bool) {
 	var unknownTypesError *manifestreader.UnknownTypesError
 	if errors.As(err, &unknownTypesError) {
 		var msg strings.Builder
-		msg.WriteString(fmt.Sprintf("Error: %d resource types not found in the cluster or as CRDs among the applied resources.", len(unknownTypesError.GroupVersionKinds)))
+		fmt.Fprintf(&msg, "Error: %d resource types not found in the cluster or as CRDs among the applied resources.", len(unknownTypesError.GroupVersionKinds))
 		msg.WriteString("\n\nResource types:\n")
 		for _, gvk := range unknownTypesError.GroupVersionKinds {
-			msg.WriteString(fmt.Sprintf("%s\n", gvk))
+			fmt.Fprintf(&msg, "%s\n", gvk)
 		}
 
 		return ResolvedResult{Message: msg.String()}, true

--- a/pkg/live/planner/cluster.go
+++ b/pkg/live/planner/cluster.go
@@ -244,7 +244,7 @@ func (r *ClusterPlanner) fetchResources(ctx context.Context, e event.Event) ([]A
 	var actions []Action
 	for _, ag := range e.InitEvent.ActionGroups {
 		// We only care about the Apply, Prune and Delete actions.
-		if !(ag.Action == event.ApplyAction || ag.Action == event.PruneAction || ag.Action == event.DeleteAction) {
+		if ag.Action != event.ApplyAction && ag.Action != event.PruneAction && ag.Action != event.DeleteAction {
 			continue
 		}
 		for _, id := range ag.Identifiers {

--- a/pkg/live/rgpath.go
+++ b/pkg/live/rgpath.go
@@ -91,8 +91,6 @@ func removeAnnotations(n *yaml.RNode, annotations ...kioutil.AnnotationKey) erro
 
 // kyamlNodeToUnstructured take a resource represented as a kyaml RNode and
 // turns it into an Unstructured object.
-//
-//nolint:interfacer
 func kyamlNodeToUnstructured(n *yaml.RNode) (*unstructured.Unstructured, error) {
 	if err := validateMetadataStringMaps(n); err != nil {
 		return nil, err

--- a/pkg/live/rgstream.go
+++ b/pkg/live/rgstream.go
@@ -98,7 +98,7 @@ func isKptfile(resource []byte) bool {
 	d := yaml.NewDecoder(bytes.NewReader(resource))
 	d.KnownFields(true)
 	if err := d.Decode(&kptFileTemplate); err == nil {
-		return kptFileTemplate.ResourceMeta.TypeMeta == kptfilev1.TypeMeta.TypeMeta
+		return kptFileTemplate.TypeMeta == kptfilev1.TypeMeta.TypeMeta
 	}
 	return false
 }

--- a/pkg/wasm/client.go
+++ b/pkg/wasm/client.go
@@ -105,7 +105,7 @@ func (r *Client) PushWasm(ctx context.Context, wasmFile string, imageName string
 	}
 
 	// Push the image to remote
-	if err = remote.Write(tag.Repository.Digest(hash.String()), img, options...); err != nil {
+	if err = remote.Write(tag.Digest(hash.String()), img, options...); err != nil {
 		return fmt.Errorf("failed to push image %s: %w", tag, err)
 	}
 	fmt.Printf("digest of the image: %v\n", hash.String())


### PR DESCRIPTION
Part of #4389

Migrated to golangci-lint v2 (specifically v2.11.4), fixed some new linter issues and adjusted the Makefile.